### PR TITLE
Add #2334: month/weekday name tokens — compiler-owned locale data, type-only backends

### DIFF
--- a/.changeset/format-date-name-tokens.md
+++ b/.changeset/format-date-name-tokens.md
@@ -1,0 +1,12 @@
+---
+'@barefootjs/client': minor
+'@barefootjs/jsx': minor
+'@barefootjs/go-template': patch
+'@barefootjs/erb': patch
+'@barefootjs/perl': patch
+'@barefootjs/php': patch
+'@barefootjs/jinja': patch
+'@barefootjs/rust': patch
+---
+
+Month/weekday name tokens for date formatting (#2334). `formatDate` gains an explicit `names` table argument (flat 38-slot layout; the `format_date` helper's canonical arity is now 4) and the `MMMM`/`MMM`/`dddd`/`ddd` tokens. The `toLocaleDateString` sugar now admits ANY literal options bag — `{ dateStyle: 'long', timeZone: 'UTC' }`, `{ weekday: 'short', … }` — probing it at build time and shipping the derived pattern plus the name table into the compiled output as an ordinary array argument, so backends stay locale-data-free (type-only) and no runtime ICU/CLDR exists anywhere. Unreproducible forms (era, dayPeriod, 2-digit year, narrow names, non-latn digits) keep refusing loudly per the fidelity rule: reproduce the user's TSX exactly or decline, never approximate.

--- a/packages/adapter-erb/lib/barefoot_js.rb
+++ b/packages/adapter-erb/lib/barefoot_js.rb
@@ -535,19 +535,28 @@ module BarefootJS
     FORMAT_DATE_OFFSET_RE = /\A([+-])(\d{2}):(\d{2})\z/
 
     # Longest-match pattern-token alternation (mirrors TOKEN_RE in
-    # packages/client/src/format-date.ts). Order matters: MM before M and DD
-    # before D so the 2-char token wins at a position where either could
-    # match -- Ruby's Onigmo engine, like JS's regex engine, resolves
-    # alternation leftmost-first (not POSIX leftmost-longest), so listing the
-    # longer alternative first is what makes "MM" consume both characters
-    # instead of two "M" matches.
-    FORMAT_DATE_TOKEN_RE = /YYYY|MM|DD|M|D/
+    # packages/client/src/format-date.ts). Order matters: Onigmo, like JS's
+    # regex engine, resolves alternation leftmost-first (not POSIX
+    # leftmost-longest), so every multi-char token must be listed before any
+    # shorter alternative it prefixes -- YYYY before (nothing shorter
+    # shares its prefix), MMMM before MMM before MM before M, DD before D,
+    # dddd before ddd. (#2334)
+    FORMAT_DATE_TOKEN_RE = /YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D/
 
-    # `format_date(recv, pattern, tz)` (#2324, spec entry "format_date" in
-    # spec/template-helpers.md) -- the lowering target for
-    # `formatDate(date, pattern, timeZone)` (packages/client/src/format-date.ts,
-    # the JS-normative reference this must match byte-for-byte). Total and
-    # deterministic: no locale, no host timezone, no `Time.now`.
+    # `names`-table section offsets (spec/template-helpers.md "format_date",
+    # #2334) -- mirrors MONTHS_WIDE/MONTHS_ABBR/WEEKDAYS_WIDE/WEEKDAYS_ABBR in
+    # packages/client/src/format-date.ts.
+    FORMAT_DATE_MONTHS_WIDE = 0
+    FORMAT_DATE_MONTHS_ABBR = 12
+    FORMAT_DATE_WEEKDAYS_WIDE = 24
+    FORMAT_DATE_WEEKDAYS_ABBR = 31
+
+    # `format_date(recv, pattern, tz, names)` (#2324/#2334, spec entry
+    # "format_date" in spec/template-helpers.md) -- the lowering target for
+    # `formatDate(date, pattern, timeZone, names)`
+    # (packages/client/src/format-date.ts, the JS-normative reference this
+    # must match byte-for-byte). Total and deterministic: no locale, no host
+    # timezone, no `Time.now`.
     #
     # recv: the same receiver contract as `date` above -- a native `Time` or
     # an ISO-8601 string, normalized identically. A nil / unparseable
@@ -563,14 +572,24 @@ module BarefootJS
     # arithmetic here is exact (Ruby represents the instant as a Rational,
     # not a floor-divided epoch-millis integer), so there's no pre-1970
     # negative-epoch floor-division trap to dodge the way a naive
-    # epoch-millis-div-86400000 implementation would hit.
+    # epoch-millis-div-86400000 implementation would hit; the shifted
+    # `Time#wday` (0 = Sunday) is likewise exact across the epoch boundary,
+    # so it doubles directly as the weekday-name table index.
     #
-    # pattern: longest-match token substitution (`YYYY|MM|DD|M|D`); every
-    # other character -- including multi-byte ones like 年/月/日 -- passes
-    # through literally. `YYYY` is `abs(year)` zero-padded to 4 digits,
-    # `-`-prefixed for a negative year; `MM`/`DD` zero-pad to 2; `M`/`D` are
-    # bare.
-    def format_date(recv, pattern, tz)
+    # names: the flat table (#2334) -- `[0..11]` wide months, `[12..23]`
+    # abbreviated months, `[24..30]` wide weekdays (Sunday-first, matching
+    # the shifted `Time#wday`), `[31..37]` abbreviated weekdays. The caller
+    # owns the values (locale selection is never this method's job). An
+    # index past a missing/short table renders '' rather than raising.
+    #
+    # pattern: longest-match token substitution
+    # (`YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D`); every other character --
+    # including multi-byte ones like 年/月/日 -- passes through literally.
+    # `YYYY` is `abs(year)` zero-padded to 4 digits, `-`-prefixed for a
+    # negative year; `MM`/`DD` zero-pad to 2; `M`/`D` are bare; `MMMM`/`MMM`
+    # read the month's wide/abbreviated name; `dddd`/`ddd` read the shifted
+    # weekday's wide/abbreviated name.
+    def format_date(recv, pattern, tz, names = [])
       t =
         if recv.is_a?(Time)
           recv
@@ -590,15 +609,21 @@ module BarefootJS
       year = shifted.year
       month = shifted.mon
       day = shifted.mday
+      weekday = shifted.wday # 0 = Sunday, matching the table's Sunday-first layout
       yyyy = (year.negative? ? '-' : '') + year.abs.to_s.rjust(4, '0')
+      name_at = ->(index) { (names[index] || '').to_s }
 
       pattern.gsub(FORMAT_DATE_TOKEN_RE) do |token|
         case token
         when 'YYYY' then yyyy
+        when 'MMMM' then name_at.call(FORMAT_DATE_MONTHS_WIDE + month - 1)
+        when 'MMM' then name_at.call(FORMAT_DATE_MONTHS_ABBR + month - 1)
         when 'MM' then format('%02d', month)
         when 'M' then month.to_s
         when 'DD' then format('%02d', day)
         when 'D' then day.to_s
+        when 'dddd' then name_at.call(FORMAT_DATE_WEEKDAYS_WIDE + weekday)
+        when 'ddd' then name_at.call(FORMAT_DATE_WEEKDAYS_ABBR + weekday)
         end
       end
     end

--- a/packages/adapter-erb/test/helper_vectors_test.rb
+++ b/packages/adapter-erb/test/helper_vectors_test.rb
@@ -96,7 +96,8 @@ class HelperVectorsTest < Minitest::Test
     'abs' => ->(v) { BF.abs(v) },
     'to_fixed' => ->(*a) { BF.to_fixed(*a) },
     'date' => ->(recv, op) { BF.date(recv, op) },
-    'format_date' => ->(recv, pattern, tz) { BF.format_date(recv, pattern, tz) },
+    # Canonical arity is 4 as of #2334 (names table for MMMM/MMM/dddd/ddd).
+    'format_date' => ->(recv, pattern, tz, names = []) { BF.format_date(recv, pattern, tz, names) },
 
     'lower' => ->(s) { BF.lc(s) },
     'upper' => ->(s) { BF.uc(s) },

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -316,15 +316,42 @@ func Date(recv any, op string) any {
 var tzOffsetRE = regexp.MustCompile(`^([+-])(\d{2}):(\d{2})$`)
 
 // formatDateTokenRE is the longest-match pattern-token alternation (mirrors
-// TOKEN_RE in packages/client/src/format-date.ts). Order matters: MM before
-// M and DD before D so the 2-char token wins at a position where either
-// could match — Go's regexp, like JS's, resolves alternation leftmost-first
-// (not POSIX leftmost-longest), so listing the longer alternative first is
-// what makes "MM" consume both characters instead of two "M" matches.
-var formatDateTokenRE = regexp.MustCompile(`YYYY|MM|DD|M|D`)
+// TOKEN_RE in packages/client/src/format-date.ts). Order matters: MMMM
+// before MMM before MM before M (and dddd before ddd, DD before D) so the
+// longer token wins at a position where a shorter one could also match —
+// Go's regexp, like JS's, resolves alternation leftmost-first (not POSIX
+// leftmost-longest), so listing the longer alternative first is what makes
+// e.g. "MMMM" consume all four characters instead of "MM" + "MM".
+var formatDateTokenRE = regexp.MustCompile(`YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D`)
 
-// FormatDate implements the `format_date` helper (#2324, spec entry
-// "format_date") — the lowering target for `formatDate(date, pattern, tz)`
+// nameTable section offsets (#2334, mirrors MONTHS_WIDE / MONTHS_ABBR /
+// WEEKDAYS_WIDE / WEEKDAYS_ABBR in packages/client/src/format-date.ts).
+const (
+	monthsWide   = 0
+	monthsAbbr   = 12
+	weekdaysWide = 24
+	weekdaysAbbr = 31
+)
+
+// formatDateName reads a name-token table entry: index out of range, or a
+// non-string element, both render "" — the same total, zero-value
+// discipline as an unparseable date (mirrors the JS reference's
+// `names[index] ?? ""` fallback, where every table element the vectors ever
+// carry is a string).
+func formatDateName(names []any, index int) string {
+	if index < 0 || index >= len(names) {
+		return ""
+	}
+	s, ok := names[index].(string)
+	if !ok {
+		return ""
+	}
+	return s
+}
+
+// FormatDate implements the `format_date` helper (#2324, #2334, spec entry
+// "format_date") — the lowering target for
+// `formatDate(date, pattern, tz, names)`
 // (packages/client/src/format-date.ts, the JS-normative reference this must
 // match byte-for-byte). Total and deterministic: no locale, no host
 // timezone, no "now".
@@ -342,11 +369,19 @@ var formatDateTokenRE = regexp.MustCompile(`YYYY|MM|DD|M|D`)
 // clock face IS the local clock face at that offset, same reasoning as the
 // JS reference.
 //
-// pattern: longest-match token substitution (`YYYY|MM|DD|M|D`); every other
-// character — including multi-byte ones like 年/月/日 — passes through
-// literally. `YYYY` is `abs(year)` zero-padded to 4 digits, `-`-prefixed for
-// a negative year; `MM`/`DD` zero-pad to 2; `M`/`D` are bare.
-func FormatDate(recv any, pattern string, tz string) string {
+// names (#2334): a flat name table in fixed layout — `[0..11]` wide month
+// names, `[12..23]` abbreviated month names, `[24..30]` wide weekday names
+// (Sunday-first), `[31..37]` abbreviated weekday names. The caller owns the
+// values; this helper only indexes the table.
+//
+// pattern: longest-match token substitution
+// (`YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D`); every other character — including
+// multi-byte ones like 年/月/日 — passes through literally. `YYYY` is
+// `abs(year)` zero-padded to 4 digits, `-`-prefixed for a negative year;
+// `MM`/`DD` zero-pad to 2; `M`/`D` are bare; `MMMM`/`MMM` and `dddd`/`ddd`
+// read the `names` table (weekday computed on the offset-shifted instant,
+// Sunday-first, matching `time.Time.Weekday()`'s own Sunday=0 encoding).
+func FormatDate(recv any, pattern string, tz string, names []any) string {
 	t, ok := toTime(recv)
 	if !ok {
 		return ""
@@ -364,6 +399,7 @@ func FormatDate(recv any, pattern string, tz string) string {
 	year := shifted.Year()
 	month := int(shifted.Month())
 	day := shifted.Day()
+	weekday := int(shifted.Weekday()) // time.Sunday == 0, matching the table's Sunday-first layout
 	absYear := year
 	if absYear < 0 {
 		absYear = -absYear
@@ -376,6 +412,10 @@ func FormatDate(recv any, pattern string, tz string) string {
 		switch token {
 		case "YYYY":
 			return yyyy
+		case "MMMM":
+			return formatDateName(names, monthsWide+month-1)
+		case "MMM":
+			return formatDateName(names, monthsAbbr+month-1)
 		case "MM":
 			return fmt.Sprintf("%02d", month)
 		case "M":
@@ -384,6 +424,10 @@ func FormatDate(recv any, pattern string, tz string) string {
 			return fmt.Sprintf("%02d", day)
 		case "D":
 			return strconv.Itoa(day)
+		case "dddd":
+			return formatDateName(names, weekdaysWide+weekday)
+		case "ddd":
+			return formatDateName(names, weekdaysAbbr+weekday)
 		default:
 			return token
 		}

--- a/packages/adapter-go-template/runtime/vectors_test.go
+++ b/packages/adapter-go-template/runtime/vectors_test.go
@@ -135,7 +135,8 @@ var vectorBindings = map[string]func(args []any) any{
 	"query": func(args []any) any { return Query(args[0].(string), args[1:]...) },
 	"date":  func(args []any) any { return Date(args[0], args[1].(string)) },
 	"format_date": func(args []any) any {
-		return FormatDate(args[0], args[1].(string), args[2].(string))
+		names, _ := args[3].([]any)
+		return FormatDate(args[0], args[1].(string), args[2].(string), names)
 	},
 	"every":      func(args []any) any { return Every(args[0], args[1].(string)) },
 	"some":       func(args []any) any { return Some(args[0], args[1].(string)) },

--- a/packages/adapter-jinja/python/barefootjs/runtime.py
+++ b/packages/adapter-jinja/python/barefootjs/runtime.py
@@ -959,15 +959,28 @@ class BarefootJS:
         return 0
 
     _FORMAT_DATE_TZ_RE = re.compile(r"^([+-])(\d{2}):(\d{2})$")
-    _FORMAT_DATE_TOKEN_RE = re.compile(r"YYYY|MM|DD|M|D")
+    _FORMAT_DATE_TOKEN_RE = re.compile(r"YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D")
 
-    def format_date(self, recv: Any, pattern: str, tz: str) -> str:
-        """`format_date(recv, pattern, tz)` -- the lowering target for a
-        `formatDate(date, pattern, timeZone)` call (#2324, spec entry
-        "format_date"). `recv` follows the same receiver contract as `date`
-        above -- this runtime's own `datetime` or an ISO-8601 string; a nil
-        or unparseable receiver renders `''` (never a crash, never "now").
-        Mirrors packages/client/src/format-date.ts byte-for-byte.
+    # `names`-table section offsets (spec/template-helpers.md "format_date",
+    # #2334) -- mirrors packages/client/src/format-date.ts's
+    # MONTHS_WIDE/MONTHS_ABBR/WEEKDAYS_WIDE/WEEKDAYS_ABBR constants.
+    _FORMAT_DATE_MONTHS_WIDE = 0
+    _FORMAT_DATE_MONTHS_ABBR = 12
+    _FORMAT_DATE_WEEKDAYS_WIDE = 24
+    _FORMAT_DATE_WEEKDAYS_ABBR = 31
+
+    def format_date(
+        self, recv: Any, pattern: str, tz: str, names: Optional[list] = None
+    ) -> str:
+        """`format_date(recv, pattern, tz, names)` -- the lowering target for
+        a `formatDate(date, pattern, timeZone, names)` call (#2324 numeric
+        tokens, #2334 name tokens; spec entry "format_date"). `recv` follows
+        the same receiver contract as `date` above -- this runtime's own
+        `datetime` or an ISO-8601 string; a nil or unparseable receiver
+        renders `''` (never a crash, never "now"). Mirrors
+        packages/client/src/format-date.ts byte-for-byte. Canonical arity is
+        4 -- the lowering always supplies `tz` and `names` (defaulting
+        `'UTC'` and `[]`).
 
         `tz` is `'UTC'` or a fixed offset matching `±HH:MM`. The helper is
         total: any other value -- an IANA zone name, a malformed offset --
@@ -981,15 +994,34 @@ class BarefootJS:
         a positive offset on 9999-12-31 lands in year 10000, past
         `datetime.max`, and must render `10000-…` like the JS reference
         instead of overflowing (golden vector "positive offset pushes the
-        far-future instant past year 9999").
+        far-future instant past year 9999"). The weekday used by `dddd`/
+        `ddd` comes from the SAME integer path -- `(shifted_ms // 86_400_000
+        + 4) % 7` (Python floor division; `+4` because epoch day 0,
+        1970-01-01, is a Thursday, and the table is Sunday-first so
+        `weekday == 0` must mean Sunday) -- rather than re-deriving it from
+        `yoe`/`doy`, so it stays correct across the same year-10000
+        overflow boundary the civil-from-days math above already handles.
 
-        `pattern` is scanned longest-match over `YYYY|MM|DD|M|D`
-        (`_FORMAT_DATE_TOKEN_RE`, alternation ordered so the 2/4-char
-        tokens win before their single-char prefixes); every other
-        character -- including multi-byte ones like 年/月/日 -- passes
-        through literally. `YYYY` is `abs(year)` zero-padded to 4 digits,
-        `-`-prefixed for a negative year; `MM`/`DD` zero-pad to 2; `M`/`D`
-        are bare."""
+        `pattern` is scanned longest-match over
+        `YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D` (`_FORMAT_DATE_TOKEN_RE`,
+        alternation ordered so longer tokens win before their shorter
+        prefixes); every other character -- including multi-byte ones like
+        年/月/日 -- passes through literally. `YYYY` is `abs(year)`
+        zero-padded to 4 digits, `-`-prefixed for a negative year; `MM`/`DD`
+        zero-pad to 2; `M`/`D` are bare. `MMMM`/`MMM` read `names[month-1]`
+        / `names[12+month-1]` (wide/abbreviated month name); `dddd`/`ddd`
+        read `names[24+weekday]` / `names[31+weekday]` (wide/abbreviated
+        weekday name, Sunday-first) -- `names` is the flat table documented
+        on the module's `formatDate` JS sibling: `[0..11]` wide months,
+        `[12..23]` abbreviated months, `[24..30]` wide weekdays, `[31..37]`
+        abbreviated weekdays. An index past the end of (or an altogether
+        missing) `names` table renders `''` for that token, never an
+        `IndexError`."""
+        names = names or []
+
+        def _name_at(index: int) -> str:
+            return names[index] if 0 <= index < len(names) else ""
+
         if isinstance(recv, datetime.datetime):
             dt = recv
         else:
@@ -1020,11 +1052,23 @@ class BarefootJS:
         month = mp + 3 if mp < 10 else mp - 9
         year = yoe + era * 400 + (1 if month <= 2 else 0)
         yyyy = ("-" if year < 0 else "") + f"{abs(year):04d}"
+        # Weekday from the SAME integer path as the civil-from-days fields
+        # above (NOT re-derived from yoe/doy) -- 0=Sunday, matching the
+        # table's Sunday-first layout. `(shifted_ms // 86_400_000)` is the
+        # signed epoch-day count (Python floor division, exact for negative
+        # epochs); `+4` anchors it since epoch day 0 (1970-01-01) is a
+        # Thursday.
+        days = shifted_ms // 86_400_000
+        weekday = (days + 4) % 7
 
         def _sub(match: "re.Match[str]") -> str:
             token = match.group(0)
             if token == "YYYY":
                 return yyyy
+            if token == "MMMM":
+                return _name_at(self._FORMAT_DATE_MONTHS_WIDE + month - 1)
+            if token == "MMM":
+                return _name_at(self._FORMAT_DATE_MONTHS_ABBR + month - 1)
             if token == "MM":
                 return f"{month:02d}"
             if token == "M":
@@ -1033,6 +1077,10 @@ class BarefootJS:
                 return f"{day:02d}"
             if token == "D":
                 return str(day)
+            if token == "dddd":
+                return _name_at(self._FORMAT_DATE_WEEKDAYS_WIDE + weekday)
+            if token == "ddd":
+                return _name_at(self._FORMAT_DATE_WEEKDAYS_ABBR + weekday)
             return token
 
         return self._FORMAT_DATE_TOKEN_RE.sub(_sub, pattern)

--- a/packages/adapter-jinja/python/tests/test_helper_vectors.py
+++ b/packages/adapter-jinja/python/tests/test_helper_vectors.py
@@ -139,7 +139,7 @@ BINDINGS = {
     "abs": bf.abs,
     "to_fixed": lambda *a: bf.to_fixed(*a),
     "date": lambda recv, op: bf.date(recv, op),
-    "format_date": lambda recv, pattern, tz: bf.format_date(recv, pattern, tz),
+    "format_date": lambda recv, pattern, tz, names=None: bf.format_date(recv, pattern, tz, names),
     "lower": bf.lc,
     "upper": bf.uc,
     "trim": bf.trim,

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -731,12 +731,12 @@ sub _date_epoch_ms ($recv) {
     return $epoch_s * 1000 + $ms;
 }
 
-# `format_date($recv, $pattern, $tz)` -- pure, explicit-timezone date
-# formatter (#2324, spec entry "format_date"). Same receiver contract as
-# `date` (a `BarefootJS::Date`, an ISO-8601 string, or undef/unparseable ->
-# ''), then pure pattern substitution over the shifted instant. Mirrors
-# packages/client/src/format-date.ts byte-for-byte -- deterministic, no
-# locale, no host TZ, no `time()`.
+# `format_date($recv, $pattern, $tz, $names)` -- pure, explicit-timezone
+# date formatter (#2324, #2334, spec entry "format_date"). Same receiver
+# contract as `date` (a `BarefootJS::Date`, an ISO-8601 string, or
+# undef/unparseable -> ''), then pure pattern substitution over the
+# shifted instant. Mirrors packages/client/src/format-date.ts
+# byte-for-byte -- deterministic, no locale, no host TZ, no `time()`.
 #
 # `$tz` is either a fixed offset `±HH:MM` or anything else (including
 # 'UTC', IANA zone names, and malformed offsets like '+9:00'), which all
@@ -748,15 +748,25 @@ sub _date_epoch_ms ($recv) {
 # (Perl's `/` truncates toward zero, which mis-floors negative ms), and
 # `gmtime`'s 0-based `mon` needs +1 here (unlike `getUTCMonth` in `date`,
 # because the pattern token `M`/`MM` is the 1-based JS `Date` display
-# month, not the raw accessor value).
+# month, not the raw accessor value). `gmtime`'s `wday` (element 6) is
+# already 0-based Sunday-first, matching JS `getUTCDay()` and the
+# `$names` table's weekday section layout -- both read off the same
+# offset-shifted `gmtime` call, so pre-1970 instants get the identical
+# floor-division-derived weekday as the numeric tokens.
+#
+# `$names` (#2334) is an arrayref of strings in fixed flat layout:
+# [0..11] wide months, [12..23] abbreviated months, [24..30] wide
+# weekdays (Sunday-first), [31..37] abbreviated weekdays. A name token
+# indexing a missing entry, or given an undef/short/absent table, renders
+# '' (defined-or guard) -- never dies.
 #
 # Token substitution mirrors the JS reference exactly: `s///ge` over the
-# `YYYY|MM|DD|M|D` alternation (longest-match order so `MM` binds before
-# `M`), any other character (including multi-byte literals) passes
-# through untouched. `YYYY` is `abs(year)` zero-padded to (at least) 4
-# digits, `-`-prefixed when the year is negative; `MM`/`DD` zero-pad to 2;
-# `M`/`D` are bare.
-sub format_date ($self, $recv, $pattern, $tz) {
+# `YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D` alternation (longest-match order so
+# e.g. `MMMM` binds before `MMM`/`MM`/`M`, `dddd` before `ddd`), any other
+# character (including multi-byte literals) passes through untouched.
+# `YYYY` is `abs(year)` zero-padded to (at least) 4 digits, `-`-prefixed
+# when the year is negative; `MM`/`DD` zero-pad to 2; `M`/`D` are bare.
+sub format_date ($self, $recv, $pattern, $tz, $names = []) {
     my $ms = _date_epoch_ms($recv);
     return '' unless defined $ms;
 
@@ -767,19 +777,25 @@ sub format_date ($self, $recv, $pattern, $tz) {
 
     my $shifted = $ms + $offset_minutes * 60_000;
     my $sec = POSIX::floor($shifted / 1000);
-    my @t = gmtime($sec);    # (sec,min,hour,mday,mon,year,...) -- mon is 0-based
+    my @t = gmtime($sec);    # (sec,min,hour,mday,mon,year,wday,...) -- mon/wday are 0-based
 
-    my $year  = $t[5] + 1900;
-    my $month = $t[4] + 1;    # 1-based JS display month, unlike getUTCMonth in `date`
-    my $day   = $t[3];
-    my $yyyy  = ($year < 0 ? '-' : '') . sprintf('%04d', CORE::abs($year));
-    my $mm    = sprintf('%02d', $month);
-    my $dd    = sprintf('%02d', $day);
+    my $year    = $t[5] + 1900;
+    my $month   = $t[4] + 1;    # 1-based JS display month, unlike getUTCMonth in `date`
+    my $day     = $t[3];
+    my $weekday = $t[6];        # 0 = Sunday, matching the $names table's Sunday-first layout
+    my $yyyy    = ($year < 0 ? '-' : '') . sprintf('%04d', CORE::abs($year));
+    my $mm      = sprintf('%02d', $month);
+    my $dd      = sprintf('%02d', $day);
+    my $name_at = sub ($index) { $names->[$index] // '' };
 
-    (my $out = $pattern) =~ s/YYYY|MM|DD|M|D/
+    (my $out = $pattern) =~ s/YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D/
         $&  eq 'YYYY' ? $yyyy
+      : $&  eq 'MMMM' ? $name_at->($month - 1)
+      : $&  eq 'MMM'  ? $name_at->(12 + $month - 1)
       : $&  eq 'MM'   ? $mm
       : $&  eq 'DD'   ? $dd
+      : $&  eq 'dddd' ? $name_at->(24 + $weekday)
+      : $&  eq 'ddd'  ? $name_at->(31 + $weekday)
       : $&  eq 'M'    ? $month
       :                 $day
     /gex;

--- a/packages/adapter-perl/t/helper_vectors.t
+++ b/packages/adapter-perl/t/helper_vectors.t
@@ -92,7 +92,7 @@ my %bindings = (
     abs    => sub { $bf->abs($_[0]) },
     to_fixed => sub { $bf->to_fixed(@_) },
     date     => sub { $bf->date($_[0], $_[1]) },
-    format_date => sub { $bf->format_date($_[0], $_[1], $_[2]) },
+    format_date => sub { $bf->format_date($_[0], $_[1], $_[2], $_[3]) },
 
     # The Mojo renderer emits native lc()/uc(); Xslate emits $bf.lc /
     # $bf.uc. The helper methods wrap CORE::lc/uc, so binding them

--- a/packages/adapter-php/src/BarefootJS.php
+++ b/packages/adapter-php/src/BarefootJS.php
@@ -773,16 +773,16 @@ final class BarefootJS
     }
 
     /**
-     * `format_date($recv, $pattern, $tz)` -- pure-function date formatter
-     * (#2324, spec entry "format_date"), mirroring
-     * packages/client/src/format-date.ts byte-for-byte. `$recv` shares
-     * `date()`'s receiver contract above (native `\DateTimeInterface` or an
-     * ISO-8601 string; a nil or unparseable receiver degrades to `''`,
-     * never throws). From there it's pure arithmetic, deliberately NOT
-     * PHP's timezone database: shift the epoch-ms instant by the offset,
-     * then read the shifted instant's own UTC calendar fields -- the
-     * shifted UTC clock face IS the local clock face at that offset. No
-     * locale, no host TZ, no time().
+     * `format_date($recv, $pattern, $tz, $names = [])` -- pure-function date
+     * formatter (#2324 numeric tokens, #2334 name tokens, spec entry
+     * "format_date"), mirroring packages/client/src/format-date.ts
+     * byte-for-byte. `$recv` shares `date()`'s receiver contract above
+     * (native `\DateTimeInterface` or an ISO-8601 string; a nil or
+     * unparseable receiver degrades to `''`, never throws). From there it's
+     * pure arithmetic, deliberately NOT PHP's timezone database: shift the
+     * epoch-ms instant by the offset, then read the shifted instant's own
+     * UTC calendar fields -- the shifted UTC clock face IS the local clock
+     * face at that offset. No locale, no host TZ, no time().
      *
      * `$tz` matches `/^([+-])(\d{2}):(\d{2})$/` or degrades to a zero
      * offset (UTC) for ANY other value -- IANA zone names ('Asia/Tokyo'),
@@ -794,14 +794,27 @@ final class BarefootJS
      * infinity), NOT `intdiv`'s truncate-toward-zero, so a pre-1970 instant
      * lands on the correct calendar day after shifting; PHP's `@<seconds>`
      * DateTimeImmutable constructor is always UTC, so no further
-     * setTimezone() is needed to read the shifted fields.
+     * setTimezone() is needed to read the shifted fields. That same
+     * `@<seconds>` instant's `format('w')` gives 0-6 with 0 = Sunday
+     * directly -- matching JS `getUTCDay()` and this doc's Sunday-first
+     * table layout -- with no further remapping.
      *
-     * Token substitution is `YYYY|MM|DD|M|D` (longest-match alternation
-     * order, `preg_replace_callback`); every other byte -- including
-     * multi-byte UTF-8 like `年`/`月`/`日` -- passes through literally since
-     * none of it can match the token alternation.
+     * `$names` (#2334) is the caller-owned flat name table this function
+     * never derives from locale/ICU data: `[0..11]` wide month names,
+     * `[12..23]` abbreviated month names, `[24..30]` wide weekday names
+     * (Sunday-first), `[31..37]` abbreviated weekday names. A name token
+     * indexing a missing/short table renders `''`, same zero-value
+     * discipline as an unparseable date.
+     *
+     * Token substitution is `YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D` (longest-match
+     * alternation order, `preg_replace_callback`, mirroring the JS
+     * reference's `TOKEN_RE`); every other byte -- including multi-byte
+     * UTF-8 like `年`/`月`/`日` or table values like `月曜日` -- passes
+     * through literally (no `/u` modifier needed: every token is ASCII, so
+     * a multi-byte UTF-8 sequence can never match the token alternation and
+     * always survives untouched).
      */
-    public function format_date($recv, string $pattern, string $tz): string
+    public function format_date($recv, string $pattern, string $tz, array $names = []): string
     {
         if ($recv instanceof \DateTimeInterface) {
             $d = \DateTimeImmutable::createFromInterface($recv);
@@ -838,13 +851,23 @@ final class BarefootJS
         $yyyy = ($year < 0 ? '-' : '') . str_pad((string) abs($year), 4, '0', STR_PAD_LEFT);
         $month = (int) $shifted->format('n');
         $day = (int) $shifted->format('j');
+        $weekday = (int) $shifted->format('w'); // 0 = Sunday, matching the table's Sunday-first layout
 
-        return preg_replace_callback('/YYYY|MM|DD|M|D/', function ($matches) use ($yyyy, $month, $day) {
+        // `$names`-table section offsets (spec/template-helpers.md
+        // "format_date"), mirroring the JS reference's MONTHS_WIDE /
+        // MONTHS_ABBR / WEEKDAYS_WIDE / WEEKDAYS_ABBR constants (#2334).
+        $nameAt = static fn (int $index): string => $names[$index] ?? '';
+
+        return preg_replace_callback('/YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D/', function ($matches) use ($yyyy, $month, $day, $weekday, $nameAt) {
             switch ($matches[0]) {
                 case 'YYYY': return $yyyy;
+                case 'MMMM': return $nameAt($month - 1);
+                case 'MMM': return $nameAt(12 + $month - 1);
                 case 'MM': return str_pad((string) $month, 2, '0', STR_PAD_LEFT);
-                case 'M': return (string) $month;
                 case 'DD': return str_pad((string) $day, 2, '0', STR_PAD_LEFT);
+                case 'dddd': return $nameAt(24 + $weekday);
+                case 'ddd': return $nameAt(31 + $weekday);
+                case 'M': return (string) $month;
                 case 'D': return (string) $day;
                 default: return $matches[0];
             }

--- a/packages/adapter-php/tests/test_helper_vectors.php
+++ b/packages/adapter-php/tests/test_helper_vectors.php
@@ -168,7 +168,7 @@ function bfv_call(BarefootJS $bf, string $fn, array $args)
         case 'abs': return $bf->abs($args[0]);
         case 'to_fixed': return $bf->to_fixed(...$args);
         case 'date': return $bf->date($args[0], $args[1]);
-        case 'format_date': return $bf->format_date($args[0], $args[1], $args[2]);
+        case 'format_date': return $bf->format_date($args[0], $args[1], $args[2], $args[3] ?? []);
         case 'lower': return $bf->lc($args[0]);
         case 'upper': return $bf->uc($args[0]);
         case 'trim': return $bf->trim($args[0]);

--- a/packages/adapter-rust/runtime/src/date.rs
+++ b/packages/adapter-rust/runtime/src/date.rs
@@ -188,12 +188,38 @@ fn parse_tz_offset(tz: &str) -> i64 {
     sign * (hh * 60 + mm)
 }
 
-/// `format_date(recv, pattern, tz)` -- the lowering target for a
-/// `formatDate(date, pattern, timeZone)` call (spec/template-helpers.md
-/// "format_date", #2324): a total, deterministic date-pattern formatter --
-/// no locale, no host timezone, no `SystemTime::now`. Mirrors
-/// `packages/client/src/format-date.ts` (the JS-normative reference) and
-/// the Go runtime's `FormatDate` byte-for-byte.
+/// `names`-table section offsets (#2334, mirrors `MONTHS_WIDE` /
+/// `MONTHS_ABBR` / `WEEKDAYS_WIDE` / `WEEKDAYS_ABBR` in
+/// `packages/client/src/format-date.ts` and the Go runtime's `bf.go`
+/// `monthsWide` / `monthsAbbr` / `weekdaysWide` / `weekdaysAbbr` constants).
+const MONTHS_WIDE: usize = 0;
+const MONTHS_ABBR: usize = 12;
+const WEEKDAYS_WIDE: usize = 24;
+const WEEKDAYS_ABBR: usize = 31;
+
+/// Read one `names` table entry (#2334): `names` is the runtime's own
+/// [`JsValue`] array value (whatever array shape `bf.arr`-equivalent
+/// template output materializes into -- see [`crate::runtime::mj_to_js`]'s
+/// `Seq`/`Iterable` arm, which is what a compiled minijinja template's
+/// 4th `format_date` argument becomes by the time it reaches here). A
+/// missing/out-of-range index, a non-array `names`, or a non-string
+/// element all render `""` -- the same total, zero-value discipline as an
+/// unparseable date, mirroring `names[index] ?? ''` in the JS reference
+/// (`packages/client/src/format-date.ts`'s `nameAt`) and `formatDateName`
+/// in the Go runtime's `bf.go`.
+fn name_at(names: &JsValue, index: usize) -> &str {
+    match names.as_array().and_then(|arr| arr.get(index)) {
+        Some(JsValue::String(s)) => s.as_str(),
+        _ => "",
+    }
+}
+
+/// `format_date(recv, pattern, tz, names)` -- the lowering target for a
+/// `formatDate(date, pattern, timeZone, names)` call
+/// (spec/template-helpers.md "format_date", #2324, #2334): a total,
+/// deterministic date-pattern formatter -- no locale, no host timezone, no
+/// `SystemTime::now`. Mirrors `packages/client/src/format-date.ts` (the
+/// JS-normative reference) and the Go runtime's `FormatDate` byte-for-byte.
 ///
 /// `recv` follows the `date` helper's receiver contract exactly (see
 /// [`epoch_ms_of`]): this runtime's own [`JsValue::Date`] or an ISO-8601
@@ -207,17 +233,29 @@ fn parse_tz_offset(tz: &str) -> i64 {
 /// fields (not the original instant's) are what the pattern tokens read --
 /// the shifted UTC clock face IS the local clock face at that offset.
 ///
+/// `names` (#2334) is a flat table in fixed layout: `[0..11]` wide month
+/// names, `[12..23]` abbreviated month names, `[24..30]` wide weekday names
+/// (Sunday-first), `[31..37]` abbreviated weekday names -- see [`name_at`].
+/// The caller owns the values (locale selection is not this function's
+/// job); this only indexes the table.
+///
 /// `pattern` is scanned left-to-right, longest-match, for the token set
-/// `YYYY|MM|DD|M|D` (checking the 4-char token before the 2-char tokens
-/// before the 1-char tokens at each position, the same alternation-order
-/// discipline the Go/JS ports use); every other character -- including
-/// multi-byte ones like 年/月/日 -- passes through literally. The scan
-/// advances by whole characters only (ASCII token matches consume exactly
-/// 1/2/4 ASCII bytes; the fallback branch consumes one full `char` via
-/// `len_utf8`), so slicing never lands mid-codepoint. `YYYY` is
-/// `abs(year)` zero-padded to 4 digits, `-`-prefixed for a negative year;
-/// `MM`/`DD` zero-pad to 2; `M`/`D` are bare.
-pub fn format_date(recv: &JsValue, pattern: &str, tz: &str) -> String {
+/// `YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D` (checking longer tokens before
+/// shorter ones at each position, the same alternation-order discipline the
+/// Go/JS ports use); every other character -- including multi-byte ones
+/// like 年/月/日 or 月-name table values -- passes through/renders
+/// literally. The scan advances by whole characters only (ASCII token
+/// matches consume exactly 1/2/4 ASCII bytes; the fallback branch consumes
+/// one full `char` via `len_utf8`), so slicing never lands mid-codepoint.
+/// `YYYY` is `abs(year)` zero-padded to 4 digits, `-`-prefixed for a
+/// negative year; `MM`/`DD` zero-pad to 2; `M`/`D` are bare. `MMMM`/`MMM`
+/// read `names[month-1]` / `names[12+month-1]`; `dddd`/`ddd` read
+/// `names[24+weekday]` / `names[31+weekday]`, where `weekday` (0 = Sunday)
+/// is derived from the shifted epoch day count via
+/// `(days + 4).rem_euclid(7)` -- 1970-01-01 (`days == 0`) is a Thursday,
+/// and `rem_euclid` (not `%`, which truncates toward zero in Rust) keeps
+/// the result in `[0, 6]` for a negative (pre-1970) `days` too.
+pub fn format_date(recv: &JsValue, pattern: &str, tz: &str, names: &JsValue) -> String {
     let ms = match epoch_ms_of(recv) {
         Some(ms) => ms,
         None => return String::new(),
@@ -227,6 +265,7 @@ pub fn format_date(recv: &JsValue, pattern: &str, tz: &str) -> String {
     let days = shifted.div_euclid(MS_PER_DAY);
     let (year, month, day) = civil_from_days(days);
     let yyyy = if year < 0 { format!("-{:04}", -year) } else { format!("{year:04}") };
+    let weekday = (days + 4).rem_euclid(7) as usize; // 0 = Sunday; epoch (days=0) is Thursday
 
     let mut out = String::with_capacity(pattern.len());
     let mut i = 0;
@@ -235,12 +274,24 @@ pub fn format_date(recv: &JsValue, pattern: &str, tz: &str) -> String {
         if rest.starts_with("YYYY") {
             out.push_str(&yyyy);
             i += 4;
+        } else if rest.starts_with("MMMM") {
+            out.push_str(name_at(names, MONTHS_WIDE + (month - 1) as usize));
+            i += 4;
+        } else if rest.starts_with("MMM") {
+            out.push_str(name_at(names, MONTHS_ABBR + (month - 1) as usize));
+            i += 3;
         } else if rest.starts_with("MM") {
             out.push_str(&format!("{month:02}"));
             i += 2;
         } else if rest.starts_with("DD") {
             out.push_str(&format!("{day:02}"));
             i += 2;
+        } else if rest.starts_with("dddd") {
+            out.push_str(name_at(names, WEEKDAYS_WIDE + weekday));
+            i += 4;
+        } else if rest.starts_with("ddd") {
+            out.push_str(name_at(names, WEEKDAYS_ABBR + weekday));
+            i += 3;
         } else if rest.starts_with('M') {
             out.push_str(&month.to_string());
             i += 1;

--- a/packages/adapter-rust/runtime/src/runtime.rs
+++ b/packages/adapter-rust/runtime/src/runtime.rs
@@ -1338,12 +1338,16 @@ impl Object for BfInstance {
             // string; `date::date` normalizes and dispatches both. `op`
             // stays a plain string arg, never routed through `js_number`.
             "date" => Ok(js_to_mj(&date::date(a(0), a(1).as_str().unwrap_or("")))),
-            // `format_date(recv, pattern, tz)` (spec/template-helpers.md
-            // "format_date", #2324) -- total, locale-free date-pattern
+            // `format_date(recv, pattern, tz, names)` (spec/template-helpers.md
+            // "format_date", #2324, #2334) -- total, locale-free date-pattern
             // formatting layered on the same `recv` normalization as
-            // `date` above. See `date::format_date`'s docstring for the
+            // `date` above. `names` stays the array-shaped `JsValue` that
+            // `mj_to_js`'s `Seq`/`Iterable` arm already produced above (the
+            // compiler's lowering always passes 4 args); a non-array or
+            // missing `names` degrades to `""` for every name token, per
+            // `date::name_at`. See `date::format_date`'s docstring for the
             // full contract.
-            "format_date" => Ok(MjValue::from(date::format_date(a(0), a(1).as_str().unwrap_or(""), a(2).as_str().unwrap_or("")))),
+            "format_date" => Ok(MjValue::from(date::format_date(a(0), a(1).as_str().unwrap_or(""), a(2).as_str().unwrap_or(""), a(3)))),
 
             // -- Array / string method helpers (#1448 Tier A) ------------------
             "includes" => Ok(MjValue::from(includes(a(0), a(1)))),

--- a/packages/adapter-rust/runtime/tests/helper_vectors.rs
+++ b/packages/adapter-rust/runtime/tests/helper_vectors.rs
@@ -150,7 +150,7 @@ fn call_binding(fn_name: &str, args: &[JsValue]) -> Option<JsValue> {
             JsValue::String(num::to_fixed(runtime::js_number(&a(0)), digits))
         }
         "date" => date::date(&a(0), a(1).as_str().unwrap_or("")),
-        "format_date" => JsValue::String(date::format_date(&a(0), a(1).as_str().unwrap_or(""), a(2).as_str().unwrap_or(""))),
+        "format_date" => JsValue::String(date::format_date(&a(0), a(1).as_str().unwrap_or(""), a(2).as_str().unwrap_or(""), &a(3))),
         "lower" => JsValue::String(runtime::js_string(&a(0)).to_lowercase()),
         "upper" => JsValue::String(runtime::js_string(&a(0)).to_uppercase()),
         "trim" => JsValue::String(runtime::trim(&a(0))),

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1480,6 +1480,21 @@
         "text"
       ]
     },
+    "date-tolocale-datestyle": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:string"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "date-tolocale-literal": {
       "kinds": [
         "call",
@@ -4160,14 +4175,14 @@
     "array-method": 62,
     "arrow": 55,
     "binary": 67,
-    "call": 161,
+    "call": 162,
     "conditional": 18,
-    "identifier": 241,
+    "identifier": 242,
     "index-access": 12,
-    "literal": 199,
+    "literal": 200,
     "logical": 41,
-    "member": 121,
-    "object-literal": 44,
+    "member": 122,
+    "object-literal": 45,
     "template-literal": 27,
     "unary": 22,
     "unsupported": 21
@@ -4210,7 +4225,7 @@
     "literal:boolean": 37,
     "literal:null": 22,
     "literal:number": 86,
-    "literal:string": 142,
+    "literal:string": 143,
     "logical:&&": 7,
     "logical:??": 37,
     "logical:||": 12,

--- a/packages/adapter-tests/fixtures/date-tolocale-datestyle.ts
+++ b/packages/adapter-tests/fixtures/date-tolocale-datestyle.ts
@@ -13,7 +13,11 @@ import { createFixture } from '../src/types'
  *     2024-03-05 is a Tuesday; the offset-shifted weekday arithmetic is
  *     what the `weekday-shift` oracle point exercises);
  *   - ja-JP `dateStyle: 'long'` → `YYYY年M月D日`, numeric — the probe
- *     discovers no names are needed and ships an empty table.
+ *     discovers no names are needed and ships an empty table;
+ *   - ru-RU `dateStyle: 'long'` → `D MMMM YYYY г.` with the GENITIVE
+ *     month table (`марта`, not standalone `март`) — the context-inflected
+ *     name derivation from the #2336 Copilot review, two-point-verified
+ *     against real ICU at build time.
  *
  * Hono evaluates the real ECMA-402 call against the same build-machine ICU
  * the pattern+table were frozen from, so reference parity IS the fidelity
@@ -29,6 +33,7 @@ function DateToLocaleDateStyle({ createdAt }: { createdAt: Date }) {
       <time>{createdAt.toLocaleDateString('en-US', { dateStyle: 'long', timeZone: 'UTC' })}</time>
       <span>{createdAt.toLocaleDateString('en-US', { dateStyle: 'full', timeZone: 'UTC' })}</span>
       <span>{createdAt.toLocaleDateString('ja-JP', { dateStyle: 'long', timeZone: 'UTC' })}</span>
+      <span>{createdAt.toLocaleDateString('ru-RU', { dateStyle: 'long', timeZone: 'UTC' })}</span>
     </div>
   )
 }
@@ -50,6 +55,7 @@ export { DateToLocaleDateStyle }
       <time bf="s1"><!--bf:s0-->March 5, 2024<!--/--></time>
       <span bf="s3"><!--bf:s2-->Tuesday, March 5, 2024<!--/--></span>
       <span bf="s5"><!--bf:s4-->2024年3月5日<!--/--></span>
+      <span bf="s7"><!--bf:s6-->5 марта 2024 г.<!--/--></span>
     </div>
   `,
 })

--- a/packages/adapter-tests/fixtures/date-tolocale-datestyle.ts
+++ b/packages/adapter-tests/fixtures/date-tolocale-datestyle.ts
@@ -1,0 +1,55 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Name tokens via the options bag (#2334): `dateStyle` / field-form options
+ * on the `toLocaleDateString` sugar. The compiler probes the exact literal
+ * options bag with the build machine's own ICU and lowers to `format_date`
+ * with the derived pattern PLUS the 38-slot name table as an ordinary
+ * array argument — the backends never own locale data (type-only rule).
+ *
+ * Three cells:
+ *   - en-US `dateStyle: 'long'` → `MMMM D, YYYY` + names ("March 5, 2024");
+ *   - en-US `dateStyle: 'full'` → `dddd, MMMM D, YYYY` (weekday token —
+ *     2024-03-05 is a Tuesday; the offset-shifted weekday arithmetic is
+ *     what the `weekday-shift` oracle point exercises);
+ *   - ja-JP `dateStyle: 'long'` → `YYYY年M月D日`, numeric — the probe
+ *     discovers no names are needed and ships an empty table.
+ *
+ * Hono evaluates the real ECMA-402 call against the same build-machine ICU
+ * the pattern+table were frozen from, so reference parity IS the fidelity
+ * contract ("what the user wrote in TSX, reproduced exactly").
+ */
+export const fixture = createFixture({
+  id: 'date-tolocale-datestyle',
+  description: 'toLocaleDateString dateStyle options lower to name-token patterns + shipped name tables',
+  source: `
+function DateToLocaleDateStyle({ createdAt }: { createdAt: Date }) {
+  return (
+    <div>
+      <time>{createdAt.toLocaleDateString('en-US', { dateStyle: 'long', timeZone: 'UTC' })}</time>
+      <span>{createdAt.toLocaleDateString('en-US', { dateStyle: 'full', timeZone: 'UTC' })}</span>
+      <span>{createdAt.toLocaleDateString('ja-JP', { dateStyle: 'long', timeZone: 'UTC' })}</span>
+    </div>
+  )
+}
+export { DateToLocaleDateStyle }
+`,
+  props: { createdAt: new Date('2024-03-05T12:00:00.000Z') },
+  dataPoints: [
+    // 23:00Z Tuesday: UTC cells stay Tuesday March 5 — pairs with the
+    // weekday-shift sibling fixture cell below via the +09:00 variant in
+    // unit tests; here it pins the LATE-day UTC weekday.
+    { name: 'weekday-shift', props: { createdAt: new Date('2024-03-05T23:00:00.000Z') } },
+    // Month-name boundary: 23:59:59.999 on Feb 29 — leap-day February in
+    // every cell (wide vs abbreviated name irrelevance is pinned by the
+    // grid's other instants).
+    { name: 'leap-day-name', props: { createdAt: new Date('2024-02-29T23:59:59.999Z') } },
+  ],
+  expectedHtml: `
+    <div bf-s="test">
+      <time bf="s1"><!--bf:s0-->March 5, 2024<!--/--></time>
+      <span bf="s3"><!--bf:s2-->Tuesday, March 5, 2024<!--/--></span>
+      <span bf="s5"><!--bf:s4-->2024年3月5日<!--/--></span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -399,6 +399,7 @@ import { fixture as dateCatalogued } from './date-catalogued'
 import { fixture as formatDate } from './format-date'
 import { fixture as dateToLocaleLiteral } from './date-tolocale-literal'
 import { fixture as dateToLocaleUnion } from './date-tolocale-union'
+import { fixture as dateToLocaleDateStyle } from './date-tolocale-datestyle'
 // #2277: the union- and object-typed catalogue extensions to the
 // type-derived adversarial catalogue (`adversarial-catalog.ts`), mirroring
 // the landed Date catalogue work above.
@@ -690,6 +691,7 @@ export const jsxFixtures: JSXFixture[] = [
   formatDate,
   dateToLocaleLiteral,
   dateToLocaleUnion,
+  dateToLocaleDateStyle,
   unionCatalogued,
   objectCatalogued,
 ]

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -522,6 +522,40 @@
       }
     }
   ],
+  "date-tolocale-datestyle": [
+    {
+      "name": "gen:createdAt:epoch",
+      "props": {
+        "createdAt": {
+          "$date": "1970-01-01T00:00:00.000Z"
+        }
+      }
+    },
+    {
+      "name": "gen:createdAt:pre-1970",
+      "props": {
+        "createdAt": {
+          "$date": "1969-07-20T20:17:40.123Z"
+        }
+      }
+    },
+    {
+      "name": "gen:createdAt:leap-day",
+      "props": {
+        "createdAt": {
+          "$date": "2024-02-29T12:00:00.000Z"
+        }
+      }
+    },
+    {
+      "name": "gen:createdAt:year-9999",
+      "props": {
+        "createdAt": {
+          "$date": "9999-12-31T23:59:59.999Z"
+        }
+      }
+    }
+  ],
   "date-tolocale-literal": [
     {
       "name": "gen:createdAt:epoch",

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -324,7 +324,7 @@ function date(recv, op) {
 // formatter. Same stripped-imports reasoning as \`date\` above — the user's
 // own \`import { formatDate } from '@barefootjs/client'\` is stripped with
 // every other import, so the call in template/init code needs this mirror.
-function formatDate(dateArg, pattern, timeZone = 'UTC') {
+function formatDate(dateArg, pattern, timeZone = 'UTC', names = []) {
   // Nullish guard mirrors the client implementation: new Date(null) is
   // epoch 0, not Invalid Date, and the contract renders nil as ''.
   if (dateArg === null || dateArg === undefined) return ''
@@ -338,13 +338,19 @@ function formatDate(dateArg, pattern, timeZone = 'UTC') {
   const yyyy = (year < 0 ? '-' : '') + String(Math.abs(year)).padStart(4, '0')
   const month = s.getUTCMonth() + 1
   const day = s.getUTCDate()
+  const weekday = s.getUTCDay()
   const pad2 = (n) => String(n).padStart(2, '0')
-  return pattern.replace(/YYYY|MM|DD|M|D/g, (token) =>
+  const nameAt = (i) => names[i] ?? ''
+  return pattern.replace(/YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D/g, (token) =>
     token === 'YYYY' ? yyyy
+      : token === 'MMMM' ? nameAt(month - 1)
+      : token === 'MMM' ? nameAt(12 + month - 1)
       : token === 'MM' ? pad2(month)
       : token === 'M' ? String(month)
       : token === 'DD' ? pad2(day)
-      : String(day),
+      : token === 'D' ? String(day)
+      : token === 'dddd' ? nameAt(24 + weekday)
+      : nameAt(31 + weekday),
   )
 }
 

--- a/packages/adapter-tests/vectors/cases.ts
+++ b/packages/adapter-tests/vectors/cases.ts
@@ -94,13 +94,17 @@ export const reference: Record<string, (...args: never[]) => unknown> = {
     return (d as unknown as Record<string, () => unknown>)[op]()
   },
 
-  // `formatDate(date, pattern, timeZone)` lowering (#2324, spec entry
-  // "format_date"). Same receiver contract as `date` (ISO-8601 string or
-  // `{"$date": …}` envelope; nil/unparseable → ''), then pure pattern
-  // substitution over the shifted instant. Mirrors
-  // packages/client/src/format-date.ts — the canonical helper arity is 3
-  // (the compiler lowering always supplies tz, defaulting 'UTC').
-  format_date: (recv: unknown, pattern: string, tz: string) => {
+  // `formatDate(date, pattern, timeZone, names)` lowering (#2324/#2334,
+  // spec entry "format_date"). Same receiver contract as `date` (ISO-8601
+  // string or `{"$date": …}` envelope; nil/unparseable → ''), then pure
+  // pattern substitution over the shifted instant. Mirrors
+  // packages/client/src/format-date.ts — the canonical helper arity is 4
+  // (the compiler lowering always supplies tz and names, defaulting 'UTC'
+  // and []). `names` is the flat table: [0..11] wide months, [12..23]
+  // abbreviated months, [24..30] wide weekdays (Sunday-first, so the index
+  // IS the epoch-anchored day-of-week), [31..37] abbreviated weekdays; a
+  // name token over a missing/short table renders ''.
+  format_date: (recv: unknown, pattern: string, tz: string, names: readonly string[]) => {
     const raw =
       recv !== null && typeof recv === 'object' && '$date' in recv
         ? (recv as { $date: string }).$date
@@ -116,11 +120,17 @@ export const reference: Record<string, (...args: never[]) => unknown> = {
     const yyyy = (year < 0 ? '-' : '') + String(Math.abs(year)).padStart(4, '0')
     const month = s.getUTCMonth() + 1
     const day = s.getUTCDate()
+    const weekday = s.getUTCDay()
     const pad2 = (n: number) => String(n).padStart(2, '0')
-    return pattern.replace(/YYYY|MM|DD|M|D/g, (token) => {
+    const nameAt = (index: number) => names[index] ?? ''
+    return pattern.replace(/YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D/g, (token) => {
       switch (token) {
         case 'YYYY':
           return yyyy
+        case 'MMMM':
+          return nameAt(month - 1)
+        case 'MMM':
+          return nameAt(12 + month - 1)
         case 'MM':
           return pad2(month)
         case 'M':
@@ -129,6 +139,10 @@ export const reference: Record<string, (...args: never[]) => unknown> = {
           return pad2(day)
         case 'D':
           return String(day)
+        case 'dddd':
+          return nameAt(24 + weekday)
+        case 'ddd':
+          return nameAt(31 + weekday)
         default:
           return token
       }
@@ -595,22 +609,39 @@ export const cases: HelperCase[] = [
   // normalization (IANA names / malformed offsets degrade to UTC on every
   // backend identically). Canonical arity is 3 — the lowering always
   // supplies tz.
-  { fn: 'format_date', args: ['1970-01-01T00:00:00.000Z', 'YYYY-MM-DD', 'UTC'], note: 'epoch 0: zero-padded tokens' },
-  { fn: 'format_date', args: ['1970-01-01T00:00:00.000Z', 'YYYY/M/D', 'UTC'], note: 'epoch 0: bare tokens' },
-  { fn: 'format_date', args: ['1969-07-20T20:17:40.123Z', 'YYYY-MM-DD', 'UTC'], note: 'pre-1970 instant with nonzero ms' },
-  { fn: 'format_date', args: ['2024-02-29T23:59:59.999Z', 'DD.MM.YYYY', 'UTC'], note: 'leap day, reordered zero-padded tokens' },
-  { fn: 'format_date', args: ['9999-12-31T23:59:59.999Z', 'YYYY-MM-DD', 'UTC'], note: 'far-future four-digit-year boundary' },
-  { fn: 'format_date', args: ['0001-01-05T00:00:00.000Z', 'YYYY/M/D', 'UTC'], note: 'year 1 zero-pads YYYY to 4 digits' },
-  { fn: 'format_date', args: ['2024-01-01T23:00:00.000Z', 'YYYY-MM-DD', '+09:00'], note: 'positive offset crosses the date boundary forward' },
-  { fn: 'format_date', args: ['2024-01-01T01:00:00.000Z', 'YYYY-MM-DD', '-05:30'], note: 'negative half-hour offset crosses the date boundary backward' },
-  { fn: 'format_date', args: ['2024-01-05T00:00:00.000Z', 'YYYY年M月D日', 'UTC'], note: 'non-token characters pass through literally' },
-  { fn: 'format_date', args: ['2024-01-01T23:00:00.000Z', 'YYYY-MM-DD', 'Asia/Tokyo'], note: 'IANA zone name normalizes to UTC (total function)' },
-  { fn: 'format_date', args: ['2024-01-01T23:00:00.000Z', 'YYYY-MM-DD', '+9:00'], note: 'malformed offset normalizes to UTC (total function)' },
-  { fn: 'format_date', args: ['9999-12-31T23:59:59.999Z', 'YYYY-MM-DD', '+09:00'], note: 'positive offset pushes the far-future instant past year 9999 (host date types capped at 9999 must not overflow)' },
-  { fn: 'format_date', args: [null, 'YYYY-MM-DD', 'UTC'], note: 'nil receiver renders the empty string' },
-  { fn: 'format_date', args: ['not a date', 'YYYY-MM-DD', 'UTC'], note: 'unparseable receiver renders the empty string' },
-  { fn: 'format_date', args: [{ $date: '2024-02-29T23:59:59.999Z' }, 'YYYY-MM-DD', 'UTC'], note: 'native leap-day receiver formats like its string sibling' },
-  { fn: 'format_date', args: [{ $date: '2024-01-01T23:00:00.000Z' }, 'YYYY/M/D', '+09:00'], note: 'native receiver with offset crosses the date boundary' },
+  { fn: 'format_date', args: ['1970-01-01T00:00:00.000Z', 'YYYY-MM-DD', 'UTC', []], note: 'epoch 0: zero-padded tokens' },
+  { fn: 'format_date', args: ['1970-01-01T00:00:00.000Z', 'YYYY/M/D', 'UTC', []], note: 'epoch 0: bare tokens' },
+  { fn: 'format_date', args: ['1969-07-20T20:17:40.123Z', 'YYYY-MM-DD', 'UTC', []], note: 'pre-1970 instant with nonzero ms' },
+  { fn: 'format_date', args: ['2024-02-29T23:59:59.999Z', 'DD.MM.YYYY', 'UTC', []], note: 'leap day, reordered zero-padded tokens' },
+  { fn: 'format_date', args: ['9999-12-31T23:59:59.999Z', 'YYYY-MM-DD', 'UTC', []], note: 'far-future four-digit-year boundary' },
+  { fn: 'format_date', args: ['0001-01-05T00:00:00.000Z', 'YYYY/M/D', 'UTC', []], note: 'year 1 zero-pads YYYY to 4 digits' },
+  { fn: 'format_date', args: ['2024-01-01T23:00:00.000Z', 'YYYY-MM-DD', '+09:00', []], note: 'positive offset crosses the date boundary forward' },
+  { fn: 'format_date', args: ['2024-01-01T01:00:00.000Z', 'YYYY-MM-DD', '-05:30', []], note: 'negative half-hour offset crosses the date boundary backward' },
+  { fn: 'format_date', args: ['2024-01-05T00:00:00.000Z', 'YYYY年M月D日', 'UTC', []], note: 'non-token characters pass through literally' },
+  { fn: 'format_date', args: ['2024-01-01T23:00:00.000Z', 'YYYY-MM-DD', 'Asia/Tokyo', []], note: 'IANA zone name normalizes to UTC (total function)' },
+  { fn: 'format_date', args: ['2024-01-01T23:00:00.000Z', 'YYYY-MM-DD', '+9:00', []], note: 'malformed offset normalizes to UTC (total function)' },
+  { fn: 'format_date', args: ['9999-12-31T23:59:59.999Z', 'YYYY-MM-DD', '+09:00', []], note: 'positive offset pushes the far-future instant past year 9999 (host date types capped at 9999 must not overflow)' },
+  { fn: 'format_date', args: [null, 'YYYY-MM-DD', 'UTC', []], note: 'nil receiver renders the empty string' },
+  { fn: 'format_date', args: ['not a date', 'YYYY-MM-DD', 'UTC', []], note: 'unparseable receiver renders the empty string' },
+  { fn: 'format_date', args: [{ $date: '2024-02-29T23:59:59.999Z' }, 'YYYY-MM-DD', 'UTC', []], note: 'native leap-day receiver formats like its string sibling' },
+  { fn: 'format_date', args: [{ $date: '2024-01-01T23:00:00.000Z' }, 'YYYY/M/D', '+09:00', []], note: 'native receiver with offset crosses the date boundary' },
+
+  // #2334 name tokens: MMMM/MMM (month names) and dddd/ddd (weekday names,
+  // Sunday-first) read the explicit flat table — [0..11] wide months,
+  // [12..23] abbreviated months, [24..30] wide weekdays, [31..37]
+  // abbreviated weekdays. Weekday is epoch-days mod 7 anchored on
+  // 1970-01-01 = Thursday — the pre-1970 case pins the floor-division
+  // discipline in every port. Tables here are explicit vector data, NOT
+  // derived from any locale machinery (backends are type-only, #2334).
+  { fn: 'format_date', args: ['2024-03-05T12:00:00.000Z', 'MMMM D, YYYY', 'UTC', ['January','February','March','April','May','June','July','August','September','October','November','December','Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec','Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sun','Mon','Tue','Wed','Thu','Fri','Sat']], note: 'wide month name from the table' },
+  { fn: 'format_date', args: ['2024-03-05T12:00:00.000Z', 'ddd, MMM D', 'UTC', ['January','February','March','April','May','June','July','August','September','October','November','December','Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec','Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sun','Mon','Tue','Wed','Thu','Fri','Sat']], note: 'abbreviated weekday + month names (2024-03-05 is a Tuesday)' },
+  { fn: 'format_date', args: ['1970-01-01T00:00:00.000Z', 'dddd', 'UTC', ['January','February','March','April','May','June','July','August','September','October','November','December','Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec','Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sun','Mon','Tue','Wed','Thu','Fri','Sat']], note: 'epoch 0 weekday is Thursday — the mod-7 anchor' },
+  { fn: 'format_date', args: ['1969-07-20T20:17:40.123Z', 'dddd', 'UTC', ['January','February','March','April','May','June','July','August','September','October','November','December','Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec','Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sun','Mon','Tue','Wed','Thu','Fri','Sat']], note: 'pre-1970 weekday (Sunday) pins the negative-epoch floor-division path' },
+  { fn: 'format_date', args: ['2024-03-05T23:00:00.000Z', 'dddd', '+09:00', ['January','February','March','April','May','June','July','August','September','October','November','December','Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec','Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sun','Mon','Tue','Wed','Thu','Fri','Sat']], note: 'weekday follows the offset-shifted clock face (Tue 23:00Z + 09:00 = Wednesday)' },
+  { fn: 'format_date', args: ['2024-03-05T12:00:00.000Z', 'YYYY年MMMM', 'UTC', ['1月','2月','3月','4月','5月','6月','7月','8月','9月','10月','11月','12月','1月','2月','3月','4月','5月','6月','7月','8月','9月','10月','11月','12月','日曜日','月曜日','火曜日','水曜日','木曜日','金曜日','土曜日','日','月','火','水','木','金','土']], note: 'multi-byte table values pass through byte-identically' },
+  { fn: 'format_date', args: ['2024-03-05T12:00:00.000Z', 'MMMM D', 'UTC', []], note: 'name token over an empty table renders the empty string' },
+  { fn: 'format_date', args: ['2024-03-05T12:00:00.000Z', 'dddd', 'UTC', ['only', 'two']], note: 'name token past a short table renders the empty string' },
+  { fn: 'format_date', args: ['2024-03-05T12:00:00.000Z', 'YYYY-MM-DD', 'UTC', ['January','February','March','April','May','June','July','August','September','October','November','December','Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec','Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sun','Mon','Tue','Wed','Thu','Fri','Sat']], note: 'numeric tokens ignore a supplied table' },
 
   // Nil/malformed receiver fallback (#2288): every backend's `date()`
   // degrades to the zero value instead of crashing mid-render or (worse)

--- a/packages/adapter-tests/vectors/vectors.json
+++ b/packages/adapter-tests/vectors/vectors.json
@@ -2836,7 +2836,8 @@
       "args": [
         "1970-01-01T00:00:00.000Z",
         "YYYY-MM-DD",
-        "UTC"
+        "UTC",
+        []
       ],
       "expect": "1970-01-01",
       "note": "epoch 0: zero-padded tokens"
@@ -2846,7 +2847,8 @@
       "args": [
         "1970-01-01T00:00:00.000Z",
         "YYYY/M/D",
-        "UTC"
+        "UTC",
+        []
       ],
       "expect": "1970/1/1",
       "note": "epoch 0: bare tokens"
@@ -2856,7 +2858,8 @@
       "args": [
         "1969-07-20T20:17:40.123Z",
         "YYYY-MM-DD",
-        "UTC"
+        "UTC",
+        []
       ],
       "expect": "1969-07-20",
       "note": "pre-1970 instant with nonzero ms"
@@ -2866,7 +2869,8 @@
       "args": [
         "2024-02-29T23:59:59.999Z",
         "DD.MM.YYYY",
-        "UTC"
+        "UTC",
+        []
       ],
       "expect": "29.02.2024",
       "note": "leap day, reordered zero-padded tokens"
@@ -2876,7 +2880,8 @@
       "args": [
         "9999-12-31T23:59:59.999Z",
         "YYYY-MM-DD",
-        "UTC"
+        "UTC",
+        []
       ],
       "expect": "9999-12-31",
       "note": "far-future four-digit-year boundary"
@@ -2886,7 +2891,8 @@
       "args": [
         "0001-01-05T00:00:00.000Z",
         "YYYY/M/D",
-        "UTC"
+        "UTC",
+        []
       ],
       "expect": "0001/1/5",
       "note": "year 1 zero-pads YYYY to 4 digits"
@@ -2896,7 +2902,8 @@
       "args": [
         "2024-01-01T23:00:00.000Z",
         "YYYY-MM-DD",
-        "+09:00"
+        "+09:00",
+        []
       ],
       "expect": "2024-01-02",
       "note": "positive offset crosses the date boundary forward"
@@ -2906,7 +2913,8 @@
       "args": [
         "2024-01-01T01:00:00.000Z",
         "YYYY-MM-DD",
-        "-05:30"
+        "-05:30",
+        []
       ],
       "expect": "2023-12-31",
       "note": "negative half-hour offset crosses the date boundary backward"
@@ -2916,7 +2924,8 @@
       "args": [
         "2024-01-05T00:00:00.000Z",
         "YYYY年M月D日",
-        "UTC"
+        "UTC",
+        []
       ],
       "expect": "2024年1月5日",
       "note": "non-token characters pass through literally"
@@ -2926,7 +2935,8 @@
       "args": [
         "2024-01-01T23:00:00.000Z",
         "YYYY-MM-DD",
-        "Asia/Tokyo"
+        "Asia/Tokyo",
+        []
       ],
       "expect": "2024-01-01",
       "note": "IANA zone name normalizes to UTC (total function)"
@@ -2936,7 +2946,8 @@
       "args": [
         "2024-01-01T23:00:00.000Z",
         "YYYY-MM-DD",
-        "+9:00"
+        "+9:00",
+        []
       ],
       "expect": "2024-01-01",
       "note": "malformed offset normalizes to UTC (total function)"
@@ -2946,7 +2957,8 @@
       "args": [
         "9999-12-31T23:59:59.999Z",
         "YYYY-MM-DD",
-        "+09:00"
+        "+09:00",
+        []
       ],
       "expect": "10000-01-01",
       "note": "positive offset pushes the far-future instant past year 9999 (host date types capped at 9999 must not overflow)"
@@ -2956,7 +2968,8 @@
       "args": [
         null,
         "YYYY-MM-DD",
-        "UTC"
+        "UTC",
+        []
       ],
       "expect": "",
       "note": "nil receiver renders the empty string"
@@ -2966,7 +2979,8 @@
       "args": [
         "not a date",
         "YYYY-MM-DD",
-        "UTC"
+        "UTC",
+        []
       ],
       "expect": "",
       "note": "unparseable receiver renders the empty string"
@@ -2978,7 +2992,8 @@
           "$date": "2024-02-29T23:59:59.999Z"
         },
         "YYYY-MM-DD",
-        "UTC"
+        "UTC",
+        []
       ],
       "expect": "2024-02-29",
       "note": "native leap-day receiver formats like its string sibling"
@@ -2990,10 +3005,386 @@
           "$date": "2024-01-01T23:00:00.000Z"
         },
         "YYYY/M/D",
-        "+09:00"
+        "+09:00",
+        []
       ],
       "expect": "2024/1/2",
       "note": "native receiver with offset crosses the date boundary"
+    },
+    {
+      "fn": "format_date",
+      "args": [
+        "2024-03-05T12:00:00.000Z",
+        "MMMM D, YYYY",
+        "UTC",
+        [
+          "January",
+          "February",
+          "March",
+          "April",
+          "May",
+          "June",
+          "July",
+          "August",
+          "September",
+          "October",
+          "November",
+          "December",
+          "Jan",
+          "Feb",
+          "Mar",
+          "Apr",
+          "May",
+          "Jun",
+          "Jul",
+          "Aug",
+          "Sep",
+          "Oct",
+          "Nov",
+          "Dec",
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+          "Sun",
+          "Mon",
+          "Tue",
+          "Wed",
+          "Thu",
+          "Fri",
+          "Sat"
+        ]
+      ],
+      "expect": "March 5, 2024",
+      "note": "wide month name from the table"
+    },
+    {
+      "fn": "format_date",
+      "args": [
+        "2024-03-05T12:00:00.000Z",
+        "ddd, MMM D",
+        "UTC",
+        [
+          "January",
+          "February",
+          "March",
+          "April",
+          "May",
+          "June",
+          "July",
+          "August",
+          "September",
+          "October",
+          "November",
+          "December",
+          "Jan",
+          "Feb",
+          "Mar",
+          "Apr",
+          "May",
+          "Jun",
+          "Jul",
+          "Aug",
+          "Sep",
+          "Oct",
+          "Nov",
+          "Dec",
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+          "Sun",
+          "Mon",
+          "Tue",
+          "Wed",
+          "Thu",
+          "Fri",
+          "Sat"
+        ]
+      ],
+      "expect": "Tue, Mar 5",
+      "note": "abbreviated weekday + month names (2024-03-05 is a Tuesday)"
+    },
+    {
+      "fn": "format_date",
+      "args": [
+        "1970-01-01T00:00:00.000Z",
+        "dddd",
+        "UTC",
+        [
+          "January",
+          "February",
+          "March",
+          "April",
+          "May",
+          "June",
+          "July",
+          "August",
+          "September",
+          "October",
+          "November",
+          "December",
+          "Jan",
+          "Feb",
+          "Mar",
+          "Apr",
+          "May",
+          "Jun",
+          "Jul",
+          "Aug",
+          "Sep",
+          "Oct",
+          "Nov",
+          "Dec",
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+          "Sun",
+          "Mon",
+          "Tue",
+          "Wed",
+          "Thu",
+          "Fri",
+          "Sat"
+        ]
+      ],
+      "expect": "Thursday",
+      "note": "epoch 0 weekday is Thursday — the mod-7 anchor"
+    },
+    {
+      "fn": "format_date",
+      "args": [
+        "1969-07-20T20:17:40.123Z",
+        "dddd",
+        "UTC",
+        [
+          "January",
+          "February",
+          "March",
+          "April",
+          "May",
+          "June",
+          "July",
+          "August",
+          "September",
+          "October",
+          "November",
+          "December",
+          "Jan",
+          "Feb",
+          "Mar",
+          "Apr",
+          "May",
+          "Jun",
+          "Jul",
+          "Aug",
+          "Sep",
+          "Oct",
+          "Nov",
+          "Dec",
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+          "Sun",
+          "Mon",
+          "Tue",
+          "Wed",
+          "Thu",
+          "Fri",
+          "Sat"
+        ]
+      ],
+      "expect": "Sunday",
+      "note": "pre-1970 weekday (Sunday) pins the negative-epoch floor-division path"
+    },
+    {
+      "fn": "format_date",
+      "args": [
+        "2024-03-05T23:00:00.000Z",
+        "dddd",
+        "+09:00",
+        [
+          "January",
+          "February",
+          "March",
+          "April",
+          "May",
+          "June",
+          "July",
+          "August",
+          "September",
+          "October",
+          "November",
+          "December",
+          "Jan",
+          "Feb",
+          "Mar",
+          "Apr",
+          "May",
+          "Jun",
+          "Jul",
+          "Aug",
+          "Sep",
+          "Oct",
+          "Nov",
+          "Dec",
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+          "Sun",
+          "Mon",
+          "Tue",
+          "Wed",
+          "Thu",
+          "Fri",
+          "Sat"
+        ]
+      ],
+      "expect": "Wednesday",
+      "note": "weekday follows the offset-shifted clock face (Tue 23:00Z + 09:00 = Wednesday)"
+    },
+    {
+      "fn": "format_date",
+      "args": [
+        "2024-03-05T12:00:00.000Z",
+        "YYYY年MMMM",
+        "UTC",
+        [
+          "1月",
+          "2月",
+          "3月",
+          "4月",
+          "5月",
+          "6月",
+          "7月",
+          "8月",
+          "9月",
+          "10月",
+          "11月",
+          "12月",
+          "1月",
+          "2月",
+          "3月",
+          "4月",
+          "5月",
+          "6月",
+          "7月",
+          "8月",
+          "9月",
+          "10月",
+          "11月",
+          "12月",
+          "日曜日",
+          "月曜日",
+          "火曜日",
+          "水曜日",
+          "木曜日",
+          "金曜日",
+          "土曜日",
+          "日",
+          "月",
+          "火",
+          "水",
+          "木",
+          "金",
+          "土"
+        ]
+      ],
+      "expect": "2024年3月",
+      "note": "multi-byte table values pass through byte-identically"
+    },
+    {
+      "fn": "format_date",
+      "args": [
+        "2024-03-05T12:00:00.000Z",
+        "MMMM D",
+        "UTC",
+        []
+      ],
+      "expect": " 5",
+      "note": "name token over an empty table renders the empty string"
+    },
+    {
+      "fn": "format_date",
+      "args": [
+        "2024-03-05T12:00:00.000Z",
+        "dddd",
+        "UTC",
+        [
+          "only",
+          "two"
+        ]
+      ],
+      "expect": "",
+      "note": "name token past a short table renders the empty string"
+    },
+    {
+      "fn": "format_date",
+      "args": [
+        "2024-03-05T12:00:00.000Z",
+        "YYYY-MM-DD",
+        "UTC",
+        [
+          "January",
+          "February",
+          "March",
+          "April",
+          "May",
+          "June",
+          "July",
+          "August",
+          "September",
+          "October",
+          "November",
+          "December",
+          "Jan",
+          "Feb",
+          "Mar",
+          "Apr",
+          "May",
+          "Jun",
+          "Jul",
+          "Aug",
+          "Sep",
+          "Oct",
+          "Nov",
+          "Dec",
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+          "Sun",
+          "Mon",
+          "Tue",
+          "Wed",
+          "Thu",
+          "Fri",
+          "Sat"
+        ]
+      ],
+      "expect": "2024-03-05",
+      "note": "numeric tokens ignore a supplied table"
     },
     {
       "fn": "date",

--- a/packages/client/__tests__/format-date.test.ts
+++ b/packages/client/__tests__/format-date.test.ts
@@ -61,4 +61,48 @@ describe('formatDate', () => {
     expect(formatDate(null as unknown as Date, 'YYYY-MM-DD')).toBe('')
     expect(formatDate(undefined as unknown as Date, 'YYYY-MM-DD')).toBe('')
   })
+
+  // #2334 name tokens. Flat table layout: [0..11] wide months, [12..23]
+  // abbreviated months, [24..30] wide weekdays (Sunday-first), [31..37]
+  // abbreviated weekdays.
+  const EN_NAMES = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December',
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday',
+    'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat',
+  ]
+
+  test('name tokens read the explicit table (#2334)', () => {
+    // 2024-03-05 is a Tuesday.
+    const d = new Date('2024-03-05T12:00:00.000Z')
+    expect(formatDate(d, 'MMMM D, YYYY', 'UTC', EN_NAMES)).toBe('March 5, 2024')
+    expect(formatDate(d, 'ddd, MMM D', 'UTC', EN_NAMES)).toBe('Tue, Mar 5')
+    expect(formatDate(d, 'dddd', 'UTC', EN_NAMES)).toBe('Tuesday')
+  })
+
+  test('weekday follows the offset-shifted clock face', () => {
+    // 23:00Z Tuesday + 09:00 = Wednesday.
+    const d = new Date('2024-03-05T23:00:00.000Z')
+    expect(formatDate(d, 'dddd', '+09:00', EN_NAMES)).toBe('Wednesday')
+    expect(formatDate(d, 'dddd', 'UTC', EN_NAMES)).toBe('Tuesday')
+  })
+
+  test('epoch 0 is a Thursday (the mod-7 anchor every backend must match)', () => {
+    expect(formatDate(new Date(0), 'dddd', 'UTC', EN_NAMES)).toBe('Thursday')
+    // Pre-1970: 1969-07-20 was a Sunday (floor-division check for ports).
+    expect(formatDate(new Date('1969-07-20T20:17:40.123Z'), 'ddd', 'UTC', EN_NAMES)).toBe('Sun')
+  })
+
+  test('a name token over a missing/short table renders the empty string', () => {
+    const d = new Date('2024-03-05T12:00:00.000Z')
+    expect(formatDate(d, 'MMMM D', 'UTC')).toBe(' 5')
+    expect(formatDate(d, 'dddd', 'UTC', ['only', 'two'])).toBe('')
+  })
+
+  test('numeric tokens ignore the table entirely', () => {
+    const d = new Date('2024-03-05T12:00:00.000Z')
+    expect(formatDate(d, 'YYYY-MM-DD', 'UTC', EN_NAMES)).toBe('2024-03-05')
+  })
 })

--- a/packages/client/src/format-date.ts
+++ b/packages/client/src/format-date.ts
@@ -9,32 +9,50 @@
  *
  * ```tsx
  * <time>{formatDate(createdAt, 'YYYY/M/D', '+09:00')}</time>
+ * <time>{formatDate(createdAt, 'MMMM D, YYYY', 'UTC', names)}</time>
  * ```
  *
- * Pattern tokens (longest-match; any other character passes through
+ * Numeric tokens (longest-match; any other character passes through
  * literally): `YYYY` (4-digit zero-padded year, `-`-prefixed for negative
  * years), `MM` / `M` (zero-padded / bare month `01`–`12` / `1`–`12`), `DD` /
- * `D` (zero-padded / bare day of month). The v1 token set is date-only and
- * numeric — locale-dependent fields (month names, weekday names) are a
- * deliberate later stage of #2324, and per-locale *pattern selection* belongs
- * to the app's i18n layer, not to this function.
+ * `D` (zero-padded / bare day of month).
+ *
+ * Name tokens (#2334) read the explicit `names` table — the caller owns the
+ * values (per-locale name selection is the i18n layer's or the compiler's
+ * job, never this function's): `MMMM` / `MMM` (wide / abbreviated month
+ * name), `dddd` / `ddd` (wide / abbreviated weekday name, Sunday-first).
+ * `names` is a flat array in fixed layout: `[0..11]` wide months, `[12..23]`
+ * abbreviated months, `[24..30]` wide weekdays, `[31..37]` abbreviated
+ * weekdays. A name token indexing a missing/short table renders `''` — the
+ * same normative zero-value discipline as an unparseable date, byte-identical
+ * on every backend.
  *
  * `timeZone` is `'UTC'` or a fixed offset `±HH:MM` (`'+09:00'`, `'-05:30'`).
  * The function is total: any other value — including IANA zone names, which
  * would drag host tzdata versions into the output — normalizes to `'UTC'`, so
  * every backend degrades identically instead of diverging. An unset or
- * unparseable `date` renders `''` (the same normative zero-value discipline as
- * the `date` helper, spec/template-helpers.md).
+ * unparseable `date` renders `''`.
  */
 
 const OFFSET_RE = /^([+-])(\d{2}):(\d{2})$/
-const TOKEN_RE = /YYYY|MM|DD|M|D/g
+const TOKEN_RE = /YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D/g
+
+/** `names`-table section offsets (spec/template-helpers.md "format_date"). */
+const MONTHS_WIDE = 0
+const MONTHS_ABBR = 12
+const WEEKDAYS_WIDE = 24
+const WEEKDAYS_ABBR = 31
 
 function pad2(n: number): string {
   return String(n).padStart(2, '0')
 }
 
-export function formatDate(date: Date | string, pattern: string, timeZone = 'UTC'): string {
+export function formatDate(
+  date: Date | string,
+  pattern: string,
+  timeZone = 'UTC',
+  names: readonly string[] = [],
+): string {
   // Explicit nullish guard: `new Date(null)` is epoch 0, not Invalid Date,
   // so without this a nil receiver would format 1970-01-01 instead of the
   // contract's '' (spec/template-helpers.md "format_date", golden vector
@@ -52,10 +70,16 @@ export function formatDate(date: Date | string, pattern: string, timeZone = 'UTC
   const yyyy = (year < 0 ? '-' : '') + String(Math.abs(year)).padStart(4, '0')
   const month = s.getUTCMonth() + 1
   const day = s.getUTCDate()
+  const weekday = s.getUTCDay() // 0 = Sunday, matching the table's Sunday-first layout
+  const nameAt = (index: number): string => names[index] ?? ''
   return pattern.replace(TOKEN_RE, (token) => {
     switch (token) {
       case 'YYYY':
         return yyyy
+      case 'MMMM':
+        return nameAt(MONTHS_WIDE + month - 1)
+      case 'MMM':
+        return nameAt(MONTHS_ABBR + month - 1)
       case 'MM':
         return pad2(month)
       case 'M':
@@ -64,6 +88,10 @@ export function formatDate(date: Date | string, pattern: string, timeZone = 'UTC
         return pad2(day)
       case 'D':
         return String(day)
+      case 'dddd':
+        return nameAt(WEEKDAYS_WIDE + weekday)
+      case 'ddd':
+        return nameAt(WEEKDAYS_ABBR + weekday)
       default:
         return token
     }

--- a/packages/jsx/src/__tests__/format-date-lowering.test.ts
+++ b/packages/jsx/src/__tests__/format-date-lowering.test.ts
@@ -54,21 +54,37 @@ export function P() { return <time>x</time> }
   })
 })
 
-describe('matchFormatDateCall (#2324)', () => {
-  test('lowers a 3-arg call as-is', () => {
+const EMPTY_NAMES = { kind: 'array-literal', elements: [], raw: '[]' }
+
+describe('matchFormatDateCall (#2324/#2334)', () => {
+  test('normalizes a 3-arg call to canonical arity 4 (empty names table)', () => {
     expect(matchFormatDateCall(CALLEE, [DATE_ARG, PATTERN_ARG, TZ_ARG], LOCALS)).toEqual({
       kind: 'helper-call',
       helper: 'format_date',
-      args: [DATE_ARG, PATTERN_ARG, TZ_ARG],
+      args: [DATE_ARG, PATTERN_ARG, TZ_ARG, EMPTY_NAMES as ParsedExpr],
     })
   })
 
-  test('normalizes a 2-arg call by supplying the UTC literal', () => {
+  test('normalizes a 2-arg call by supplying the UTC literal and empty names', () => {
     const node = matchFormatDateCall(CALLEE, [DATE_ARG, PATTERN_ARG], LOCALS)
     expect(node).toEqual({
       kind: 'helper-call',
       helper: 'format_date',
-      args: [DATE_ARG, PATTERN_ARG, { kind: 'literal', value: 'UTC', literalType: 'string' }],
+      args: [
+        DATE_ARG,
+        PATTERN_ARG,
+        { kind: 'literal', value: 'UTC', literalType: 'string' },
+        EMPTY_NAMES as ParsedExpr,
+      ],
+    })
+  })
+
+  test('a caller-supplied 4th (names) argument passes through', () => {
+    const namesArg: ParsedExpr = { kind: 'identifier', name: 'names' }
+    expect(matchFormatDateCall(CALLEE, [DATE_ARG, PATTERN_ARG, TZ_ARG, namesArg], LOCALS)).toEqual({
+      kind: 'helper-call',
+      helper: 'format_date',
+      args: [DATE_ARG, PATTERN_ARG, TZ_ARG, namesArg],
     })
   })
 
@@ -82,7 +98,7 @@ describe('matchFormatDateCall (#2324)', () => {
       ),
     ).toBeNull()
     expect(matchFormatDateCall(CALLEE, [DATE_ARG], LOCALS)).toBeNull()
-    expect(matchFormatDateCall(CALLEE, [DATE_ARG, PATTERN_ARG, TZ_ARG, TZ_ARG], LOCALS)).toBeNull()
+    expect(matchFormatDateCall(CALLEE, [DATE_ARG, PATTERN_ARG, TZ_ARG, TZ_ARG, TZ_ARG], LOCALS)).toBeNull()
   })
 
   test('the plugin prepares only for components that import formatDate', () => {

--- a/packages/jsx/src/__tests__/to-locale-date-lowering.test.ts
+++ b/packages/jsx/src/__tests__/to-locale-date-lowering.test.ts
@@ -166,6 +166,26 @@ describe('name tokens via the options bag (#2334)', () => {
     })
   })
 
+  test('context-inflected month names pick the form the format actually uses (Copilot, #2336)', () => {
+    // Russian inflects month names by date context: dateStyle 'long'
+    // renders genitive `марта`, а month-only format nominative `март`.
+    // Each call site ships the table whose form ICU uses THERE, verified
+    // at a second instant so a probe-index coincidence can't slip through.
+    const long = match(`createdAt.toLocaleDateString('ru-RU', { dateStyle: 'long', timeZone: 'UTC' })`)
+    // NOTE: read args BEFORE any toMatchObject with expect.anything() —
+    // bun 1.3.11's toMatchObject MUTATES the received object, emptying
+    // entries an expect.anything() matched (minimal repro pinned in this
+    // PR's description; upstream bun bug).
+    const longNames = (long as { args: ParsedExpr[] }).args[3] as Extract<ParsedExpr, { kind: 'array-literal' }>
+    const longPattern = (long as { args: ParsedExpr[] }).args[1]
+    expect(longPattern).toEqual({ kind: 'literal', value: 'D MMMM YYYY г.', literalType: 'string' })
+    expect(longNames.elements[2]).toEqual({ kind: 'literal', value: 'марта', literalType: 'string' })
+
+    const monthOnly = match(`createdAt.toLocaleDateString('ru-RU', { month: 'long', timeZone: 'UTC' })`)
+    const standaloneNames = (monthOnly as { args: ParsedExpr[] }).args[3] as Extract<ParsedExpr, { kind: 'array-literal' }>
+    expect(standaloneNames.elements[2]).toEqual({ kind: 'literal', value: 'март', literalType: 'string' })
+  })
+
   test('unreproducible forms decline loudly: 2-digit year, era', () => {
     expect(match(`createdAt.toLocaleDateString('en-US', { dateStyle: 'short', timeZone: 'UTC' })`)).toBeNull()
     expect(match(`createdAt.toLocaleDateString('en-US', { era: 'short', year: 'numeric', timeZone: 'UTC' })`)).toBeNull()

--- a/packages/jsx/src/__tests__/to-locale-date-lowering.test.ts
+++ b/packages/jsx/src/__tests__/to-locale-date-lowering.test.ts
@@ -70,6 +70,7 @@ describe('matchToLocaleDateStringCall accept/decline table', () => {
         { kind: 'identifier', name: 'createdAt' },
         { kind: 'literal', value: 'M/D/YYYY', literalType: 'string' },
         { kind: 'literal', value: 'UTC', literalType: 'string' },
+        { kind: 'array-literal', elements: [], raw: '[]' },
       ],
     })
   })
@@ -82,6 +83,7 @@ describe('matchToLocaleDateStringCall accept/decline table', () => {
         { kind: 'identifier', name: 'createdAt' },
         { kind: 'literal', value: 'YYYY/M/D' },
         { kind: 'literal', value: '+09:00' },
+        { kind: 'array-literal', elements: [] },
       ],
     })
   })
@@ -101,9 +103,10 @@ describe('matchToLocaleDateStringCall accept/decline table', () => {
     expect(match(`createdAt.toLocaleDateString('ja-JP', { timeZone: '+25:00' })`)).toBeNull()
     expect(match(`createdAt.toLocaleDateString('ja-JP', { timeZone: '+99:99' })`)).toBeNull()
     expect(match(`createdAt.toLocaleDateString('ja-JP', { timeZone: '-12:60' })`)).toBeNull()
-    // options beyond timeZone: the name-table stage, not this slice
-    expect(match(`createdAt.toLocaleDateString('ja-JP', { timeZone: 'UTC', month: 'long' })`)).toBeNull()
+    // an options bag WITHOUT timeZone still declines (host-TZ read)
     expect(match(`createdAt.toLocaleDateString('ja-JP', { dateStyle: 'long' })`)).toBeNull()
+    // a non-literal option value declines (unprobeable)
+    expect(match(`createdAt.toLocaleDateString('en-US', { timeZone: 'UTC', dateStyle: style })`)).toBeNull()
     // unrepresentable locale default
     expect(match(`createdAt.toLocaleDateString('ar-SA', { timeZone: 'UTC' })`)).toBeNull()
   })
@@ -115,6 +118,69 @@ describe('matchToLocaleDateStringCall accept/decline table', () => {
       }
     `)
     expect(toLocaleDatePlugin.prepare(stringMd)).toBeNull()
+  })
+})
+
+describe('name tokens via the options bag (#2334)', () => {
+  const md = metadata(DATE_PROP_SRC)
+
+  function match(expr: string) {
+    const { callee, args } = callParts(expr)
+    return matchToLocaleDateStringCall(callee, args, md)
+  }
+
+  test('dateStyle long resolves a named pattern plus the 38-slot table', () => {
+    const node = match(`createdAt.toLocaleDateString('en-US', { dateStyle: 'long', timeZone: 'UTC' })`)
+    expect(node).toMatchObject({
+      helper: 'format_date',
+      args: [
+        { kind: 'identifier', name: 'createdAt' },
+        { kind: 'literal', value: 'MMMM D, YYYY' },
+        { kind: 'literal', value: 'UTC' },
+        { kind: 'array-literal' },
+      ],
+    })
+    const names = (node as { args: ParsedExpr[] }).args[3] as Extract<ParsedExpr, { kind: 'array-literal' }>
+    expect(names.elements).toHaveLength(38)
+    expect(names.elements[2]).toEqual({ kind: 'literal', value: 'March', literalType: 'string' })
+    expect(names.elements[24]).toEqual({ kind: 'literal', value: 'Sunday', literalType: 'string' })
+  })
+
+  test('dateStyle full adds the weekday token; medium picks abbreviated names', () => {
+    expect(match(`createdAt.toLocaleDateString('en-US', { dateStyle: 'full', timeZone: 'UTC' })`)).toMatchObject({
+      args: [expect.anything(), { kind: 'literal', value: 'dddd, MMMM D, YYYY' }, expect.anything(), expect.anything()],
+    })
+    expect(match(`createdAt.toLocaleDateString('en-US', { dateStyle: 'medium', timeZone: 'UTC' })`)).toMatchObject({
+      args: [expect.anything(), { kind: 'literal', value: 'MMM D, YYYY' }, expect.anything(), expect.anything()],
+    })
+  })
+
+  test("ja-JP's long form is numeric — the probe ships no table", () => {
+    expect(match(`createdAt.toLocaleDateString('ja-JP', { dateStyle: 'long', timeZone: 'UTC' })`)).toMatchObject({
+      args: [
+        expect.anything(),
+        { kind: 'literal', value: 'YYYY年M月D日' },
+        { kind: 'literal', value: 'UTC' },
+        { kind: 'array-literal', elements: [] },
+      ],
+    })
+  })
+
+  test('unreproducible forms decline loudly: 2-digit year, era', () => {
+    expect(match(`createdAt.toLocaleDateString('en-US', { dateStyle: 'short', timeZone: 'UTC' })`)).toBeNull()
+    expect(match(`createdAt.toLocaleDateString('en-US', { era: 'short', year: 'numeric', timeZone: 'UTC' })`)).toBeNull()
+  })
+
+  test('client rewrite carries the names table', () => {
+    const result = compile(`
+export function Foo({ createdAt }: { createdAt: Date }) {
+  return <div>{createdAt.toLocaleDateString('en-US', { dateStyle: 'long', timeZone: 'UTC' })}</div>
+}
+`)
+    expect(result.errors.filter((e) => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)).toEqual([])
+    const js = result.files.find((f) => f.type === 'clientJs')!.content
+    expect(js).toContain('formatDate(_p.createdAt, "MMMM D, YYYY", "UTC", ["January","February"')
+    expect(js).not.toContain('toLocaleDateString')
   })
 })
 
@@ -146,6 +212,9 @@ export { Foo }
           alternate: { kind: 'literal', value: 'YYYY/M/D', literalType: 'string' },
         },
         { kind: 'literal', value: 'UTC', literalType: 'string' },
+        // both members are numeric-only, so the names tables are equal ([])
+        // and collapse to a single empty leaf
+        { kind: 'array-literal', elements: [], raw: '[]' },
       ],
     })
   })
@@ -164,6 +233,7 @@ export { Foo }
         { kind: 'identifier', name: 'createdAt' },
         { kind: 'literal', value: 'M/D/YYYY' },
         { kind: 'literal', value: 'UTC' },
+        { kind: 'array-literal', elements: [] },
       ],
     })
   })
@@ -181,6 +251,7 @@ export function Foo(props: { createdAt: Date; locale: 'en-US' | 'ja-JP' }) {
         expect.anything(),
         { kind: 'conditional' },
         { kind: 'literal', value: 'UTC' },
+        { kind: 'array-literal', elements: [] },
       ],
     })
     // A bare `locale` identifier in object-props mode is a LOCAL binding,

--- a/packages/jsx/src/format-date-lowering.ts
+++ b/packages/jsx/src/format-date-lowering.ts
@@ -21,11 +21,15 @@ import type { LoweringNode, LoweringPlugin } from './lowering-registry.ts'
 import { formatDateLocalNames } from './adapters/env-signal.ts'
 
 const UTC_LITERAL: ParsedExpr = { kind: 'literal', value: 'UTC', literalType: 'string' }
+const EMPTY_NAMES: ParsedExpr = { kind: 'array-literal', elements: [], raw: '[]' } as ParsedExpr
 
 /**
- * Recognise `formatDate(date, pattern[, timeZone])` against the component's
- * local import bindings, or decline (null): a non-identifier callee, a name
- * not bound to the `@barefootjs/client` import, or an arity outside 2–3.
+ * Recognise `formatDate(date, pattern[, timeZone[, names]])` against the
+ * component's local import bindings, or decline (null): a non-identifier
+ * callee, a name not bound to the `@barefootjs/client` import, or an arity
+ * outside 2–4. The canonical helper arity is 4 (#2334): omitted `timeZone` /
+ * `names` normalize to the `'UTC'` literal and the empty table the client
+ * function defaults to, so backend helpers stay fixed-arity.
  */
 export function matchFormatDateCall(
   callee: ParsedExpr,
@@ -33,11 +37,11 @@ export function matchFormatDateCall(
   locals: ReadonlySet<string>,
 ): LoweringNode | null {
   if (callee.kind !== 'identifier' || !locals.has(callee.name)) return null
-  if (args.length < 2 || args.length > 3) return null
+  if (args.length < 2 || args.length > 4) return null
   return {
     kind: 'helper-call',
     helper: 'format_date',
-    args: [args[0], args[1], args[2] ?? UTC_LITERAL],
+    args: [args[0], args[1], args[2] ?? UTC_LITERAL, args[3] ?? EMPTY_NAMES],
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/emit-reactive.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-reactive.ts
@@ -181,10 +181,17 @@ function lowerToLocaleCallsInReactiveExpr(expr: string, matcher: LoweringMatcher
       call.arguments.map((a) => tsNodeToParsedExpr(a)),
     )
     if (!node || node.kind !== 'helper-call' || node.helper !== 'format_date') continue
-    const [, patternArg, tzArg] = node.args
+    const [, patternArg, tzArg, namesArg] = node.args
     if (!patternArg || tzArg?.kind !== 'literal') continue
-    const patternJs = patternArgToClientJs(patternArg, call.arguments[0].getText(sourceFile))
+    const localeText = call.arguments[0].getText(sourceFile)
+    const patternJs = patternArgToClientJs(patternArg, localeText)
     if (patternJs === null) continue
+    // The names table (#2334) — omitted when empty, same as the static path.
+    let namesJs: string | null = null
+    if (namesArg && !(namesArg.kind === 'array-literal' && namesArg.elements.length === 0)) {
+      namesJs = patternArgToClientJs(namesArg, localeText)
+      if (namesJs === null) continue
+    }
     const receiverText = propAccess.expression.getText(sourceFile)
     const matchText = call.getText(sourceFile)
     // The call text contains string literals (placeholders in the protected
@@ -193,7 +200,8 @@ function lowerToLocaleCallsInReactiveExpr(expr: string, matcher: LoweringMatcher
     result = replaceProtectedCall(
       result,
       matchText,
-      () => `formatDate(${receiverText}, ${patternJs}, ${JSON.stringify(tzArg.value)})`,
+      () =>
+        `formatDate(${receiverText}, ${patternJs}, ${JSON.stringify(tzArg.value)}${namesJs !== null ? `, ${namesJs}` : ''})`,
     )
   }
   return restore(result)

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -462,10 +462,18 @@ function lowerToLocaleDateCalls(text: string, expr: ts.Node, ctx: TransformConte
       call.arguments.map((a) => tsNodeToParsedExpr(a)),
     )
     if (!node || node.kind !== 'helper-call' || node.helper !== 'format_date') continue
-    const [, patternArg, tzArg] = node.args
+    const [, patternArg, tzArg, namesArg] = node.args
     if (!patternArg || tzArg?.kind !== 'literal') continue
-    const patternJs = patternArgToClientJs(patternArg, ctx.getJS(call.arguments[0]))
+    const localeText = ctx.getJS(call.arguments[0])
+    const patternJs = patternArgToClientJs(patternArg, localeText)
     if (patternJs === null) continue
+    // The names table (#2334) — omitted from the client call when empty
+    // (the client function defaults to []).
+    let namesJs: string | null = null
+    if (namesArg && !(namesArg.kind === 'array-literal' && namesArg.elements.length === 0)) {
+      namesJs = patternArgToClientJs(namesArg, localeText)
+      if (namesJs === null) continue
+    }
     const receiverText = ctx.getJS(propAccess.expression)
     const matchText = ctx.getJS(call)
     // Unlike `lowerDateCalls`' zero-arg needle, this call text CONTAINS
@@ -475,7 +483,8 @@ function lowerToLocaleDateCalls(text: string, expr: ts.Node, ctx: TransformConte
     result = replaceProtectedCall(
       result,
       matchText,
-      () => `formatDate(${receiverText}, ${patternJs}, ${JSON.stringify(tzArg.value)})`,
+      () =>
+        `formatDate(${receiverText}, ${patternJs}, ${JSON.stringify(tzArg.value)}${namesJs !== null ? `, ${namesJs}` : ''})`,
     )
   }
   return restore(result)

--- a/packages/jsx/src/to-locale-date-lowering.ts
+++ b/packages/jsx/src/to-locale-date-lowering.ts
@@ -91,32 +91,79 @@ const formatCache = new Map<string, LocaleDateFormat | null>()
 const namesCache = new Map<string, string[] | null>()
 
 /**
- * Derive a locale's 38-slot name table from the build machine's own ICU —
- * the compiler is the only owner of locale data; backends receive the
- * values as an ordinary array argument and stay type-only (#2334).
- * Sunday-first weekday order matches `Date.prototype.getUTCDay`.
+ * Name-derivation context (Copilot review on #2336): many locales inflect
+ * month (and sometimes weekday) names by DATE CONTEXT — Russian renders
+ * `{month:'long'}` alone as nominative `март` but `dateStyle:'long'` as
+ * genitive `марта`. So each section of the table is derived under BOTH a
+ * `formatting` probe (name alongside a day — the form full date styles
+ * use) and a `standalone` probe (name alone), and `deriveFormat` ships
+ * whichever table the probed output actually matches.
  */
-function deriveLocaleNames(locale: string): string[] | null {
-  const cached = namesCache.get(locale)
+type NameContext = 'formatting' | 'standalone'
+
+/**
+ * Derive a locale's 24 month names (12 wide + 12 abbreviated) under one
+ * {@link NameContext}, or null when any probe fails. The compiler is the
+ * only owner of locale data; backends receive the values as an ordinary
+ * array argument and stay type-only (#2334).
+ */
+function deriveMonthNames(locale: string, ctx: NameContext): string[] | null {
+  return deriveNamesCached(`${locale}|m|${ctx}`, () => {
+    const months = (width: 'long' | 'short') =>
+      Array.from({ length: 12 }, (_, m) =>
+        probePart(
+          locale,
+          ctx === 'formatting' ? { month: width, day: 'numeric' } : { month: width },
+          Date.UTC(2001, m, 15),
+          'month',
+        ),
+      )
+    return [...months('long'), ...months('short')]
+  })
+}
+
+/**
+ * Derive a locale's 14 weekday names (7 wide + 7 abbreviated,
+ * Sunday-first — matching `Date.prototype.getUTCDay`) under one context.
+ */
+function deriveWeekdayNames(locale: string, ctx: NameContext): string[] | null {
+  return deriveNamesCached(`${locale}|w|${ctx}`, () => {
+    // 2023-01-01 was a Sunday; day offsets walk Sunday..Saturday.
+    const weekdays = (width: 'long' | 'short') =>
+      Array.from({ length: 7 }, (_, d) =>
+        probePart(
+          locale,
+          ctx === 'formatting' ? { weekday: width, month: 'numeric', day: 'numeric' } : { weekday: width },
+          Date.UTC(2023, 0, 1 + d),
+          'weekday',
+        ),
+      )
+    return [...weekdays('long'), ...weekdays('short')]
+  })
+}
+
+function probePart(
+  locale: string,
+  options: Intl.DateTimeFormatOptions,
+  utc: number,
+  type: string,
+): string {
+  const parts = new Intl.DateTimeFormat(locale, { ...options, timeZone: 'UTC' }).formatToParts(new Date(utc))
+  const found = parts.find((p) => p.type === type)
+  if (!found || !found.value) throw new Error('missing part')
+  return found.value
+}
+
+function deriveNamesCached(key: string, derive: () => string[]): string[] | null {
+  const cached = namesCache.get(key)
   if (cached !== undefined) return cached
   let derived: string[] | null
   try {
-    const part = (options: Intl.DateTimeFormatOptions, utc: number, type: string): string => {
-      const parts = new Intl.DateTimeFormat(locale, { ...options, timeZone: 'UTC' }).formatToParts(new Date(utc))
-      const found = parts.find((p) => p.type === type)
-      if (!found || !found.value) throw new Error('missing part')
-      return found.value
-    }
-    const months = (width: 'long' | 'short') =>
-      Array.from({ length: 12 }, (_, m) => part({ month: width }, Date.UTC(2001, m, 15), 'month'))
-    // 2023-01-01 was a Sunday; day offsets walk Sunday..Saturday.
-    const weekdays = (width: 'long' | 'short') =>
-      Array.from({ length: 7 }, (_, d) => part({ weekday: width }, Date.UTC(2023, 0, 1 + d), 'weekday'))
-    derived = [...months('long'), ...months('short'), ...weekdays('long'), ...weekdays('short')]
+    derived = derive()
   } catch {
     derived = null
   }
-  namesCache.set(locale, derived)
+  namesCache.set(key, derived)
   return derived
 }
 
@@ -155,10 +202,58 @@ export function resolveLocaleDateFormat(
   return derived
 }
 
+/**
+ * Second verification instant: 2001-05-13 UTC — a SUNDAY in MAY, so both
+ * the month and weekday indexes differ from {@link PROBE_UTC}'s. The
+ * chosen name tables are re-verified against the real ICU output at this
+ * instant, closing the coincidental-match hole: a table whose form only
+ * happens to agree with the probed format AT the probe month/weekday (but
+ * diverges elsewhere) would otherwise ship a silently-wrong name — the
+ * one failure class the fidelity rule ("reproduce exactly or decline")
+ * cannot tolerate (Copilot review on #2336).
+ */
+const VERIFY_UTC = new Date(Date.UTC(2001, 4, 13))
+
+/** Render `pattern` + `names` at a fixed calendar point — the compiler-side
+ *  mirror of the runtime token scan, used only for the VERIFY_UTC check. */
+function renderPatternAt(
+  pattern: string,
+  names: readonly string[],
+  y: number,
+  m: number,
+  d: number,
+  wd: number,
+): string {
+  const pad2 = (n: number) => String(n).padStart(2, '0')
+  return pattern.replace(/YYYY|MMMM|MMM|MM|DD|dddd|ddd|M|D/g, (token) => {
+    switch (token) {
+      case 'YYYY':
+        return String(y).padStart(4, '0')
+      case 'MMMM':
+        return names[m - 1] ?? ''
+      case 'MMM':
+        return names[12 + m - 1] ?? ''
+      case 'MM':
+        return pad2(m)
+      case 'M':
+        return String(m)
+      case 'DD':
+        return pad2(d)
+      case 'D':
+        return String(d)
+      case 'dddd':
+        return names[24 + wd] ?? ''
+      default:
+        return names[31 + wd] ?? ''
+    }
+  })
+}
+
 function deriveFormat(locale: string, probeOptions: Record<string, string>): LocaleDateFormat | null {
+  let dtf: Intl.DateTimeFormat
   let parts: Intl.DateTimeFormatPart[]
   try {
-    const dtf = new Intl.DateTimeFormat(locale, {
+    dtf = new Intl.DateTimeFormat(locale, {
       ...(probeOptions as Intl.DateTimeFormatOptions),
       timeZone: 'UTC',
     })
@@ -169,8 +264,20 @@ function deriveFormat(locale: string, probeOptions: Record<string, string>): Loc
     return null // invalid language tag or invalid/conflicting options
   }
   // Probe instant 2001-02-03 is a Saturday in February: month index 1,
-  // weekday index 6 in the Sunday-first table.
-  const names = deriveLocaleNames(locale)
+  // weekday index 6 in the Sunday-first table. Each name part is matched
+  // against BOTH derivation contexts (formatting first — full date styles
+  // use the in-context form) so context-inflecting locales (ru: `марта`
+  // vs `март`) resolve to the table whose form the format actually uses.
+  const monthTables: Array<string[] | null> = [
+    deriveMonthNames(locale, 'formatting'),
+    deriveMonthNames(locale, 'standalone'),
+  ]
+  const weekdayTables: Array<string[] | null> = [
+    deriveWeekdayNames(locale, 'formatting'),
+    deriveWeekdayNames(locale, 'standalone'),
+  ]
+  let monthTable: string[] | null = null
+  let weekdayTable: string[] | null = null
   let pattern = ''
   let usesNames = false
   for (const part of parts) {
@@ -179,31 +286,39 @@ function deriveFormat(locale: string, probeOptions: Record<string, string>): Loc
         if (part.value !== '2001') return null // 2-digit-year form has no token
         pattern += 'YYYY'
         break
-      case 'month':
-        if (part.value === '2') pattern += 'M'
-        else if (part.value === '02') pattern += 'MM'
-        else if (names && part.value === names[1]) {
-          pattern += 'MMMM'
-          usesNames = true
-        } else if (names && part.value === names[12 + 1]) {
-          pattern += 'MMM'
-          usesNames = true
-        } else return null // narrow / unmatched month form
+      case 'month': {
+        if (part.value === '2') {
+          pattern += 'M'
+          break
+        }
+        if (part.value === '02') {
+          pattern += 'MM'
+          break
+        }
+        const wide = monthTables.find((t) => t && part.value === t[1]) ?? null
+        const abbr = wide ? null : (monthTables.find((t) => t && part.value === t[12 + 1]) ?? null)
+        if (wide) pattern += 'MMMM'
+        else if (abbr) pattern += 'MMM'
+        else return null // narrow / unmatched month form
+        monthTable = wide ?? abbr
+        usesNames = true
         break
+      }
       case 'day':
         if (part.value === '3') pattern += 'D'
         else if (part.value === '03') pattern += 'DD'
         else return null
         break
-      case 'weekday':
-        if (names && part.value === names[24 + 6]) {
-          pattern += 'dddd'
-          usesNames = true
-        } else if (names && part.value === names[31 + 6]) {
-          pattern += 'ddd'
-          usesNames = true
-        } else return null // narrow / unmatched weekday form
+      case 'weekday': {
+        const wide = weekdayTables.find((t) => t && part.value === t[6]) ?? null
+        const abbr = wide ? null : (weekdayTables.find((t) => t && part.value === t[7 + 6]) ?? null)
+        if (wide) pattern += 'dddd'
+        else if (abbr) pattern += 'ddd'
+        else return null // narrow / unmatched weekday form
+        weekdayTable = wide ?? abbr
+        usesNames = true
         break
+      }
       case 'literal':
         // A literal colliding with the token alphabet would be re-tokenized
         // by the helper's scan: any uppercase Y/M/D, or a lowercase run of
@@ -218,7 +333,18 @@ function deriveFormat(locale: string, probeOptions: Record<string, string>): Loc
   // The probed format must actually be a date (guards a pathological
   // options bag that yields, say, only a weekday).
   if (!/YYYY|MMMM|MMM|MM|M/.test(pattern) && !/DD|D/.test(pattern)) return null
-  return { pattern, names: usesNames ? names : null }
+  if (!usesNames) return { pattern, names: null }
+  // Compose the shipped 38-slot table from whichever context matched each
+  // section (unused sections default to the formatting context).
+  const names = [
+    ...(monthTable ?? monthTables[0] ?? monthTables[1] ?? Array<string>(24).fill('')),
+    ...(weekdayTable ?? weekdayTables[0] ?? weekdayTables[1] ?? Array<string>(14).fill('')),
+  ]
+  // Two-point verification: reproduce the SECOND instant (Sunday, May 13)
+  // with the frozen pattern + table and byte-compare against real ICU. A
+  // probe-index coincidence between contexts cannot survive both points.
+  if (renderPatternAt(pattern, names, 2001, 5, 13, 0) !== dtf.format(VERIFY_UTC)) return null
+  return { pattern, names }
 }
 
 /**

--- a/packages/jsx/src/to-locale-date-lowering.ts
+++ b/packages/jsx/src/to-locale-date-lowering.ts
@@ -36,11 +36,18 @@
  *     the host locale, which no frozen pattern table can reproduce;
  *   - an IANA `timeZone` name — couples output to the host's tzdata version
  *     (only `'UTC'` and fixed `±HH:MM` offsets are deterministic);
- *   - options beyond `timeZone` (`dateStyle`, `month: 'long'`, …) — the
- *     name-table stage of #2324, not this slice;
- *   - a locale whose default format needs anything beyond numeric
- *     year/month/day in latin digits on the gregorian calendar (e.g.
- *     `ar-SA`: islamic-umalqura calendar, arabic-indic digits).
+ *   - an options bag the probe cannot reproduce EXACTLY in the token+table
+ *     vocabulary — era, dayPeriod, 2-digit year, narrow name forms,
+ *     non-literal option values ("faithful or loud", never approximate);
+ *   - a locale/options combination needing non-latin digits or a
+ *     non-gregorian calendar (e.g. `ar-SA`: islamic-umalqura, arabic-indic
+ *     digits).
+ *
+ * Options beyond `timeZone` ARE admitted when literal (#2334): the compiler
+ * probes the exact bag with `formatToParts`; month/weekday NAME parts
+ * resolve to the `MMMM`/`MMM`/`dddd`/`ddd` tokens plus the 38-slot name
+ * table shipped as an ordinary array argument — the backend receives
+ * values, never locale knowledge.
  */
 
 import type { IRMetadata, TypeInfo } from './types.ts'
@@ -68,68 +75,150 @@ export const TO_LOCALE_TZ_RE = /^(?:UTC|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/
  */
 const PROBE_UTC = new Date(Date.UTC(2001, 1, 3))
 
-/** Build-time cache: locale tag → derived pattern (or null = not representable). */
-const patternCache = new Map<string, string | null>()
+/**
+ * The 38-slot `names` table layout (spec/template-helpers.md "format_date"):
+ * [0..11] wide months, [12..23] abbreviated months, [24..30] wide weekdays
+ * (Sunday-first), [31..37] abbreviated weekdays.
+ */
+export interface LocaleDateFormat {
+  pattern: string
+  /** The 38-slot table, present iff `pattern` contains a name token. */
+  names: string[] | null
+}
+
+/** Build-time caches: locale tag (+ options key) → derived result (null = not representable). */
+const formatCache = new Map<string, LocaleDateFormat | null>()
+const namesCache = new Map<string, string[] | null>()
 
 /**
- * Resolve a locale literal to its default date pattern in the v1
- * `format_date` token language (`YYYY`/`MM`/`M`/`DD`/`D` + literal text), or
- * null when the locale's default format is not representable. The gate is
- * structural, not an allowlist: the format must resolve to the gregorian
- * calendar in latin digits and consist solely of numeric year/month/day
- * parts (4-digit year) plus separator literals that cannot collide with the
- * token alphabet. `en-US` → `M/D/YYYY`, `ja-JP` → `YYYY/M/D`, `en-GB` →
- * `DD/MM/YYYY`, `de-DE` → `D.M.YYYY`; `ar-SA` (islamic-umalqura/arab) and
- * any 2-digit-year or era/weekday-bearing default → null.
+ * Derive a locale's 38-slot name table from the build machine's own ICU —
+ * the compiler is the only owner of locale data; backends receive the
+ * values as an ordinary array argument and stay type-only (#2334).
+ * Sunday-first weekday order matches `Date.prototype.getUTCDay`.
  */
-export function resolveLocaleDatePattern(locale: string): string | null {
-  const cached = patternCache.get(locale)
+function deriveLocaleNames(locale: string): string[] | null {
+  const cached = namesCache.get(locale)
   if (cached !== undefined) return cached
-  const derived = derivePattern(locale)
-  patternCache.set(locale, derived)
+  let derived: string[] | null
+  try {
+    const part = (options: Intl.DateTimeFormatOptions, utc: number, type: string): string => {
+      const parts = new Intl.DateTimeFormat(locale, { ...options, timeZone: 'UTC' }).formatToParts(new Date(utc))
+      const found = parts.find((p) => p.type === type)
+      if (!found || !found.value) throw new Error('missing part')
+      return found.value
+    }
+    const months = (width: 'long' | 'short') =>
+      Array.from({ length: 12 }, (_, m) => part({ month: width }, Date.UTC(2001, m, 15), 'month'))
+    // 2023-01-01 was a Sunday; day offsets walk Sunday..Saturday.
+    const weekdays = (width: 'long' | 'short') =>
+      Array.from({ length: 7 }, (_, d) => part({ weekday: width }, Date.UTC(2023, 0, 1 + d), 'weekday'))
+    derived = [...months('long'), ...months('short'), ...weekdays('long'), ...weekdays('short')]
+  } catch {
+    derived = null
+  }
+  namesCache.set(locale, derived)
   return derived
 }
 
-function derivePattern(locale: string): string | null {
+/**
+ * Back-compat convenience over {@link resolveLocaleDateFormat}: the
+ * default-options pattern (numeric-only or it doesn't resolve — the default
+ * date format of every locale is name-free, so `names` is always null here).
+ */
+export function resolveLocaleDatePattern(locale: string): string | null {
+  return resolveLocaleDateFormat(locale, {})?.pattern ?? null
+}
+
+/**
+ * Resolve (locale, probe options) to a `format_date` pattern — and, when the
+ * probed format contains month/weekday NAMES, the 38-slot table those tokens
+ * read (#2334). The fidelity contract: the result is exactly what the user's
+ * `toLocaleDateString(locale, options)` evaluates to under the build
+ * machine's ECMA-402 — reproduce it exactly or decline (null), never
+ * approximate. The gate is structural, not an allowlist: gregorian calendar,
+ * latin digits, and every part must be a numeric 4-digit year / numeric or
+ * named month / numeric day / named weekday / non-colliding literal.
+ * `en-US` default → `M/D/YYYY`; `en-US` + `{dateStyle:'long'}` → `MMMM D,
+ * YYYY` + names; `ja-JP` + `{dateStyle:'long'}` → `YYYY年M月D日` (numeric —
+ * no names needed, which the probe discovers naturally); era / dayPeriod /
+ * 2-digit-year / non-latn digits → null.
+ */
+export function resolveLocaleDateFormat(
+  locale: string,
+  probeOptions: Record<string, string>,
+): LocaleDateFormat | null {
+  const key = `${locale}|${JSON.stringify(probeOptions, Object.keys(probeOptions).sort())}`
+  const cached = formatCache.get(key)
+  if (cached !== undefined) return cached
+  const derived = deriveFormat(locale, probeOptions)
+  formatCache.set(key, derived)
+  return derived
+}
+
+function deriveFormat(locale: string, probeOptions: Record<string, string>): LocaleDateFormat | null {
   let parts: Intl.DateTimeFormatPart[]
   try {
-    const dtf = new Intl.DateTimeFormat(locale, { timeZone: 'UTC' })
+    const dtf = new Intl.DateTimeFormat(locale, {
+      ...(probeOptions as Intl.DateTimeFormatOptions),
+      timeZone: 'UTC',
+    })
     const resolved = dtf.resolvedOptions()
     if (resolved.calendar !== 'gregory' || resolved.numberingSystem !== 'latn') return null
     parts = dtf.formatToParts(PROBE_UTC)
   } catch {
-    return null // invalid language tag
+    return null // invalid language tag or invalid/conflicting options
   }
+  // Probe instant 2001-02-03 is a Saturday in February: month index 1,
+  // weekday index 6 in the Sunday-first table.
+  const names = deriveLocaleNames(locale)
   let pattern = ''
+  let usesNames = false
   for (const part of parts) {
     switch (part.type) {
       case 'year':
-        if (part.value !== '2001') return null // 2-digit-year default has no v1 token
+        if (part.value !== '2001') return null // 2-digit-year form has no token
         pattern += 'YYYY'
         break
       case 'month':
         if (part.value === '2') pattern += 'M'
         else if (part.value === '02') pattern += 'MM'
-        else return null // name/narrow month — the later name-table stage
+        else if (names && part.value === names[1]) {
+          pattern += 'MMMM'
+          usesNames = true
+        } else if (names && part.value === names[12 + 1]) {
+          pattern += 'MMM'
+          usesNames = true
+        } else return null // narrow / unmatched month form
         break
       case 'day':
         if (part.value === '3') pattern += 'D'
         else if (part.value === '03') pattern += 'DD'
         else return null
         break
+      case 'weekday':
+        if (names && part.value === names[24 + 6]) {
+          pattern += 'dddd'
+          usesNames = true
+        } else if (names && part.value === names[31 + 6]) {
+          pattern += 'ddd'
+          usesNames = true
+        } else return null // narrow / unmatched weekday form
+        break
       case 'literal':
-        // A literal containing the token alphabet would be re-tokenized by
-        // the helper's scan; no real numeric-format separator does, but the
-        // gate must prove it rather than assume it.
-        if (/[YMD]/.test(part.value)) return null
+        // A literal colliding with the token alphabet would be re-tokenized
+        // by the helper's scan: any uppercase Y/M/D, or a lowercase run of
+        // three-plus `d`s (single/double `d` is not a token).
+        if (/[YMD]/.test(part.value) || /ddd/.test(part.value)) return null
         pattern += part.value
         break
       default:
-        return null // era, weekday, dayPeriod, … — not representable
+        return null // era, dayPeriod, … — not representable
     }
   }
-  if (!pattern.includes('YYYY') || !/M/.test(pattern) || !/D/.test(pattern)) return null
-  return pattern
+  // The probed format must actually be a date (guards a pathological
+  // options bag that yields, say, only a weekday).
+  if (!/YYYY|MMMM|MMM|MM|M/.test(pattern) && !/DD|D/.test(pattern)) return null
+  return { pattern, names: usesNames ? names : null }
 }
 
 /**
@@ -196,6 +285,39 @@ function resolveLocaleUnionMembers(locale: ParsedExpr, metadata: IRMetadata): st
 
 const strLit = (value: string): ParsedExpr => ({ kind: 'literal', value, literalType: 'string' })
 
+/** Array-literal ParsedExpr over string values (the `names` helper argument). */
+function strArr(values: readonly string[]): ParsedExpr {
+  return {
+    kind: 'array-literal',
+    elements: values.map((v) => strLit(v)),
+    raw: JSON.stringify(values),
+  } as ParsedExpr
+}
+
+/**
+ * Fold per-union-member values into a right-folded ternary over the runtime
+ * locale expression (last member needs no guard — the TS type keeps the
+ * value inside the union). Equal values collapse to the plain leaf.
+ */
+function foldMembers(
+  locale: ParsedExpr,
+  members: readonly string[],
+  leaves: readonly ParsedExpr[],
+  allEqual: boolean,
+): ParsedExpr {
+  let expr = leaves[leaves.length - 1]
+  if (allEqual) return expr
+  for (let i = leaves.length - 2; i >= 0; i--) {
+    expr = {
+      kind: 'conditional',
+      test: { kind: 'binary', op: '===', left: locale, right: strLit(members[i]) },
+      consequent: leaves[i],
+      alternate: expr,
+    }
+  }
+  return expr
+}
+
 export function matchToLocaleDateStringCall(
   callee: ParsedExpr,
   args: readonly ParsedExpr[],
@@ -204,12 +326,25 @@ export function matchToLocaleDateStringCall(
   if (callee.kind !== 'member' || callee.computed) return null
   if (callee.property !== 'toLocaleDateString' || args.length !== 2) return null
   const [locale, options] = args
-  if (options.kind !== 'object-literal' || options.properties.length !== 1) return null
-  const prop = options.properties[0]
-  if (prop.key !== 'timeZone') return null
-  if (prop.value.kind !== 'literal' || prop.value.literalType !== 'string') return null
-  const tz = String(prop.value.value)
-  if (!TO_LOCALE_TZ_RE.test(tz)) return null
+  // Options bag: `timeZone` is REQUIRED (a literal 'UTC' | valid ±HH:MM —
+  // its omission would read the host timezone); every OTHER key rides into
+  // the Intl probe as-is when its value is a string literal (#2334's
+  // fidelity rule: admit any literal options bag the probe can reproduce
+  // exactly, decline everything else — dateStyle, month/weekday forms, …).
+  if (options.kind !== 'object-literal') return null
+  let tz: string | null = null
+  const probeOptions: Record<string, string> = {}
+  for (const prop of options.properties) {
+    if (prop.value.kind !== 'literal' || prop.value.literalType !== 'string') return null
+    const value = String(prop.value.value)
+    if (prop.key === 'timeZone') {
+      if (!TO_LOCALE_TZ_RE.test(value)) return null
+      tz = value
+    } else {
+      probeOptions[prop.key] = value
+    }
+  }
+  if (tz === null) return null
 
   const receiverType = resolveReceiverType(callee.object, metadata, new Map())
   if (!receiverType || receiverType.kind !== 'interface') return null
@@ -217,46 +352,47 @@ export function matchToLocaleDateStringCall(
   if (typeName !== 'Date') return null
   if (metadata.typeDefinitions.some((d) => d.name === typeName)) return null
 
-  // Literal locale: resolve one pattern at build time.
+  // Literal locale: resolve one pattern (+ name table when the probed
+  // format contains month/weekday names) at build time.
   if (locale.kind === 'literal' && locale.literalType === 'string') {
-    const pattern = resolveLocaleDatePattern(String(locale.value))
-    if (pattern === null) return null
+    const format = resolveLocaleDateFormat(String(locale.value), probeOptions)
+    if (format === null) return null
     return {
       kind: 'helper-call',
       helper: 'format_date',
-      args: [callee.object, strLit(pattern), strLit(tz)],
+      args: [callee.object, strLit(format.pattern), strLit(tz), strArr(format.names ?? [])],
     }
   }
 
   // Union-typed locale (#2324's union stage): a REQUIRED prop typed as a
-  // closed string-literal union resolves every member's pattern at build
-  // time and lowers the pattern argument to a right-folded ternary over the
-  // runtime locale value — runtime locale switching with zero runtime CLDR.
-  // (A TS-typed value can't leave the union, so the final alternate needs no
-  // guard; equal patterns collapse the ternary away entirely.)
+  // closed string-literal union resolves every member's format at build
+  // time; the pattern AND names arguments each lower to a right-folded
+  // ternary over the runtime locale value — runtime locale switching with
+  // zero runtime CLDR.
   const members = resolveLocaleUnionMembers(locale, metadata)
   if (!members) return null
-  const patterns: string[] = []
+  const formats: LocaleDateFormat[] = []
   for (const member of members) {
-    const pattern = resolveLocaleDatePattern(member)
-    if (pattern === null) return null
-    patterns.push(pattern)
+    const format = resolveLocaleDateFormat(member, probeOptions)
+    if (format === null) return null
+    formats.push(format)
   }
-  let patternExpr: ParsedExpr = strLit(patterns[patterns.length - 1])
-  if (new Set(patterns).size > 1) {
-    for (let i = patterns.length - 2; i >= 0; i--) {
-      patternExpr = {
-        kind: 'conditional',
-        test: { kind: 'binary', op: '===', left: locale, right: strLit(members[i]) },
-        consequent: strLit(patterns[i]),
-        alternate: patternExpr,
-      }
-    }
-  }
+  const patterns = formats.map((f) => f.pattern)
+  const nameTables = formats.map((f) => JSON.stringify(f.names ?? []))
   return {
     kind: 'helper-call',
     helper: 'format_date',
-    args: [callee.object, patternExpr, strLit(tz)],
+    args: [
+      callee.object,
+      foldMembers(locale, members, patterns.map(strLit), new Set(patterns).size === 1),
+      strLit(tz),
+      foldMembers(
+        locale,
+        members,
+        formats.map((f) => strArr(f.names ?? [])),
+        new Set(nameTables).size === 1,
+      ),
+    ],
   }
 }
 
@@ -271,13 +407,24 @@ export function matchToLocaleDateStringCall(
  */
 export function patternArgToClientJs(patternArg: ParsedExpr, localeText: string): string | null {
   if (patternArg.kind === 'literal') return JSON.stringify(patternArg.value)
+  // The `names` argument's leaf (#2334): an array-literal of string literals.
+  if (patternArg.kind === 'array-literal') {
+    const values: string[] = []
+    for (const el of patternArg.elements) {
+      if (el.kind !== 'literal') return null
+      values.push(String(el.value))
+    }
+    return JSON.stringify(values)
+  }
   if (patternArg.kind !== 'conditional') return null
   const t = patternArg.test
   if (t.kind !== 'binary' || t.op !== '===' || t.right.kind !== 'literal') return null
-  if (patternArg.consequent.kind !== 'literal') return null
+  if (t.right.kind !== 'literal') return null
+  const cons = patternArgToClientJs(patternArg.consequent, localeText)
   const rest = patternArgToClientJs(patternArg.alternate, localeText)
-  if (rest === null) return null
-  return `${localeText} === ${JSON.stringify(t.right.value)} ? ${JSON.stringify(patternArg.consequent.value)} : ${rest}`
+  if (cons === null || rest === null) return null
+  if (patternArg.consequent.kind !== 'literal' && patternArg.consequent.kind !== 'array-literal') return null
+  return `${localeText} === ${JSON.stringify(t.right.value)} ? ${cons} : ${rest}`
 }
 
 export const toLocaleDatePlugin: LoweringPlugin = {

--- a/spec/template-helpers.md
+++ b/spec/template-helpers.md
@@ -318,25 +318,38 @@ ISO-8601 string form), for every backend (#2288).
 
 ### format_date
 
-`format_date(recv, pattern, tz)` — the lowering target for a
-`formatDate(date, pattern, timeZone)` call (`@barefootjs/client`,
-#2324): the pure-function date formatter whose inputs are all
-explicit, so the output is a deterministic function of its arguments
-— no host locale, no host timezone, no ICU/CLDR data anywhere.
+`format_date(recv, pattern, tz, names)` — the lowering target for a
+`formatDate(date, pattern, timeZone, names?)` call
+(`@barefootjs/client`, #2324/#2334): the pure-function date formatter
+whose inputs are all explicit, so the output is a deterministic
+function of its arguments — no host locale, no host timezone, no
+ICU/CLDR data anywhere. Canonical arity is 4; the compiler lowering
+always supplies `tz` (default `'UTC'`) and `names` (default the empty
+table).
 
 `recv` follows the `date` helper's receiver contract exactly: the
 backend's own native date/time type or an ISO-8601 string, both
 normalized to the same instant; a `nil`/unset or unparseable `recv`
 renders `''` (normative zero value, never a crash and never "now").
 
-`pattern` is scanned longest-match for the token set `YYYY` / `MM` /
-`M` / `DD` / `D`; every other character passes through literally
-(`'YYYY年M月D日'` works). `YYYY` is the zero-padded-to-4 year with a
-`-` prefix for negative years; `MM`/`DD` zero-pad to 2; `M`/`D` are
-bare. The v1 token set is date-only and numeric — locale-dependent
-fields (month/weekday names) are a deliberate later stage of #2324
-(they need framework-owned name tables), and per-locale *pattern
-selection* is the app's i18n layer's job, not the helper's.
+`pattern` is scanned longest-match for the token set `YYYY` / `MMMM`
+/ `MMM` / `MM` / `DD` / `dddd` / `ddd` / `M` / `D`; every other
+character passes through literally (`'YYYY年M月D日'` works). `YYYY`
+is the zero-padded-to-4 year with a `-` prefix for negative years;
+`MM`/`DD` zero-pad to 2; `M`/`D` are bare.
+
+The NAME tokens (#2334) read the explicit `names` table — a flat
+string list in fixed layout: `[0..11]` wide months, `[12..23]`
+abbreviated months, `[24..30]` wide weekdays (Sunday-first, so the
+index IS the day-of-week), `[31..37]` abbreviated weekdays. `MMMM` /
+`MMM` index by month; `dddd` / `ddd` index by the day-of-week of the
+OFFSET-SHIFTED instant (epoch-days mod 7 anchored on 1970-01-01 =
+Thursday — floor division for pre-1970 instants). A name token
+indexing a missing/short table renders `''`. The backend never owns
+locale data: the values arrive as an ordinary array argument (the
+compiler derives them from its own ICU at build time, or the app's
+i18n layer passes them at the `formatDate` API level) — backends
+know the SHAPE, never the locale.
 
 `tz` is `'UTC'` or a fixed offset matching `±HH:MM` (`'+09:00'`,
 `'-05:30'`). The helper is **total**: any other value — including

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 260,
+    "totalFixtures": 261,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 261,
+    "totalFixtures": 262,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -526,11 +526,11 @@
       }
     },
     "call": {
-      "total": 161,
+      "total": 162,
       "cells": {
         "hono": {
-          "pass": 160,
-          "total": 161,
+          "pass": 161,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -541,8 +541,8 @@
           ]
         },
         "blade": {
-          "pass": 156,
-          "total": 161,
+          "pass": 157,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -577,8 +577,8 @@
           ]
         },
         "erb": {
-          "pass": 157,
-          "total": 161,
+          "pass": 158,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -607,8 +607,8 @@
           ]
         },
         "go-template": {
-          "pass": 156,
-          "total": 161,
+          "pass": 157,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -643,8 +643,8 @@
           ]
         },
         "jinja": {
-          "pass": 156,
-          "total": 161,
+          "pass": 157,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -679,8 +679,8 @@
           ]
         },
         "minijinja": {
-          "pass": 156,
-          "total": 161,
+          "pass": 157,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -715,8 +715,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 157,
-          "total": 161,
+          "pass": 158,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -745,8 +745,8 @@
           ]
         },
         "twig": {
-          "pass": 156,
-          "total": 161,
+          "pass": 157,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -781,8 +781,8 @@
           ]
         },
         "xslate": {
-          "pass": 156,
-          "total": 161,
+          "pass": 157,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -860,11 +860,11 @@
       }
     },
     "identifier": {
-      "total": 241,
+      "total": 242,
       "cells": {
         "hono": {
-          "pass": 240,
-          "total": 241,
+          "pass": 241,
+          "total": 242,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -875,8 +875,8 @@
           ]
         },
         "blade": {
-          "pass": 235,
-          "total": 241,
+          "pass": 236,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -917,8 +917,8 @@
           ]
         },
         "erb": {
-          "pass": 236,
-          "total": 241,
+          "pass": 237,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -953,8 +953,8 @@
           ]
         },
         "go-template": {
-          "pass": 235,
-          "total": 241,
+          "pass": 236,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -995,8 +995,8 @@
           ]
         },
         "jinja": {
-          "pass": 235,
-          "total": 241,
+          "pass": 236,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1037,8 +1037,8 @@
           ]
         },
         "minijinja": {
-          "pass": 235,
-          "total": 241,
+          "pass": 236,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1079,8 +1079,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 236,
-          "total": 241,
+          "pass": 237,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1115,8 +1115,8 @@
           ]
         },
         "twig": {
-          "pass": 235,
-          "total": 241,
+          "pass": 236,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1157,8 +1157,8 @@
           ]
         },
         "xslate": {
-          "pass": 235,
-          "total": 241,
+          "pass": 236,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1242,15 +1242,15 @@
       }
     },
     "literal": {
-      "total": 199,
+      "total": 200,
       "cells": {
         "hono": {
-          "pass": 199,
-          "total": 199
+          "pass": 200,
+          "total": 200
         },
         "blade": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1261,8 +1261,8 @@
           ]
         },
         "erb": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1273,8 +1273,8 @@
           ]
         },
         "go-template": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1285,8 +1285,8 @@
           ]
         },
         "jinja": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1297,8 +1297,8 @@
           ]
         },
         "minijinja": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1309,8 +1309,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1321,8 +1321,8 @@
           ]
         },
         "twig": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1333,8 +1333,8 @@
           ]
         },
         "xslate": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1452,11 +1452,11 @@
       }
     },
     "member": {
-      "total": 121,
+      "total": 122,
       "cells": {
         "hono": {
-          "pass": 120,
-          "total": 121,
+          "pass": 121,
+          "total": 122,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1467,8 +1467,8 @@
           ]
         },
         "blade": {
-          "pass": 116,
-          "total": 121,
+          "pass": 117,
+          "total": 122,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1503,8 +1503,8 @@
           ]
         },
         "erb": {
-          "pass": 117,
-          "total": 121,
+          "pass": 118,
+          "total": 122,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1533,8 +1533,8 @@
           ]
         },
         "go-template": {
-          "pass": 116,
-          "total": 121,
+          "pass": 117,
+          "total": 122,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1569,8 +1569,8 @@
           ]
         },
         "jinja": {
-          "pass": 116,
-          "total": 121,
+          "pass": 117,
+          "total": 122,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1605,8 +1605,8 @@
           ]
         },
         "minijinja": {
-          "pass": 116,
-          "total": 121,
+          "pass": 117,
+          "total": 122,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1641,8 +1641,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 117,
-          "total": 121,
+          "pass": 118,
+          "total": 122,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1671,8 +1671,8 @@
           ]
         },
         "twig": {
-          "pass": 116,
-          "total": 121,
+          "pass": 117,
+          "total": 122,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1707,8 +1707,8 @@
           ]
         },
         "xslate": {
-          "pass": 116,
-          "total": 121,
+          "pass": 117,
+          "total": 122,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1745,15 +1745,15 @@
       }
     },
     "object-literal": {
-      "total": 44,
+      "total": 45,
       "cells": {
         "hono": {
-          "pass": 44,
-          "total": 44
+          "pass": 45,
+          "total": 45
         },
         "blade": {
-          "pass": 42,
-          "total": 44,
+          "pass": 43,
+          "total": 45,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1770,8 +1770,8 @@
           ]
         },
         "erb": {
-          "pass": 42,
-          "total": 44,
+          "pass": 43,
+          "total": 45,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1788,8 +1788,8 @@
           ]
         },
         "go-template": {
-          "pass": 42,
-          "total": 44,
+          "pass": 43,
+          "total": 45,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1806,8 +1806,8 @@
           ]
         },
         "jinja": {
-          "pass": 42,
-          "total": 44,
+          "pass": 43,
+          "total": 45,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1824,8 +1824,8 @@
           ]
         },
         "minijinja": {
-          "pass": 42,
-          "total": 44,
+          "pass": 43,
+          "total": 45,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1842,8 +1842,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 42,
-          "total": 44,
+          "pass": 43,
+          "total": 45,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1860,8 +1860,8 @@
           ]
         },
         "twig": {
-          "pass": 42,
-          "total": 44,
+          "pass": 43,
+          "total": 45,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1878,8 +1878,8 @@
           ]
         },
         "xslate": {
-          "pass": 42,
-          "total": 44,
+          "pass": 43,
+          "total": 45,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -3905,15 +3905,15 @@
       }
     },
     "literal:string": {
-      "total": 142,
+      "total": 143,
       "cells": {
         "hono": {
-          "pass": 142,
-          "total": 142
+          "pass": 143,
+          "total": 143
         },
         "blade": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3924,8 +3924,8 @@
           ]
         },
         "erb": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3936,8 +3936,8 @@
           ]
         },
         "go-template": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3948,8 +3948,8 @@
           ]
         },
         "jinja": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3960,8 +3960,8 @@
           ]
         },
         "minijinja": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3972,8 +3972,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3984,8 +3984,8 @@
           ]
         },
         "twig": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3996,8 +3996,8 @@
           ]
         },
         "xslate": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -526,11 +526,11 @@
       }
     },
     "call": {
-      "total": 162,
+      "total": 163,
       "cells": {
         "hono": {
-          "pass": 161,
-          "total": 162,
+          "pass": 162,
+          "total": 163,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -541,8 +541,8 @@
           ]
         },
         "blade": {
-          "pass": 157,
-          "total": 162,
+          "pass": 158,
+          "total": 163,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -577,8 +577,8 @@
           ]
         },
         "erb": {
-          "pass": 158,
-          "total": 162,
+          "pass": 159,
+          "total": 163,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -607,8 +607,8 @@
           ]
         },
         "go-template": {
-          "pass": 157,
-          "total": 162,
+          "pass": 158,
+          "total": 163,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -643,8 +643,8 @@
           ]
         },
         "jinja": {
-          "pass": 157,
-          "total": 162,
+          "pass": 158,
+          "total": 163,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -679,8 +679,8 @@
           ]
         },
         "minijinja": {
-          "pass": 157,
-          "total": 162,
+          "pass": 158,
+          "total": 163,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -715,8 +715,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 158,
-          "total": 162,
+          "pass": 159,
+          "total": 163,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -745,8 +745,8 @@
           ]
         },
         "twig": {
-          "pass": 157,
-          "total": 162,
+          "pass": 158,
+          "total": 163,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -781,8 +781,8 @@
           ]
         },
         "xslate": {
-          "pass": 157,
-          "total": 162,
+          "pass": 158,
+          "total": 163,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -860,11 +860,11 @@
       }
     },
     "identifier": {
-      "total": 242,
+      "total": 243,
       "cells": {
         "hono": {
-          "pass": 241,
-          "total": 242,
+          "pass": 242,
+          "total": 243,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -875,8 +875,8 @@
           ]
         },
         "blade": {
-          "pass": 236,
-          "total": 242,
+          "pass": 237,
+          "total": 243,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -917,8 +917,8 @@
           ]
         },
         "erb": {
-          "pass": 237,
-          "total": 242,
+          "pass": 238,
+          "total": 243,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -953,8 +953,8 @@
           ]
         },
         "go-template": {
-          "pass": 236,
-          "total": 242,
+          "pass": 237,
+          "total": 243,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -995,8 +995,8 @@
           ]
         },
         "jinja": {
-          "pass": 236,
-          "total": 242,
+          "pass": 237,
+          "total": 243,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1037,8 +1037,8 @@
           ]
         },
         "minijinja": {
-          "pass": 236,
-          "total": 242,
+          "pass": 237,
+          "total": 243,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1079,8 +1079,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 237,
-          "total": 242,
+          "pass": 238,
+          "total": 243,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1115,8 +1115,8 @@
           ]
         },
         "twig": {
-          "pass": 236,
-          "total": 242,
+          "pass": 237,
+          "total": 243,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1157,8 +1157,8 @@
           ]
         },
         "xslate": {
-          "pass": 236,
-          "total": 242,
+          "pass": 237,
+          "total": 243,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1242,15 +1242,15 @@
       }
     },
     "literal": {
-      "total": 200,
+      "total": 201,
       "cells": {
         "hono": {
-          "pass": 200,
-          "total": 200
+          "pass": 201,
+          "total": 201
         },
         "blade": {
-          "pass": 199,
-          "total": 200,
+          "pass": 200,
+          "total": 201,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1261,8 +1261,8 @@
           ]
         },
         "erb": {
-          "pass": 199,
-          "total": 200,
+          "pass": 200,
+          "total": 201,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1273,8 +1273,8 @@
           ]
         },
         "go-template": {
-          "pass": 199,
-          "total": 200,
+          "pass": 200,
+          "total": 201,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1285,8 +1285,8 @@
           ]
         },
         "jinja": {
-          "pass": 199,
-          "total": 200,
+          "pass": 200,
+          "total": 201,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1297,8 +1297,8 @@
           ]
         },
         "minijinja": {
-          "pass": 199,
-          "total": 200,
+          "pass": 200,
+          "total": 201,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1309,8 +1309,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 199,
-          "total": 200,
+          "pass": 200,
+          "total": 201,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1321,8 +1321,8 @@
           ]
         },
         "twig": {
-          "pass": 199,
-          "total": 200,
+          "pass": 200,
+          "total": 201,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1333,8 +1333,8 @@
           ]
         },
         "xslate": {
-          "pass": 199,
-          "total": 200,
+          "pass": 200,
+          "total": 201,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3905,15 +3905,15 @@
       }
     },
     "literal:string": {
-      "total": 143,
+      "total": 144,
       "cells": {
         "hono": {
-          "pass": 143,
-          "total": 143
+          "pass": 144,
+          "total": 144
         },
         "blade": {
-          "pass": 142,
-          "total": 143,
+          "pass": 143,
+          "total": 144,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3924,8 +3924,8 @@
           ]
         },
         "erb": {
-          "pass": 142,
-          "total": 143,
+          "pass": 143,
+          "total": 144,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3936,8 +3936,8 @@
           ]
         },
         "go-template": {
-          "pass": 142,
-          "total": 143,
+          "pass": 143,
+          "total": 144,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3948,8 +3948,8 @@
           ]
         },
         "jinja": {
-          "pass": 142,
-          "total": 143,
+          "pass": 143,
+          "total": 144,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3960,8 +3960,8 @@
           ]
         },
         "minijinja": {
-          "pass": 142,
-          "total": 143,
+          "pass": 143,
+          "total": 144,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3972,8 +3972,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 142,
-          "total": 143,
+          "pass": 143,
+          "total": 144,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3984,8 +3984,8 @@
           ]
         },
         "twig": {
-          "pass": 142,
-          "total": 143,
+          "pass": 143,
+          "total": 144,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3996,8 +3996,8 @@
           ]
         },
         "xslate": {
-          "pass": 142,
-          "total": 143,
+          "pass": 143,
+          "total": 144,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",


### PR DESCRIPTION
## What

The last capability stage of #2324, implementing the design settled in #2334 (body + review comments): **CLDR-ish data has exactly one owner — the compiler at build time — and backends know shapes, never locale values.** No locale JSON, no per-language codegen, no drift gates.

```tsx
function PostMeta({ createdAt }: { createdAt: Date }) {
  return <time>{createdAt.toLocaleDateString('en-US', { dateStyle: 'long', timeZone: 'UTC' })}</time>
  // → "March 5, 2024" — identical on Go, Ruby, Perl, PHP, Python, Rust, Hono, and the browser
}
```

## How

- **`formatDate` / `format_date` canonical arity is now 4**: an explicit flat 38-slot `names` table (`[0..11]` wide months, `[12..23]` abbreviated, `[24..30]` wide weekdays Sunday-first, `[31..37]` abbreviated). New tokens `MMMM`/`MMM` and `dddd`/`ddd`; weekday = epoch-days mod 7 anchored on 1970-01-01 = Thursday (floor-safe pre-1970). A name token over a missing/short table renders `''` — total, byte-identical everywhere. Six backend ports (~25 lines each), pinned by **9 new golden vectors** (387 total: epoch-Thursday, pre-1970-Sunday, offset-shifted weekday, multi-byte 月 names, empty/short tables) with **zero divergence declarations**.
- **The sugar admits ANY literal options bag** per the fidelity rule (*reproduce the user's exact ECMA-402 call or decline loudly — never approximate*). The compiler probes the bag with its own `Intl.DateTimeFormat.formatToParts`: en-US `dateStyle:'long'` → `MMMM D, YYYY` + names; `'full'` → `dddd, MMMM D, YYYY`; ja-JP `long` → `YYYY年M月D日` numeric — **the probe discovers no names are needed and ships an empty table**. Era / dayPeriod / 2-digit-year / narrow forms / non-literal option values keep BF021.
- **The names table rides the compiled artifact as an ordinary array-literal helper argument** — proven zero-machinery: every adapter's existing `arr` lowering renders it (Go: `(bf_arr "January" …)`), and it composes with the union-locale ternary fold from #2331 for free. Client-JS rewrite carries the table (omitted when empty); CSR-harness mirror updated.
- **Conformance fixture `date-tolocale-datestyle`** (change-time coupling): en-US long + full (weekday token) + ja-JP long (numeric contrast) in one component; oracle points pin the late-day UTC weekday and leap-day month names. Hono — evaluating the *real* ECMA-402 call against the same build-machine ICU the pattern+table were frozen from — must agree byte-for-byte, and does: reference parity IS the fidelity contract.
- `spec/template-helpers.md` `format_date` entry updated (arity, tokens, table layout, type-only rule).

## Verification

- client 526 / jsx 2598 / adapter-tests 1341 (CSR incl.) / Hono 942 / compat 80 — all 0 fail
- 6 backend vector harnesses: 387/387 each (Go under go1.25; Rust `-D warnings` clean)
- New unit coverage: options-bag probe table (long/medium/full/short/era/month-only/field combos), ja-JP numeric discovery, client rewrite with table, arity-4 normalization of plain `formatDate` calls
- `bun run lint` clean; compat + support-matrix locks regenerated (261 fixtures; `date-tolocale-datestyle` absent from the divergence table = parity on all 9 adapters)
- 8-adapter real-backend conformance running locally; CI runs the same suites
- Changeset: `@barefootjs/client` + `@barefootjs/jsx` minor, six runtime carriers patch

Closes #2334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dBKFhtumbPwjNZaU3LRpy

---
_Generated by [Claude Code](https://claude.ai/code/session_015dBKFhtumbPwjNZaU3LRpy)_