### PR TITLE
Go adapter: unify conditional lowering on pipeline bf_ternary (#2335)

### DIFF
--- a/.changeset/go-bf-ternary-conditional-lowering.md
+++ b/.changeset/go-bf-ternary-conditional-lowering.md
@@ -1,0 +1,5 @@
+---
+'@barefootjs/go-template': patch
+---
+
+Go adapter: unify value-position conditional lowering on the pipeline `bf_ternary` helper (#2335). The ParsedExpr `conditional()` emitter, boolean sub-conditions, and attribute-value ternaries now all lower to `(bf_ternary <test> <a> <b>)` instead of `{{if}}…{{end}}` action fragments, deleting the fragment special-casing. This also fixes a correctness bug: a ternary used as a boolean sub-condition (`(x ? y : z) && w`) previously returned only its `test`, silently discarding both branches; it now lowers faithfully. The ternary test is coerced to a real Go bool via the new `bf_truthy` runtime helper (JS `Boolean(x)` semantics) when it isn't already a comparison/negation.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -61,6 +61,7 @@ func FuncMap() template.FuncMap {
 		"bf_pad_end":     PadEnd,
 		"bf_string":      String,
 		"bf_ternary":     Ternary,
+		"bf_truthy":      Truthy,
 
 		// URL query builder (#1897 PostList href helpers): conditional
 		// (include, key, value) triples → "base?k=v&…", mirroring a
@@ -1973,10 +1974,17 @@ func FilterTruthy(items any) []any {
 }
 
 // Truthy is the exported form of isTruthy — JavaScript's `Boolean(x)`
-// semantics — for generated `NewXxxProps` code lowering a conditional
-// inline-object spread condition on an `interface{}` prop (whose runtime
-// value may be a string, number, bool, …). Keeps the spread bag's
-// inclusion test faithful to JS rather than string-biased (#1752).
+// semantics. Two callers:
+//   - generated `NewXxxProps` code lowering a conditional inline-object
+//     spread condition on an `interface{}` prop (whose runtime value may be
+//     a string, number, bool, …), keeping the spread bag's inclusion test
+//     faithful to JS rather than string-biased (#1752); and
+//   - the `bf_truthy` template FuncMap entry (#2335), which coerces a
+//     `bf_ternary` test to a real bool when it isn't already a comparison /
+//     negation (`Ternary`'s `cond` parameter is typed `bool`, unlike
+//     `{{if}}`'s built-in truthiness). Uniform across string/number/bool/nil,
+//     so a `bf_ternary` test on any prop type can't hit a `bool`-vs-`string`
+//     comparison error the way a string-only `ne <value> ""` would.
 func Truthy(v any) bool { return isTruthy(v) }
 
 // isTruthy mirrors JavaScript's `Boolean(x)` for the value shapes the

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -927,7 +927,7 @@ func TestFuncMap(t *testing.T) {
 		"bf_add", "bf_sub", "bf_mul", "bf_div", "bf_mod", "bf_neg",
 		"bf_lower", "bf_upper", "bf_trim", "bf_contains", "bf_join",
 		"bf_len", "bf_at", "bf_includes", "bf_first", "bf_last",
-		"bf_arr", "bf_filter_truthy",
+		"bf_arr", "bf_filter_truthy", "bf_ternary", "bf_truthy",
 		"bf_every", "bf_some", "bf_filter", "bf_find", "bf_find_index", "bf_sort",
 		"bf_sort_eval", "bf_reduce_eval", "bf_env",
 		"bf_filter_eval", "bf_every_eval", "bf_some_eval",

--- a/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
+++ b/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
@@ -133,10 +133,11 @@ export function P() {
 `
     const { template } = generate(src)
     expect(template).not.toContain('.SortClass')
-    // `.Params.Sort` is interface{} (a map value), so `eq` coerces it via
-    // `bf_string` before comparing to the string literal.
+    // The inlined ternary lowers to the pipeline `bf_ternary` (#2335), not an
+    // `{{if}}…{{end}}` fragment. `.Params.Sort` is interface{} (a map value),
+    // so `eq` coerces it via `bf_string` before comparing to the string literal.
     expect(template).toContain(
-      'class="{{if eq (bf_string .Params.Sort) "date"}}sort on{{else}}sort{{end}}"',
+      'class="{{(bf_ternary (eq (bf_string .Params.Sort) "date") "sort on" "sort")}}"',
     )
   })
 
@@ -156,8 +157,9 @@ export function P(props: { tags: string[] }) {
 `
     const { template } = generate(src)
     expect(template).not.toContain('.TagClass')
-    // params() is a root memo (→ $.Params) and t is the loop var (→ .)
-    expect(template).toContain('{{if eq $.Params.Tag .}}tag on{{else}}tag{{end}}')
+    // params() is a root memo (→ $.Params) and t is the loop var (→ .); the
+    // inlined ternary lowers to the pipeline `bf_ternary` (#2335).
+    expect(template).toContain('{{(bf_ternary (eq $.Params.Tag .) "tag on" "tag")}}')
   })
 
   test('a helper that delegates to a non-URL-builder local helper is not inlined', () => {
@@ -192,12 +194,15 @@ export function P(props: { a?: string; b?: string }) {
 `
     const { template } = generate(src)
     expect(template).not.toContain('.Cls')
-    // `===` must stay the outer operation (`eq .Sig …`). Without parenthesizing
-    // the arg, `sig() === props.a ?? props.b` would bind as
-    // `(sig() === props.a) ?? props.b` → an outer `{{if or …}}`. This matches
-    // what a direct `sig() === (props.a ?? props.b)` lowers to.
-    expect(template).toContain('{{if eq .Sig')
-    expect(template).not.toContain('{{if or')
+    // The inlined ternary lowers to the pipeline `bf_ternary` (#2335), so the
+    // test sits in `bf_ternary`'s first argument. `===` must stay the outer
+    // operation there (`eq .Sig …`). Without parenthesizing the arg,
+    // `sig() === props.a ?? props.b` would bind as
+    // `(sig() === props.a) ?? props.b` → a `bf_nullish`/`or`-rooted test. This
+    // matches what a direct `sig() === (props.a ?? props.b)` lowers to.
+    expect(template).toContain('(bf_ternary (eq .Sig')
+    expect(template).not.toContain('(bf_ternary (bf_nullish')
+    expect(template).not.toContain('(bf_ternary (or')
   })
 
   // The splicer is scope-blind, so a helper whose body contains a nested

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -299,16 +299,21 @@ export function Label() {
 // template literals off their parsed kind. That is correct because of a
 // load-bearing invariant: a template literal is the *only* expression form that
 // interleaves author literal text with `{{...}}` actions, so every OTHER
-// fragment producer (ternary, find().prop, filter().length, …) emits a pure
-// action block that begins with `{{`. These tests pin that invariant: if a
-// future emitter prepends literal text to an action block, its output stops
-// starting with `{{`, this fails, and the fix is to give that shape a parsed
-// kind `isTemplateFragment` can detect (as template literals are handled) —
-// NOT to fall back to a fragile `{{` substring scan.
+// fragment producer (find().prop, filter().length, …) emits a pure action block
+// that begins with `{{`. These tests pin that invariant: if a future emitter
+// prepends literal text to an action block, its output stops starting with
+// `{{`, this fails, and the fix is to give that shape a parsed kind
+// `isTemplateFragment` can detect (as template literals are handled) — NOT to
+// fall back to a fragile `{{` substring scan.
+//
+// Ternary is deliberately NOT in this list: as of #2335 a value-position
+// ternary lowers to the pipeline `(bf_ternary …)`, NOT a `{{if}}…{{end}}`
+// fragment, so it is wrapped by the normal expression path like any other
+// pipeline — it is no longer a self-contained action block. See the
+// `bf_ternary value-position lowering` describe below.
 describe('GoTemplateAdapter - template-fragment invariant (#1937)', () => {
   const adapter = new GoTemplateAdapter()
   const blockProducers: [string, string][] = [
-    ['ternary', "flag ? 'a' : 'b'"],
     ['find().prop', 'items.find(i => i.active).name'],
     ['findLast().prop', 'items.findLast(i => i.active).name'],
     ['filter().length', 'items.filter(i => i.active).length'],
@@ -319,6 +324,90 @@ describe('GoTemplateAdapter - template-fragment invariant (#1937)', () => {
       expect(out.startsWith('{{')).toBe(true)
     })
   }
+})
+
+// #2335: Go `text/template` has no expression-level conditional, so every
+// VALUE-position ternary lowers to the pipeline `(bf_ternary <test> <a> <b>)`
+// runtime helper — the SAME form helper-call args already used (#2331) — rather
+// than a text-position `{{if}}…{{end}}` action fragment. `Ternary`'s `cond`
+// parameter is a strict `bool` (not `{{if}}`-style truthiness), so a
+// non-comparison test is wrapped `bf_truthy <value>` (JS `Boolean(x)`).
+describe('GoTemplateAdapter - bf_ternary value-position lowering (#2335)', () => {
+  const adapter = new GoTemplateAdapter()
+  const render = (expr: string) => adapter.renderExpression({ expr } as IRExpression)
+
+  test('a bare-value (non-comparison) test is truthiness-wrapped with bf_truthy', () => {
+    // `.Flag`'s Go type is unknown at emit time — `bf_truthy` coerces string /
+    // number / bool / nil uniformly, where `{{if}}` truthiness used to.
+    expect(render("flag ? 'a' : 'b'")).toBe('{{(bf_ternary (bf_truthy .Flag) "a" "b")}}')
+  })
+
+  test('a comparison test is already a bool — no bf_truthy wrap', () => {
+    expect(render("n >= 10 ? 'big' : 'small'")).toBe('{{(bf_ternary (ge .N 10) "big" "small")}}')
+  })
+
+  test('a negation test is already a bool — no bf_truthy wrap', () => {
+    expect(render("!open ? 'x' : 'y'")).toBe('{{(bf_ternary (not .Open) "x" "y")}}')
+  })
+
+  test('a right-folded chain nests as (bf_ternary … (bf_ternary …))', () => {
+    expect(render("a ? 'x' : b ? 'y' : 'z'")).toBe(
+      '{{(bf_ternary (bf_truthy .A) "x" (bf_ternary (bf_truthy .B) "y" "z"))}}',
+    )
+  })
+
+  test('nested inside a template literal, it is wrapped once (not a raw fragment)', () => {
+    // The ternary is no longer `{{`-leading, so the template-literal emitter
+    // wraps it in a single `{{…}}` alongside the literal text.
+    expect(render("`btn ${active ? 'on' : 'off'}`")).toBe(
+      'btn {{(bf_ternary (bf_truthy .Active) "on" "off")}}',
+    )
+  })
+
+  test('emits no {{if}} action fragment for a value-position ternary', () => {
+    expect(render("flag ? 'a' : 'b'")).not.toContain('{{if')
+  })
+})
+
+// #2335 item 2 (correctness): a ternary used as a boolean CONDITION used to
+// return only its lowered `test`, silently discarding both branches. It now
+// lowers faithfully to `(bf_ternary …)`, truthiness-checked by the enclosing
+// `{{if}}`. Rendered-output parity is pinned by the `condition-position-ternary`
+// conformance fixture; this pins the template SOURCE shape.
+describe('GoTemplateAdapter - bf_ternary condition-position lowering (#2335)', () => {
+  test('a ternary sub-condition keeps both branches inside the {{if}} test', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function P() {
+  const [mode, setMode] = createSignal('a')
+  const [show, setShow] = createSignal(true)
+  const [hide, setHide] = createSignal(false)
+  return <div>{(mode() === 'a' ? show() : hide()) ? <span>Y</span> : <span>N</span>}</div>
+}
+`)
+    expect(template).toContain('{{if (bf_ternary (eq (bf_string .Mode) "a") .Show .Hide)}}')
+    // The old bug collapsed the condition to just the test — assert we no
+    // longer emit the branch-discarding `{{if (eq (bf_string .Mode) "a")}}`.
+    expect(template).not.toContain('{{if (eq (bf_string .Mode) "a")}}')
+  })
+})
+
+// #2335 item 3 (cleanup): an attribute-value ternary reached through the
+// ParsedExpr `conditional` emitter lowers to a single `{{bf_ternary …}}` action
+// inside the attribute string, not an inline `{{if}}…{{end}}` fragment.
+describe('GoTemplateAdapter - bf_ternary attribute-position lowering (#2335)', () => {
+  test('a numeric-branch attr ternary emits name="{{bf_ternary …}}"', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function P() {
+  const [active, setActive] = createSignal(false)
+  return <button data-step={active() ? 2 : 1}>x</button>
+}
+`)
+    expect(template).toContain('data-step="{{(bf_ternary (bf_truthy .Active) 2 1)}}"')
+  })
 })
 
 describe('GoTemplateAdapter - Adapter Specific', () => {

--- a/packages/adapter-go-template/src/adapter/expr/url-builder.ts
+++ b/packages/adapter-go-template/src/adapter/expr/url-builder.ts
@@ -66,6 +66,69 @@ function lowerUrlGuard(ctx: GoEmitContext, g: ParsedExpr): string {
 }
 
 /**
+ * Lower a `conditional` (ternary) ParsedExpr to the pipeline-position
+ * `(bf_ternary <test> <consequent> <alternate>)` form (#2335). Go
+ * `text/template` is the only backend without an expression-level
+ * conditional, so a ternary sitting in VALUE position — a helper-call arg, a
+ * template-literal interpolation, an attribute value, or a boolean
+ * sub-condition — cannot be an `{{if}}…{{end}}` action fragment (a parse error
+ * inside a pipeline, and a silent branch-discard in condition position). This
+ * is the single lowering every such position shares; each caller passes the
+ * ternary's three child nodes directly (the ParsedExpr emitter hands them over
+ * unwrapped).
+ *
+ *   - branches are quoted VALUES, recursing so a right-folded chain
+ *     (`a ? x : b ? y : z`) nests as `(bf_ternary … (bf_ternary …))`.
+ *   - the test is coerced to a real Go `bool` (see `lowerTernaryTest`).
+ *
+ * NOT for the text-position `IRConditional` (`renderConditional`), whose
+ * branches are arbitrary markup, not values.
+ */
+export function lowerTernary(
+  ctx: GoEmitContext,
+  test: ParsedExpr,
+  consequent: ParsedExpr,
+  alternate: ParsedExpr,
+): string {
+  const t = lowerTernaryTest(ctx, test)
+  return `(bf_ternary ${t} ${lowerTernaryOperand(ctx, consequent)} ${lowerTernaryOperand(ctx, alternate)})`
+}
+
+/**
+ * A ternary branch in value position: a nested ternary recurses to another
+ * `bf_ternary`; anything else lowers to its Go value (parenthesised when
+ * multi-token so it stays one argument). String branches become quoted,
+ * html/template-escaped values — not the bare unquoted text the old `{{if}}`
+ * fragment path emitted — which is exactly right for the value positions this
+ * is reached for.
+ */
+function lowerTernaryOperand(ctx: GoEmitContext, n: ParsedExpr): string {
+  if (n.kind === 'conditional') {
+    return lowerTernary(ctx, n.test, n.consequent, n.alternate)
+  }
+  return wrapIfMultiToken(ctx.convertExpressionToGo(stringifyParsedExpr(n), undefined, n))
+}
+
+/**
+ * Lower a ternary TEST to a Go bool. `Ternary`'s first parameter is typed
+ * `bool` and is NOT truthiness-coerced the way `{{if}}` is, so a non-bool test
+ * (`x` where x is a string/number, `a && b`, …) fed in raw would fail the
+ * runtime type assertion. A comparison / `!x` / bool literal already renders
+ * to a bool via the generic emitter and passes through; every other shape is
+ * wrapped `bf_truthy <value>`, which mirrors JS `Boolean(x)` (the runtime's
+ * `isTruthy`) across string / number / bool / nil uniformly — the general
+ * counterpart of `lowerUrlGuard`'s string-only `ne <value> ""`.
+ */
+function lowerTernaryTest(ctx: GoEmitContext, test: ParsedExpr): string {
+  const go = wrapIfMultiToken(ctx.convertExpressionToGo(stringifyParsedExpr(test), undefined, test))
+  const isBoolShape =
+    (test.kind === 'binary' && BOOL_COMPARISON_OPS.has(test.op)) ||
+    (test.kind === 'unary' && test.op === '!') ||
+    (test.kind === 'literal' && test.literalType === 'boolean')
+  return isBoolShape ? go : `(bf_truthy ${go})`
+}
+
+/**
  * Lower a helper call to a Go template expression, or null when no registered
  * plugin recognises it (→ the generic lowering). Matchers — including the
  * built-in `queryHref` plugin (#2042) — are bound to the component metadata at
@@ -114,19 +177,17 @@ function renderLoweringNode(ctx: GoEmitContext, node: LoweringNode): string | nu
   const lowerExpr = (n: ParsedExpr): string =>
     ctx.convertExpressionToGo(stringifyParsedExpr(n), undefined, n)
   // A `conditional` in ARGUMENT position cannot go through the generic
-  // emitter: its `conditional` method renders an `{{if}}…{{end}}` action
-  // fragment (text position only), which is a parse error inside a
-  // pipeline ("unexpected { in parenthesized pipeline"). Render it as the
-  // pipeline-position `bf_ternary` runtime helper instead, recursing so a
-  // right-folded chain (the #2324 union stage's locale→pattern table)
-  // nests as `(bf_ternary <cond> <a> (bf_ternary …))`.
-  const lowerArg = (n: ParsedExpr): string => {
-    if (n.kind === 'conditional') {
-      const test = wrapIfMultiToken(lowerExpr(n.test))
-      return `(bf_ternary ${test} ${lowerArg(n.consequent)} ${lowerArg(n.alternate)})`
-    }
-    return wrapIfMultiToken(lowerExpr(n))
-  }
+  // emitter: its `conditional` method would render an `{{if}}…{{end}}` action
+  // fragment (a parse error inside a pipeline, "unexpected { in parenthesized
+  // pipeline"). Route it through the shared `bf_ternary` lowering — the same
+  // pipeline-position form the `conditional()` emitter and the condition-
+  // expression emitter now use (#2335) — so a right-folded chain (the #2324
+  // union stage's locale→pattern table) nests as
+  // `(bf_ternary <cond> <a> (bf_ternary …))`.
+  const lowerArg = (n: ParsedExpr): string =>
+    n.kind === 'conditional'
+      ? lowerTernary(ctx, n.test, n.consequent, n.alternate)
+      : wrapIfMultiToken(lowerExpr(n))
   if (node.kind === 'helper-call') {
     const args = node.args.map(a => lowerArg(a))
     return [helper, ...args].join(' ')

--- a/packages/adapter-go-template/src/adapter/expr/url-builder.ts
+++ b/packages/adapter-go-template/src/adapter/expr/url-builder.ts
@@ -176,14 +176,14 @@ function renderLoweringNode(ctx: GoEmitContext, node: LoweringNode): string | nu
   if (!helper) return null
   const lowerExpr = (n: ParsedExpr): string =>
     ctx.convertExpressionToGo(stringifyParsedExpr(n), undefined, n)
-  // A `conditional` in ARGUMENT position cannot go through the generic
-  // emitter: its `conditional` method would render an `{{if}}…{{end}}` action
-  // fragment (a parse error inside a pipeline, "unexpected { in parenthesized
-  // pipeline"). Route it through the shared `bf_ternary` lowering — the same
-  // pipeline-position form the `conditional()` emitter and the condition-
-  // expression emitter now use (#2335) — so a right-folded chain (the #2324
-  // union stage's locale→pattern table) nests as
-  // `(bf_ternary <cond> <a> (bf_ternary …))`.
+  // A `conditional` in ARGUMENT position lowers to the pipeline-position
+  // `(bf_ternary …)` form via the shared `lowerTernary` (#2335) — the same
+  // form the ParsedExpr `conditional()` emitter and the condition-expression
+  // emitter produce. Routing it here explicitly (rather than leaning on the
+  // generic `lowerExpr`, whose `conditional()` dispatch now reaches the very
+  // same helper) keeps the arg lowering self-contained and its intent local;
+  // `lowerTernary` itself right-folds a nested chain (the #2324 union stage's
+  // locale→pattern table) into `(bf_ternary <cond> <a> (bf_ternary …))`.
   const lowerArg = (n: ParsedExpr): string =>
     n.kind === 'conditional'
       ? lowerTernary(ctx, n.test, n.consequent, n.alternate)

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -122,7 +122,7 @@ import { analyzeBakeableStaticChildLoop, scalarToGoLiteral, type BakedStaticChil
 import { analyzeBakeableStaticElementLoop } from "./analysis/static-element-loop-bake.ts"
 import type { GoEmitContext } from "./emit-context.ts"
 import { inlineLocalHelperCall } from "./expr/helper-inline.ts"
-import { lowerRegisteredCall } from "./expr/url-builder.ts"
+import { lowerRegisteredCall, lowerTernary } from "./expr/url-builder.ts"
 import {
   convertInitialValue,
   jsLiteralToGo,
@@ -3784,21 +3784,27 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       : null
   }
 
-  // JSX-level ternaries (`{expr ? a : b}`) are handled at the IR level as
-  // IRConditional (via convertConditionToGo → renderConditionExpr). This method
-  // is only reached for ternaries nested inside other ParsedExpr trees (e.g.
-  // template-literal interpolation), where the test is always a simple pipeline
-  // expression (runtime helpers, not template blocks).
+  // JSX-level ternaries (`{expr ? a : b}`) in TEXT position are handled at the
+  // IR level as IRConditional (via convertConditionToGo → renderConditionExpr →
+  // renderConditional). This method is only reached for ternaries nested inside
+  // other ParsedExpr trees in VALUE position (e.g. template-literal
+  // interpolation, an attribute value), where both branches are values.
+  //
+  // #2335: emit the pipeline-position `(bf_ternary …)` form — the same lowering
+  // helper-call args (`lowerArg`) and boolean sub-conditions
+  // (`renderConditionExpr`) now share — instead of a text-position
+  // `{{if}}…{{end}}` action fragment. Callers wrap the returned pipeline in
+  // `{{…}}` via the normal expression path (it no longer `{{`-leads, so
+  // `isTemplateFragment` correctly declines it). `emit` is unused: the shared
+  // lowering re-derives each child's Go form (branches as quoted values, the
+  // test coerced to a real bool) rather than the generic emit.
   conditional(
     test: ParsedExpr,
     consequent: ParsedExpr,
     alternate: ParsedExpr,
-    emit: (e: ParsedExpr) => string,
+    _emit: (e: ParsedExpr) => string,
   ): string {
-    const t = emit(test)
-    const c = this.renderConditionalBranch(consequent)
-    const a = this.renderConditionalBranch(alternate)
-    return `{{if ${t}}}${c}{{else}}${a}{{end}}`
+    return lowerTernary(this.emitCtx, test, consequent, alternate)
   }
 
   templateLiteral(parts: TemplatePart[], emit: (e: ParsedExpr) => string): string {
@@ -4763,24 +4769,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
-   * Render a branch of a conditional expression. String literals render as bare
-   * text (no quotes); nested conditionals render as complete `{{if}}…{{end}}`
-   * blocks; everything else is wrapped in `{{...}}`.
-   */
-  private renderConditionalBranch(expr: ParsedExpr): string {
-    if (expr.kind === 'literal' && expr.literalType === 'string') {
-      return String(expr.value)
-    }
-    if (expr.kind === 'conditional') {
-      const test = this.renderParsedExpr(expr.test)
-      const consequent = this.renderConditionalBranch(expr.consequent)
-      const alternate = this.renderConditionalBranch(expr.alternate)
-      return `{{if ${test}}}${consequent}{{else}}${alternate}{{end}}`
-    }
-    return `{{${this.renderParsedExpr(expr)}}}`
-  }
-
-  /**
    * Whether a ParsedExpr renders to a Go template function call (`len .X`,
    * `bf_add .A .B`) that needs parentheses when used as an argument to a
    * comparison operator (eq, gt, lt, …).
@@ -5369,8 +5357,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
 
       case 'conditional': {
-        const test = this.renderConditionExpr(expr.test)
-        return test
+        // #2335: a ternary used as (part of) a boolean sub-condition —
+        // `(x ? y : z) && w`, `!(a ? b : c)` — must lower FAITHFULLY. The old
+        // code returned only the lowered `test`, silently discarding both
+        // branches (a `(x ? y : z)` collapsed to `x`) — not refused, silently
+        // wrong. Emit the pipeline-position `(bf_ternary <test> <y> <z>)`
+        // value; the enclosing condition (`{{if}}`, `and`/`or`, `not`)
+        // truthiness-checks its result, exactly as it would the JS ternary's.
+        return plain(lowerTernary(this.emitCtx, expr.test, expr.consequent, expr.alternate))
       }
 
       case 'template-literal':
@@ -6111,8 +6105,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           const body = `${name}="{{${valueExpr}}}"`
           return `${preamble}{{if ${goCond}}}${body}{{end}}`
         }
-        // Inline Go template syntax with embedded `{{...}}` actions.
-        return `${name}="${this.renderParsedExpr(parsed)}"`
+        // #2335: the ternary lowers to the pipeline-position `(bf_ternary …)`
+        // value (no longer a `{{if}}…{{end}}` fragment), so wrap it in a single
+        // `{{…}}` action inside the attribute string — `name="{{bf_ternary …}}"`.
+        return `${name}="{{${this.renderParsedExpr(parsed)}}}"`
       }
       if (parsed.kind === 'template-literal') {
         // Inline Go template syntax with embedded `{{...}}` actions.

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1188,6 +1188,22 @@
         "text"
       ]
     },
+    "condition-position-ternary": {
+      "kinds": [
+        "call",
+        "conditional",
+        "identifier",
+        "literal"
+      ],
+      "axes": [
+        "literal:boolean",
+        "literal:string"
+      ],
+      "contexts": [
+        "condition",
+        "text"
+      ]
+    },
     "conditional-class": {
       "kinds": [
         "literal"
@@ -4160,11 +4176,11 @@
     "array-method": 62,
     "arrow": 55,
     "binary": 67,
-    "call": 161,
-    "conditional": 18,
-    "identifier": 241,
+    "call": 162,
+    "conditional": 19,
+    "identifier": 242,
     "index-access": 12,
-    "literal": 199,
+    "literal": 200,
     "logical": 41,
     "member": 121,
     "object-literal": 44,
@@ -4207,10 +4223,10 @@
     "binary:===": 30,
     "binary:>": 11,
     "binary:>=": 1,
-    "literal:boolean": 37,
+    "literal:boolean": 38,
     "literal:null": 22,
     "literal:number": 86,
-    "literal:string": 142,
+    "literal:string": 143,
     "logical:&&": 7,
     "logical:??": 37,
     "logical:||": 12,

--- a/packages/adapter-tests/fixtures/condition-position-ternary.ts
+++ b/packages/adapter-tests/fixtures/condition-position-ternary.ts
@@ -1,0 +1,32 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A ternary used as a boolean CONDITION (`(x ? y : z) ? … : …`), not as a
+ * value. Pins the #2335 correctness fix: the Go adapter's condition-expression
+ * lowering used to return only the ternary's `test`, silently discarding both
+ * branches — a `(flag ? yes : no)` sub-condition collapsed to `flag`. It now
+ * lowers faithfully via the pipeline `bf_ternary`, truthiness-checked by the
+ * enclosing `{{if}}`.
+ *
+ * The seeds are chosen so the bug and the fix diverge visibly: `flag` is
+ * truthy but selects `yes` which is FALSY, so the correct condition is false
+ * (render "OFF"). The old test-only lowering would have seen `flag` (truthy)
+ * and wrongly rendered "ON".
+ */
+export const fixture = createFixture({
+  id: 'condition-position-ternary',
+  description: 'Ternary as a boolean sub-condition lowers faithfully (#2335)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function ConditionPositionTernary() {
+  const [flag, setFlag] = createSignal(true)
+  const [yes, setYes] = createSignal(false)
+  const [no, setNo] = createSignal(true)
+  return <div>{(flag() ? yes() : no()) ? 'ON' : 'OFF'}</div>
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf-cond-start:s0-->OFF<!--bf-cond-end:s0--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -106,6 +106,7 @@ import { fixture as nestedElements } from './nested-elements'
 // Priority 3: Conditionals
 import { fixture as ternary } from './ternary'
 import { fixture as nestedTernary } from './nested-ternary'
+import { fixture as conditionPositionTernary } from './condition-position-ternary'
 import { fixture as topLevelTernary } from './top-level-ternary'
 import { fixture as logicalAnd } from './logical-and'
 import { fixture as conditionalClass } from './conditional-class'
@@ -458,6 +459,7 @@ export const jsxFixtures: JSXFixture[] = [
   // Priority 3: Conditionals
   ternary,
   nestedTernary,
+  conditionPositionTernary,
   topLevelTernary,
   logicalAnd,
   conditionalClass,

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 260,
+    "totalFixtures": 261,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -526,11 +526,11 @@
       }
     },
     "call": {
-      "total": 161,
+      "total": 162,
       "cells": {
         "hono": {
-          "pass": 160,
-          "total": 161,
+          "pass": 161,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -541,8 +541,8 @@
           ]
         },
         "blade": {
-          "pass": 156,
-          "total": 161,
+          "pass": 157,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -577,8 +577,8 @@
           ]
         },
         "erb": {
-          "pass": 157,
-          "total": 161,
+          "pass": 158,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -607,8 +607,8 @@
           ]
         },
         "go-template": {
-          "pass": 156,
-          "total": 161,
+          "pass": 157,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -643,8 +643,8 @@
           ]
         },
         "jinja": {
-          "pass": 156,
-          "total": 161,
+          "pass": 157,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -679,8 +679,8 @@
           ]
         },
         "minijinja": {
-          "pass": 156,
-          "total": 161,
+          "pass": 157,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -715,8 +715,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 157,
-          "total": 161,
+          "pass": 158,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -745,8 +745,8 @@
           ]
         },
         "twig": {
-          "pass": 156,
-          "total": 161,
+          "pass": 157,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -781,8 +781,8 @@
           ]
         },
         "xslate": {
-          "pass": 156,
-          "total": 161,
+          "pass": 157,
+          "total": 162,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -819,52 +819,52 @@
       }
     },
     "conditional": {
-      "total": 18,
+      "total": 19,
       "cells": {
         "hono": {
-          "pass": 18,
-          "total": 18
+          "pass": 19,
+          "total": 19
         },
         "blade": {
-          "pass": 18,
-          "total": 18
+          "pass": 19,
+          "total": 19
         },
         "erb": {
-          "pass": 18,
-          "total": 18
+          "pass": 19,
+          "total": 19
         },
         "go-template": {
-          "pass": 18,
-          "total": 18
+          "pass": 19,
+          "total": 19
         },
         "jinja": {
-          "pass": 18,
-          "total": 18
+          "pass": 19,
+          "total": 19
         },
         "minijinja": {
-          "pass": 18,
-          "total": 18
+          "pass": 19,
+          "total": 19
         },
         "mojolicious": {
-          "pass": 18,
-          "total": 18
+          "pass": 19,
+          "total": 19
         },
         "twig": {
-          "pass": 18,
-          "total": 18
+          "pass": 19,
+          "total": 19
         },
         "xslate": {
-          "pass": 18,
-          "total": 18
+          "pass": 19,
+          "total": 19
         }
       }
     },
     "identifier": {
-      "total": 241,
+      "total": 242,
       "cells": {
         "hono": {
-          "pass": 240,
-          "total": 241,
+          "pass": 241,
+          "total": 242,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -875,8 +875,8 @@
           ]
         },
         "blade": {
-          "pass": 235,
-          "total": 241,
+          "pass": 236,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -917,8 +917,8 @@
           ]
         },
         "erb": {
-          "pass": 236,
-          "total": 241,
+          "pass": 237,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -953,8 +953,8 @@
           ]
         },
         "go-template": {
-          "pass": 235,
-          "total": 241,
+          "pass": 236,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -995,8 +995,8 @@
           ]
         },
         "jinja": {
-          "pass": 235,
-          "total": 241,
+          "pass": 236,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1037,8 +1037,8 @@
           ]
         },
         "minijinja": {
-          "pass": 235,
-          "total": 241,
+          "pass": 236,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1079,8 +1079,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 236,
-          "total": 241,
+          "pass": 237,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1115,8 +1115,8 @@
           ]
         },
         "twig": {
-          "pass": 235,
-          "total": 241,
+          "pass": 236,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1157,8 +1157,8 @@
           ]
         },
         "xslate": {
-          "pass": 235,
-          "total": 241,
+          "pass": 236,
+          "total": 242,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1242,15 +1242,15 @@
       }
     },
     "literal": {
-      "total": 199,
+      "total": 200,
       "cells": {
         "hono": {
-          "pass": 199,
-          "total": 199
+          "pass": 200,
+          "total": 200
         },
         "blade": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1261,8 +1261,8 @@
           ]
         },
         "erb": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1273,8 +1273,8 @@
           ]
         },
         "go-template": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1285,8 +1285,8 @@
           ]
         },
         "jinja": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1297,8 +1297,8 @@
           ]
         },
         "minijinja": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1309,8 +1309,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1321,8 +1321,8 @@
           ]
         },
         "twig": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1333,8 +1333,8 @@
           ]
         },
         "xslate": {
-          "pass": 198,
-          "total": 199,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3782,43 +3782,43 @@
       }
     },
     "literal:boolean": {
-      "total": 37,
+      "total": 38,
       "cells": {
         "hono": {
-          "pass": 37,
-          "total": 37
+          "pass": 38,
+          "total": 38
         },
         "blade": {
-          "pass": 37,
-          "total": 37
+          "pass": 38,
+          "total": 38
         },
         "erb": {
-          "pass": 37,
-          "total": 37
+          "pass": 38,
+          "total": 38
         },
         "go-template": {
-          "pass": 37,
-          "total": 37
+          "pass": 38,
+          "total": 38
         },
         "jinja": {
-          "pass": 37,
-          "total": 37
+          "pass": 38,
+          "total": 38
         },
         "minijinja": {
-          "pass": 37,
-          "total": 37
+          "pass": 38,
+          "total": 38
         },
         "mojolicious": {
-          "pass": 37,
-          "total": 37
+          "pass": 38,
+          "total": 38
         },
         "twig": {
-          "pass": 37,
-          "total": 37
+          "pass": 38,
+          "total": 38
         },
         "xslate": {
-          "pass": 37,
-          "total": 37
+          "pass": 38,
+          "total": 38
         }
       }
     },
@@ -3905,15 +3905,15 @@
       }
     },
     "literal:string": {
-      "total": 142,
+      "total": 143,
       "cells": {
         "hono": {
-          "pass": 142,
-          "total": 142
+          "pass": 143,
+          "total": 143
         },
         "blade": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3924,8 +3924,8 @@
           ]
         },
         "erb": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3936,8 +3936,8 @@
           ]
         },
         "go-template": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3948,8 +3948,8 @@
           ]
         },
         "jinja": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3960,8 +3960,8 @@
           ]
         },
         "minijinja": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3972,8 +3972,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3984,8 +3984,8 @@
           ]
         },
         "twig": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3996,8 +3996,8 @@
           ]
         },
         "xslate": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",


### PR DESCRIPTION
Fixes #2335.

Go `text/template` is the only backend without an expression-level conditional, so #2331 added `bf_ternary` (a pipeline-position runtime helper) for helper-call args. The rest of the Go adapter still worked around the gap with `{{if}}…{{else}}…{{end}}` action fragments plus guards to avoid double-wrapping them. This PR routes every **value-position** conditional through the same `bf_ternary` lowering, deleting the fragment special-casing and fixing a silent branch-discard.

## What changed

### 1. HIGH — `conditional()` emitter → `bf_ternary`
The ParsedExpr `conditional()` emitter now emits `(bf_ternary <test> <a> <b>)` instead of an `{{if}}…{{end}}` fragment. Consequences:
- `renderConditionalBranch` (its only caller) is **deleted**.
- Value-position ternaries stop being `{{`-leading, so they wrap through the normal expression path (`isTemplateFragment` correctly declines them). `isTemplateFragment` keeps its `startsWith('{{')` check — `find()`/`findLast()` (`{{with …}}`) and callback-method blocks are still self-contained fragments, so this could not collapse to `template-literal` alone.
- **Branch quoting**: string branches move from bare unquoted text to quoted, html/template-escaped values — safe for the value positions this path is reached for.
- **Bool test**: `Ternary`'s `cond` parameter is a strict `bool` (not `{{if}}` truthiness), so a comparison / `!x` / bool-literal passes through, and anything else is wrapped `bf_truthy <value>` (JS `Boolean(x)`, backed by the existing `Truthy`/`isTruthy`).

### 2. MEDIUM (correctness) — condition-position ternary no longer discards its branches
`renderConditionExpr`'s `conditional` case returned only the lowered `test`, silently dropping both branches — a `(x ? y : z)` boolean sub-condition collapsed to `x` (not refused, silently wrong). It now lowers faithfully to `(bf_ternary …)`, truthiness-checked by the enclosing `{{if}}`/`and`/`or`/`not`.

### 3. LOW — attribute-position uniformity
Attribute-value ternaries reached through the `conditional()` emitter now emit `name="{{bf_ternary …}}"`.

The shared lowering (`lowerTernary`) lives beside `lowerArg` in `url-builder.ts`; `lowerArg` now delegates to it, unifying the two parallel conditional-lowering paths (and incidentally giving `lowerArg` the same `bf_truthy` test-coercion, fixing the same latent non-bool-test hazard there). `bf_truthy` is registered in the runtime FuncMap.

## Testing
- **New conformance fixture** `condition-position-ternary` — a ternary used as a boolean sub-condition, with seeds chosen so the bug and the fix diverge visibly (`flag` truthy but selects a falsy branch → renders `OFF`; the old test-only lowering wrongly rendered `ON`). Verified to render to Hono parity on real Go.
- New Go-adapter unit tests pinning the template SOURCE for value/condition/attribute positions (`#2335` describes), plus `bf_truthy` in the runtime FuncMap test.
- Updated three `derived-state-memo` assertions and the `#1937` template-fragment invariant to reflect ternary's new (non-fragment) lowering.
- Full Go adapter conformance suite (real `go run` rendering of the whole fixture corpus): **1128 pass, 0 fail**. Go runtime tests, coverage-map freshness, and snapshot-determinism all green.

Refs: #2331 (`bf_ternary` introduction), #2324 (the union stage that surfaced it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDqnBRdhnQCkxQK29MDZAc)_