### PR TITLE
fix(compiler): BF112 should only decline genuinely helper-local bindings; re-provision imported ones (#2332)

### DIFF
--- a/.changeset/reactive-factory-import-reprovisioning.md
+++ b/.changeset/reactive-factory-import-reprovisioning.md
@@ -1,0 +1,18 @@
+---
+'@barefootjs/jsx': minor
+---
+
+Cross-file reactive-factory imports (#2332): BF112 now declines inlining only
+for bindings genuinely local to the helper file (top-level const/let/var,
+function/class/enum names, default/namespace imports). A helper-file named
+value import that an inlined factory body references is instead re-imported
+into the component file, using a component-relative specifier (bare/npm
+specifiers pass through unchanged) and deduped across every factory inlined
+into that file. New diagnostic BF113: a re-provisioned import whose local
+name collides with an existing binding in the component file declines that
+specific call site instead of risking a silent shadow.
+
+Known limitation: the CLI's build-cache dependency scanner does not track the
+existence of a factory's helper-file imports, only its own resolved path, so
+deleting/renaming that third module can leave a stale build until a
+content change to a tracked file triggers a rebuild. Left as a follow-up.

--- a/packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts
@@ -344,6 +344,61 @@ export function Pair() {
     expect((clientJs!.content.match(/from '\.\.\/lib\/mathmod'/g) ?? []).length).toBe(1)
   })
 
+  test('re-provisioned imports are emitted in sorted order regardless of inlining order (Copilot review, PR #2338)', () => {
+    // `importsBySpecifier`/`inlinedFactories` are populated in AST-traversal/
+    // insertion order — deliberately adversarial here: the component calls
+    // the factory needing '../lib/zmod' BEFORE the one needing
+    // '../lib/amod', so insertion order is z-then-a. Emission must still be
+    // alphabetical (a-then-z), or the generated import block would be
+    // order-unstable across unrelated analyzer refactors.
+    writeFixture('lib/zmod.ts', `export function zHelper(x: number): number {
+  return x
+}
+`)
+    writeFixture('lib/amod.ts', `export function aHelper(x: number): number {
+  return x
+}
+`)
+    writeFixture('hooks/useZFactory.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+import { zHelper } from '../lib/zmod'
+
+export function useZFactory(initial: number) {
+  const [zValue, setZValue] = createSignal(zHelper(initial))
+  return { zValue, setZValue }
+}
+`)
+    writeFixture('hooks/useAFactory.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+import { aHelper } from '../lib/amod'
+
+export function useAFactory(initial: number) {
+  const [aValue, setAValue] = createSignal(aHelper(initial))
+  return { aValue, setAValue }
+}
+`)
+    const consumerSource = `'use client'
+import { useZFactory } from '../hooks/useZFactory'
+import { useAFactory } from '../hooks/useAFactory'
+
+export function Ordered() {
+  const { zValue } = useZFactory(1)
+  const { aValue } = useAFactory(2)
+  return <p>{zValue()} / {aValue()}</p>
+}
+`
+    const consumerPath = writeFixture('components/Ordered.tsx', consumerSource)
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const amodIndex = clientJs!.content.indexOf("from '../lib/amod'")
+    const zmodIndex = clientJs!.content.indexOf("from '../lib/zmod'")
+    expect(amodIndex).toBeGreaterThan(-1)
+    expect(zmodIndex).toBeGreaterThan(-1)
+    expect(amodIndex).toBeLessThan(zmodIndex)
+  })
+
   test('matrix 4: local-name collision with a re-provisioned import declines with BF113', () => {
     const consumerSource = `'use client'
 import { useDouble } from '../hooks/useDouble'

--- a/packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts
@@ -237,3 +237,183 @@ export function Config() {
     expect(objectResult.errors.find(e => e.code === 'BF111')).toBeUndefined()
   })
 })
+
+describe('Cross-file factory import re-provisioning (#2332)', () => {
+  beforeAll(() => {
+    // lib/mathmod.ts — the third module, deliberately .ts and in a different
+    // directory than both hook and component so the relative-path math is real.
+    writeFixture('lib/mathmod.ts', `export function doubleIt(x: number): number {
+  return x * 2
+}
+`)
+    // hooks/useDouble.tsx — the helper: factory body calls an import.
+    writeFixture('hooks/useDouble.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+import { doubleIt } from '../lib/mathmod'
+
+export function useDouble(initial: number) {
+  const [value, setValue] = createSignal(doubleIt(initial))
+  const bump = () => setValue(doubleIt(value()))
+  return { value, bump }
+}
+`)
+  })
+
+  test('matrix 1: re-provisioned import, different directory depths', () => {
+    const consumerSource = `'use client'
+import { useDouble } from '../hooks/useDouble'
+
+export function Doubler() {
+  const { value, bump } = useDouble(21)
+  return <button onClick={bump}>{value()}</button>
+}
+`
+    const consumerPath = writeFixture('components/Doubler.tsx', consumerSource)
+    const ctx = analyzeComponent(consumerSource, consumerPath, 'Doubler')
+    expect(ctx.signals.length).toBe(1)
+    expect(ctx.signals[0].getter).toBe('value')
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    // Specifier rewritten relative to components/, not hooks/ — the off-by-one trap.
+    expect(clientJs!.content).toMatch(/import\s*\{\s*doubleIt\s*\}\s*from\s*'\.\.\/lib\/mathmod'/)
+    expect(clientJs!.content).not.toContain('../hooks/useDouble') // factory inlined, not imported
+  })
+
+  test('matrix 2: bare specifier passes through unchanged', () => {
+    writeFixture('hooks/useClamped.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+import { clamp } from 'tiny-clamp'
+
+export function useClamped(initial: number) {
+  const [value, setValue] = createSignal(clamp(initial))
+  const bump = () => setValue(clamp(value() + 1))
+  return { value, bump }
+}
+`)
+    const consumerSource = `'use client'
+import { useClamped } from '../hooks/useClamped'
+
+export function Clamped() {
+  const { value, bump } = useClamped(21)
+  return <button onClick={bump}>{value()}</button>
+}
+`
+    const consumerPath = writeFixture('components/Clamped.tsx', consumerSource)
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    // Bare specifiers skip resolution entirely, so the package need not exist on disk.
+    expect(clientJs!.content).toMatch(/import\s*\{\s*clamp\s*\}\s*from\s*'tiny-clamp'/)
+  })
+
+  test('matrix 3: dedupe across two factories sharing the same helper import', () => {
+    writeFixture('hooks/pair.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+import { doubleIt } from '../lib/mathmod'
+
+export function useA(initial: number) {
+  const [value, setValue] = createSignal(doubleIt(initial))
+  const bump = () => setValue(doubleIt(value()))
+  return { value, bump }
+}
+
+export function useB(initial: number) {
+  const [other, setOther] = createSignal(doubleIt(initial))
+  const bumpOther = () => setOther(doubleIt(other()))
+  return { other, bumpOther }
+}
+`)
+    const consumerSource = `'use client'
+import { useA, useB } from '../hooks/pair'
+
+export function Pair() {
+  const { value, bump } = useA(1)
+  const { other, bumpOther } = useB(2)
+  return <button onClick={() => { bump(); bumpOther() }}>{value()} / {other()}</button>
+}
+`
+    const consumerPath = writeFixture('components/Pair.tsx', consumerSource)
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect((clientJs!.content.match(/from '\.\.\/lib\/mathmod'/g) ?? []).length).toBe(1)
+  })
+
+  test('matrix 5b: default-import reference stays BF112, not re-provisioned', () => {
+    writeFixture('lib/mathmod-default.ts', `export default {
+  doubleIt(x: number): number {
+    return x * 2
+  },
+}
+`)
+    writeFixture('hooks/useDefault.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+import mathmod from '../lib/mathmod-default'
+
+export function useDefault(initial: number) {
+  const [value, setValue] = createSignal(mathmod.doubleIt(initial))
+  const bump = () => setValue(mathmod.doubleIt(value()))
+  return { value, bump }
+}
+`)
+    const consumerSource = `'use client'
+import { useDefault } from '../hooks/useDefault'
+
+export function Defaulter() {
+  const { value, bump } = useDefault(21)
+  return <button onClick={bump}>{value()}</button>
+}
+`
+    const consumerPath = writeFixture('components/Defaulter.tsx', consumerSource)
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    const bf112 = result.errors.find(e => e.code === 'BF112')
+    expect(bf112).toBeDefined()
+    expect(bf112!.message).toContain('mathmod')
+    expect(result.errors.find(e => e.code === 'BF113')).toBeUndefined()
+  })
+
+  test('matrix 6: SSR output reflects the re-provisioned import', () => {
+    const consumerSource = `'use client'
+import { useDouble } from '../hooks/useDouble'
+
+export function DoublerSSR() {
+  const { value, bump } = useDouble(21)
+  return <button onClick={bump}>{value()}</button>
+}
+`
+    const consumerPath = writeFixture('components/DoublerSSR.tsx', consumerSource)
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const template = result.files.find(f => f.type === 'markedTemplate')
+    expect(template).toBeDefined()
+    // The injected import is part of the same rewritten source both passes read:
+    // the adapter re-emits it via metadata.templateImports…
+    expect(template!.content).toMatch(/import\s*\{\s*doubleIt\s*\}\s*from\s*'\.\.\/lib\/mathmod'/)
+    // …and the inlined signal initializer calls it at SSR render.
+    expect(template!.content).toContain('doubleIt(')
+  })
+
+  test('already-satisfied import dedupes: no BF113, no duplicate declaration', () => {
+    const consumerSource = `'use client'
+import { useDouble } from '../hooks/useDouble'
+import { doubleIt } from '../lib/mathmod'
+
+export function DoublerSelfImporting() {
+  const { value, bump } = useDouble(21)
+  return <button onClick={() => { bump(); doubleIt(value()) }}>{value()}</button>
+}
+`
+    const consumerPath = writeFixture('components/DoublerSelfImporting.tsx', consumerSource)
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    expect(result.errors.find(e => e.code === 'BF113')).toBeUndefined()
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect((clientJs!.content.match(/from '\.\.\/lib\/mathmod'/g) ?? []).length).toBe(1)
+  })
+})

--- a/packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts
@@ -344,6 +344,34 @@ export function Pair() {
     expect((clientJs!.content.match(/from '\.\.\/lib\/mathmod'/g) ?? []).length).toBe(1)
   })
 
+  test('matrix 4: local-name collision with a re-provisioned import declines with BF113', () => {
+    const consumerSource = `'use client'
+import { useDouble } from '../hooks/useDouble'
+
+function doubleIt(): number {
+  return 1
+}
+
+export function Collide() {
+  const { value, bump } = useDouble(21)
+  return <button onClick={bump}>{value()} {doubleIt()}</button>
+}
+`
+    const consumerPath = writeFixture('components/Collide.tsx', consumerSource)
+    const ctx = analyzeComponent(consumerSource, consumerPath, 'Collide')
+    expect(ctx.signals.length).toBe(0)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    const bf113 = result.errors.find(e => e.code === 'BF113')
+    expect(bf113).toBeDefined()
+    expect(bf113!.message).toContain('doubleIt')
+    expect(bf113!.message).toContain('../lib/mathmod')
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    if (clientJs) {
+      expect(clientJs.content).not.toContain(`from '../lib/mathmod'`)
+    }
+  })
+
   test('matrix 5b: default-import reference stays BF112, not re-provisioned', () => {
     writeFixture('lib/mathmod-default.ts', `export default {
   doubleIt(x: number): number {

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -4112,7 +4112,13 @@ function prescanImportedReactiveFactories(
           result.declined.set(spec.local, det.declined)
           break
         case 'factory': {
-          const offending = moduleCaptureCheck(fn, det.info, moduleBindings, fn.name!.text)
+          // #2332 prep: behavior-preserving shim — still decline BF112 on
+          // ANY module-scope reference (local or a re-importable helper
+          // import), byte-identical message text to before the split.
+          // Re-provisioning imported refs instead of declining lands in a
+          // later commit.
+          const capture = moduleCaptureCheck(fn, det.info, moduleBindings, fn.name!.text)
+          const offending = [...capture.captured, ...capture.importedRefs.map(r => r.localName)].sort()
           if (offending.length > 0) {
             result.declined.set(spec.local, {
               code: 'BF112',
@@ -4131,34 +4137,56 @@ function prescanImportedReactiveFactories(
 }
 
 /**
- * Value bindings at the helper file's module scope that an inlined factory
- * body must not capture (#2325 §4h / BF112): top-level const/let/var,
- * function/class/enum names, and value import specifiers — EXCEPT imports
- * from '@barefootjs/client' / '@barefootjs/client/runtime'. Those are
- * re-provisioned from usage by the client-JS emitter regardless of where
- * the call that used them textually came from (`resolveFinalImports` /
- * `detectUsedImports` regex-scan the *generated* code, not the consumer's
- * source imports — see #2325 spec C1), so an inlined body calling
- * `createSignal` is never a capture even though the helper file itself
- * imports it. Type-only imports/declarations carry no runtime binding and
- * are excluded.
+ * Value bindings at the helper file's module scope, split by whether they
+ * have a re-importable module of their own (#2332).
+ *
+ * `local` bindings — top-level const/let/var, function/class/enum names,
+ * plus default-import and namespace-import names — have no module a
+ * component file could re-import them from, so an inlined factory body
+ * referencing one unconditionally declines with BF112 (#2325 §4h): moving
+ * the body into the component file would leave a dangling reference.
+ *
+ * `imported` bindings — the helper file's own named value imports — CAN be
+ * re-provisioned: the component file can import the same binding under the
+ * same specifier (#2332). These are collected here (keyed by the helper
+ * file's local name) but are NOT captures; `moduleCaptureCheck` below
+ * reports them separately from `local` hits so the caller can decide
+ * whether to re-import rather than unconditionally decline.
+ *
+ * EXCEPT in both cases: imports from '@barefootjs/client' /
+ * '@barefootjs/client/runtime'. Those are re-provisioned from usage by the
+ * client-JS emitter regardless of where the call that used them textually
+ * came from (`resolveFinalImports` / `detectUsedImports` regex-scan the
+ * *generated* code, not the consumer's source imports — see #2325 spec C1),
+ * so an inlined body calling `createSignal` is never a capture even though
+ * the helper file itself imports it. Type-only imports/declarations carry
+ * no runtime binding and are excluded.
  */
-function collectHelperModuleValueBindings(sf: ts.SourceFile): Set<string> {
-  const names = new Set<string>()
+interface HelperModuleBindings {
+  /** Declared directly in the helper file — unconditional BF112 capture. */
+  local: Set<string>
+  /** Named value-import specifiers, keyed by helper-file local name —
+   *  re-provisionable into the component file (#2332). */
+  imported: Map<string, { source: string; exportedName: string }>
+}
+
+function collectHelperModuleValueBindings(sf: ts.SourceFile): HelperModuleBindings {
+  const local = new Set<string>()
+  const imported = new Map<string, { source: string; exportedName: string }>()
   for (const stmt of sf.statements) {
     if (ts.isVariableStatement(stmt)) {
       const out: string[] = []
       for (const decl of stmt.declarationList.declarations) {
         addBindingNames(decl.name, out)
       }
-      for (const n of out) names.add(n)
+      for (const n of out) local.add(n)
       continue
     }
     if (
       (ts.isFunctionDeclaration(stmt) || ts.isClassDeclaration(stmt) || ts.isEnumDeclaration(stmt)) &&
       stmt.name
     ) {
-      names.add(stmt.name.text)
+      local.add(stmt.name.text)
       continue
     }
     if (ts.isImportDeclaration(stmt)) {
@@ -4166,42 +4194,62 @@ function collectHelperModuleValueBindings(sf: ts.SourceFile): Set<string> {
       if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
       const src = stmt.moduleSpecifier.text
       if (src === '@barefootjs/client' || src === '@barefootjs/client/runtime') continue
-      if (stmt.importClause?.name) names.add(stmt.importClause.name.text)
+      // Default/namespace imports stay hard BF112 (#2332 scope decision):
+      // no single named export to re-provision under one local name.
+      if (stmt.importClause?.name) local.add(stmt.importClause.name.text)
       const namedBindings = stmt.importClause?.namedBindings
       if (namedBindings && ts.isNamedImports(namedBindings)) {
         for (const el of namedBindings.elements) {
           if (el.isTypeOnly) continue
-          names.add(el.name.text)
+          imported.set(el.name.text, { source: src, exportedName: (el.propertyName ?? el.name).text })
         }
       }
       if (namedBindings && ts.isNamespaceImport(namedBindings)) {
-        names.add(namedBindings.name.text)
+        local.add(namedBindings.name.text)
       }
     }
   }
-  return names
+  return { local, imported }
+}
+
+/**
+ * Categorized free-identifier references of a reactive-factory body into
+ * its own module scope (#2332): `captured` are unconditional BF112 hits
+ * (helper-local bindings — the body would dangle if inlined verbatim);
+ * `importedRefs` are references to the helper file's own named value
+ * imports, which the caller may re-provision into the component file
+ * instead of declining (§3.4 in the #2332 spec).
+ */
+interface ModuleCaptureResult {
+  /** Free refs resolving to helper-local bindings (BF112), sorted. */
+  captured: string[]
+  /** Free refs resolving to the helper's own named value imports, sorted by localName. */
+  importedRefs: Array<{ localName: string; source: string; exportedName: string }>
 }
 
 /**
  * Free identifiers of a reactive-factory body that resolve to bindings at
- * its own module scope (#2325 §4h / BF112) — references the inlined body
- * would silently lose once spliced into the component file. Returns the
- * offending names sorted, for stable diagnostic text.
+ * its own module scope (#2325 §4h / BF112, #2332) — references the inlined
+ * body would silently lose once spliced into the component file, unless
+ * re-provisioned as an import. Returns `captured` (unconditional BF112) and
+ * `importedRefs` (re-provisionable) separately, each sorted for stable
+ * diagnostic/injection text.
  *
  * Known accepted limitation: `extractFreeIdentifiersFromNode` only scope-
  * tracks arrow-function parameters, not nested `function` declarations'
  * parameters or nested-block declarations — a body-nested binding that
  * happens to shadow a helper-module binding could false-positive into
- * BF112. Acceptable: the failure direction is a loud build error on a rare
- * shape, never a silent runtime break.
+ * BF112 or `importedRefs`. Acceptable: the failure direction is always a
+ * loud build error (BF112/BF113) or a redundant-but-harmless injected
+ * import, never a silent dangling reference.
  */
 function moduleCaptureCheck(
   fn: ts.FunctionDeclaration,
   info: ReactiveFactoryInfo,
-  moduleBindings: Set<string>,
+  moduleBindings: HelperModuleBindings,
   selfName: string
-): string[] {
-  if (!fn.body) return []
+): ModuleCaptureResult {
+  if (!fn.body) return { captured: [], importedRefs: [] }
   const free = extractFreeIdentifiersFromNode(fn.body)
   const exclude = new Set<string>(info.params)
   for (const b of info.localBindings) exclude.add(b)
@@ -4209,12 +4257,20 @@ function moduleCaptureCheck(
   for (const p of REACTIVE_PRIMITIVES) exclude.add(p)
   exclude.add(selfName)
 
-  const offending: string[] = []
+  const captured: string[] = []
+  const importedRefs: ModuleCaptureResult['importedRefs'] = []
   for (const id of free) {
     if (exclude.has(id)) continue
-    if (moduleBindings.has(id)) offending.push(id)
+    if (moduleBindings.local.has(id)) {
+      captured.push(id)
+      continue
+    }
+    const imp = moduleBindings.imported.get(id)
+    if (imp) importedRefs.push({ localName: id, source: imp.source, exportedName: imp.exportedName })
   }
-  return offending.sort()
+  captured.sort()
+  importedRefs.sort((a, b) => (a.localName < b.localName ? -1 : 1))
+  return { captured, importedRefs }
 }
 
 /**

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -3950,12 +3950,14 @@ function prescanReactiveFactoriesInSource(
  * absolute helper-import target. Same `'.'`/`'./'` prefix convention as the
  * CLI's buildRelativeImportRewriter (packages/cli/src/lib/build.ts); strips
  * the resolved extension to match the codebase's extensionless-import
- * style. Like `buildRelativeImportRewriter`, this does not normalize
- * `path.relative`'s separators — on win32 that yields backslashes, a
- * pre-existing exposure in the same convention, not fixed here.
+ * style. Unlike `buildRelativeImportRewriter`, this normalizes
+ * `path.relative`'s separators to POSIX (`/`) — a backslash-separated
+ * specifier is not valid ESM syntax, so on win32 `path.relative`'s native
+ * output would inject a broken import rather than merely an unconventional
+ * one (Copilot review, PR #2338).
  */
 function toComponentRelativeSpecifier(resolvedAbs: string, componentFilePath: string): string {
-  let rel = path.relative(path.dirname(componentFilePath), resolvedAbs)
+  let rel = path.relative(path.dirname(componentFilePath), resolvedAbs).split(path.sep).join('/')
   rel = rel.replace(/\.(tsx|ts|jsx|js)$/, '')
   if (rel === '') rel = '.'
   if (!rel.startsWith('.')) rel = './' + rel
@@ -4792,9 +4794,19 @@ function rewriteFactoryCallsInSource(
     }
   }
   if (importsBySpecifier.size > 0) {
-    const lines = [...importsBySpecifier].map(([spec, names]) =>
-      `import { ${[...names].map(([local, exported]) =>
-        exported === local ? local : `${exported} as ${local}`).join(', ')} } from '${spec}'`)
+    // Sort specifiers and, within each, named-import entries by local name —
+    // `importsBySpecifier`/`inlinedFactories` iterate in incidental AST-
+    // traversal/insertion order, which would otherwise make this generated
+    // text order-unstable across unrelated refactors (Copilot review, PR
+    // #2338).
+    const lines = [...importsBySpecifier]
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([spec, names]) => {
+        const specifiers = [...names]
+          .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+          .map(([local, exported]) => (exported === local ? local : `${exported} as ${local}`))
+        return `import { ${specifiers.join(', ')} } from '${spec}'`
+      })
     const at = factoryImportInsertionOffset(sourceFile)
     edits.push({ start: at, end: at, replacement: at === 0 ? lines.join('\n') + '\n' : '\n' + lines.join('\n') })
   }

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -23,7 +23,7 @@ import {
   isArrowComponentFunction,
   collectReactiveGetterNames,
 } from './analyzer-context.ts'
-import { createError, createWarning, ErrorCodes } from './errors.ts'
+import { createError, createWarning, ErrorCodes, type ErrorCode } from './errors.ts'
 import { baseTypeName } from './rich-type-evidence.ts'
 import { CATALOGUED_RICH_TYPE_NAMES } from './date-lowering.ts'
 import path from 'node:path'
@@ -3996,6 +3996,56 @@ function buildEntryImportIndex(
 }
 
 /**
+ * Every value-binding name anywhere in the entry file (imports, variable
+ * declarations at any depth, function/class/enum names, function
+ * parameters) — used by the #2332 re-provisioned-import collision check
+ * (BF113). Deliberately over-broad: the inlined factory body lands INSIDE a
+ * component function, where any nested binding (params, destructures,
+ * locals) would silently shadow a top-level import injected by this round.
+ * A scan limited to top-level bindings would miss that, so any hit anywhere
+ * in the file declines re-provisioning with a loud BF113 rather than
+ * risking a silent shadow — matching `moduleCaptureCheck`'s stated failure-
+ * direction philosophy (loud build error over silent runtime break).
+ */
+function collectEntryBindingNames(sf: ts.SourceFile): Set<string> {
+  const names = new Set<string>()
+  function visit(node: ts.Node): void {
+    if (ts.isImportDeclaration(node) && node.importClause) {
+      if (node.importClause.name) names.add(node.importClause.name.text)
+      const namedBindings = node.importClause.namedBindings
+      if (namedBindings && ts.isNamedImports(namedBindings)) {
+        // Type-only specifiers still occupy the identifier at the TS level.
+        for (const el of namedBindings.elements) names.add(el.name.text)
+      }
+      if (namedBindings && ts.isNamespaceImport(namedBindings)) {
+        names.add(namedBindings.name.text)
+      }
+    }
+    if (ts.isVariableDeclaration(node)) {
+      const out: string[] = []
+      addBindingNames(node.name, out)
+      for (const n of out) names.add(n)
+    }
+    if (
+      (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node) || ts.isEnumDeclaration(node)) &&
+      node.name
+    ) {
+      names.add(node.name.text)
+    }
+    if (ts.isFunctionLike(node)) {
+      for (const p of node.parameters) {
+        const out: string[] = []
+        addBindingNames(p.name, out)
+        for (const n of out) names.add(n)
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sf)
+  return names
+}
+
+/**
  * Cross-file half of the factory prescan (#2325 round 2): resolve factories
  * defined in a relative-imported helper file so `const { count } =
  * createCounter(0)` inlines the same way whether `createCounter` lives in
@@ -4071,7 +4121,11 @@ function prescanImportedReactiveFactories(
   if (importsToCheck.length === 0) return
 
   // #2332 — computed once per entry file, shared across all helper files.
+  const entryBindingNames = collectEntryBindingNames(entrySourceFile)
   const entryImportIndex = buildEntryImportIndex(entrySourceFile, filePath)
+  // localName -> planned injection identity; a later factory requiring the
+  // same name from a DIFFERENT (targetKey, exportedName) is a collision.
+  const plannedInjections = new Map<string, { targetKey: string; exportedName: string }>()
 
   for (const { src, specs } of importsToCheck) {
     const resolved = resolveRelativeImportToFile(src, filePath)
@@ -4179,8 +4233,13 @@ function prescanImportedReactiveFactories(
           // ref resolves to a component-relative specifier (or passes
           // through unchanged for bare/npm specifiers); a ref already
           // satisfied by an identical top-level import in the component
-          // file is dropped rather than injected (would redeclare it).
+          // file is dropped rather than injected (would redeclare it). A
+          // ref whose local name collides with a DIFFERENT existing/planned
+          // binding declines with BF113 — `pending` is only merged into
+          // `plannedInjections` on full factory success (§3.4), so a
+          // factory that declines mid-loop reserves nothing.
           const required: RequiredFactoryImport[] = []
+          const pending: Array<[string, { targetKey: string; exportedName: string }]> = []
           let declinedEntry: DeclinedReactiveFactory | null = null
           for (const ref of capture.importedRefs) {
             let specifier: string
@@ -4204,16 +4263,33 @@ function prescanImportedReactiveFactories(
               specifier = ref.source // bare/npm specifier — unchanged (#2332 test 2)
               targetKey = ref.source
             }
+            // Already satisfied by an identical top-level import in the
+            // component file — injecting again would redeclare the binding.
             const existing = entryImportIndex.get(ref.localName)
             if (existing && existing.targetKey === targetKey && existing.exportedName === ref.exportedName) {
-              continue // already satisfied by an identical top-level import
+              continue
             }
+            const planned = plannedInjections.get(ref.localName)
+            const collides =
+              (existing !== undefined) ||
+              (planned !== undefined && (planned.targetKey !== targetKey || planned.exportedName !== ref.exportedName)) ||
+              (planned === undefined && entryBindingNames.has(ref.localName))
+            if (collides) {
+              declinedEntry = {
+                code: 'BF113',
+                detail: `'${ref.localName}' from '${specifier}'`,
+                loc: det.info.loc,
+              }
+              break
+            }
+            pending.push([ref.localName, { targetKey, exportedName: ref.exportedName }])
             required.push({ localName: ref.localName, exportedName: ref.exportedName, specifier })
           }
           if (declinedEntry) {
             result.declined.set(spec.local, declinedEntry)
             break
           }
+          for (const [name, id] of pending) plannedInjections.set(name, id)
           det.info.sourceFilePath = resolved
           if (required.length > 0) det.info.requiredImports = required
           result.factories.set(spec.local, det.info)
@@ -4776,11 +4852,12 @@ function escapeRegex(s: string): string {
 /**
  * Build the diagnostic for a call site whose callee was recognised but
  * declined for inlining (#2325 — cross-file factories that rename their
- * return properties, or capture their own module scope). BF112's wording is
- * specific to module-scope capture; every other declined reason (currently
- * only BF111 — non-shorthand return properties) shares BF111's generic
- * "cannot be inlined: <detail>" phrasing, matching the wording used for the
- * tuple call-site path.
+ * return properties or capture their own module scope; #2332 — a
+ * re-provisioned helper import collides with an existing binding). BF112
+ * and BF113's wording is specific to their respective failure; every other
+ * declined reason (currently only BF111 — non-shorthand return properties)
+ * shares BF111's generic "cannot be inlined: <detail>" phrasing, matching
+ * the wording used for the tuple call-site path.
  */
 function declinedFactoryMessage(callee: string, d: DeclinedReactiveFactory): string {
   if (d.code === 'BF112') {
@@ -4790,7 +4867,24 @@ function declinedFactoryMessage(callee: string, d: DeclinedReactiveFactory): str
       `pass them as factory arguments, or inline the factory here.`
     )
   }
+  if (d.code === 'BF113') {
+    return (
+      `Reactive factory '${callee}' cannot be inlined: it needs ${d.detail} ` +
+      `imported into this file, but that name is already bound here to something ` +
+      `else. Rename the conflicting binding in this file, or alias the import in ` +
+      `the factory's own file (import { x as y }).`
+    )
+  }
   return `Reactive factory '${callee}' cannot be inlined: ${d.detail}.`
+}
+
+/** Diagnostic code for a declined reactive-factory call site (#2325 / #2332). */
+function declinedFactoryErrorCode(code: DeclinedReactiveFactory['code']): ErrorCode {
+  switch (code) {
+    case 'BF112': return ErrorCodes.REACTIVE_FACTORY_MODULE_CAPTURE
+    case 'BF113': return ErrorCodes.REACTIVE_FACTORY_IMPORT_COLLISION
+    default: return ErrorCodes.REACTIVE_FACTORY_RENAME_UNSUPPORTED
+  }
 }
 
 /**
@@ -4832,9 +4926,7 @@ export function validateReactiveFactoryCalls(ctx: AnalyzerContext): void {
         const declinedEntry = ctx.declinedReactiveFactories.get(callee)
         if (declinedEntry) {
           ctx.errors.push(createError(
-            declinedEntry.code === 'BF112'
-              ? ErrorCodes.REACTIVE_FACTORY_MODULE_CAPTURE
-              : ErrorCodes.REACTIVE_FACTORY_RENAME_UNSUPPORTED,
+            declinedFactoryErrorCode(declinedEntry.code),
             loc,
             { severity: 'error', message: declinedFactoryMessage(callee, declinedEntry) }
           ))
@@ -4892,8 +4984,8 @@ export function validateReactiveFactoryCalls(ctx: AnalyzerContext): void {
  * covers the previously-silent object-destructure failure modes: an
  * unrecognised callee, a tuple factory destructured as an object, a rename/
  * default/rest destructure of a shorthand-only factory, an unknown
- * property, a declined (BF111/BF112) factory, or an uninspectable import
- * that looks reactive-factory-shaped by name.
+ * property, a declined (BF111/BF112/BF113) factory, or an uninspectable
+ * import that looks reactive-factory-shaped by name.
  */
 function validateObjectFactoryDestructure(
   ctx: AnalyzerContext,
@@ -4955,9 +5047,7 @@ function validateObjectFactoryDestructure(
   const declinedEntry = ctx.declinedReactiveFactories.get(callee)
   if (declinedEntry) {
     ctx.errors.push(createError(
-      declinedEntry.code === 'BF112'
-        ? ErrorCodes.REACTIVE_FACTORY_MODULE_CAPTURE
-        : ErrorCodes.REACTIVE_FACTORY_RENAME_UNSUPPORTED,
+      declinedFactoryErrorCode(declinedEntry.code),
       loc,
       { severity: 'error', message: declinedFactoryMessage(callee, declinedEntry) }
     ))

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -7,7 +7,7 @@
  */
 
 import ts from 'typescript'
-import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo, DeclinedReactiveFactory, SourceLocation } from './types.ts'
+import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo, DeclinedReactiveFactory, RequiredFactoryImport, SourceLocation } from './types.ts'
 import { parseExpression, parseBlockBodyTolerant, foldBlockToExpr } from './expression-parser.ts'
 import { rewriteBarePropRefs } from './prop-rewrite.ts'
 import { incrementCounter } from './instrumentation.ts'
@@ -3946,6 +3946,56 @@ function prescanReactiveFactoriesInSource(
 }
 
 /**
+ * #2332 — portable component-relative import specifier for a resolved
+ * absolute helper-import target. Same `'.'`/`'./'` prefix convention as the
+ * CLI's buildRelativeImportRewriter (packages/cli/src/lib/build.ts); strips
+ * the resolved extension to match the codebase's extensionless-import
+ * style. Like `buildRelativeImportRewriter`, this does not normalize
+ * `path.relative`'s separators — on win32 that yields backslashes, a
+ * pre-existing exposure in the same convention, not fixed here.
+ */
+function toComponentRelativeSpecifier(resolvedAbs: string, componentFilePath: string): string {
+  let rel = path.relative(path.dirname(componentFilePath), resolvedAbs)
+  rel = rel.replace(/\.(tsx|ts|jsx|js)$/, '')
+  if (rel === '') rel = '.'
+  if (!rel.startsWith('.')) rel = './' + rel
+  return rel
+}
+
+/**
+ * localName -> identity of what the entry file's own top-level named value
+ * imports bind, for the satisfied-import dedupe check (#2332): if the
+ * component file already imports the exact binding a factory needs to
+ * re-provision, injecting it again would be a duplicate declaration rather
+ * than a shadow, so that case is skipped instead of injected. `targetKey` is
+ * the resolved absolute path for relative sources (or `unresolved:<source>`
+ * when probing fails) and the raw specifier for bare sources.
+ */
+function buildEntryImportIndex(
+  sf: ts.SourceFile,
+  filePath: string
+): Map<string, { targetKey: string; exportedName: string }> {
+  const index = new Map<string, { targetKey: string; exportedName: string }>()
+  for (const stmt of sf.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    if (stmt.importClause?.isTypeOnly) continue
+    const src = stmt.moduleSpecifier.text
+    const targetKey = src.startsWith('./') || src.startsWith('../')
+      ? (resolveRelativeImportToFile(src, filePath) ?? 'unresolved:' + src)
+      : src
+    const namedBindings = stmt.importClause?.namedBindings
+    if (namedBindings && ts.isNamedImports(namedBindings)) {
+      for (const el of namedBindings.elements) {
+        if (el.isTypeOnly) continue
+        index.set(el.name.text, { targetKey, exportedName: (el.propertyName ?? el.name).text })
+      }
+    }
+  }
+  return index
+}
+
+/**
  * Cross-file half of the factory prescan (#2325 round 2): resolve factories
  * defined in a relative-imported helper file so `const { count } =
  * createCounter(0)` inlines the same way whether `createCounter` lives in
@@ -4019,6 +4069,9 @@ function prescanImportedReactiveFactories(
     importsToCheck.push({ src, specs })
   }
   if (importsToCheck.length === 0) return
+
+  // #2332 — computed once per entry file, shared across all helper files.
+  const entryImportIndex = buildEntryImportIndex(entrySourceFile, filePath)
 
   for (const { src, specs } of importsToCheck) {
     const resolved = resolveRelativeImportToFile(src, filePath)
@@ -4112,23 +4165,58 @@ function prescanImportedReactiveFactories(
           result.declined.set(spec.local, det.declined)
           break
         case 'factory': {
-          // #2332 prep: behavior-preserving shim — still decline BF112 on
-          // ANY module-scope reference (local or a re-importable helper
-          // import), byte-identical message text to before the split.
-          // Re-provisioning imported refs instead of declining lands in a
-          // later commit.
           const capture = moduleCaptureCheck(fn, det.info, moduleBindings, fn.name!.text)
-          const offending = [...capture.captured, ...capture.importedRefs.map(r => r.localName)].sort()
-          if (offending.length > 0) {
+          if (capture.captured.length > 0) {
             result.declined.set(spec.local, {
               code: 'BF112',
-              detail: `'${offending.join("', '")}'`,
+              detail: `'${capture.captured.join("', '")}'`,
               loc: det.info.loc,
             })
-          } else {
-            det.info.sourceFilePath = resolved
-            result.factories.set(spec.local, det.info)
+            break
           }
+          // #2332 — re-provision the helper file's own named value imports
+          // that the factory body references, instead of declining. Each
+          // ref resolves to a component-relative specifier (or passes
+          // through unchanged for bare/npm specifiers); a ref already
+          // satisfied by an identical top-level import in the component
+          // file is dropped rather than injected (would redeclare it).
+          const required: RequiredFactoryImport[] = []
+          let declinedEntry: DeclinedReactiveFactory | null = null
+          for (const ref of capture.importedRefs) {
+            let specifier: string
+            let targetKey: string
+            if (ref.source.startsWith('./') || ref.source.startsWith('../')) {
+              // Resolve from the HELPER file's directory (`resolved` is its
+              // absolute path). Unresolvable → same posture as a local
+              // capture: nothing importable to re-provision (BF112).
+              const abs = resolveRelativeImportToFile(ref.source, resolved)
+              if (!abs) {
+                declinedEntry = {
+                  code: 'BF112',
+                  detail: `'${ref.localName}' (import '${ref.source}' did not resolve from the helper file)`,
+                  loc: det.info.loc,
+                }
+                break
+              }
+              specifier = toComponentRelativeSpecifier(abs, filePath)
+              targetKey = abs
+            } else {
+              specifier = ref.source // bare/npm specifier — unchanged (#2332 test 2)
+              targetKey = ref.source
+            }
+            const existing = entryImportIndex.get(ref.localName)
+            if (existing && existing.targetKey === targetKey && existing.exportedName === ref.exportedName) {
+              continue // already satisfied by an identical top-level import
+            }
+            required.push({ localName: ref.localName, exportedName: ref.exportedName, specifier })
+          }
+          if (declinedEntry) {
+            result.declined.set(spec.local, declinedEntry)
+            break
+          }
+          det.info.sourceFilePath = resolved
+          if (required.length > 0) det.info.requiredImports = required
+          result.factories.set(spec.local, det.info)
           break
         }
       }
@@ -4449,6 +4537,12 @@ function rewriteFactoryCallsInSource(
   type Edit = { start: number; end: number; replacement: string }
   const edits: Edit[] = []
   let callSiteIndex = 0
+  // #2332 — factories actually inlined in this walk (not merely present in
+  // `prescan.factories`; `maybeRewriteDecl` bails on arity mismatch/omitted
+  // elements/rename destructures without inlining), so their
+  // `requiredImports` can be re-provisioned without adding a dead import
+  // for a factory that was never actually spliced in.
+  const inlinedFactories = new Set<ReactiveFactoryInfo>()
 
   function visitStmt(node: ts.Node, inComponent: boolean): void {
     if (ts.isVariableStatement(node) && inComponent) {
@@ -4600,19 +4694,65 @@ function rewriteFactoryCallsInSource(
       end: stmt.getEnd(),
       replacement: body,
     })
+    inlinedFactories.add(factory)
   }
 
   visitStmt(sourceFile, false)
 
   if (edits.length === 0) return source
 
-  // Apply edits from bottom to top so earlier offsets stay valid.
+  // #2332 — one deduped import statement per specifier for every inlined
+  // cross-file factory's re-provisioned imports. Injected as a zero-width
+  // edit so the ordinary bottom-to-top splice below applies it; the result
+  // is indistinguishable from a hand-written import for every downstream
+  // consumer (ctx.imports → SSR templateImports AND client
+  // collectExternalImports both parse this same rewritten string).
+  const importsBySpecifier = new Map<string, Map<string, string>>() // specifier -> localName -> exportedName
+  for (const f of inlinedFactories) {
+    for (const r of f.requiredImports ?? []) {
+      let names = importsBySpecifier.get(r.specifier)
+      if (!names) { names = new Map(); importsBySpecifier.set(r.specifier, names) }
+      names.set(r.localName, r.exportedName) // same-key duplicates are identical by prescan construction
+    }
+  }
+  if (importsBySpecifier.size > 0) {
+    const lines = [...importsBySpecifier].map(([spec, names]) =>
+      `import { ${[...names].map(([local, exported]) =>
+        exported === local ? local : `${exported} as ${local}`).join(', ')} } from '${spec}'`)
+    const at = factoryImportInsertionOffset(sourceFile)
+    edits.push({ start: at, end: at, replacement: at === 0 ? lines.join('\n') + '\n' : '\n' + lines.join('\n') })
+  }
+
+  // Apply edits from bottom to top so earlier offsets stay valid. A factory
+  // with `requiredImports` is by definition imported, so the entry file has
+  // at least one import statement and `at` above lands strictly inside the
+  // import prologue — every call-site edit's start is strictly greater
+  // (separated at minimum by the statement break after the last import), so
+  // starts never tie and no sort tiebreak is needed.
   edits.sort((a, b) => b.start - a.start)
   let out = source
   for (const e of edits) {
     out = out.slice(0, e.start) + e.replacement + out.slice(e.end)
   }
   return out
+}
+
+/**
+ * Offset just after the last top-level import (else after the 'use client'
+ * directive, else 0) in the prescan source file — where re-provisioned
+ * factory imports are injected (#2332).
+ */
+function factoryImportInsertionOffset(sf: ts.SourceFile): number {
+  let lastImportEnd = -1
+  let directiveEnd = -1
+  for (const stmt of sf.statements) {
+    if (ts.isImportDeclaration(stmt)) { lastImportEnd = stmt.getEnd(); continue }
+    if (directiveEnd === -1 && ts.isExpressionStatement(stmt) &&
+        ts.isStringLiteral(stmt.expression) && stmt.expression.text === 'use client') {
+      directiveEnd = stmt.getEnd()
+    }
+  }
+  return lastImportEnd >= 0 ? lastImportEnd : directiveEnd >= 0 ? directiveEnd : 0
 }
 
 function isPascalCaseComponentFn(node: ts.Node): boolean {

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -89,6 +89,7 @@ export const ErrorCodes = {
   UNRECOGNIZED_REACTIVE_FACTORY: 'BF110',
   REACTIVE_FACTORY_RENAME_UNSUPPORTED: 'BF111',
   REACTIVE_FACTORY_MODULE_CAPTURE: 'BF112',
+  REACTIVE_FACTORY_IMPORT_COLLISION: 'BF113',
 } as const
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes]
@@ -178,6 +179,11 @@ const errorMessages: Record<ErrorCode, string> = {
     'body cannot be inlined into the component file. Move those helpers into the ' +
     'component file, pass them to the factory as parameters, or define the factory ' +
     'in the component file.',
+
+  [ErrorCodes.REACTIVE_FACTORY_IMPORT_COLLISION]:
+    'Inlining an imported reactive factory requires re-importing one of its helper ' +
+    'imports into this file, but that name is already bound here to something else. ' +
+    "Rename the conflicting binding in this file, or alias the import in the factory's own file.",
 }
 
 // =============================================================================

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1521,11 +1521,12 @@ export interface RequiredFactoryImport {
 /**
  * A helper that was recognized as a would-be reactive factory but declined
  * for inlining (#2325). Recorded so validateReactiveFactoryCalls can emit
- * the specific diagnostic (BF111 rename / BF112 module-scope capture) at
- * the call site instead of the generic BF110.
+ * the specific diagnostic (BF111 rename / BF112 module-scope capture /
+ * BF113 re-provisioned-import name collision) at the call site instead of
+ * the generic BF110.
  */
 export interface DeclinedReactiveFactory {
-  code: 'BF111' | 'BF112'
+  code: 'BF111' | 'BF112' | 'BF113'
   /** Detail spliced into the call-site message (e.g. offending identifier list). */
   detail: string
   /** Definition site (in the helper file for cross-file declines). */

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1492,6 +1492,30 @@ export interface ReactiveFactoryInfo {
    * (local factories win), not by consulting this field.
    */
   sourceFilePath?: string
+  /**
+   * Imports to re-provision into the component file when this cross-file
+   * factory is inlined (#2332). Absent/empty for same-file factories and
+   * for factories whose body references no helper-file import. Entries
+   * already satisfied by an identical top-level import in the component
+   * file are dropped at prescan time.
+   */
+  requiredImports?: RequiredFactoryImport[]
+}
+
+/**
+ * An import the helper file holds that an inlined factory body references
+ * (#2332). Not a BF112 capture: the component file can import the same
+ * binding itself. Collected at prescan with the specifier ALREADY rewritten
+ * relative to the component file (or unchanged for bare/npm specifiers);
+ * the source rewriter injects one deduped import statement per specifier.
+ */
+export interface RequiredFactoryImport {
+  /** Local binding name as referenced inside the factory body. */
+  localName: string
+  /** Name exported by the target module (`import { exportedName as localName }`). */
+  exportedName: string
+  /** Component-file-relative specifier (`../lib/mathmod`), or the unchanged bare specifier. */
+  specifier: string
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #2332. Fixes a spurious-rejection regression in #2325/#2329 (0.23.0): cross-file reactive-factory inlining's `BF112` safety guard treated every module-scope value binding in the helper file the same way — a locally-declared helper (the original #930/#931 motivating case, correctly unrepresentable in the component file) and an ordinary named import from a third module (perfectly re-importable) both declined inlining unconditionally. In practice this blocked nearly every realistic cross-file hook, since almost any non-trivial state-management factory calls out to sibling modules.

### What this PR does

- **`BF112` now only fires on genuinely helper-local bindings** — top-level `const`/`let`/`var`, `function`/`class`/`enum` names, and default/namespace imports (no single named export to re-provision under one local name — out of scope for this round).
- **Named value imports the helper file holds are re-provisioned into the component file** when an inlined factory body references them: the specifier is rewritten relative to the component file (bare/npm specifiers pass through unchanged), and imports needed by multiple inlined factories in the same file are deduped into one statement. Since #931/#2325's whole mechanism is source-text rewriting before any analysis runs, the re-provisioned import is injected as a zero-width edit into that same rewritten source — indistinguishable from a hand-written import for both the SSR-emit and client-JS-emit passes, which both read the identical rewritten string.
- **New diagnostic `BF113`**: a re-provisioned import whose local name would collide with an existing binding anywhere in the component file (top-level or nested — an inlined body lands inside a component function, where any param/local could silently shadow an injected top-level import) declines that specific call site with a loud, actionable error instead of risking a silent shadow.
- Already-satisfied imports (the component file already imports the exact same binding itself) are recognized and skipped rather than injected again as a duplicate declaration.

### Verified

- Minimal repro from #2332 (a cross-file factory calling a plain exported function from a third module) now compiles with 0 errors instead of `BF112`.
- New test suite (`reactive-factory-cross-file.test.ts`, #2332 describe block) covers: re-provisioned import with correct relative-path rewriting across differing directory depths, bare/npm specifier pass-through, dedup across two factories importing the same helper, `BF113` on a real collision, the original #930/#931 BF112 regression (still declines, unmodified), default-import scope decision (still `BF112`), and SSR template output (not just client JS) reflecting the re-provisioned import.
- `tsc --noEmit -p packages/jsx/tsconfig.json` clean.
- `reactive-factory-cross-file.test.ts` + `reactive-factory-inlining.test.ts`: 31/31 pass.
- Full `@barefootjs/jsx` suite: 2560+/2592 pass consistently; the ~3-4 failures seen across repeated runs are `bun test`'s 5000ms per-test timeout firing on a machine under heavy concurrent load from unrelated processes — a *different* unrelated test (loop-binding analysis, debug/profiling formatting, turn-marker tracking — none touching this change's code paths) failed each run, with implausible reported durations (900,000ms+ against a 5000ms timeout), consistent with OS-level scheduling starvation rather than a deterministic regression. Not reproducible in isolation.
- `@barefootjs/cli` suite: 916/921 pass — the 5 failures are the pre-existing macOS case-insensitive-filesystem artifacts in `resolve-source.test.ts`/`meta-loader.test.ts`, unrelated to this change (same failures present on clean `main`).

### Known limitation (documented in the changeset, not fixed here)

The CLI's build-cache dependency scanner tracks a factory helper's own resolved path but not the *existence* of the third modules its re-provisioned imports point to, so deleting/renaming one of those third modules can leave a stale build until an unrelated tracked-file change triggers a rebuild. Left as a follow-up — recursing one level into helper files that contributed factories is the likely fix.

## Test plan

- [x] `tsc --noEmit -p packages/jsx/tsconfig.json` — clean
- [x] `bun test packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts packages/jsx/src/__tests__/reactive-factory-inlining.test.ts` — 31/31 pass
- [x] `bun run --filter '@barefootjs/jsx' test` — clean modulo unrelated machine-load flakiness (see above)
- [x] `bun run --filter '@barefootjs/cli' test` — 916/921 pass, 5 pre-existing unrelated failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
