### PR TITLE
Simplify #2336's client-JS arg serializer (rename + dead check + guard order)

### DIFF
--- a/.changeset/simplify-folded-arg-serializer.md
+++ b/.changeset/simplify-folded-arg-serializer.md
@@ -1,0 +1,5 @@
+---
+'@barefootjs/jsx': patch
+---
+
+Internal cleanup of the `toLocaleDateString` client-JS rewrite serializer: rename `patternArgToClientJs` to `foldedArgToClientJs` (it serializes both the pattern and the #2334 names-table arguments), drop an unreachable duplicate kind check, and hoist the right-fold leaf validation ahead of the recursive descent. No behavior change; the function is module-internal to the compiler (not re-exported from the package index).

--- a/packages/jsx/src/ir-to-client-js/emit-reactive.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-reactive.ts
@@ -11,7 +11,7 @@ import type { ClientJsContext } from './types.ts'
 import { toHtmlAttrName, varSlotId, PROPS_PARAM } from './utils.ts'
 import { createTemplateAwareStringProtector } from './html-template.ts'
 import { datePlugin, DATE_METHODS } from '../date-lowering.ts'
-import { toLocaleDatePlugin, patternArgToClientJs } from '../to-locale-date-lowering.ts'
+import { toLocaleDatePlugin, foldedArgToClientJs } from '../to-locale-date-lowering.ts'
 import { tsNodeToParsedExpr } from '../expression-parser.ts'
 import type { LoweringMatcher } from '../lowering-registry.ts'
 
@@ -184,12 +184,12 @@ function lowerToLocaleCallsInReactiveExpr(expr: string, matcher: LoweringMatcher
     const [, patternArg, tzArg, namesArg] = node.args
     if (!patternArg || tzArg?.kind !== 'literal') continue
     const localeText = call.arguments[0].getText(sourceFile)
-    const patternJs = patternArgToClientJs(patternArg, localeText)
+    const patternJs = foldedArgToClientJs(patternArg, localeText)
     if (patternJs === null) continue
     // The names table (#2334) — omitted when empty, same as the static path.
     let namesJs: string | null = null
     if (namesArg && !(namesArg.kind === 'array-literal' && namesArg.elements.length === 0)) {
-      namesJs = patternArgToClientJs(namesArg, localeText)
+      namesJs = foldedArgToClientJs(namesArg, localeText)
       if (namesJs === null) continue
     }
     const receiverText = propAccess.expression.getText(sourceFile)

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -49,7 +49,7 @@ import { resolveFreeRefs, isNameBound as isNameBoundInEnv, type BindingEnvironme
 import { computeFileScope } from './ir-to-client-js/component-scope.ts'
 import { createTemplateAwareStringProtector } from './ir-to-client-js/html-template.ts'
 import { datePlugin, DATE_METHODS } from './date-lowering.ts'
-import { toLocaleDatePlugin, patternArgToClientJs } from './to-locale-date-lowering.ts'
+import { toLocaleDatePlugin, foldedArgToClientJs } from './to-locale-date-lowering.ts'
 import type { LoweringMatcher } from './lowering-registry.ts'
 import { extractFreeIdentifiersFromNode, initializerShapeContainsJsx } from './analyzer.ts'
 import { iterateJsTokens, replaceInExprContexts } from './scanner/js-scanner.ts'
@@ -465,13 +465,13 @@ function lowerToLocaleDateCalls(text: string, expr: ts.Node, ctx: TransformConte
     const [, patternArg, tzArg, namesArg] = node.args
     if (!patternArg || tzArg?.kind !== 'literal') continue
     const localeText = ctx.getJS(call.arguments[0])
-    const patternJs = patternArgToClientJs(patternArg, localeText)
+    const patternJs = foldedArgToClientJs(patternArg, localeText)
     if (patternJs === null) continue
     // The names table (#2334) — omitted from the client call when empty
     // (the client function defaults to []).
     let namesJs: string | null = null
     if (namesArg && !(namesArg.kind === 'array-literal' && namesArg.elements.length === 0)) {
-      namesJs = patternArgToClientJs(namesArg, localeText)
+      namesJs = foldedArgToClientJs(namesArg, localeText)
       if (namesJs === null) continue
     }
     const receiverText = ctx.getJS(propAccess.expression)

--- a/packages/jsx/src/to-locale-date-lowering.ts
+++ b/packages/jsx/src/to-locale-date-lowering.ts
@@ -523,33 +523,34 @@ export function matchToLocaleDateStringCall(
 }
 
 /**
- * Render a matched node's PATTERN argument as client-JS text for the
- * #2292-style rewrite sites (`jsx-to-ir.ts` / `emit-reactive.ts`). A literal
- * pattern stringifies directly; the union stage's right-folded ternary
- * re-serializes against `localeText` — the rewrite site's own source text
- * for the locale argument, so downstream prop-prefix rewrites treat it like
- * any other reference. Returns null for any shape this module didn't build
- * (the caller then leaves the expression raw rather than guessing).
+ * Render a matched node's helper argument — the pattern (`strLit` leaf) or
+ * the #2334 names table (`strArr` leaf), either possibly wrapped in
+ * `foldMembers`' right-folded ternary — as client-JS text for the
+ * #2292-style rewrite sites (`jsx-to-ir.ts` / `emit-reactive.ts`). Leaves
+ * stringify directly; a fold re-serializes its tests against `localeText` —
+ * the rewrite site's own source text for the locale argument, so downstream
+ * prop-prefix rewrites treat it like any other reference. Returns null for
+ * any shape this module didn't build (the caller then leaves the expression
+ * raw rather than guessing).
  */
-export function patternArgToClientJs(patternArg: ParsedExpr, localeText: string): string | null {
-  if (patternArg.kind === 'literal') return JSON.stringify(patternArg.value)
-  // The `names` argument's leaf (#2334): an array-literal of string literals.
-  if (patternArg.kind === 'array-literal') {
+export function foldedArgToClientJs(arg: ParsedExpr, localeText: string): string | null {
+  if (arg.kind === 'literal') return JSON.stringify(arg.value)
+  if (arg.kind === 'array-literal') {
     const values: string[] = []
-    for (const el of patternArg.elements) {
+    for (const el of arg.elements) {
       if (el.kind !== 'literal') return null
       values.push(String(el.value))
     }
     return JSON.stringify(values)
   }
-  if (patternArg.kind !== 'conditional') return null
-  const t = patternArg.test
+  if (arg.kind !== 'conditional') return null
+  const t = arg.test
   if (t.kind !== 'binary' || t.op !== '===' || t.right.kind !== 'literal') return null
-  if (t.right.kind !== 'literal') return null
-  const cons = patternArgToClientJs(patternArg.consequent, localeText)
-  const rest = patternArgToClientJs(patternArg.alternate, localeText)
+  // Right-fold shape: the consequent must be a leaf (only alternates nest).
+  if (arg.consequent.kind !== 'literal' && arg.consequent.kind !== 'array-literal') return null
+  const cons = foldedArgToClientJs(arg.consequent, localeText)
+  const rest = foldedArgToClientJs(arg.alternate, localeText)
   if (cons === null || rest === null) return null
-  if (patternArg.consequent.kind !== 'literal' && patternArg.consequent.kind !== 'array-literal') return null
   return `${localeText} === ${JSON.stringify(t.right.value)} ? ${cons} : ${rest}`
 }
 


### PR DESCRIPTION
## What

`/simplify` follow-up to #2336, no behavior change. The client-JS rewrite serializer in `to-locale-date-lowering.ts` had grown into a general-purpose serializer while keeping its pattern-specific name.

- **Rename `patternArgToClientJs` → `foldedArgToClientJs`** (+ doc rewrite): since #2334 it serializes *both* `format_date` args this module builds — the `strLit` pattern leaf and the `strArr` names-table leaf, either wrapped in `foldMembers`' right-folded ternary — so the old name misled at both call sites (`jsx-to-ir.ts`, `emit-reactive.ts`).
- **Drop the duplicated `t.right.kind !== 'literal'` check** — the compound condition one line above already returns `null` for it; the second check was unreachable.
- **Hoist the consequent-must-be-leaf check above the recursive calls.** The check is load-bearing for the documented null-on-foreign-shape contract (a hand-built conditional whose consequent is itself a conditional can serialize non-null), but it previously ran only *after* both subtrees had been serialized. Validation now gates the descent instead of following it.

Considered and rejected (review notes): reusing `stringifyParsedExpr` (its `', '` array join breaks the pinned no-space golden output, and its conditional arm can't perform the `localeText` substitution this function exists for) and builder-side eager serialization (the locale's rewrite-site source text doesn't exist at match time — the build→serialize round trip is structural, not incidental).

## Verification

- jsx suite: 2579 pass / 0 fail (2607 tests, 200 files)
- `tsc --noEmit` clean on `packages/jsx`
- No remaining source references to the old name (dist artifacts regenerate on build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dBKFhtumbPwjNZaU3LRpy

---
_Generated by [Claude Code](https://claude.ai/code/session_015dBKFhtumbPwjNZaU3LRpy)_