### PR TITLE
fix(jsx): reactive-factory inlining silently corrupted/broke realistic patterns (#2341)

### DIFF
--- a/.changeset/reactive-factory-inlining-fidelity.md
+++ b/.changeset/reactive-factory-inlining-fidelity.md
@@ -1,0 +1,22 @@
+---
+'@barefootjs/jsx': minor
+---
+
+Fix three reactive-factory inlining bugs that produced silently corrupted or
+broken output with zero compile diagnostics (#2341):
+
+- Identifier renames during factory inlining now operate on precise AST
+  positions instead of a whole-body regex, so string/template-literal
+  contents, property keys, and JSX intrinsic tags that happen to share a
+  renamed name are no longer corrupted. A factory parameter shadowed by a
+  nested declaration inside the body can no longer be silently substituted
+  with an invalid expression — it now declines with a new diagnostic,
+  **BF114**.
+- Cross-file factory resolution now follows one `export ... from` hop
+  through a barrel `index.ts` file, so `export { useToggle } from
+  './useToggle'` re-exports resolve to the real factory instead of silently
+  falling through to a dangling reference at runtime.
+- `detectReactiveFactory` now counts `return` statements anywhere in the
+  body (not just at the top level), so a guard-clause `return` nested
+  inside `if`/`try`/a loop correctly declines the factory instead of being
+  spliced into the component's init function as an inert early return.

--- a/packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts
@@ -500,3 +500,290 @@ export function DoublerSelfImporting() {
     expect((clientJs!.content.match(/from '\.\.\/lib\/mathmod'/g) ?? []).length).toBe(1)
   })
 })
+
+describe('Barrel re-exports (#2341 BUG-2)', () => {
+  beforeAll(() => {
+    writeFixture('barrel/useToggle.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function useToggle(initial: boolean) {
+  const [on, setOn] = createSignal(initial)
+  return [on, setOn] as const
+}
+`)
+    writeFixture('barrel/index.ts', `export { useToggle } from './useToggle'
+`)
+  })
+
+  test('B1: factory reached through a barrel index.ts inlines (issue repro)', () => {
+    // `../barrel` has no extension and is not itself a file — this also
+    // exercises directory-index resolution (`./hooks` -> `hooks/index.ts`),
+    // already supported by `resolveRelativeImportToFile`.
+    const consumerSource = `'use client'
+import { useToggle } from '../barrel'
+
+export function Switch() {
+  const [on, setOn] = useToggle(false)
+  return <button onClick={() => setOn(!on())}>{on() ? 'on' : 'off'}</button>
+}
+`
+    const consumerPath = writeFixture('barrel-consumer/Switch.tsx', consumerSource)
+
+    const ctx = analyzeComponent(consumerSource, consumerPath, 'Switch')
+    expect(ctx.signals.length).toBe(1)
+    expect(ctx.signals[0].getter).toBe('on')
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('createSignal')
+    expect(clientJs!.content).not.toContain('../barrel')
+    expect(clientJs!.content).toMatch(/import\s*\{[^}]*createSignal[^}]*\}\s*from\s*'@barefootjs\/client\/runtime'/)
+  })
+
+  test('B2: barrel alias (export { useToggle as useFlip } from) inlines', () => {
+    writeFixture('barrel-alias/index.ts', `export { useToggle as useFlip } from '../barrel/useToggle'
+`)
+    const consumerSource = `'use client'
+import { useFlip } from '../barrel-alias'
+
+export function FlipSwitch() {
+  const [on, setOn] = useFlip(false)
+  return <button onClick={() => setOn(!on())}>{on() ? 'on' : 'off'}</button>
+}
+`
+    const consumerPath = writeFixture('barrel-consumer/FlipSwitch.tsx', consumerSource)
+
+    const ctx = analyzeComponent(consumerSource, consumerPath, 'FlipSwitch')
+    expect(ctx.signals.length).toBe(1)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  })
+
+  test('B3: barrel alias + consumer alias both resolve through the hop', () => {
+    const consumerSource = `'use client'
+import { useFlip as flip } from '../barrel-alias'
+
+export function FlipSwitch2() {
+  const [on, setOn] = flip(false)
+  return <button onClick={() => setOn(!on())}>{on() ? 'on' : 'off'}</button>
+}
+`
+    const consumerPath = writeFixture('barrel-consumer/FlipSwitch2.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('createSignal')
+  })
+
+  test('B4: export * from stays loud (BF110), never silently marked clean', () => {
+    writeFixture('barrel-star/index.ts', `export * from '../barrel/useToggle'
+`)
+    const consumerSource = `'use client'
+import { useToggle } from '../barrel-star'
+
+export function StarConsumer() {
+  const [on, setOn] = useToggle(false)
+  return <button onClick={() => setOn(!on())}>{on() ? 'on' : 'off'}</button>
+}
+`
+    const consumerPath = writeFixture('barrel-consumer/StarConsumer.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    const bf110 = result.errors.find(e => e.code === 'BF110')
+    expect(bf110).toBeDefined()
+    expect(bf110!.message).toContain('useToggle')
+  })
+
+  test('B5: self-referential barrel does not loop', () => {
+    writeFixture('loop/index.ts', `export { useToggle } from './index'
+`)
+    const consumerSource = `'use client'
+import { useToggle } from '../loop'
+
+export function LoopConsumer() {
+  const [on, setOn] = useToggle(false)
+  return <button onClick={() => setOn(!on())}>{on() ? 'on' : 'off'}</button>
+}
+`
+    const consumerPath = writeFixture('barrel-consumer/LoopConsumer.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    const bf110 = result.errors.find(e => e.code === 'BF110')
+    expect(bf110).toBeDefined()
+  })
+
+  test('B6: unresolvable re-export target stays loud, never cleanFactoryImports-silenced', () => {
+    writeFixture('barrel-missing/index.ts', `export { useToggle } from './missing'
+`)
+    const consumerSource = `'use client'
+import { useToggle } from '../barrel-missing'
+
+export function MissingConsumer() {
+  const [on, setOn] = useToggle(false)
+  return <button onClick={() => setOn(!on())}>{on() ? 'on' : 'off'}</button>
+}
+`
+    const consumerPath = writeFixture('barrel-consumer/MissingConsumer.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    const bf110 = result.errors.find(e => e.code === 'BF110')
+    expect(bf110).toBeDefined()
+  })
+
+  test('B7: module-scope capture through a barrel still declines with BF112 (defining-file anchor)', () => {
+    // If the capture check were (incorrectly) anchored to the barrel file
+    // instead of the file that actually DEFINES the factory, `readStored`/
+    // `KEY` (declared only in useStoredCounter.tsx, not in the barrel's
+    // index.ts) would never be found as a capture, and the factory would
+    // wrongly inline with a dangling `readStored()` reference (#2341 BUG-2).
+    writeFixture('barrel-capture/useStoredCounter.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+
+const KEY = 'stored-value'
+
+function readStored() {
+  return KEY.length
+}
+
+export function useStoredCounter() {
+  const [count, setCount] = createSignal(readStored())
+  return { count, setCount }
+}
+`)
+    writeFixture('barrel-capture/index.ts', `export { useStoredCounter } from './useStoredCounter'
+`)
+    const consumerSource = `'use client'
+import { useStoredCounter } from '../barrel-capture'
+
+export function CaptureConsumer() {
+  const { count, setCount } = useStoredCounter()
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+    const consumerPath = writeFixture('barrel-consumer/CaptureConsumer.tsx', consumerSource)
+
+    const ctx = analyzeComponent(consumerSource, consumerPath, 'CaptureConsumer')
+    expect(ctx.signals.length).toBe(0)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    const bf112 = result.errors.find(e => e.code === 'BF112')
+    expect(bf112).toBeDefined()
+    expect(bf112!.message).toContain('readStored')
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    if (clientJs) {
+      expect(clientJs.content).not.toContain('readStored')
+    }
+  })
+
+  test('B8: re-provisioned helper import is anchored to the defining file, not the barrel', () => {
+    // The barrel (`hooks2barrel/nested/index.ts`) and the file that
+    // actually defines `useDouble` (`hooks2/useDouble.tsx`) live at
+    // DIFFERENT depths — anchoring the re-provisioned `doubleIt` import to
+    // the barrel's directory instead of the defining file's directory
+    // would resolve to a nonexistent path (#2341 BUG-2).
+    writeFixture('lib2/mathmod.ts', `export function doubleIt(x: number): number {
+  return x * 2
+}
+`)
+    writeFixture('hooks2/useDouble.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+import { doubleIt } from '../lib2/mathmod'
+
+export function useDouble(initial: number) {
+  const [value, setValue] = createSignal(doubleIt(initial))
+  const bump = () => setValue(doubleIt(value()))
+  return { value, bump }
+}
+`)
+    writeFixture('hooks2barrel/nested/index.ts', `export { useDouble } from '../../hooks2/useDouble'
+`)
+    const consumerSource = `'use client'
+import { useDouble } from '../../hooks2barrel/nested'
+
+export function DoubleViaBarrel() {
+  const { value, bump } = useDouble(21)
+  return <button onClick={bump}>{value()}</button>
+}
+`
+    const consumerPath = writeFixture('components/deep/DoubleViaBarrel.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toMatch(/from\s*'\.\.\/\.\.\/lib2\/mathmod'/)
+    expect(clientJs!.content).not.toContain('hooks2barrel')
+  })
+
+  test('B9: two barrel hops exceed MAX_REEXPORT_HOPS and stay loud', () => {
+    writeFixture('twohop-b/useToggle.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function useToggle(initial: boolean) {
+  const [on, setOn] = createSignal(initial)
+  return [on, setOn] as const
+}
+`)
+    writeFixture('twohop-b/index.ts', `export { useToggle } from './useToggle'
+`)
+    writeFixture('twohop-a/index.ts', `export { useToggle } from '../twohop-b'
+`)
+    const consumerSource = `'use client'
+import { useToggle } from '../twohop-a'
+
+export function TwoHopConsumer() {
+  const [on, setOn] = useToggle(false)
+  return <button onClick={() => setOn(!on())}>{on() ? 'on' : 'off'}</button>
+}
+`
+    const consumerPath = writeFixture('barrel-consumer/TwoHopConsumer.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    const bf110 = result.errors.find(e => e.code === 'BF110')
+    expect(bf110).toBeDefined()
+  })
+
+  test('B10: mixed barrel (own factory + re-export) inlines both', () => {
+    // Pins exportedFns-before-reexports lookup order: `useLocal` is defined
+    // directly in index.ts, `useToggle` only reaches it via a re-export.
+    writeFixture('mixed/useToggle.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function useToggle(initial: boolean) {
+  const [on, setOn] = createSignal(initial)
+  return [on, setOn] as const
+}
+`)
+    writeFixture('mixed/index.ts', `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function useLocal(initial: number) {
+  const [count, setCount] = createSignal(initial)
+  return [count, setCount] as const
+}
+
+export { useToggle } from './useToggle'
+`)
+    const consumerSource = `'use client'
+import { useLocal, useToggle } from '../mixed'
+
+export function MixedConsumer() {
+  const [count, setCount] = useLocal(0)
+  const [on, setOn] = useToggle(false)
+  return <button onClick={() => { setCount(count() + 1); setOn(!on()) }}>{count()} {on() ? 'on' : 'off'}</button>
+}
+`
+    const consumerPath = writeFixture('barrel-consumer/MixedConsumer.tsx', consumerSource)
+
+    const ctx = analyzeComponent(consumerSource, consumerPath, 'MixedConsumer')
+    expect(ctx.signals.length).toBe(2)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  })
+})

--- a/packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts
@@ -787,3 +787,298 @@ export function MixedConsumer() {
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
   })
 })
+
+describe('Real-world factory matrix, cross-file (#2341)', () => {
+  test('M15: deep relative paths resolve and inline', () => {
+    writeFixture('deep/hooks/state/useCounter.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function useCounter(initial: number) {
+  const [count, setCount] = createSignal(initial)
+  return [count, setCount] as const
+}
+`)
+    const consumerSource = `'use client'
+import { useCounter } from '../../hooks/state/useCounter'
+
+export function Counter() {
+  const [count, setCount] = useCounter(0)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+    const consumerPath = writeFixture('deep/components/pages/Counter.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('createSignal')
+  })
+
+  test('M16: two factories from two different modules compose in one component', () => {
+    writeFixture('compose/useA.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function useA(initial: number) {
+  const [a, setA] = createSignal(initial)
+  return [a, setA] as const
+}
+`)
+    writeFixture('compose/useB.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function useB(initial: number) {
+  const [b, setB] = createSignal(initial)
+  return [b, setB] as const
+}
+`)
+    const consumerSource = `'use client'
+import { useA } from './useA'
+import { useB } from './useB'
+
+export function Composed() {
+  const [a, setA] = useA(1)
+  const [b, setB] = useB(2)
+  return <button onClick={() => { setA(a() + 1); setB(b() + 1) }}>{a()} {b()}</button>
+}
+`
+    const consumerPath = writeFixture('compose/Composed.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content.match(/createSignal\(/g)?.length).toBe(2)
+  })
+
+  test('M17: onMount is provisioned from usage for a cross-file factory', () => {
+    writeFixture('matrix17/useTick.tsx', `'use client'
+import { createSignal, onMount } from '@barefootjs/client'
+
+export function useTick(initial: number) {
+  const [tick, setTick] = createSignal(initial)
+  onMount(() => setTick(initial))
+  return [tick, setTick] as const
+}
+`)
+    const consumerSource = `'use client'
+import { useTick } from './useTick'
+
+export function Ticker() {
+  const [tick, setTick] = useTick(0)
+  return <button onClick={() => setTick(tick() + 1)}>{tick()}</button>
+}
+`
+    const consumerPath = writeFixture('matrix17/Ticker.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toMatch(/import\s*\{[^}]*onMount[^}]*\}\s*from\s*'@barefootjs\/client\/runtime'/)
+  })
+
+  test('M18: a type-only helper import does not trigger BF112 and is not re-provisioned', () => {
+    writeFixture('matrix18/todo-types.ts', `export interface Todo {
+  id: number
+  text: string
+}
+`)
+    writeFixture('matrix18/useTodos.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+import type { Todo } from './todo-types'
+
+export function useTodos(initial: Todo[]) {
+  const [todos, setTodos] = createSignal<Todo[]>(initial)
+  return [todos, setTodos] as const
+}
+`)
+    const consumerSource = `'use client'
+import { useTodos } from './useTodos'
+
+export function TodoList() {
+  const [todos, setTodos] = useTodos([])
+  return <button onClick={() => setTodos([])}>{todos().length}</button>
+}
+`
+    const consumerPath = writeFixture('matrix18/TodoList.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    expect(result.errors.find(e => e.code === 'BF112')).toBeUndefined()
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).not.toContain('./todo-types')
+  })
+
+  test('M19: a colliding binding nested inside a JSX callback still triggers BF113', () => {
+    // Pins collectEntryBindingNames's depth: the ONLY `doubleIt` binding in
+    // the consumer file is declared inside an onClick callback, not at any
+    // top level, yet the re-provisioning collision check must still find it
+    // (an over-broad scan is required — a narrower one would silently
+    // shadow the injected import at runtime instead of declining loudly).
+    writeFixture('matrix19/lib/mathmod.ts', `export function doubleIt(x: number): number {
+  return x * 2
+}
+`)
+    writeFixture('matrix19/hooks/useDouble.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+import { doubleIt } from '../lib/mathmod'
+
+export function useDouble(initial: number) {
+  const [value, setValue] = createSignal(doubleIt(initial))
+  const bump = () => setValue(doubleIt(value()))
+  return { value, bump }
+}
+`)
+    const consumerSource = `'use client'
+import { useDouble } from '../hooks/useDouble'
+
+export function Collide() {
+  const { value, bump } = useDouble(21)
+  return <button onClick={() => { const doubleIt = 1; bump(); console.log(doubleIt) }}>{value()}</button>
+}
+`
+    const consumerPath = writeFixture('matrix19/components/Collide.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    const bf113 = result.errors.find(e => e.code === 'BF113')
+    expect(bf113).toBeDefined()
+    expect(bf113!.message).toContain('doubleIt')
+  })
+
+  test('M20: 3 call sites of one imported factory with distinct tuple caller names', () => {
+    writeFixture('matrix20/useCounter.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function useCounter(initial: number) {
+  const [count, setCount] = createSignal(initial)
+  return [count, setCount] as const
+}
+`)
+    const consumerSource = `'use client'
+import { useCounter } from './useCounter'
+
+export function Triple() {
+  const [a, setA] = useCounter(1)
+  const [b, setB] = useCounter(2)
+  const [c, setC] = useCounter(3)
+  return <button onClick={() => { setA(a() + 1); setB(b() + 1); setC(c() + 1) }}>{a()} {b()} {c()}</button>
+}
+`
+    const consumerPath = writeFixture('matrix20/Triple.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content.match(/createSignal\(/g)?.length).toBe(3)
+    for (const name of ['a', 'setA', 'b', 'setB', 'c', 'setC']) {
+      expect(clientJs!.content).toContain(name)
+    }
+  })
+
+  test('M21: SSR through a barrel reflects the re-provisioned import (mirrors matrix 6)', () => {
+    writeFixture('matrix21/lib2/mathmod.ts', `export function doubleIt(x: number): number {
+  return x * 2
+}
+`)
+    writeFixture('matrix21/hooks2/useDouble.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+import { doubleIt } from '../lib2/mathmod'
+
+export function useDouble(initial: number) {
+  const [value, setValue] = createSignal(doubleIt(initial))
+  const bump = () => setValue(doubleIt(value()))
+  return { value, bump }
+}
+`)
+    writeFixture('matrix21/hooks2barrel/index.ts', `export { useDouble } from '../hooks2/useDouble'
+`)
+    const consumerSource = `'use client'
+import { useDouble } from '../hooks2barrel'
+
+export function DoublerSSR() {
+  const { value, bump } = useDouble(21)
+  return <button onClick={bump}>{value()}</button>
+}
+`
+    const consumerPath = writeFixture('matrix21/components/DoublerSSR.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const template = result.files.find(f => f.type === 'markedTemplate')
+    expect(template).toBeDefined()
+    expect(template!.content).toMatch(/import\s*\{\s*doubleIt\s*\}\s*from\s*'\.\.\/lib2\/mathmod'/)
+    expect(template!.content).toContain('doubleIt(')
+  })
+
+  test('M22: aliased factory import + aliased helper import both resolve correctly', () => {
+    writeFixture('matrix22/lib/mathmod.ts', `export function doubleIt(x: number): number {
+  return x * 2
+}
+`)
+    writeFixture('matrix22/hooks/useDouble.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+import { doubleIt as dbl } from '../lib/mathmod'
+
+export function useDouble(initial: number) {
+  const [value, setValue] = createSignal(dbl(initial))
+  const bump = () => setValue(dbl(value()))
+  return { value, bump }
+}
+`)
+    const consumerSource = `'use client'
+import { useDouble as useDoubleAliased } from '../hooks/useDouble'
+
+export function Doubler() {
+  const { value, bump } = useDoubleAliased(21)
+  return <button onClick={bump}>{value()}</button>
+}
+`
+    const consumerPath = writeFixture('matrix22/components/Doubler.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    // The re-provisioned import preserves the HELPER file's own local alias.
+    expect(clientJs!.content).toMatch(/import\s*\{\s*doubleIt as dbl\s*\}/)
+  })
+
+  test('M23: an already-satisfied import through a barrel dedupes (no BF113, one occurrence)', () => {
+    writeFixture('matrix23/lib/mathmod.ts', `export function doubleIt(x: number): number {
+  return x * 2
+}
+`)
+    writeFixture('matrix23/hooks/useDouble.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+import { doubleIt } from '../lib/mathmod'
+
+export function useDouble(initial: number) {
+  const [value, setValue] = createSignal(doubleIt(initial))
+  const bump = () => setValue(doubleIt(value()))
+  return { value, bump }
+}
+`)
+    writeFixture('matrix23/hooks/index.ts', `export { useDouble } from './useDouble'
+`)
+    const consumerSource = `'use client'
+import { useDouble } from '../hooks'
+import { doubleIt } from '../lib/mathmod'
+
+export function DoublerSelfImporting() {
+  const { value, bump } = useDouble(21)
+  return <button onClick={() => { bump(); doubleIt(value()) }}>{value()}</button>
+}
+`
+    const consumerPath = writeFixture('matrix23/components/DoublerSelfImporting.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    expect(result.errors.find(e => e.code === 'BF113')).toBeUndefined()
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect((clientJs!.content.match(/from '\.\.\/lib\/mathmod'/g) ?? []).length).toBe(1)
+  })
+})

--- a/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
@@ -593,6 +593,41 @@ describe('Guard-clause / nested-return factories decline (#2341 BUG-3)', () => {
     expect(clientJs).toContain('createSignal')
   })
 
+  test('T4b: return inside an object-literal method does NOT decline (Copilot review, PR #2342)', () => {
+    // The nested-return boundary check originally stopped only at
+    // FunctionDeclaration/FunctionExpression/ArrowFunction, so a `return`
+    // inside an object-literal method (or a class method/accessor) declared
+    // in the factory body was incorrectly counted toward the total, wrongly
+    // declassifying an otherwise-inlinable factory. ts.isFunctionLike
+    // (methods/accessors/constructors, not just plain functions) fixes it.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function createLogger(initial: number) {
+        const [n, setN] = createSignal(initial)
+        const logger = {
+          describe() {
+            if (n() > 0) return 'positive'
+            return 'non-positive'
+          },
+        }
+        return { n, setN, logger }
+      }
+      export function Counter() {
+        const { n, setN, logger } = createLogger(0)
+        return <button onClick={() => setN(n() + 1)}>{logger.describe()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+    expect(ctx.signals.length).toBe(1)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).toContain('createSignal')
+    expect(clientJs).toContain("'positive'")
+  })
+
   describe('T5: cross-file guard-clause factory', () => {
     let fixtureDir: string
 

--- a/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
@@ -641,3 +641,335 @@ export function Bounded() {
     })
   })
 })
+
+describe('Real-world factory matrix (#2341)', () => {
+  test('M1: onMount/onCleanup inside a factory body', () => {
+    const source = `
+      'use client'
+      import { createSignal, onMount, onCleanup } from '@barefootjs/client'
+
+      function useTick() {
+        const [tick, setTick] = createSignal(0)
+        onMount(() => setTick(1))
+        onCleanup(() => setTick(0))
+        return { tick, setTick }
+      }
+
+      export function Ticker() {
+        const { tick, setTick } = useTick()
+        return <button onClick={() => setTick(tick() + 1)}>{tick()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Ticker.tsx')
+    expect(ctx.signals.length).toBe(1)
+
+    const result = compileJSX(source, 'Ticker.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).toContain('onMount(')
+    expect(clientJs).toContain('onCleanup(')
+  })
+
+  test('M2: createEffect inside a factory body', () => {
+    const source = `
+      'use client'
+      import { createSignal, createEffect } from '@barefootjs/client'
+
+      function useTitle(initial: number) {
+        const [count, setCount] = createSignal(initial)
+        createEffect(() => { document.title = String(count()) })
+        return [count, setCount] as const
+      }
+
+      export function TitleUpdater() {
+        const [count, setCount] = useTitle(0)
+        return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'TitleUpdater.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).toContain('createEffect')
+  })
+
+  test('M3: createDisposableEffect inside a factory body', () => {
+    const source = `
+      'use client'
+      import { createSignal, createDisposableEffect } from '@barefootjs/client'
+
+      function useDisposableTitle(initial: number) {
+        const [count, setCount] = createSignal(initial)
+        createDisposableEffect(() => { document.title = String(count()) })
+        return [count, setCount] as const
+      }
+
+      export function DisposableTitleUpdater() {
+        const [count, setCount] = useDisposableTitle(0)
+        return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'DisposableTitleUpdater.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).toContain('createDisposableEffect')
+  })
+
+  test('M4: realistic store (Sora useListStore scale) — 3 signals + 2 memos', () => {
+    const source = `
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/client'
+
+      function useListStore(initial: string[]) {
+        const [items, setItems] = createSignal(initial)
+        const [filter, setFilter] = createSignal('')
+        const [editing, setEditing] = createSignal('')
+        const visible = createMemo(() => items().filter(i => i.includes(filter())))
+        const count = createMemo(() => visible().length)
+        const clear = () => setItems([])
+        return { items, setItems, filter, setFilter, editing, setEditing, visible, count, clear }
+      }
+
+      export function ListView() {
+        const { items, setItems, filter, setFilter, editing, setEditing, visible, count, clear } = useListStore([])
+        return (
+          <div onClick={() => { setItems([...items(), 'x']); setFilter('a'); setEditing('x'); clear() }}>
+            {visible().length} / {count()} / {editing()}
+          </div>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'ListView.tsx')
+    expect(ctx.signals.length).toBe(3)
+    expect(ctx.memos.length).toBe(2)
+
+    const result = compileJSX(source, 'ListView.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  })
+
+  test('M5: identifier hygiene across 3 call sites of the same factory', () => {
+    // Each call site inlines a fresh copy of the factory body; the
+    // undestructured internal `setValue` must be suffix-renamed uniquely
+    // per call site (_bf0/_bf1/_bf2) while `value`/`bump` are renamed
+    // directly to each call site's own tuple names.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createPair(initial: number) {
+        const [value, setValue] = createSignal(initial)
+        const bump = () => setValue(value() + 1)
+        return [value, bump] as const
+      }
+
+      export function Triple() {
+        const [a, bumpA] = createPair(1)
+        const [b, bumpB] = createPair(2)
+        const [c, bumpC] = createPair(3)
+        return <button onClick={() => { bumpA(); bumpB(); bumpC() }}>{a()} {b()} {c()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Triple.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs.match(/createSignal\(/g)?.length).toBe(3)
+    expect(clientJs).toContain('_bf0')
+    expect(clientJs).toContain('_bf1')
+    expect(clientJs).toContain('_bf2')
+  })
+
+  test('M6: generic factory — type arguments do not disturb inlining', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createBox<T>(initial: T) {
+        const [v, setV] = createSignal<T>(initial)
+        return { v, setV }
+      }
+
+      export function Box() {
+        const { v, setV } = createBox<string>('x')
+        return <button onClick={() => setV('y')}>{v()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Box.tsx')
+    expect(ctx.signals.length).toBe(1)
+
+    const result = compileJSX(source, 'Box.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  })
+
+  test('M7: mixed reactive/non-reactive body — plain locals are also renamed correctly', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createSession(initial: number) {
+        const startedAt = Date.now()
+        const label = \`session-\${startedAt}\`
+        const [count, setCount] = createSignal(initial)
+        const bump = () => { setCount(count() + 1); console.log(label) }
+        return [count, bump] as const
+      }
+
+      export function Session() {
+        const [count, bump] = createSession(0)
+        return <button onClick={bump}>{count()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Session.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).toContain('Date.now()')
+    expect(clientJs).toMatch(/startedAt_bf\d+/)
+  })
+
+  test('M8: default-value destructure of an object-return factory declines with BF111', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [count, setCount] = createSignal(initial)
+        return { count, setCount }
+      }
+
+      export function Counter() {
+        const { count = 5 } = createCounter(0)
+        return <p>{count}</p>
+      }
+    `
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
+    const bf111 = result.errors.find(e => e.code === 'BF111')
+    expect(bf111).toBeDefined()
+  })
+
+  test('M9: unknown destructured property declines with BF110', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [count, setCount] = createSignal(initial)
+        return { count, setCount }
+      }
+
+      export function Counter() {
+        const { missing } = createCounter(0)
+        return <p>{missing}</p>
+      }
+    `
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
+    const bf110 = result.errors.find(e => e.code === 'BF110')
+    expect(bf110).toBeDefined()
+    expect(bf110!.message).toContain('missing')
+    expect(bf110!.message).toContain('not present in its return')
+  })
+
+  test('M10: whole-store (non-destructured) call is left untouched', () => {
+    // Pins the current fallback posture — a non-destructured factory call
+    // is not inlined at all, so none of the factory diagnostics apply.
+    // Whether it should eventually be double-invocation-safe is out of
+    // scope for #2341 (tracked separately in the issue).
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [count, setCount] = createSignal(initial)
+        return { count, setCount }
+      }
+
+      export function Counter() {
+        const store = createCounter(0)
+        return <p>{store.count}</p>
+      }
+    `
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
+    expect(result.errors.find(e => e.code?.startsWith('BF11'))).toBeUndefined()
+  })
+
+  test('M11: 3-element tuple return', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createResettable(initial: number) {
+        const [value, setValue] = createSignal(initial)
+        const reset = () => setValue(initial)
+        return [value, setValue, reset] as const
+      }
+
+      export function Resettable() {
+        const [count, setCount, resetCount] = createResettable(0)
+        return <button onClick={() => { setCount(count() + 1); resetCount() }}>{count()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Resettable.tsx')
+    expect(ctx.signals.length).toBe(1)
+
+    const result = compileJSX(source, 'Resettable.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).toContain('count')
+    expect(clientJs).toContain('setCount')
+    expect(clientJs).toContain('resetCount')
+  })
+
+  test('M12: a complex (non-atomic) argument expression keeps its parens at the splice site', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [count, setCount] = createSignal(initial)
+        return [count, setCount] as const
+      }
+
+      export function Counter() {
+        const a = 1
+        const [count, setCount] = createCounter(a > 0 ? a : 0)
+        return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).toContain('(a > 0 ? a : 0)')
+  })
+
+  test('M13: SSR seed value flows through the inlined factory', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [count, setCount] = createSignal(initial)
+        return [count, setCount] as const
+      }
+
+      export function Counter() {
+        const [count, setCount] = createCounter(42)
+        return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const template = result.files.find(f => f.type === 'markedTemplate')
+    expect(template).toBeDefined()
+    expect(template!.content).toContain('42')
+  })
+})

--- a/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
@@ -10,7 +10,10 @@
  * for destructures of non-recognised factory shapes.
  */
 
-import { describe, test, expect } from 'bun:test'
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
 import { analyzeComponent } from '../analyzer'
 import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
@@ -480,5 +483,161 @@ describe('Object-return reactive factories (#2325)', () => {
 
     const result = compileJSX(source, 'Comp.tsx', { adapter })
     expect(result.errors.find(e => e.code === 'BF110')).toBeUndefined()
+  })
+})
+
+describe('Guard-clause / nested-return factories decline (#2341 BUG-3)', () => {
+  test('T1: if-guard return declines with BF110, no inert splice (issue repro)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function useBounded(initial: number, max: number) {
+        const [n, setN] = createSignal(initial)
+        const bump = () => setN(Math.min(n() + 1, max))
+        if (initial > max) {
+          return { n, bump }
+        }
+        return { n, bump }
+      }
+      export function Bounded() {
+        const { n, bump } = useBounded(0, 10)
+        return <button onClick={bump}>{n()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Bounded.tsx')
+    expect(ctx.signals.length).toBe(0)
+
+    const result = compileJSX(source, 'Bounded.tsx', { adapter })
+    const bf110 = result.errors.find(e => e.code === 'BF110')
+    expect(bf110).toBeDefined()
+    expect(bf110!.message).toContain('useBounded')
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    if (clientJs) {
+      expect(clientJs.content).not.toContain('if (0 > 10)')
+    }
+  })
+
+  test('T2: return inside try/catch declines', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function useBounded(initial: number, max: number) {
+        const [n, setN] = createSignal(initial)
+        const bump = () => setN(Math.min(n() + 1, max))
+        try {
+          return { n, bump }
+        } catch {}
+        return { n, bump }
+      }
+      export function Bounded() {
+        const { n, bump } = useBounded(0, 10)
+        return <button onClick={bump}>{n()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Bounded.tsx')
+    expect(ctx.signals.length).toBe(0)
+
+    const result = compileJSX(source, 'Bounded.tsx', { adapter })
+    const bf110 = result.errors.find(e => e.code === 'BF110')
+    expect(bf110).toBeDefined()
+  })
+
+  test('T3: return inside a for-loop declines', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function useBounded(initial: number, max: number, seed: number[]) {
+        const [n, setN] = createSignal(initial)
+        const bump = () => setN(Math.min(n() + 1, max))
+        for (const x of seed) {
+          if (x < 0) return { n, bump }
+        }
+        return { n, bump }
+      }
+      export function Bounded() {
+        const { n, bump } = useBounded(0, 10, [1, 2, 3])
+        return <button onClick={bump}>{n()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Bounded.tsx')
+    expect(ctx.signals.length).toBe(0)
+
+    const result = compileJSX(source, 'Bounded.tsx', { adapter })
+    const bf110 = result.errors.find(e => e.code === 'BF110')
+    expect(bf110).toBeDefined()
+  })
+
+  test('T4: braced-arrow-callback returns do NOT decline (false-positive guard)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function createCounter(initial: number) {
+        const [n, setN] = createSignal(initial)
+        const bump = () => { return setN(n() + 1) }
+        return { n, bump }
+      }
+      export function Counter() {
+        const { n, bump } = createCounter(0)
+        return <button onClick={bump}>{n()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+    expect(ctx.signals.length).toBe(1)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).toContain('createSignal')
+  })
+
+  describe('T5: cross-file guard-clause factory', () => {
+    let fixtureDir: string
+
+    beforeAll(() => {
+      fixtureDir = mkdtempSync(path.join(tmpdir(), 'bf-factory-guard-clause-'))
+    })
+
+    afterAll(() => {
+      rmSync(fixtureDir, { recursive: true, force: true })
+    })
+
+    function writeFixture(name: string, content: string): string {
+      const p = path.join(fixtureDir, name)
+      mkdirSync(path.dirname(p), { recursive: true })
+      writeFileSync(p, content, 'utf8')
+      return p
+    }
+
+    test('guard-clause factory in an imported helper declines with BF110 (reactive-shaped path)', () => {
+      writeFixture('hooks-bounded.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function useBounded(initial: number, max: number) {
+  const [n, setN] = createSignal(initial)
+  const bump = () => setN(Math.min(n() + 1, max))
+  if (initial > max) {
+    return { n, bump }
+  }
+  return { n, bump }
+}
+`)
+      const consumerSource = `'use client'
+import { useBounded } from './hooks-bounded'
+
+export function Bounded() {
+  const { n, bump } = useBounded(0, 10)
+  return <button onClick={bump}>{n()}</button>
+}
+`
+      const consumerPath = writeFixture('bounded-consumer.tsx', consumerSource)
+
+      const result = compileJSX(consumerSource, consumerPath, { adapter })
+      const bf110 = result.errors.find(e => e.code === 'BF110')
+      expect(bf110).toBeDefined()
+      expect(bf110!.message).toContain('does not match the inlinable factory shape')
+    })
   })
 })

--- a/packages/jsx/src/__tests__/reactive-factory-rename-fidelity.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-rename-fidelity.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Regression tests for #2341 BUG-1: reactive-factory call-site inlining used
+ * to rename identifiers with a whole-body regex (`\bname\b` -> `name_bf0`,
+ * applied three times in sequence for suffix-renaming, param substitution,
+ * and return->caller renaming). A regex has no notion of AST position, so
+ * it also matched string-literal contents, template-literal text chunks,
+ * object/property-access keys, and JSX intrinsic tags that merely happened
+ * to spell the same identifier — corrupting them.
+ *
+ * Fix: collect exact identifier-node rename sites once at detection time
+ * (`detectReactiveFactory`), then apply a single merged bottom-to-top
+ * position splice at inline time (`inlineFactoryCallAtSite`) instead of any
+ * text search. This file pins the corruption classes the old regex produced
+ * and the BF114 diagnostic for the one shape the new approach must decline
+ * rather than silently substitute (a factory parameter re-declared inside
+ * the body).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('AST-position-based rename fidelity (#2341 BUG-1)', () => {
+  test('R1: string-literal argument sharing a local-binding name is preserved', () => {
+    // `stored` must feed into `createSignal` (not merely sit unused) so the
+    // general local-constant retention pass keeps the statement — an
+    // unrelated, pre-existing behavior of the component-body pipeline, out
+    // of scope for #2341.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createTheme(initial: string) {
+        const stored = localStorage.getItem('stored') ?? initial
+        const [theme, setTheme] = createSignal(stored)
+        return [theme, setTheme] as const
+      }
+
+      export function App() {
+        const [theme, setTheme] = createTheme('light')
+        return <button onClick={() => setTheme('dark')}>{theme()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'App.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    // The string literal argument to getItem must stay untouched...
+    expect(clientJs).toMatch(/localStorage\.getItem\('stored'\)/)
+    expect(clientJs).not.toMatch(/'stored_bf/)
+    // ...while the local binding declaration is still suffix-renamed.
+    expect(clientJs).toMatch(/stored_bf\d+ = localStorage/)
+  })
+
+  test('R2: SSR template also preserves the string literal', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createTheme(initial: string) {
+        const stored = localStorage.getItem('stored') ?? initial
+        const [theme, setTheme] = createSignal(stored)
+        return [theme, setTheme] as const
+      }
+
+      export function App() {
+        const [theme, setTheme] = createTheme('light')
+        return <button onClick={() => setTheme('dark')}>{theme()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'App.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const template = result.files.find(f => f.type === 'markedTemplate')
+    expect(template).toBeDefined()
+    expect(template!.content).toContain("getItem('stored')")
+  })
+
+  test('R3: template-literal text chunks are preserved, only substitutions rename', () => {
+    // Tuple factories require every return element to be destructured at
+    // the call site (arity must match), so all three elements are bound.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createLabelled(initial: string) {
+        const [value, setValue] = createSignal(initial)
+        const stored = initial
+        const label = \`\${stored} stored\`
+        return [value, setValue, label] as const
+      }
+
+      export function Labelled() {
+        const [value, setValue, label] = createLabelled('x')
+        return <p>{value()} {label}</p>
+      }
+    `
+
+    const result = compileJSX(source, 'Labelled.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    // The substitution `${stored}` renames with the local; the literal text
+    // chunk ` stored` after it must not.
+    expect(clientJs).toMatch(/`\$\{stored_bf\d+\} stored`/)
+  })
+
+  test('R4: shorthand property + string-literal argument expands to longhand (Repro B)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createUser(name: string) {
+        const [user, setUser] = createSignal({ name, loggedIn: false })
+        return [user, setUser] as const
+      }
+
+      export function Profile() {
+        const [user, setUser] = createUser('Alice')
+        return <p onClick={() => setUser({ name: 'Bob', loggedIn: true })}>{user().name}</p>
+      }
+    `
+
+    const result = compileJSX(source, 'Profile.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).toMatch(/\{\s*name:\s*'Alice',\s*loggedIn:\s*false\s*\}/)
+  })
+
+  test('R5: shorthand property with a suffix-renamed local keeps its key', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createBox(initial: number) {
+        const size = initial + 1
+        const [box, setBox] = createSignal({ size })
+        return { box, setBox }
+      }
+
+      export function BoxDisplay() {
+        const { box, setBox } = createBox(1)
+        return <p onClick={() => setBox({ size: 2 })}>{box().size}</p>
+      }
+    `
+
+    const result = compileJSX(source, 'BoxDisplay.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).toMatch(/\{\s*size:\s*size_bf\d+\s*\}/)
+  })
+
+  test('R6: caller-rename of a return identifier leaves unrelated strings alone (Repro C)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createInput(initial: string) {
+        const [value, setValue] = createSignal(initial)
+        const update = (next: string) => {
+          if (next.length > 10) throw new Error('value too long')
+          setValue(next)
+        }
+        return [value, update] as const
+      }
+
+      export function Field() {
+        const [email, setEmail] = createInput('')
+        return <input value={email()} onInput={(e) => setEmail(e.target.value)} />
+      }
+    `
+
+    const result = compileJSX(source, 'Field.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).toContain("'value too long'")
+    expect(clientJs).not.toContain("throw new Error('email")
+    // The wrapper's declaration is renamed to the caller's setter name.
+    expect(clientJs).toMatch(/setEmail\s*=/)
+  })
+
+  test('R7: object-pattern shorthand binding (nested callback parameter) expands and keeps its key', () => {
+    // The ObjectBindingPattern shape is exercised on a nested callback's own
+    // parameter — `({ pos }) => ...` — rather than a top-level `const { pos }
+    // = ...` body statement: the latter is dropped by an unrelated,
+    // pre-existing gap in the component-body local-constant pipeline (out of
+    // scope for #2341; confirmed to reproduce identically outside any
+    // factory). The callback parameter here deliberately shadows the
+    // factory's own `pos` binding, pinning the alpha-rename guarantee from
+    // the #2341 BUG-1 spec: the walker does not stop at nested-function
+    // boundaries, so the shadowing parameter and the outer binding rename
+    // identically and consistently.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createPoint(seed: number) {
+        const [pos, setPos] = createSignal(seed)
+        const moveTo = ({ pos }: { pos: number }) => setPos(pos)
+        return { pos, moveTo }
+      }
+
+      export function PointDisplay() {
+        const { moveTo } = createPoint(0)
+        return <p onClick={() => moveTo({ pos: 5 })}>ok</p>
+      }
+    `
+
+    const result = compileJSX(source, 'PointDisplay.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).toMatch(/\{\s*pos:\s*pos_bf\d+\s*\}/)
+  })
+
+  test('R8: property keys and .prop tails sharing a param name are untouched', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createConfigured(initial: number) {
+        const config = { initial: 0 }
+        const [n, setN] = createSignal(config.initial ?? initial)
+        return [n, setN] as const
+      }
+
+      export function Counter() {
+        const [n, setN] = createConfigured(5)
+        return <button onClick={() => setN(n() + 1)}>{n()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).toMatch(/\{\s*initial:\s*0\s*\}/)
+    expect(clientJs).toMatch(/config_bf\d+\.initial/)
+    expect(clientJs).toMatch(/\?\?\s*5/)
+  })
+
+  test('R9: a nested declaration that shadows a factory parameter declines with BF114', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createOops(initial: number) {
+        const [n, setN] = createSignal(initial)
+        const reset = (initial: number) => setN(initial)
+        return { n, reset }
+      }
+
+      export function Oops() {
+        const { n, reset } = createOops(0)
+        return <button onClick={() => reset(0)}>{n()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Oops.tsx')
+    expect(ctx.signals.length).toBe(0)
+
+    const result = compileJSX(source, 'Oops.tsx', { adapter })
+    const bf114 = result.errors.find(e => e.code === 'BF114')
+    expect(bf114).toBeDefined()
+    expect(bf114!.message).toContain('initial')
+    expect(bf114!.message).toContain('createOops')
+  })
+
+  test('R10: an argument expression is never re-scanned by a later rename pass (cascade fix)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createInput(initial: string) {
+        const [value, setValue] = createSignal(initial)
+        const update = (next: string) => setValue(next)
+        return [value, update] as const
+      }
+
+      export function Field() {
+        const value = 'seed'
+        const [email, setEmail] = createInput(value)
+        return <input value={email()} onInput={(e) => setEmail(e.target.value)} />
+      }
+    `
+
+    const result = compileJSX(source, 'Field.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    // `value` (the outer local passed as the argument) must reach
+    // createSignal verbatim — a later return->caller rename pass renaming
+    // the factory's own `value` return identifier to `email` must not
+    // re-scan and corrupt the already-substituted argument text.
+    expect(clientJs).toMatch(/createSignal\(\s*value\s*\)/)
+  })
+
+  test('R11: a tuple array-binding pattern in the body is not shorthand-expanded (ArrayBindingPattern trap)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [c, s] = createSignal(initial)
+        return [c, s] as const
+      }
+
+      export function Counter() {
+        const [count, setCount] = createCounter(0)
+        return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).not.toMatch(/\[\s*\w+:\s/)
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -4598,15 +4598,22 @@ function detectReactiveFactory(
 
   const loc = getSourceLocation(node, sourceFile, filePath)
 
-  // Count `return`s ANYWHERE in the body, stopping at nested function
-  // boundaries (same rule as isMultiReturnJsxFunctionBody, #932) — a return
-  // inside an arrow/function-expression callback belongs to that callback.
-  // A return nested in if/try/loop blocks DOES count, so guard-clause
-  // factories are declassified instead of splicing an early `return` into
-  // the component's init function (#2341 BUG-3).
+  // Count `return`s ANYWHERE in the body, stopping at nested function-like
+  // boundaries (ts.isFunctionLike — functions, arrows, methods, accessors,
+  // and constructors; broader than isMultiReturnJsxFunctionBody's #932
+  // three-kind check, which only needs to catch JSX-returning callbacks and
+  // was never exercised against class/object methods) — a return inside a
+  // nested callback OR a class/object method declared in the factory body
+  // belongs to that inner scope, not this factory (Copilot review, PR
+  // #2342: the narrower check would misclassify a factory with, e.g., a
+  // helper class whose method contains a `return` as having multiple
+  // returns, declining it unnecessarily). A return nested in if/try/loop
+  // blocks DOES count, so guard-clause factories are declassified instead
+  // of splicing an early `return` into the component's init function
+  // (#2341 BUG-3).
   let totalReturnCount = 0
   function countReturns(n: ts.Node): void {
-    if (ts.isFunctionDeclaration(n) || ts.isFunctionExpression(n) || ts.isArrowFunction(n)) return
+    if (ts.isFunctionLike(n)) return
     if (ts.isReturnStatement(n)) { totalReturnCount++; return }
     ts.forEachChild(n, countReturns)
   }
@@ -4819,13 +4826,25 @@ function detectReactiveFactory(
   // out exactly the identifier text it was collected for, or the
   // bottom-to-top splice in inlineFactoryCallAtSite would corrupt
   // unrelated text. Cheap (bounded by body size) — kept as a permanent
-  // guard against the offset math drifting under a future edit.
+  // guard against the offset math drifting under a future edit. Declines
+  // rather than throwing (Copilot review, PR #2342): compileJSX does not
+  // catch analyzer errors, so a thrown exception here would crash the
+  // whole compilation instead of failing one factory loudly-but-
+  // gracefully as a diagnostic — this should never trigger in practice,
+  // but the failure mode if it ever does must stay "loud decline," not
+  // "hard crash," matching this feature's whole design philosophy.
   for (const site of renameSites) {
     if (bodyStatements.slice(site.start, site.end) !== site.name) {
-      throw new Error(
-        `Internal error: reactive-factory rename-site offset mismatch for '${site.name}' ` +
-        `in '${node.name.text}' — expected bodyStatements[${site.start}:${site.end}] to equal '${site.name}'.`
-      )
+      return {
+        kind: 'declined',
+        declined: {
+          code: 'BF111',
+          detail:
+            `internal rename-site offset mismatch for '${site.name}' — this is a compiler bug, ` +
+            `please report it`,
+          loc,
+        },
+      }
     }
   }
 

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -7,7 +7,7 @@
  */
 
 import ts from 'typescript'
-import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo, DeclinedReactiveFactory, RequiredFactoryImport, SourceLocation } from './types.ts'
+import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo, DeclinedReactiveFactory, RequiredFactoryImport, FactoryRenameSite, SourceLocation } from './types.ts'
 import { parseExpression, parseBlockBodyTolerant, foldBlockToExpr } from './expression-parser.ts'
 import { rewriteBarePropRefs } from './prop-rewrite.ts'
 import { incrementCounter } from './instrumentation.ts'
@@ -4549,6 +4549,22 @@ function detectReactiveFactory(
     return { kind: 'reactive-shaped' }
   }
 
+  // Collect parameter names first — the rename-site walk below needs them
+  // as part of `relevantNames` and to detect param-shadowing declarations
+  // (BF114). Hoisted above local-binding/body-serialization collection
+  // (#2341 BUG-1); it has no dependency on either.
+  const params: string[] = []
+  for (const p of node.parameters) {
+    if (ts.isIdentifier(p.name)) {
+      params.push(p.name.text)
+      continue
+    }
+    // Destructured params are uncommon for this helper shape and out of
+    // initial scope; the factory still wraps a reactive primitive, so
+    // classify it as reactive-shaped rather than silently ignoring it.
+    return { kind: 'reactive-shaped' }
+  }
+
   // Collect local bindings in the factory body for identifier hygiene at
   // inlining time. Only direct-child declarations of the block are
   // considered — good enough for the typical helper shape.
@@ -4563,24 +4579,134 @@ function detectReactiveFactory(
     }
   }
 
+  // Names that call-site inlining may rename: params (substituted with
+  // arbitrary argument expressions), local bindings (suffix-renamed for
+  // per-call-site hygiene), and return identifiers (renamed to the
+  // caller's destructure names). Every other identifier in the body is
+  // left untouched — the #2341 BUG-1 fix for the old whole-body regex
+  // renames, which corrupted string/template literals, property keys,
+  // and `.prop` tails that merely happened to share a relevant name.
+  const relevantNames = new Set<string>([...params, ...localBindings, ...returnTupleIdentifiers])
+
+  const renameSites: FactoryRenameSite[] = []
+  let shadowedParam: string | null = null
+
+  /**
+   * Recursive AST walk collecting rename sites for one kept statement.
+   * `toBodyOffset` converts a position in `sourceFile` (this statement's
+   * original source) to an offset in the final joined `bodyStatements`
+   * string — see the join loop below for why this must stay a pure
+   * function of `stmtStart`/`base`.
+   */
+  function collectRenameSites(root: ts.Node, toBodyOffset: (pos: number) => number): void {
+    function push(id: ts.Identifier, form: 'plain' | 'shorthand'): void {
+      renameSites.push({
+        name: id.text,
+        start: toBodyOffset(id.getStart(sourceFile)),
+        end: toBodyOffset(id.getEnd()),
+        form,
+      })
+    }
+
+    function classify(id: ts.Identifier): void {
+      if (!relevantNames.has(id.text)) return
+      const p = id.parent
+      // Pure-key / non-reference positions — never rename:
+      if (ts.isPropertyAccessExpression(p) && p.name === id) return        // obj.name tail (incl. ?. chains)
+      if (ts.isPropertyAssignment(p) && p.name === id) return              // { name: v } key
+      if (ts.isBindingElement(p) && p.propertyName === id) return          // { name: local } pattern key
+      if ((ts.isMethodDeclaration(p) || ts.isGetAccessorDeclaration(p) ||
+           ts.isSetAccessorDeclaration(p) || ts.isPropertyDeclaration(p) ||
+           ts.isEnumMember(p)) && p.name === id) return                    // member keys
+      if (ts.isJsxAttribute(p) && p.name === id) return                    // JSX attr name
+      if ((ts.isLabeledStatement(p) && p.label === id) ||
+          ((ts.isBreakStatement(p) || ts.isContinueStatement(p)) && p.label === id)) return
+      if ((ts.isJsxOpeningElement(p) || ts.isJsxSelfClosingElement(p) || ts.isJsxClosingElement(p)) &&
+          p.tagName === id && /^[a-z]/.test(id.text)) return               // intrinsic tag <div>
+
+      // Shorthand dual-role positions → expansion form (renaming must
+      // preserve the implied key): `{ name }` object literal / pattern.
+      if (ts.isShorthandPropertyAssignment(p) && p.name === id) { push(id, 'shorthand'); return }
+      if (ts.isBindingElement(p) && p.name === id && !p.propertyName &&
+          ts.isObjectBindingPattern(p.parent)) {
+        // ArrayBindingPattern trap: a tuple destructure element
+        // (`const [a, b] = ...`) ALSO has propertyName === undefined —
+        // the ts.isObjectBindingPattern(p.parent) check above is what
+        // keeps tuple elements out of the shorthand-expansion path.
+        if (params.includes(id.text)) shadowedParam = id.text            // decl of a param name → BF114
+        push(id, 'shorthand')
+        return
+      }
+
+      // Declaration-name positions → plain rename, but a param name
+      // re-declared here is a shadow: params are substituted with
+      // arbitrary argument expressions, so a shadowing declaration would
+      // receive an invalid left-hand side (BF114 declines instead).
+      const isDecl =
+        (ts.isVariableDeclaration(p) || ts.isParameter(p) || ts.isBindingElement(p) ||
+         ts.isFunctionDeclaration(p) || ts.isFunctionExpression(p) ||
+         ts.isClassDeclaration(p) || ts.isClassExpression(p)) && p.name === id
+      if (isDecl && params.includes(id.text)) shadowedParam = id.text
+
+      push(id, 'plain')                                                   // genuine value reference or decl
+    }
+
+    function visit(n: ts.Node): void {
+      // Never descend into type-land: annotations are stripped downstream,
+      // and splicing an argument EXPRESSION into a type position would be
+      // invalid JS.
+      if (ts.isTypeNode(n) || ts.isTypeParameterDeclaration(n) ||
+          ts.isTypeAliasDeclaration(n) || ts.isInterfaceDeclaration(n)) return
+      if (ts.isIdentifier(n)) { classify(n); return }                      // identifiers have no relevant children
+      ts.forEachChild(n, visit)
+    }
+
+    visit(root)
+  }
+
   // Serialize the body without the outer braces and without the return
   // statement — the return tuple/object is dissolved into caller-named
-  // identifiers.
-  const bodyStatements = node.body.statements
-    .filter(s => !ts.isReturnStatement(s))
-    .map(s => s.getText(sourceFile))
-    .join('\n')
+  // identifiers. `renameSites` is collected in this SAME loop so its
+  // offsets (relative to the joined `bodyStatements` string) can never
+  // drift from the join logic — this invariant is the single most fragile
+  // part of the rename mechanism (#2341 BUG-1): site collection and
+  // `bodyStatements` construction must use the identical statement filter,
+  // identical `getText` slices, and identical '\n' join.
+  const keptStatements = node.body.statements.filter(s => !ts.isReturnStatement(s))
+  const pieces: string[] = []
+  let base = 0
+  for (const stmt of keptStatements) {
+    const text = stmt.getText(sourceFile)
+    const stmtStart = stmt.getStart(sourceFile)
+    collectRenameSites(stmt, (pos) => pos - stmtStart + base)
+    pieces.push(text)
+    base += text.length + 1 // +1 for the '\n' join — MUST match the join below
+  }
+  const bodyStatements = pieces.join('\n')
 
-  const params: string[] = []
-  for (const p of node.parameters) {
-    if (ts.isIdentifier(p.name)) {
-      params.push(p.name.text)
-      continue
+  if (shadowedParam !== null) {
+    return {
+      kind: 'declined',
+      declined: {
+        code: 'BF114',
+        detail: `parameter '${shadowedParam}' of '${node.name.text}' is shadowed by a nested declaration inside the factory body`,
+        loc,
+      },
     }
-    // Destructured params are uncommon for this helper shape and out of
-    // initial scope; the factory still wraps a reactive primitive, so
-    // classify it as reactive-shaped rather than silently ignoring it.
-    return { kind: 'reactive-shaped' }
+  }
+
+  // Dev invariant: every collected site's [start, end) range must slice
+  // out exactly the identifier text it was collected for, or the
+  // bottom-to-top splice in inlineFactoryCallAtSite would corrupt
+  // unrelated text. Cheap (bounded by body size) — kept as a permanent
+  // guard against the offset math drifting under a future edit.
+  for (const site of renameSites) {
+    if (bodyStatements.slice(site.start, site.end) !== site.name) {
+      throw new Error(
+        `Internal error: reactive-factory rename-site offset mismatch for '${site.name}' ` +
+        `in '${node.name.text}' — expected bodyStatements[${site.start}:${site.end}] to equal '${site.name}'.`
+      )
+    }
   }
 
   return {
@@ -4592,6 +4718,7 @@ function detectReactiveFactory(
       returnKind,
       localBindings,
       loc,
+      renameSites,
     },
   }
 }
@@ -4760,30 +4887,49 @@ function rewriteFactoryCallsInSource(
     const thisCallIndex = callSiteIndex++
     const suffix = `_bf${thisCallIndex}`
 
-    // Apply renames to the factory body source.
-    let body = factory.bodySource
-    // 1. Suffix-rename internal bindings.
-    const internalRenames = new Set<string>(factory.localBindings)
-    for (const ex of excludeFromSuffixRename) internalRenames.delete(ex)
-    for (const name of internalRenames) {
-      body = body.replace(new RegExp(`\\b${escapeRegex(name)}\\b`, 'g'), name + suffix)
+    // Merged rename map, one entry per old name → replacement text.
+    // Precedence (matches the pre-#2341 sequential-pass outcome): param
+    // substitution > return→caller rename > internal suffix rename — later
+    // `.set()` calls for the same key overwrite earlier ones below.
+    const renames = new Map<string, string>()
+    // 1. Suffix-rename internal bindings not excluded (tuple params/returns,
+    //    or object-path destructured names — see excludeFromSuffixRename's
+    //    callers).
+    for (const name of factory.localBindings) {
+      if (!excludeFromSuffixRename.has(name)) renames.set(name, name + suffix)
     }
-    // 2. Parameters → argument expressions. Atomic arguments (bare
+    // 2. Return identifiers → caller destructure names (tuple path only).
+    if (renameReturnToCallerNames) {
+      for (const [n, caller] of renameReturnToCallerNames) {
+        if (caller !== n) renames.set(n, caller) // identity rename = no-op, skip
+      }
+    }
+    // 3. Parameters → argument expressions. Atomic arguments (bare
     //    identifiers, numeric literals, string literals) are spliced
     //    directly; anything more complex is wrapped in parens to preserve
-    //    operator precedence at the splice site.
+    //    operator precedence at the splice site. Overwrites any same-name
+    //    return rename above — param substitution wins, as before #2341.
     const atomicArg = /^(?:[\w$.]+|'[^'\\]*'|"[^"\\]*"|-?\d+(?:\.\d+)?)$/
     for (let i = 0; i < factory.params.length; i++) {
       const p = factory.params[i]
-      const a = argTexts[i] ?? 'undefined'
-      const wrapped = atomicArg.test(a.trim()) ? a.trim() : `(${a})`
-      body = body.replace(new RegExp(`\\b${escapeRegex(p)}\\b`, 'g'), wrapped)
+      const a = (argTexts[i] ?? 'undefined').trim()
+      renames.set(p, atomicArg.test(a) ? a : `(${a})`)
     }
-    // 3. Return identifiers → caller destructure names (tuple path only).
-    if (renameReturnToCallerNames) {
-      for (const [n, caller] of renameReturnToCallerNames) {
-        body = body.replace(new RegExp(`\\b${escapeRegex(n)}\\b`, 'g'), caller)
-      }
+
+    // Apply the merged renames as a single bottom-to-top position splice
+    // over `bodySource`, using the sites collected once at detection time
+    // (#2341 BUG-1) — never a text search, so string/template-literal
+    // contents, property keys, `.prop` tails, and JSX intrinsic tags are
+    // never touched, and (unlike the old sequential regex passes) an
+    // argument expression already spliced in for an earlier site can never
+    // be re-scanned and corrupted by a later rename.
+    let body = factory.bodySource
+    for (let i = factory.renameSites.length - 1; i >= 0; i--) {
+      const site = factory.renameSites[i]
+      const repl = renames.get(site.name)
+      if (repl === undefined) continue
+      const text = site.form === 'shorthand' ? `${site.name}: ${repl}` : repl
+      body = body.slice(0, site.start) + text + body.slice(site.end)
     }
 
     edits.push({
@@ -4872,10 +5018,6 @@ function isPascalCaseComponentFn(node: ts.Node): boolean {
   return false
 }
 
-function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
 // =============================================================================
 // BF110 diagnostic (#931)
 // =============================================================================
@@ -4914,6 +5056,7 @@ function declinedFactoryErrorCode(code: DeclinedReactiveFactory['code']): ErrorC
   switch (code) {
     case 'BF112': return ErrorCodes.REACTIVE_FACTORY_MODULE_CAPTURE
     case 'BF113': return ErrorCodes.REACTIVE_FACTORY_IMPORT_COLLISION
+    case 'BF114': return ErrorCodes.REACTIVE_FACTORY_PARAM_SHADOWED
     default: return ErrorCodes.REACTIVE_FACTORY_RENAME_UNSUPPORTED
   }
 }

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -4478,6 +4478,20 @@ function detectReactiveFactory(
 
   const loc = getSourceLocation(node, sourceFile, filePath)
 
+  // Count `return`s ANYWHERE in the body, stopping at nested function
+  // boundaries (same rule as isMultiReturnJsxFunctionBody, #932) — a return
+  // inside an arrow/function-expression callback belongs to that callback.
+  // A return nested in if/try/loop blocks DOES count, so guard-clause
+  // factories are declassified instead of splicing an early `return` into
+  // the component's init function (#2341 BUG-3).
+  let totalReturnCount = 0
+  function countReturns(n: ts.Node): void {
+    if (ts.isFunctionDeclaration(n) || ts.isFunctionExpression(n) || ts.isArrowFunction(n)) return
+    if (ts.isReturnStatement(n)) { totalReturnCount++; return }
+    ts.forEachChild(n, countReturns)
+  }
+  ts.forEachChild(node.body, countReturns)
+
   // Require exactly one top-level `return`, whose argument (after unwrapping
   // parens / `as const` / type-assertion) is a tuple (array literal) or a
   // shorthand-object literal.
@@ -4494,7 +4508,12 @@ function detectReactiveFactory(
     if (ts.isTypeAssertionExpression(expr)) expr = expr.expression
     returnExpr = expr
   }
-  if (returnCount !== 1 || !returnExpr) return { kind: 'reactive-shaped' }
+  // `totalReturnCount === 1 && returnCount === 1` jointly guarantee the
+  // single return is a direct child of `node.body` (top-level returns are a
+  // subset of total) — so a guard-clause / try-catch / loop return
+  // declassifies the factory instead of silently producing an inert
+  // component (#2341 BUG-3).
+  if (totalReturnCount !== 1 || returnCount !== 1 || !returnExpr) return { kind: 'reactive-shaped' }
 
   const returnTupleIdentifiers: string[] = []
   let returnKind: 'tuple' | 'object'

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -4047,18 +4047,56 @@ function collectEntryBindingNames(sf: ts.SourceFile): Set<string> {
   return names
 }
 
+// One `export ... from` hop is followed when resolving a re-exported name
+// (#2341 BUG-2) — a visited-set guards against cycles regardless, so
+// raising this later is safe without further changes.
+const MAX_REEXPORT_HOPS = 1
+
+/** A helper file's export surface, cached per absolute path for the
+ *  lifetime of one `prescanImportedReactiveFactories` call (#2341 BUG-2). */
+interface HelperFileInfo {
+  sf: ts.SourceFile
+  /** Module-scope function declarations exported under their external name
+   *  (own `export function`, or a local `export { f as g }`). */
+  exportedFns: Map<string, ts.FunctionDeclaration>
+  /** `export { a as b } from 'src'` re-exports, keyed by the EXTERNAL name
+   *  `b` — a barrel file's whole reason for existing (#2341 BUG-2). */
+  reexports: Map<string, { source: string; innerName: string }>
+  /** Any `export * from '...'` in this file — a named lookup that misses
+   *  `exportedFns`/`reexports` might still resolve through one of these, so
+   *  it can never be classified `'clean'`. (`export * as ns from` is a
+   *  `NamespaceExport` clause and is excluded: a named lookup can never
+   *  come through it.) */
+  hasStarReexport: boolean
+  moduleBindings: HelperModuleBindings
+}
+/** `'clean'` = read, parsed (or gate-skipped), and proven to define no
+ *  reactive factory under any name reachable from it. `null` = unreadable. */
+type LoadedHelper = HelperFileInfo | 'clean' | null
+type ExportLookup =
+  | { kind: 'fn'; fn: ts.FunctionDeclaration; file: HelperFileInfo; definingPath: string }
+  | { kind: 'clean' } // proven non-reactive under this name → cleanFactoryImports
+  | { kind: 'unknown' } // cannot prove → leave unclassified so the BF110 name heuristic still fires
+
 /**
  * Cross-file half of the factory prescan (#2325 round 2): resolve factories
  * defined in a relative-imported helper file so `const { count } =
  * createCounter(0)` inlines the same way whether `createCounter` lives in
- * this file or in `./hooks`. Mutates `result`'s maps in place.
+ * this file or in `./hooks`. Follows one `export ... from` hop so a barrel
+ * `index.ts` re-exporting the real helper resolves to the file that
+ * actually DEFINES it (#2341 BUG-2) — every classification (factory /
+ * declined / reactive-shaped / clean) and every downstream anchor (module-
+ * capture check, helper-import re-provisioning, `sourceFilePath`) is keyed
+ * off that defining file, never the barrel. Mutates `result`'s maps in
+ * place.
  *
  * Perf: gated on a candidate-callee set collected from the ALREADY-parsed
  * entry AST (no regex over source text, per CONTRIBUTING.md's "never parse
  * imports with regex" rule) — files with no tuple/object-destructured call
  * at all skip every filesystem access below. A second cheap gate (does the
- * helper file's raw text contain any `REACTIVE_PRIMITIVES` substring) skips
- * the AST parse of helper files that plainly aren't reactive; this is a
+ * helper file's raw text contain any `REACTIVE_PRIMITIVES` substring, or
+ * any `export ... from` re-export text) skips the AST parse of helper files
+ * that plainly define no factory and re-export nothing; this is a
  * skip-gate over content, not an import parse, so it doesn't run afoul of
  * that same rule.
  *
@@ -4129,45 +4167,42 @@ function prescanImportedReactiveFactories(
   // same name from a DIFFERENT (targetKey, exportedName) is a collision.
   const plannedInjections = new Map<string, { targetKey: string; exportedName: string }>()
 
-  for (const { src, specs } of importsToCheck) {
-    const resolved = resolveRelativeImportToFile(src, filePath)
-    // Unresolvable — left alone here; the name-heuristic BF110 branch in
-    // validateReactiveFactoryCalls handles it at validation time.
-    if (!resolved) continue
+  // #2341 BUG-2 — one read+parse per helper file per entry file, memoized
+  // across every spec/hop that touches it (a barrel is typically visited
+  // once per re-exported name it satisfies).
+  const helperCache = new Map<string, LoadedHelper>()
+
+  function loadHelperFile(abs: string): LoadedHelper {
+    const cached = helperCache.get(abs)
+    if (cached !== undefined) return cached
 
     let content: string
     try {
-      content = fs.readFileSync(resolved, 'utf8')
+      content = fs.readFileSync(abs, 'utf8')
     } catch {
-      continue
+      helperCache.set(abs, null)
+      return null
     }
-
-    const alreadyKnown = (name: string): boolean =>
-      result.factories.has(name) || result.declined.has(name) || result.reactiveShaped.has(name)
 
     // Cheap text-level skip-gate (not an import/JS parse — see docstring):
-    // a helper file with no reactive-primitive substring anywhere cannot
-    // define a reactive factory, so skip parsing it entirely.
+    // a file with no reactive-primitive substring AND no re-export gate
+    // text (`export` ... `from`) can neither define a reactive factory nor
+    // re-export one, so skip parsing it entirely. Substring checks only —
+    // false positives merely cause an AST parse whose outcome is still
+    // correct, they never cause a false 'clean'.
     const hasAnyPrimitiveText = [...REACTIVE_PRIMITIVES].some(p => content.includes(p))
-    if (!hasAnyPrimitiveText) {
-      for (const spec of specs) {
-        if (!alreadyKnown(spec.local)) result.cleanFactoryImports.add(spec.local)
-      }
-      continue
+    const hasReexportText = content.includes('export') && content.includes('from')
+    if (!hasAnyPrimitiveText && !hasReexportText) {
+      helperCache.set(abs, 'clean')
+      return 'clean'
     }
 
-    const helperSf = ts.createSourceFile(
-      resolved + '.prescan',
-      content,
-      ts.ScriptTarget.Latest,
-      true,
-      ts.ScriptKind.TSX
-    )
+    const sf = ts.createSourceFile(abs + '.prescan', content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
 
     // Map exported name -> module-scope FunctionDeclaration via the AST.
     const localFns = new Map<string, ts.FunctionDeclaration>()
     const exportedFns = new Map<string, ts.FunctionDeclaration>()
-    for (const stmt of helperSf.statements) {
+    for (const stmt of sf.statements) {
       if (ts.isFunctionDeclaration(stmt) && stmt.name && stmt.body) {
         localFns.set(stmt.name.text, stmt)
         const hasExportModifier = stmt.modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
@@ -4177,20 +4212,37 @@ function prescanImportedReactiveFactories(
         }
       }
     }
-    // `export { f }` / `export { f as g }` — keyed by the EXTERNAL export name.
-    for (const stmt of helperSf.statements) {
-      if (
-        ts.isExportDeclaration(stmt) &&
-        stmt.exportClause &&
-        ts.isNamedExports(stmt.exportClause) &&
-        !stmt.moduleSpecifier &&
-        !stmt.isTypeOnly
-      ) {
+
+    const reexports = new Map<string, { source: string; innerName: string }>()
+    let hasStarReexport = false
+    for (const stmt of sf.statements) {
+      if (!ts.isExportDeclaration(stmt) || stmt.isTypeOnly) continue
+      if (!stmt.moduleSpecifier) {
+        // `export { f }` / `export { f as g }` — keyed by the EXTERNAL export name.
+        if (stmt.exportClause && ts.isNamedExports(stmt.exportClause)) {
+          for (const el of stmt.exportClause.elements) {
+            if (el.isTypeOnly) continue
+            const fn = localFns.get((el.propertyName ?? el.name).text)
+            if (fn) exportedFns.set(el.name.text, fn)
+          }
+        }
+        continue
+      }
+      if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+      if (stmt.exportClause && ts.isNamedExports(stmt.exportClause)) {
+        // `export { a as b } from 'src'` — keyed by the EXTERNAL name `b`.
         for (const el of stmt.exportClause.elements) {
           if (el.isTypeOnly) continue
-          const fn = localFns.get((el.propertyName ?? el.name).text)
-          if (fn) exportedFns.set(el.name.text, fn)
+          reexports.set(el.name.text, {
+            source: stmt.moduleSpecifier.text,
+            innerName: (el.propertyName ?? el.name).text,
+          })
         }
+      } else if (!stmt.exportClause) {
+        // `export * from 'src'`. (`export * as ns from` carries a
+        // NamespaceExport clause here, not `undefined` — excluded on
+        // purpose: a named lookup can never come through it.)
+        hasStarReexport = true
       }
     }
 
@@ -4198,17 +4250,77 @@ function prescanImportedReactiveFactories(
     // body must not reference any of these (#2325 §4h / BF112), since
     // inlining moves the body into the component file where they don't
     // exist.
-    const moduleBindings = collectHelperModuleValueBindings(helperSf)
+    const moduleBindings = collectHelperModuleValueBindings(sf)
+
+    const info: HelperFileInfo = { sf, exportedFns, reexports, hasStarReexport, moduleBindings }
+    helperCache.set(abs, info)
+    return info
+  }
+
+  /**
+   * Resolve `exportedName` from the file at `abs`, following one
+   * `export ... from` hop through a barrel re-export (#2341 BUG-2).
+   * `visited` guards against self/indirect barrel cycles.
+   */
+  function lookupExportedFactory(
+    abs: string,
+    exportedName: string,
+    visited: Set<string>,
+    hopsLeft: number
+  ): ExportLookup {
+    if (visited.has(abs)) return { kind: 'unknown' }
+    visited.add(abs)
+
+    const file = loadHelperFile(abs)
+    if (file === null) return { kind: 'unknown' }
+    if (file === 'clean') return { kind: 'clean' }
+
+    const fn = file.exportedFns.get(exportedName)
+    if (fn) return { kind: 'fn', fn, file, definingPath: abs }
+
+    const re = file.reexports.get(exportedName)
+    if (re) {
+      if (hopsLeft <= 0) return { kind: 'unknown' }
+      // Non-relative re-export specifiers (`export { x } from 'pkg'`)
+      // resolve through bundler/tsconfig-paths configuration this layer
+      // doesn't consume — same restriction as direct imports.
+      if (!re.source.startsWith('./') && !re.source.startsWith('../')) return { kind: 'unknown' }
+      const target = resolveRelativeImportToFile(re.source, abs)
+      if (!target) return { kind: 'unknown' } // unresolvable re-export target: never mark clean
+      return lookupExportedFactory(target, re.innerName, visited, hopsLeft - 1)
+    }
+
+    // `export * from` might still reach this name through a file this
+    // layer doesn't enumerate — never clean. Otherwise the file was fully
+    // inspected and genuinely doesn't define or re-export this name.
+    if (file.hasStarReexport) return { kind: 'unknown' }
+    return { kind: 'clean' }
+  }
+
+  for (const { src, specs } of importsToCheck) {
+    const resolved = resolveRelativeImportToFile(src, filePath)
+    // Unresolvable — left alone here; the name-heuristic BF110 branch in
+    // validateReactiveFactoryCalls handles it at validation time.
+    if (!resolved) continue
+
+    const alreadyKnown = (name: string): boolean =>
+      result.factories.has(name) || result.declined.has(name) || result.reactiveShaped.has(name)
 
     for (const spec of specs) {
       if (alreadyKnown(spec.local)) continue
 
-      const fn = exportedFns.get(spec.exported)
-      if (!fn) {
+      const found = lookupExportedFactory(resolved, spec.exported, new Set<string>(), MAX_REEXPORT_HOPS)
+      if (found.kind === 'clean') {
         result.cleanFactoryImports.add(spec.local)
         continue
       }
-      const det = detectReactiveFactory(fn, helperSf, resolved)
+      if (found.kind === 'unknown') continue
+
+      const { fn, file, definingPath } = found
+      const helperSf = file.sf
+      const moduleBindings = file.moduleBindings
+
+      const det = detectReactiveFactory(fn, helperSf, definingPath)
       if (!det) {
         result.cleanFactoryImports.add(spec.local)
         continue
@@ -4221,6 +4333,9 @@ function prescanImportedReactiveFactories(
           result.declined.set(spec.local, det.declined)
           break
         case 'factory': {
+          // Module-capture check is anchored to the DEFINING file's own
+          // module bindings, not the barrel's (#2341 BUG-2) — the barrel
+          // itself contributes no bindings the inlined body could reference.
           const capture = moduleCaptureCheck(fn, det.info, moduleBindings, fn.name!.text)
           if (capture.captured.length > 0) {
             result.declined.set(spec.local, {
@@ -4247,10 +4362,12 @@ function prescanImportedReactiveFactories(
             let specifier: string
             let targetKey: string
             if (ref.source.startsWith('./') || ref.source.startsWith('../')) {
-              // Resolve from the HELPER file's directory (`resolved` is its
-              // absolute path). Unresolvable → same posture as a local
+              // Resolve from the DEFINING file's directory (#2341 BUG-2 —
+              // `definingPath` is the file that actually declares this
+              // import, which may differ from the barrel that was
+              // imported). Unresolvable → same posture as a local
               // capture: nothing importable to re-provision (BF112).
-              const abs = resolveRelativeImportToFile(ref.source, resolved)
+              const abs = resolveRelativeImportToFile(ref.source, definingPath)
               if (!abs) {
                 declinedEntry = {
                   code: 'BF112',
@@ -4292,7 +4409,10 @@ function prescanImportedReactiveFactories(
             break
           }
           for (const [name, id] of pending) plannedInjections.set(name, id)
-          det.info.sourceFilePath = resolved
+          // #2341 BUG-2 — anchored to the file that actually defines the
+          // factory, not the (possibly barrel) import path the component
+          // used to reach it.
+          det.info.sourceFilePath = definingPath
           if (required.length > 0) det.info.requiredImports = required
           result.factories.set(spec.local, det.info)
           break

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -90,6 +90,7 @@ export const ErrorCodes = {
   REACTIVE_FACTORY_RENAME_UNSUPPORTED: 'BF111',
   REACTIVE_FACTORY_MODULE_CAPTURE: 'BF112',
   REACTIVE_FACTORY_IMPORT_COLLISION: 'BF113',
+  REACTIVE_FACTORY_PARAM_SHADOWED: 'BF114',
 } as const
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes]
@@ -184,6 +185,9 @@ const errorMessages: Record<ErrorCode, string> = {
     'Inlining an imported reactive factory requires re-importing one of its helper ' +
     'imports into this file, but that name is already bound here to something else. ' +
     "Rename the conflicting binding in this file, or alias the import in the factory's own file.",
+
+  [ErrorCodes.REACTIVE_FACTORY_PARAM_SHADOWED]:
+    'Reactive factory parameter is shadowed by a nested declaration inside the factory body, so argument substitution at the inline site would be ambiguous. Rename the inner binding so it does not collide with the parameter.',
 }
 
 // =============================================================================

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1455,6 +1455,19 @@ export interface NamedExportSpecifier {
   isTypeOnly: boolean
 }
 
+/** One identifier occurrence in a factory body that call-site inlining may
+ *  rename (#2341 BUG-1). Offsets are relative to ReactiveFactoryInfo.bodySource. */
+export interface FactoryRenameSite {
+  name: string
+  start: number
+  end: number
+  /** 'shorthand' = the identifier is simultaneously a property key and a
+   *  value/binding reference ({ name } literal, or { name } object-pattern
+   *  element). Renaming it must EXPAND to `name: <replacement>` to preserve
+   *  the key. 'plain' = ordinary reference or declaration name. */
+  form: 'plain' | 'shorthand'
+}
+
 /**
  * Reactive factory helper metadata (#931). Collected when a same-file
  * function matches the factory shape: exactly one top-level `return` whose
@@ -1500,6 +1513,14 @@ export interface ReactiveFactoryInfo {
    * file are dropped at prescan time.
    */
   requiredImports?: RequiredFactoryImport[]
+  /**
+   * Identifier occurrences within `bodySource` that call-site inlining may
+   * rename (#2341 BUG-1) — collected by the same AST walk that produces
+   * `bodySource`, so offsets stay in lockstep with the serialized text.
+   * Same-file and cross-file factories both get this (both flow through
+   * `detectReactiveFactory`).
+   */
+  renameSites: FactoryRenameSite[]
 }
 
 /**
@@ -1526,7 +1547,7 @@ export interface RequiredFactoryImport {
  * the generic BF110.
  */
 export interface DeclinedReactiveFactory {
-  code: 'BF111' | 'BF112' | 'BF113'
+  code: 'BF111' | 'BF112' | 'BF113' | 'BF114'
   /** Detail spliced into the call-site message (e.g. offending identifier list). */
   detail: string
   /** Definition site (in the helper file for cross-file declines). */


### PR DESCRIPTION
## Summary

Closes #2341. Three confirmed bugs in reactive-factory inlining (#931/#2325/#2332), each violating this project's own fidelity bar in `spec/subset-conformance.md` ("reproduce the user's TSX exactly or decline, never approximate") by silently corrupting or breaking realistic patterns with **zero compile-time diagnostics**:

### BUG-1 — textual regex renames corrupted strings, property keys, and could emit invalid JS

Factory inlining renamed identifiers with a whole-body `\b`-regex over raw text, in three sequential passes. A regex has no notion of AST position, so it also matched string-literal contents, template-literal text chunks, shorthand/longhand property keys, and JSX intrinsic tags that merely happened to spell the same identifier. Concretely: a `localStorage.getItem('stored')` key string got silently renamed; `createSignal({ name, loggedIn: false })` with a string-literal argument produced **invalid JavaScript** (`{ 'Alice', loggedIn: false }`); an error message's text silently changed depending on the caller's destructure name. The sequential passes also let a later pass re-scan and corrupt text an earlier pass had already spliced in for an argument expression.

**Fix**: collect exact identifier-node rename sites once at detection time (`detectReactiveFactory`), tagging each as a plain reference or a shorthand property that must expand (`{ name }` → `{ name: <replacement> }`) to preserve its key. At inline time, apply one merged rename map as a single bottom-to-top position splice over the original body text — never a text search, never a second pass over already-substituted text. A factory parameter re-declared inside the body (shadowed by a nested binding) can no longer be soundly substituted with an arbitrary argument expression, so that shape now declines loudly with a new **BF114** diagnostic instead of silently emitting invalid JS.

### BUG-2 — barrel-file re-exports produced dangling references with zero diagnostics

`prescanImportedReactiveFactories` only resolved a factory import against the file directly named in the import specifier. A barrel `index.ts` (`export { useToggle } from './useToggle'`) has no local function matching the name, so the old lookup silently marked it "proven non-reactive" — suppressing even the BF110 fallback — leaving a genuinely dangling reference (`ReferenceError` at hydration) once the component destructured the never-inlined call. Barrel files are a ubiquitous convention; this was the worst outcome of the three (crash, no compile-time signal).

**Fix**: follow one `export ... from` hop through a barrel (guarded by a visited-set against cycles and a hop budget so a two-hop chain stays loud-unknown rather than silently clean). The module-capture check, helper-import re-provisioning, and the factory's recorded source path are all anchored to the file that actually *defines* the factory, never the barrel it was reached through.

### BUG-3 — guard-clause returns produced inert components with zero diagnostics

`detectReactiveFactory`'s "exactly one return" check only scanned top-level statements. A factory with a guard-clause `return` nested inside `if`/`try`/a loop passed the check, and the nested return got spliced verbatim into the component's init function — silently aborting hydration (element lookup, effect creation, event binding never run) whenever the guard was truthy at runtime.

**Fix**: count returns anywhere in the body, stopping at nested function boundaries (mirroring the `isMultiReturnJsxFunctionBody` precedent from #932) — any nested return now declassifies the factory to `reactive-shaped`, producing a loud BF110 instead of a silent broken component.

### Real-world test matrix

~30 additional test cases (same-file + cross-file) covering patterns not previously exercised in factory context: every reactive primitive (`onMount`/`onCleanup`/`createEffect`, not just `createSignal`/`createMemo`), a Sora-`useListStore`-scale multi-signal/multi-memo store, hygiene at 3+ call sites, generics, type-only imports, deep relative paths, aliasing combinations, barrel-file variants (alias, `export *`, self-referential, two-hop, mixed local+re-exported), BF113 collisions with nested/JSX-scope bindings, and SSR-specific composition.

## Test plan

- [x] `tsc --noEmit -p packages/jsx/tsconfig.json` — clean
- [x] `bun test packages/jsx` — 2626-2655 pass (count varies only from unrelated pre-existing test flakiness under local machine load, confirmed via isolated re-runs — see below), 0 real fail
- [x] `cd packages/cli && bun test` — 916 pass, 5 fail; all 5 confirmed pre-existing and unrelated (macOS/APFS case-insensitive-filesystem artifacts in `resolve-source.test.ts`/`meta-loader.test.ts`), reproduced identically against unmodified `main`
- [x] Verified locally that isolated re-runs of any test that timed out under load pass cleanly (0 fail) — the flakiness is machine-load-induced (`bun test`'s 5000ms per-test timeout firing under heavy concurrent load from unrelated local processes), not a regression from this change; a different unrelated test times out each run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
