### PR TITLE
Add timeout-minutes to every CI workflow job

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -12,6 +12,7 @@ jobs:
   check:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changeset') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci-blade.yml
+++ b/.github/workflows/ci-blade.yml
@@ -38,6 +38,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # PR/push run the fast sampled data-point tier; the nightly `schedule`
     # (and a manual `workflow_dispatch`) run the full generated-point matrix
     # (#2278).
@@ -86,6 +87,7 @@ jobs:
 
   e2e-blade:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: test
 
     steps:
@@ -138,6 +140,7 @@ jobs:
   # PHP/Composer, same as the adapter jobs above.
   e2e-laravel:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: test
 
     steps:

--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci-compat.yml
+++ b/.github/workflows/ci-compat.yml
@@ -47,6 +47,7 @@ permissions:
 jobs:
   lockfile:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci-create-barefootjs.yml
+++ b/.github/workflows/ci-create-barefootjs.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci-deno.yml
+++ b/.github/workflows/ci-deno.yml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -35,6 +35,7 @@ env:
 jobs:
   naming:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci-elysia.yml
+++ b/.github/workflows/ci-elysia.yml
@@ -25,6 +25,7 @@ permissions:
 jobs:
   e2e-elysia:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci-erb.yml
+++ b/.github/workflows/ci-erb.yml
@@ -32,6 +32,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # PR/push run the fast sampled data-point tier; the nightly `schedule`
     # (and a manual `workflow_dispatch`) run the full generated-point matrix
     # (#2278).

--- a/.github/workflows/ci-form.yml
+++ b/.github/workflows/ci-form.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci-go-template.yml
+++ b/.github/workflows/ci-go-template.yml
@@ -34,6 +34,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # PR/push run the fast sampled data-point tier; the nightly `schedule`
     # (and a manual `workflow_dispatch`) run the full generated-point matrix
     # (#2278).
@@ -73,6 +74,7 @@ jobs:
 
   e2e-echo:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: test
 
     steps:

--- a/.github/workflows/ci-h3.yml
+++ b/.github/workflows/ci-h3.yml
@@ -25,6 +25,7 @@ permissions:
 jobs:
   e2e-h3:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci-hono.yml
+++ b/.github/workflows/ci-hono.yml
@@ -34,6 +34,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # PR/push run the fast sampled data-point tier; the nightly `schedule`
     # (and a manual `workflow_dispatch`) run the full generated-point matrix
     # (#2278).
@@ -60,6 +61,7 @@ jobs:
 
   e2e-hono:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: test
 
     steps:

--- a/.github/workflows/ci-jsr-check.yml
+++ b/.github/workflows/ci-jsr-check.yml
@@ -46,6 +46,7 @@ permissions:
 jobs:
   deno-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -37,6 +37,7 @@ permissions:
 jobs:
   biome:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci-mojolicious.yml
+++ b/.github/workflows/ci-mojolicious.yml
@@ -34,6 +34,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # PR/push run the fast sampled data-point tier; the nightly `schedule`
     # (and a manual `workflow_dispatch`) run the full generated-point matrix
     # (#2278).

--- a/.github/workflows/ci-perl-dist.yml
+++ b/.github/workflows/ci-perl-dist.yml
@@ -25,6 +25,7 @@ permissions:
 jobs:
   dist:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -36,6 +36,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # PR/push run the fast sampled data-point tier; the nightly `schedule`
     # (and a manual `workflow_dispatch`) run the full generated-point matrix
     # (#2278).
@@ -91,6 +92,7 @@ jobs:
 
   e2e-php:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: test
 
     steps:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -38,6 +38,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # PR/push run the fast sampled data-point tier; the nightly `schedule`
     # (and a manual `workflow_dispatch`) run the full generated-point matrix
     # (#2278).
@@ -82,6 +83,7 @@ jobs:
 
   e2e-flask:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: test
 
     steps:
@@ -136,6 +138,7 @@ jobs:
 
   e2e-fastapi:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: test
 
     steps:
@@ -190,6 +193,7 @@ jobs:
 
   e2e-django:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: test
 
     steps:

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -34,6 +34,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # PR/push run the fast sampled data-point tier; the nightly `schedule`
     # (and a manual `workflow_dispatch`) run the full generated-point matrix
     # (#2278).
@@ -88,6 +89,7 @@ jobs:
 
   e2e-axum:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: test
 
     steps:

--- a/.github/workflows/ci-smoke-publish.yml
+++ b/.github/workflows/ci-smoke-publish.yml
@@ -58,6 +58,7 @@ permissions:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci-xslate.yml
+++ b/.github/workflows/ci-xslate.yml
@@ -34,6 +34,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # PR/push run the fast sampled data-point tier; the nightly `schedule`
     # (and a manual `workflow_dispatch`) run the full generated-point matrix
     # (#2278).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     name: test (${{ matrix.group }})
     strategy:
       fail-fast: false
@@ -88,6 +89,7 @@ jobs:
 
   test-ui:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -108,6 +110,7 @@ jobs:
 
   e2e-site-ui:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'core')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -90,6 +91,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'ui')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -134,6 +136,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-hono')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -170,6 +173,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-h3')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -206,6 +210,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-elysia')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -242,6 +247,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-echo')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -281,6 +287,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-gin')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -320,6 +327,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-chi')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -359,6 +367,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-nethttp')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -398,6 +407,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-mojolicious')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -437,6 +447,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-xslate')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -476,6 +487,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-flask')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -515,6 +527,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-fastapi')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -554,6 +567,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-sinatra')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -593,6 +607,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-rails')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -632,6 +647,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-axum')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -671,6 +687,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-php')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -710,6 +727,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-django')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -749,6 +767,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-blade')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -788,6 +807,7 @@ jobs:
       github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-laravel')
       || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -22,6 +22,7 @@ jobs:
   publish:
     if: contains(github.event.pull_request.labels.*.name, 'cr-tracked')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/update-doc-snapshots.yml
+++ b/.github/workflows/update-doc-snapshots.yml
@@ -34,6 +34,7 @@ concurrency:
 jobs:
   update-doc-snapshots:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Skip fork PRs (no write permission to push back to the head branch).
     if: github.event.pull_request.head.repo.full_name == github.repository
 

--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   update-expected-html:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Skip fork PRs (no write permission)
     if: github.event.pull_request.head.repo.full_name == github.repository
 

--- a/.github/workflows/update-meta.yml
+++ b/.github/workflows/update-meta.yml
@@ -30,6 +30,7 @@ concurrency:
 jobs:
   update-meta:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Skip fork PRs (no write permission to push back to the head branch).
     if: github.event.pull_request.head.repo.full_name == github.repository
 


### PR DESCRIPTION
## Summary

- Prompted by a `CI — Xslate Adapter` run on #2348 that sat `in_progress` for 40+ minutes with no timeout to stop it — GitHub's default job timeout is 6 hours.
- 29 of 31 workflow files had no `timeout-minutes` set at any job. Added `timeout-minutes: 15` to every job that was missing one (59 jobs across 29 files) — comfortably above normal runtimes (most jobs complete in well under 10 minutes per recent CI history) but well short of the 6-hour default, so a hang fails fast and visibly instead of quietly occupying a runner.
- The 2 files that already had a timeout (`jsr-publish.yml`, `release.yml`, both using 30 min) were left untouched.
- Purely additive: one `timeout-minutes: 15` line inserted directly after each job's `runs-on: ubuntu-latest`, no other changes. Validated every workflow file still parses as valid YAML after the edit.

Follow-up: if any specific job legitimately needs more than 15 minutes under normal conditions, its timeout can be bumped individually — this PR just establishes the floor everywhere.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` for all 31 workflow files — all parse cleanly
- [x] Spot-checked multi-job files (`ci-blade.yml`, `ci.yml`'s matrix jobs, `deploy.yml`'s 20 `if:`-gated jobs) — `timeout-minutes` lands correctly under each job regardless of other job-level keys


---
_Generated by [Claude Code](https://claude.ai/code/session_01WFBDwcZ7fohj65PqMRGQSE)_