### PR TITLE
Cancel in-progress CI runs when a newer commit lands

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: benchmark-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: changeset-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changeset') }}

--- a/.github/workflows/ci-blade.yml
+++ b/.github/workflows/ci-blade.yml
@@ -35,6 +35,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-blade-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -20,6 +20,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-cli-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-compat.yml
+++ b/.github/workflows/ci-compat.yml
@@ -44,6 +44,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-compat-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lockfile:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-create-barefootjs.yml
+++ b/.github/workflows/ci-create-barefootjs.yml
@@ -16,6 +16,10 @@ on:
       - 'packages/cli/**'
       - '.github/workflows/ci-create-barefootjs.yml'
 
+concurrency:
+  group: ci-create-barefootjs-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-deno.yml
+++ b/.github/workflows/ci-deno.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-deno-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -32,6 +32,10 @@ env:
   VALE_VERSION: 3.15.1
   VALE_SHA256: c024d9c157874fb043d4f24a055d60050d1bb18755251f590593eed5bace1857
 
+concurrency:
+  group: ci-docs-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   naming:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-elysia.yml
+++ b/.github/workflows/ci-elysia.yml
@@ -22,6 +22,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-elysia-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e-elysia:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-erb.yml
+++ b/.github/workflows/ci-erb.yml
@@ -29,6 +29,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-erb-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-form.yml
+++ b/.github/workflows/ci-form.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-form-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-go-template.yml
+++ b/.github/workflows/ci-go-template.yml
@@ -31,6 +31,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-go-template-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-h3.yml
+++ b/.github/workflows/ci-h3.yml
@@ -22,6 +22,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-h3-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e-h3:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-hono.yml
+++ b/.github/workflows/ci-hono.yml
@@ -31,6 +31,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-hono-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-jsr-check.yml
+++ b/.github/workflows/ci-jsr-check.yml
@@ -43,6 +43,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-jsr-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deno-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -34,6 +34,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-lint-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   biome:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-mojolicious.yml
+++ b/.github/workflows/ci-mojolicious.yml
@@ -31,6 +31,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-mojolicious-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-perl-dist.yml
+++ b/.github/workflows/ci-perl-dist.yml
@@ -22,6 +22,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-perl-dist-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dist:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -33,6 +33,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-php-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -35,6 +35,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-python-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -31,6 +31,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-rust-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-smoke-publish.yml
+++ b/.github/workflows/ci-smoke-publish.yml
@@ -55,6 +55,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-smoke-publish-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-xslate.yml
+++ b/.github/workflows/ci-xslate.yml
@@ -31,6 +31,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-xslate-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -18,6 +18,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: pkg-pr-new-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     if: contains(github.event.pull_request.labels.*.name, 'cr-tracked')


### PR DESCRIPTION
## Summary

Stacked on #2352 (same motivation — reduce wasted/stuck CI time — split out per request to keep it out of that PR).

- Confirmed the gap: pushing a follow-up commit to a branch/PR does **not** cancel the previous commit's still-running CI jobs today — 24 of the `ci*.yml`/`ci.yml` workflows (plus `benchmark.yml`, `changeset-check.yml`, `pkg-pr-new.yml`) had no `concurrency` block at all, so every push queues a fresh run alongside whatever's already in flight for that ref.
- Added the same pattern already established by `deploy.yml`: `concurrency: { group: <workflow>-${{ github.ref }}, cancel-in-progress: true }`, so a new push cancels the previous (now-superseded) run for that same branch/PR instead of letting both race to completion.
- Left `release.yml` / `jsr-publish.yml` alone — those already have `concurrency` with `cancel-in-progress: false` **intentionally**, since killing a publish mid-flight is unsafe; this PR doesn't touch that.
- Purely additive: one `concurrency` block per file, placed right before `jobs:`. No job logic changed.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` for every touched workflow file — all parse cleanly
- [x] Spot-checked placement in files with unusual structure (`ci-docs.yml`'s extra `env:` block, `ci-create-barefootjs.yml`'s missing `permissions:` block) — `concurrency` lands correctly before `jobs:` in both
- [x] Each group name is derived uniquely from its filename, so no two workflows share a concurrency group and unintentionally cancel each other


---
_Generated by [Claude Code](https://claude.ai/code/session_01WFBDwcZ7fohj65PqMRGQSE)_