### PR TITLE
fix(test): resolve bare className ternaries instead of leaking ?/: tokens

### DIFF
--- a/.changeset/test-bare-classname-ternary.md
+++ b/.changeset/test-bare-classname-ternary.md
@@ -1,0 +1,5 @@
+---
+'@barefootjs/test': patch
+---
+
+`renderToTest`'s `TestNode.classes` no longer leaks raw ternary operator tokens (`?`, `:`) and unresolved expression fragments for a bare `className={cond ? a : b}` expression (#2354). An inline ternary className (no backticks) is now walked structurally through the attribute's parsed tree — the `expression`-kind analogue of the existing `template`-kind `ternary` part handling — unioning both arms and resolving string literals, local-const / prop-default identifiers, and object-property member access. Object-literal constants with string-valued properties additionally seed member-path lookups (`rowClass.active` → `'row row-active'`), so the common per-item-styled list pattern (`className={item.active ? rowClass.active : rowClass.plain}`) resolves to `["row", "row-active", "row"]` instead of `["item.active", "?", "rowClass.active", ":", "rowClass.plain"]`. An unresolvable ternary now yields `[]` rather than the operator-token garbage.

--- a/packages/test/__tests__/render-to-test.test.ts
+++ b/packages/test/__tests__/render-to-test.test.ts
@@ -76,6 +76,84 @@ export { Label }
 })
 
 // ---------------------------------------------------------------------------
+// Bare `className={cond ? a : b}` ternary resolution (#2354)
+//
+// A ternary written INLINE in className (no backticks) is an
+// `expression`-kind attr, not a structured `template`. Before #2354 the
+// `template`-branch ternary handling had no `expression`-branch analogue,
+// so `collectClassTokens` fell through to splitting the raw JS source —
+// leaking the ternary's own operator tokens (`?`/`:`) and unresolved
+// member fragments (`rowClass.active`) into `.classes` as if they were
+// class names. These pins keep the structured walk (both arms union,
+// member access resolved through the object-literal member-path keys)
+// and the no-garbage fallback (`[]` when nothing resolves) from
+// regressing.
+// ---------------------------------------------------------------------------
+
+describe('bare inline className ternary resolution (#2354)', () => {
+  const listSource = (className: string) => `
+'use client'
+const rowClass = { active: 'row row-active', plain: 'row' }
+export function List(props: { items: { id: string; active: boolean }[] }) {
+  return (
+    <ul>
+      {props.items.map((item) => (
+        <li key={item.id} className={${className}}>{item.id}</li>
+      ))}
+    </ul>
+  )
+}
+`
+
+  test('object-property member-access branches resolve to both arms union', () => {
+    const li = renderToTest(listSource('item.active ? rowClass.active : rowClass.plain'), 'list.tsx', 'List').find({
+      tag: 'li',
+    })!
+    expect(li.classes).toEqual(['row', 'row-active', 'row'])
+    // The ternary's own operator tokens are never class names.
+    expect(li.classes).not.toContain('?')
+    expect(li.classes).not.toContain(':')
+    // Nor are the unresolved expression fragments.
+    expect(li.classes).not.toContain('item.active')
+    expect(li.classes).not.toContain('rowClass.active')
+  })
+
+  test('string-literal branches resolve to both arms union', () => {
+    const li = renderToTest(listSource("item.active ? 'row row-active' : 'row'"), 'list.tsx', 'List').find({
+      tag: 'li',
+    })!
+    expect(li.classes).toEqual(['row', 'row-active', 'row'])
+  })
+
+  test('bare member access (no ternary) resolves through member-path key', () => {
+    const li = renderToTest(listSource('rowClass.active'), 'list.tsx', 'List').find({ tag: 'li' })!
+    expect(li.classes).toEqual(['row', 'row-active'])
+  })
+
+  test('unresolvable ternary yields [] rather than leaking ?/: operator tokens', () => {
+    // Both arms reference members of an object the resolver can't reduce,
+    // so neither arm resolves. The result must be empty — never the raw
+    // ternary source with its `?`/`:` operator tokens.
+    const source = `
+'use client'
+export function List(props: { items: { id: string; active: boolean; a: { x: string }; b: { y: string } }[] }) {
+  return (
+    <ul>
+      {props.items.map((item) => (
+        <li key={item.id} className={item.active ? item.a.x : item.b.y}>{item.id}</li>
+      ))}
+    </ul>
+  )
+}
+`
+    const li = renderToTest(source, 'list.tsx', 'List').find({ tag: 'li' })!
+    expect(li.classes).toEqual([])
+    expect(li.classes).not.toContain('?')
+    expect(li.classes).not.toContain(':')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Record<T, string>[key] indexed lookups (#2069)
 //
 // Long documented as a renderToTest resolution limit, resolved by the

--- a/packages/test/src/ir-to-test-node.ts
+++ b/packages/test/src/ir-to-test-node.ts
@@ -18,8 +18,9 @@ import type {
   IRProvider,
   IRAsync,
   IRMetadata,
+  ParsedExpr,
 } from '@barefootjs/jsx'
-import { resolveSetters, buildLocalFunctionSetterMap, type SetterRef, type FnSetterResolution } from '@barefootjs/jsx'
+import { resolveSetters, buildLocalFunctionSetterMap, identifierPath, type SetterRef, type FnSetterResolution } from '@barefootjs/jsx'
 
 type IRAttribute = IRElement['attrs'][number]
 type AttrValue = IRAttribute['value']
@@ -500,8 +501,17 @@ function splitClassTokens(value: string): string[] {
  *   - `string` spans → literal text, with `${ident}` interpolations
  *     substituted from resolved consts / literal prop defaults
  * For expression attrs the value resolves through local consts (cmap)
- * and literal prop defaults. Anything still carrying a `${...}`
- * interpolation is dropped by `splitClassTokens`.
+ * and literal prop defaults. A bare `className={cond ? a : b}` ternary
+ * (no backticks) is walked structurally through the attr's `parsed`
+ * tree — the `expression`-kind analogue of the `template` branch's
+ * `ternary` part handling — so both arms union with the same semantics,
+ * and an unresolvable ternary yields `[]` rather than leaking its own
+ * operator tokens (`?`/`:`) and member fragments as class names (#2354).
+ * A non-ternary expression keeps the historical fallback: a resolved
+ * value splits into tokens, otherwise the raw source passes through
+ * (an unresolvable bare identifier surfaces as its name — a proxy some
+ * tests assert on). Anything still carrying a `${...}` interpolation is
+ * dropped by `splitClassTokens`.
  */
 function collectClassTokens(attrValue: AttrValue, resolved: string | boolean | null, ctx: ConvertContext): string[] {
   if (attrValue.kind === 'template') {
@@ -519,10 +529,51 @@ function collectClassTokens(attrValue: AttrValue, resolved: string | boolean | n
 
   const isDynamic = attrValue.kind === 'expression' || attrValue.kind === 'spread'
   if (isDynamic) {
+    // Bare `className={cond ? a : b}`: no backticks, so it never becomes a
+    // structured `template` attr. Walk the parsed ternary and union both
+    // arms — resolving identifier / member-access branches through the
+    // same cmap as everything else. A CSS class can never contain the
+    // `?`/`:` operator tokens the old raw-source fallback leaked here, so
+    // an unresolvable ternary suppresses to `[]` instead (#2354).
+    if (attrValue.kind === 'expression' && attrValue.parsed?.kind === 'conditional') {
+      const value = resolveParsedClass(attrValue.parsed, ctx)
+      return value === null ? [] : splitClassTokens(value)
+    }
     const value = resolveClassValue(resolved, ctx)
     if (value !== null) return splitClassTokens(value)
   }
   return splitClassTokens(resolved)
+}
+
+/**
+ * Reduce a parsed className expression to its resolved class string, or
+ * `null` when no branch resolves. Handles the shapes a className ternary
+ * reaches for: string literals, local-const / prop-default identifiers,
+ * object-property member access (`rowClass.active`, resolved through the
+ * member-path keys `resolveConstants` seeds), and nested ternaries. Both
+ * arms of a ternary union (matching the `template` ternary part and the
+ * intermediate-const `valueBranches` handling), since the IR can't pick a
+ * concrete arm without the runtime condition. (#2354)
+ */
+function resolveParsedClass(expr: ParsedExpr, ctx: ConvertContext): string | null {
+  switch (expr.kind) {
+    case 'literal':
+      return expr.literalType === 'string' ? String(expr.value) : null
+    case 'identifier':
+      return ctx.cmap.get(expr.name) ?? ctx.defaults.get(expr.name) ?? null
+    case 'member': {
+      const path = identifierPath(expr)
+      return path === null ? null : ctx.cmap.get(path) ?? null
+    }
+    case 'conditional': {
+      const whenTrue = resolveParsedClass(expr.consequent, ctx)
+      const whenFalse = resolveParsedClass(expr.alternate, ctx)
+      if (whenTrue === null && whenFalse === null) return null
+      return [whenTrue, whenFalse].filter((v): v is string => v !== null).join(' ')
+    }
+    default:
+      return null
+  }
 }
 
 /**

--- a/packages/test/src/resolve-constants.ts
+++ b/packages/test/src/resolve-constants.ts
@@ -8,20 +8,38 @@
  * re-parsing from the string representation.
  */
 
+import type { ParsedExpr } from '@barefootjs/jsx'
+
 /**
  * Build a map of constant name → resolved string value.
  * Resolves string literals, template literals, array.join() patterns,
  * and plain identifier references. When `valueBranches` is present
  * (from ternary initializers), each branch is resolved and merged
- * with union semantics. Record lookups, function expressions, and
- * other complex values are skipped.
+ * with union semantics. An object-literal const with string-valued
+ * properties (`const rowClass = { active: 'row row-active', plain: 'row' }`)
+ * additionally seeds member-path keys (`rowClass.active` → `'row row-active'`)
+ * so a member-access className (`className={rowClass.active}`, or a
+ * ternary arm) resolves through the same lookup (#2354). Function
+ * expressions and other complex values are skipped.
  */
 export function resolveConstants(
-  constants: Array<{ name: string; value?: string; valueBranches?: string[] }>
+  constants: Array<{ name: string; value?: string; valueBranches?: string[]; parsed?: ParsedExpr }>
 ): Map<string, string> {
   const resolved = new Map<string, string>()
 
   for (const c of constants) {
+    // Object-literal const: expose each string-valued property as a
+    // `name.key` member-path key. The bare identifier stays unresolved
+    // (an object is not a class string), matching prior behavior.
+    if (c.parsed?.kind === 'object-literal') {
+      for (const prop of c.parsed.properties) {
+        if (prop.value.kind === 'literal' && prop.value.literalType === 'string') {
+          resolved.set(`${c.name}.${prop.key}`, String(prop.value.value))
+        }
+      }
+      continue
+    }
+
     if (!c.value) continue
 
     // When the analyzer provides structured branch info, resolve each


### PR DESCRIPTION
## Summary

Fixes #2354 — `@barefootjs/test`'s `TestNode.classes` leaked raw ternary operator tokens (`?`, `:`) and unresolved expression fragments for a bare `className={cond ? a : b}` expression.

`collectClassTokens` (`packages/test/src/ir-to-test-node.ts`) only had structural handling for the `template`-kind `ternary` part. A bare inline ternary (no backticks) is an `expression`-kind attr, so it fell through to `splitClassTokens` on the **raw JS source** — leaking the ternary's own `?`/`:` operators and expression fragments (`item.active`, `rowClass.active`) as if they were class names. None of those can ever be a valid CSS class.

## Repro (from the issue)

```tsx
const rowClass = { active: 'row row-active', plain: 'row' }
// ...
<li className={item.active ? rowClass.active : rowClass.plain}>
```

| | `.classes` before | `.classes` after |
|---|---|---|
| member-access ternary | `["item.active", "?", "rowClass.active", ":", "rowClass.plain"]` | `["row", "row-active", "row"]` |

## What changed

- **`ir-to-test-node.ts`** — when an `expression`-kind className attr's `parsed` tree is a `conditional`, walk it structurally (new `resolveParsedClass` helper): union both arms, resolving string literals, local-const / prop-default identifiers, object-property member access, and nested ternaries. This is the `expression`-kind analogue of the `template` branch's existing `ternary` handling and unions both arms with the same semantics. An unresolvable ternary yields `[]` rather than `?`/`:` garbage.
- **`resolve-constants.ts`** — an object-literal constant with string-valued properties now also seeds member-path keys (`rowClass.active` → `'row row-active'`) so member-access branches resolve through the same `cmap` as everything else. The bare identifier stays unresolved (an object is not a class string), matching prior behavior.
- The non-ternary fallback is deliberately **unchanged**: an unresolvable bare identifier still surfaces as its name — a proxy the chart component IR tests (`ui/components/ui/chart/index.test.tsx`) assert on.

## Scope

Purely a `@barefootjs/test` change — no `@barefootjs/jsx` compiler behavior is touched, no new `ParsedExpr` kind or acceptance surface is added (the fix consumes IR the analyzer already produces), so no adapter conformance fixture is required. Runtime behavior of compiled components was never affected.

## Testing

- Added a `bare inline className ternary resolution (#2354)` describe block to `packages/test/__tests__/render-to-test.test.ts`: member-access branches, string-literal branches, bare member access, and the unresolvable-ternary → `[]` (no `?`/`:`) case.
- `bun test packages/test/__tests__` → 42 pass
- `bun test ui/components` (component IR suite, incl. chart pins) → 1240 pass, 0 fail
- `build:types` and `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVkkYtgbeYXhCADw9AzG1g)_