### PR TITLE
fix(test): resolve template-literal-valued object properties in className (#2360)

### DIFF
--- a/.changeset/test-object-literal-template-prop-classes.md
+++ b/.changeset/test-object-literal-template-prop-classes.md
@@ -1,0 +1,5 @@
+---
+'@barefootjs/test': patch
+---
+
+Fix `resolveConstants` (used by `renderToTest`'s `TestNode.classes`) to also resolve an object-literal className constant's template-literal-valued properties (`{ active: \`${base} row-active\` }`), not just plain string literals — a member-access className ternary (`className={cond ? rowClass.active : rowClass.plain}`) previously fell back to `[]` for this common shape instead of the actual class tokens (#2360, follow-up to #2354/#2355).

--- a/.changeset/test-object-literal-template-prop-classes.md
+++ b/.changeset/test-object-literal-template-prop-classes.md
@@ -2,4 +2,4 @@
 '@barefootjs/test': patch
 ---
 
-Fix `resolveConstants` (used by `renderToTest`'s `TestNode.classes`) to also resolve an object-literal className constant's template-literal-valued properties (`{ active: \`${base} row-active\` }`), not just plain string literals — a member-access className ternary (`className={cond ? rowClass.active : rowClass.plain}`) previously fell back to `[]` for this common shape instead of the actual class tokens (#2360, follow-up to #2354/#2355).
+Fix `resolveConstants` (used by `renderToTest`'s `TestNode.classes`) to also resolve an object-literal className constant's template-literal-valued properties (`` { active: `${base} row-active` } ``), not just plain string literals — a member-access className ternary (`className={cond ? rowClass.active : rowClass.plain}`) previously fell back to `[]` for this common shape instead of the actual class tokens (#2360, follow-up to #2354/#2355).

--- a/packages/test/__tests__/render-to-test.test.ts
+++ b/packages/test/__tests__/render-to-test.test.ts
@@ -244,6 +244,26 @@ export function List(props: { items: { id: string; active: boolean }[] }) {
     // Only the resolvable arm (`rowClass.plain`) contributes.
     expect(li.classes).toEqual(['row'])
   })
+
+  test('a bare identifier property (referencing an earlier module-scope const) resolves too', () => {
+    // Matches resolveConstants' own JSDoc example verbatim (Copilot review, PR #2361).
+    const source = `
+'use client'
+const base = 'row'
+const rowClass = { active: \`\${base} row-active\`, plain: base }
+export function List(props: { items: { id: string; active: boolean }[] }) {
+  return (
+    <ul>
+      {props.items.map((item) => (
+        <li key={item.id} className={item.active ? rowClass.active : rowClass.plain}>{item.id}</li>
+      ))}
+    </ul>
+  )
+}
+`
+    const li = renderToTest(source, 'list.tsx', 'List').find({ tag: 'li' })!
+    expect(li.classes).toEqual(['row', 'row-active', 'row'])
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/test/__tests__/render-to-test.test.ts
+++ b/packages/test/__tests__/render-to-test.test.ts
@@ -264,6 +264,48 @@ export function List(props: { items: { id: string; active: boolean }[] }) {
     const li = renderToTest(source, 'list.tsx', 'List').find({ tag: 'li' })!
     expect(li.classes).toEqual(['row', 'row-active', 'row'])
   })
+
+  test('a template-literal property with a non-identifier interpolation stays unresolved, not partially folded to "" (Copilot review, PR #2361)', () => {
+    // `${item.active ? 'x' : 'y'}` inside the template can't resolve to a
+    // plain identifier lookup — the whole property must stay unresolved
+    // (contributing nothing), not fold the interpolation to '' and seed a
+    // misleadingly "resolved" partial string.
+    const source = `
+'use client'
+const rowClass = { active: \`row-\${item.active ? 'x' : 'y'}\`, plain: 'row' }
+export function List(props: { items: { id: string; active: boolean }[] }) {
+  return (
+    <ul>
+      {props.items.map((item) => (
+        <li key={item.id} className={item.active ? rowClass.active : rowClass.plain}>{item.id}</li>
+      ))}
+    </ul>
+  )
+}
+`
+    const li = renderToTest(source, 'list.tsx', 'List').find({ tag: 'li' })!
+    // Only the resolvable arm (`rowClass.plain`) contributes — no partial
+    // `row-` token from the unresolved interpolation.
+    expect(li.classes).toEqual(['row'])
+  })
+
+  test('a template-literal property interpolating an identifier that never resolves stays unresolved', () => {
+    const source = `
+'use client'
+const rowClass = { active: \`row \${undeclaredHelper()}\`, plain: 'row' }
+export function List(props: { items: { id: string; active: boolean }[] }) {
+  return (
+    <ul>
+      {props.items.map((item) => (
+        <li key={item.id} className={item.active ? rowClass.active : rowClass.plain}>{item.id}</li>
+      ))}
+    </ul>
+  )
+}
+`
+    const li = renderToTest(source, 'list.tsx', 'List').find({ tag: 'li' })!
+    expect(li.classes).toEqual(['row'])
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/test/__tests__/render-to-test.test.ts
+++ b/packages/test/__tests__/render-to-test.test.ts
@@ -154,6 +154,99 @@ export function List(props: { items: { id: string; active: boolean; a: { x: stri
 })
 
 // ---------------------------------------------------------------------------
+// Object-literal properties whose value is a template literal (#2360)
+//
+// #2354's member-path seeding only handled a plain string-literal property
+// value (`{ active: 'row row-active' }`) — a property built from a shared
+// base-class constant plus a per-variant suffix (`{ active: \`${base}
+// row-active\` }`, an extremely common way to compose a small related set
+// of class strings) fell through unresolved, silently degrading to `[]`
+// rather than the actual class tokens. Found via a real component
+// (piconic-ai/sora's ListSidebar) using exactly this shape for every one
+// of its per-row state classes.
+// ---------------------------------------------------------------------------
+
+describe('object-literal properties as template literals (#2360)', () => {
+  test('ternary branches referencing template-literal properties resolve to both arms union', () => {
+    const source = `
+'use client'
+const base = 'row'
+const rowClass = { active: \`\${base} row-active\`, plain: \`\${base}\` }
+export function List(props: { items: { id: string; active: boolean }[] }) {
+  return (
+    <ul>
+      {props.items.map((item) => (
+        <li key={item.id} className={item.active ? rowClass.active : rowClass.plain}>{item.id}</li>
+      ))}
+    </ul>
+  )
+}
+`
+    const li = renderToTest(source, 'list.tsx', 'List').find({ tag: 'li' })!
+    expect(li.classes).toEqual(['row', 'row-active', 'row'])
+  })
+
+  test('a nested ternary over four template-literal properties resolves every arm (ListSidebar shape)', () => {
+    const source = `
+'use client'
+const listItemBase = 'group flex items-center'
+const listItemActiveBg = 'bg-active'
+const listItemClass = {
+  plain: \`list-item \${listItemBase}\`,
+  active: \`list-item is-active \${listItemBase} \${listItemActiveBg}\`,
+  renaming: \`list-item is-renaming \${listItemBase}\`,
+  activeRenaming: \`list-item is-active is-renaming \${listItemBase} \${listItemActiveBg}\`,
+}
+export function List(props: { items: { id: string; active: boolean; renaming: boolean }[] }) {
+  return (
+    <ul>
+      {props.items.map((entry) => (
+        <li
+          key={entry.id}
+          className={
+            entry.renaming
+              ? entry.active
+                ? listItemClass.activeRenaming
+                : listItemClass.renaming
+              : entry.active
+                ? listItemClass.active
+                : listItemClass.plain
+          }
+        >{entry.id}</li>
+      ))}
+    </ul>
+  )
+}
+`
+    const li = renderToTest(source, 'list.tsx', 'List').find({ tag: 'li' })!
+    for (const token of ['list-item', 'is-active', 'is-renaming', 'group', 'flex', 'items-center', 'bg-active']) {
+      expect(li.classes).toContain(token)
+    }
+    expect(li.classes).not.toContain('?')
+    expect(li.classes).not.toContain(':')
+  })
+
+  test('a property value that is neither a string nor template literal stays unresolved', () => {
+    const source = `
+'use client'
+const rowClass = { active: 1 + 1, plain: 'row' }
+export function List(props: { items: { id: string; active: boolean }[] }) {
+  return (
+    <ul>
+      {props.items.map((item) => (
+        <li key={item.id} className={item.active ? rowClass.active : rowClass.plain}>{item.id}</li>
+      ))}
+    </ul>
+  )
+}
+`
+    const li = renderToTest(source, 'list.tsx', 'List').find({ tag: 'li' })!
+    // Only the resolvable arm (`rowClass.plain`) contributes.
+    expect(li.classes).toEqual(['row'])
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Record<T, string>[key] indexed lookups (#2069)
 //
 // Long documented as a renderToTest resolution limit, resolved by the

--- a/packages/test/__tests__/render-to-test.test.ts
+++ b/packages/test/__tests__/render-to-test.test.ts
@@ -266,13 +266,16 @@ export function List(props: { items: { id: string; active: boolean }[] }) {
   })
 
   test('a template-literal property with a non-identifier interpolation stays unresolved, not partially folded to "" (Copilot review, PR #2361)', () => {
-    // `${item.active ? 'x' : 'y'}` inside the template can't resolve to a
+    // `${flag ? 'x' : 'y'}` inside the template is a conditional, not a
     // plain identifier lookup — the whole property must stay unresolved
     // (contributing nothing), not fold the interpolation to '' and seed a
-    // misleadingly "resolved" partial string.
+    // misleadingly "resolved" partial string. `flag` is a real module-scope
+    // const (unlike a component-scope `.map()` param) so this fixture stays
+    // valid TSX on its own (Copilot review, PR #2361).
     const source = `
 'use client'
-const rowClass = { active: \`row-\${item.active ? 'x' : 'y'}\`, plain: 'row' }
+const flag = true
+const rowClass = { active: \`row-\${flag ? 'x' : 'y'}\`, plain: 'row' }
 export function List(props: { items: { id: string; active: boolean }[] }) {
   return (
     <ul>
@@ -289,10 +292,18 @@ export function List(props: { items: { id: string; active: boolean }[] }) {
     expect(li.classes).toEqual(['row'])
   })
 
-  test('a template-literal property interpolating an identifier that never resolves stays unresolved', () => {
+  test('a template-literal property interpolating a declared identifier that never resolves to a string stays unresolved', () => {
+    // `count` is a real module-scope const (so `resolveObjectPropValue`
+    // actually reaches its `identifier` branch, unlike a call expression,
+    // which is a different, already-covered non-identifier shape) but its
+    // value is a number, so it never lands in `resolved` (string-only) —
+    // exercises the "identifier declared but not string-resolvable" path
+    // distinctly from the conditional-interpolation case above (Copilot
+    // review, PR #2361).
     const source = `
 'use client'
-const rowClass = { active: \`row \${undeclaredHelper()}\`, plain: 'row' }
+const count = 42
+const rowClass = { active: \`row \${count}\`, plain: 'row' }
 export function List(props: { items: { id: string; active: boolean }[] }) {
   return (
     <ul>

--- a/packages/test/src/resolve-constants.ts
+++ b/packages/test/src/resolve-constants.ts
@@ -68,19 +68,23 @@ export function resolveConstants(
 /**
  * Resolve one object-literal property's value to a string, for the
  * `name.key` member-path seeding above. Mirrors `tryResolve`'s string-
- * literal and template-literal handling, but walks the already-structured
- * `ParsedExpr` (available here, unlike `tryResolve`'s raw-string input)
- * instead of re-parsing with a regex. An interpolated identifier resolves
- * against `resolved` — safe because `resolveConstants` processes
- * `constants` in declaration order, so a module-scope const referenced
- * inside a later object literal's template-literal property is already
- * in the map (#2360). Anything else (a nested object/array, a call, a
- * binary expression, ...) is left unresolved, same posture as `tryResolve`
- * skipping "complex values".
+ * literal, template-literal, and plain-identifier-reference handling, but
+ * walks the already-structured `ParsedExpr` (available here, unlike
+ * `tryResolve`'s raw-string input) instead of re-parsing with a regex. A
+ * bare identifier property (`{ plain: base }`) and an interpolated
+ * identifier inside a template literal both resolve against `resolved` —
+ * safe because `resolveConstants` processes `constants` in declaration
+ * order, so a module-scope const referenced inside a later object
+ * literal's property is already in the map (#2360). Anything else (a
+ * nested object/array, a call, a binary expression, ...) is left
+ * unresolved, same posture as `tryResolve` skipping "complex values".
  */
 function resolveObjectPropValue(expr: ParsedExpr, resolved: Map<string, string>): string | null {
   if (expr.kind === 'literal' && expr.literalType === 'string') {
     return String(expr.value)
+  }
+  if (expr.kind === 'identifier') {
+    return resolved.get(expr.name) ?? null
   }
   if (expr.kind === 'template-literal') {
     return expr.parts

--- a/packages/test/src/resolve-constants.ts
+++ b/packages/test/src/resolve-constants.ts
@@ -15,12 +15,13 @@ import type { ParsedExpr } from '@barefootjs/jsx'
  * Resolves string literals, template literals, array.join() patterns,
  * and plain identifier references. When `valueBranches` is present
  * (from ternary initializers), each branch is resolved and merged
- * with union semantics. An object-literal const with string-valued
- * properties (`const rowClass = { active: 'row row-active', plain: 'row' }`)
- * additionally seeds member-path keys (`rowClass.active` → `'row row-active'`)
- * so a member-access className (`className={rowClass.active}`, or a
- * ternary arm) resolves through the same lookup (#2354). Function
- * expressions and other complex values are skipped.
+ * with union semantics. An object-literal const with string- or
+ * template-literal-valued properties (`const rowClass = { active:
+ * \`${base} row-active\`, plain: base }`) additionally seeds member-path
+ * keys (`rowClass.active` → `'row row-active'`) so a member-access
+ * className (`className={rowClass.active}`, or a ternary arm) resolves
+ * through the same lookup (#2354, template-literal values #2360).
+ * Function expressions and other complex property values are skipped.
  */
 export function resolveConstants(
   constants: Array<{ name: string; value?: string; valueBranches?: string[]; parsed?: ParsedExpr }>
@@ -28,14 +29,13 @@ export function resolveConstants(
   const resolved = new Map<string, string>()
 
   for (const c of constants) {
-    // Object-literal const: expose each string-valued property as a
+    // Object-literal const: expose each resolvable property as a
     // `name.key` member-path key. The bare identifier stays unresolved
     // (an object is not a class string), matching prior behavior.
     if (c.parsed?.kind === 'object-literal') {
       for (const prop of c.parsed.properties) {
-        if (prop.value.kind === 'literal' && prop.value.literalType === 'string') {
-          resolved.set(`${c.name}.${prop.key}`, String(prop.value.value))
-        }
+        const value = resolveObjectPropValue(prop.value, resolved)
+        if (value !== null) resolved.set(`${c.name}.${prop.key}`, value)
       }
       continue
     }
@@ -63,6 +63,31 @@ export function resolveConstants(
   }
 
   return resolved
+}
+
+/**
+ * Resolve one object-literal property's value to a string, for the
+ * `name.key` member-path seeding above. Mirrors `tryResolve`'s string-
+ * literal and template-literal handling, but walks the already-structured
+ * `ParsedExpr` (available here, unlike `tryResolve`'s raw-string input)
+ * instead of re-parsing with a regex. An interpolated identifier resolves
+ * against `resolved` — safe because `resolveConstants` processes
+ * `constants` in declaration order, so a module-scope const referenced
+ * inside a later object literal's template-literal property is already
+ * in the map (#2360). Anything else (a nested object/array, a call, a
+ * binary expression, ...) is left unresolved, same posture as `tryResolve`
+ * skipping "complex values".
+ */
+function resolveObjectPropValue(expr: ParsedExpr, resolved: Map<string, string>): string | null {
+  if (expr.kind === 'literal' && expr.literalType === 'string') {
+    return String(expr.value)
+  }
+  if (expr.kind === 'template-literal') {
+    return expr.parts
+      .map((part) => (part.type === 'string' ? part.value : (part.expr.kind === 'identifier' ? (resolved.get(part.expr.name) ?? '') : '')))
+      .join('')
+  }
+  return null
 }
 
 function tryResolve(raw: string, resolved: Map<string, string>): string | null {

--- a/packages/test/src/resolve-constants.ts
+++ b/packages/test/src/resolve-constants.ts
@@ -31,8 +31,12 @@ export function resolveConstants(
 
   for (const c of constants) {
     // Object-literal const: expose each resolvable property as a
-    // `name.key` member-path key. The bare identifier stays unresolved
-    // (an object is not a class string), matching prior behavior.
+    // `name.key` member-path key. The object's OWN bare identifier
+    // (`c.name` referenced directly, e.g. `className={rowClass}`) stays
+    // unresolved — an object is not a class string — matching prior
+    // behavior; this is unrelated to a resolvable identifier-valued
+    // PROPERTY (`{ plain: base }`), handled by resolveObjectPropValue
+    // below (Copilot review, PR #2361).
     if (c.parsed?.kind === 'object-literal') {
       for (const prop of c.parsed.properties) {
         const value = resolveObjectPropValue(prop.value, resolved)

--- a/packages/test/src/resolve-constants.ts
+++ b/packages/test/src/resolve-constants.ts
@@ -15,9 +15,10 @@ import type { ParsedExpr } from '@barefootjs/jsx'
  * Resolves string literals, template literals, array.join() patterns,
  * and plain identifier references. When `valueBranches` is present
  * (from ternary initializers), each branch is resolved and merged
- * with union semantics. An object-literal const with string- or
- * template-literal-valued properties (`const rowClass = { active:
- * \`${base} row-active\`, plain: base }`) additionally seeds member-path
+ * with union semantics. An object-literal const with string-literal,
+ * template-literal, or bare-identifier-valued properties (`const rowClass
+ * = { active: \`${base} row-active\`, plain: base }`) additionally seeds
+ * member-path
  * keys (`rowClass.active` → `'row row-active'`) so a member-access
  * className (`className={rowClass.active}`, or a ternary arm) resolves
  * through the same lookup (#2354, template-literal values #2360).
@@ -67,17 +68,24 @@ export function resolveConstants(
 
 /**
  * Resolve one object-literal property's value to a string, for the
- * `name.key` member-path seeding above. Mirrors `tryResolve`'s string-
- * literal, template-literal, and plain-identifier-reference handling, but
- * walks the already-structured `ParsedExpr` (available here, unlike
- * `tryResolve`'s raw-string input) instead of re-parsing with a regex. A
- * bare identifier property (`{ plain: base }`) and an interpolated
- * identifier inside a template literal both resolve against `resolved` —
- * safe because `resolveConstants` processes `constants` in declaration
- * order, so a module-scope const referenced inside a later object
- * literal's property is already in the map (#2360). Anything else (a
- * nested object/array, a call, a binary expression, ...) is left
- * unresolved, same posture as `tryResolve` skipping "complex values".
+ * `name.key` member-path seeding above. Supports the same shapes as
+ * `tryResolve` — string literal, template literal, plain identifier
+ * reference — but walks the already-structured `ParsedExpr` (available
+ * here, unlike `tryResolve`'s raw-string input) instead of re-parsing
+ * with a regex, and is stricter about "unresolvable": `tryResolve`'s
+ * template-literal branch folds an unresolved `${...}` to `''` (its
+ * caller only ever uses that for the whole-constant case, where a
+ * partial string is an acceptable degrade), but a property value here
+ * returns `null` for the whole property instead — seeding `name.key`
+ * with a misleadingly partial class string would be worse than not
+ * seeding it at all. A bare identifier property (`{ plain: base }`) and
+ * an interpolated identifier inside a template literal both resolve
+ * against `resolved` — safe because `resolveConstants` processes
+ * `constants` in declaration order, so a module-scope const referenced
+ * inside a later object literal's property is already in the map
+ * (#2360). Anything else (a nested object/array, a call, a binary
+ * expression, ...) is left unresolved, same posture as `tryResolve`
+ * skipping "complex values".
  */
 function resolveObjectPropValue(expr: ParsedExpr, resolved: Map<string, string>): string | null {
   if (expr.kind === 'literal' && expr.literalType === 'string') {

--- a/packages/test/src/resolve-constants.ts
+++ b/packages/test/src/resolve-constants.ts
@@ -87,9 +87,23 @@ function resolveObjectPropValue(expr: ParsedExpr, resolved: Map<string, string>)
     return resolved.get(expr.name) ?? null
   }
   if (expr.kind === 'template-literal') {
-    return expr.parts
-      .map((part) => (part.type === 'string' ? part.value : (part.expr.kind === 'identifier' ? (resolved.get(part.expr.name) ?? '') : '')))
-      .join('')
+    const strs: string[] = []
+    for (const part of expr.parts) {
+      if (part.type === 'string') {
+        strs.push(part.value)
+        continue
+      }
+      // An interpolation that isn't a plain identifier reference (a
+      // conditional, a member access, ...), or one that IS an identifier
+      // but doesn't resolve, makes the whole template unresolved — don't
+      // fold it to '' and seed a partial, misleadingly "resolved" string
+      // (Copilot review, PR #2361).
+      if (part.expr.kind !== 'identifier') return null
+      const value = resolved.get(part.expr.name)
+      if (value === undefined) return null
+      strs.push(value)
+    }
+    return strs.join('')
   }
   return null
 }


### PR DESCRIPTION
## Summary

Closes #2360 (follow-up to #2354 / #2355, released as 0.26.1).

- `#2354`/`#2355`'s member-path seeding for object-literal className constants (`resolveConstants`) only handled a plain string-literal property value (`{ active: 'row row-active' }`). A property built from a shared base-class constant plus a per-variant suffix (`` { active: `${base} row-active` } `` — an extremely common way to compose a small set of related class strings) has `prop.value.kind === 'template-literal'`, not `'literal'`, so it fell through unresolved: no `?`/`:` garbage anymore (that part of #2355's fix holds), but a ternary over such a property silently resolved to `[]` instead of the actual class tokens.
- Found via a real component (piconic-ai/sora's `ListSidebar.tsx`) that uses exactly this shape for every one of its per-row state classes — `listItemClass`/`listItemSelectClass`/`listItemMenuWrapClass`/`listItemMenuClass`/`listItemRenameInputClass` are all object literals whose properties compose a shared base constant via a template literal.
- New `resolveObjectPropValue` walks a property's `ParsedExpr` (string literal, template literal, or bare identifier reference — resolving an interpolated/bare identifier through the same `resolved` map `tryResolve`'s own handling already relies on — safe since `resolveConstants` processes constants in declaration order) and replaces the inline `prop.value.kind === 'literal'` check in the object-literal branch. An interpolation that isn't a resolvable plain identifier voids the WHOLE property (`null`) rather than folding to `''` and seeding a misleadingly partial class string (a distinction from `tryResolve`'s own template-literal handling, called out in review).

## Test plan

- [x] Scratch repro matching the issue exactly (`{ active: `${base} row-active}`, plain: `${base}` }`) — resolves to `["row", "row-active", "row"]` instead of `[]`
- [x] Scratch repro matching the real ListSidebar shape (nested ternary over 4 template-literal-composed properties) — resolves every branch's tokens correctly
- [x] 6 new tests in `packages/test/__tests__/render-to-test.test.ts`: basic template-literal property; nested-ternary ListSidebar shape; a genuinely unresolvable property value degrades `[]` for that arm only; a bare-identifier property value (matching the docstring's own example); a non-identifier template interpolation (a conditional) voids the whole property rather than leaking a partial string; a declared-but-not-string-resolvable identifier interpolation (a number const) does the same
- [x] Verified every new test isn't vacuous: for each round of review feedback, temporarily reverted that round's fix and confirmed exactly the expected tests failed, nothing else
- [x] `bun test packages/test/` — 48 pass, 0 fail
- [x] `bun test ui/components/ui/ packages/jsx/` — 3923 pass, 0 fail (no regression across the UI kit's own Component IR tests or the compiler)
- [x] `tsc --noEmit -p packages/test/tsconfig.json` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)