### PR TITLE
Compatibility Matrix: link Construct Support rows to example fixtures with inline code snippets

### DIFF
--- a/packages/compat/src/construct-examples.ts
+++ b/packages/compat/src/construct-examples.ts
@@ -1,0 +1,135 @@
+// Representative example per `kind` / `axis` construct for the docs
+// page's Construct Support tables: a definition-line permalink
+// (construct-source-links.ts) tells a reader where `array-method:at` is
+// *registered*, but not what the case looks like. Each construct's
+// covering conformance fixtures are exactly that documentation — a
+// small self-contained component with a human-written `description`
+// ("`.at(-1)` returns the last element") and a docstring — so the docs
+// page links the construct to one of those instead, and shows the
+// description inline.
+//
+// Exemplar choice is mechanical: among the fixtures the coverage map
+// says exercise the construct, take the one with the SMALLEST total
+// coverage set (fewest kinds + axes = the most narrowly targeted
+// fixture — `array-at`, not a kitchen-sink component that happens to
+// call `.at()` somewhere), tie-broken by id. Recomputed on every
+// `support-matrix:lock` regen and drift-checked in CI with the rest of
+// the lock file, so the exemplar, its description, and its file link
+// can never silently go stale.
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'path'
+import ts from 'typescript'
+import { jsxFixtures } from '../../adapter-tests/fixtures'
+import type { SupportMatrixCoverageMap } from './support-matrix'
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
+const GITHUB_BLOB_BASE = 'https://github.com/piconic-ai/barefootjs/blob/main'
+const FIXTURES_DIR = 'packages/adapter-tests/fixtures'
+
+/** One construct's exemplar fixture: what the case looks like, in prose and in code. */
+export interface ConstructExample {
+  /** Exemplar fixture id (the most narrowly targeted covering fixture). */
+  fixture: string
+  /** The fixture's human-written one-line description. */
+  description: string
+  /** GitHub permalink to the fixture source file. */
+  url: string
+}
+
+/**
+ * Fixture id → repo-relative file path, built by AST-walking every
+ * `.ts` under the fixtures tree for a string-literal `id:` property
+ * (never regex — CLAUDE.md). Fixture files declare their id exactly
+ * once (`createFixture({ id: '...' })` or a shared `spec` object), and
+ * ids are corpus-unique, so the first declaration wins.
+ */
+function fixtureFileMap(): Map<string, string> {
+  const map = new Map<string, string>()
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(path.join(REPO_ROOT, dir), { withFileTypes: true })) {
+      const rel = `${dir}/${entry.name}`
+      if (entry.isDirectory()) {
+        walk(rel)
+        continue
+      }
+      if (!entry.name.endsWith('.ts')) continue
+      const sourceFile = ts.createSourceFile(
+        rel,
+        readFileSync(path.join(REPO_ROOT, rel), 'utf8'),
+        ts.ScriptTarget.Latest,
+        true,
+      )
+      const visit = (node: ts.Node): void => {
+        if (
+          ts.isPropertyAssignment(node) &&
+          ts.isIdentifier(node.name) &&
+          node.name.text === 'id' &&
+          (ts.isStringLiteral(node.initializer) || ts.isNoSubstitutionTemplateLiteral(node.initializer)) &&
+          !map.has(node.initializer.text)
+        ) {
+          map.set(node.initializer.text, rel)
+        }
+        ts.forEachChild(node, visit)
+      }
+      visit(sourceFile)
+    }
+  }
+  walk(FIXTURES_DIR)
+  return map
+}
+
+/** Coverage-set size per fixture id — the exemplar-choice metric (smaller = more targeted). */
+function coverageSizes(coverage: SupportMatrixCoverageMap): Map<string, number> {
+  const sizes = new Map<string, number>()
+  for (const [id, c] of Object.entries(coverage.fixtures)) {
+    sizes.set(id, c.kinds.length + c.axes.length)
+  }
+  return sizes
+}
+
+export interface ConstructExamples {
+  kinds: Record<string, ConstructExample>
+  axes: Record<string, ConstructExample>
+}
+
+export function computeConstructExamples(coverage: SupportMatrixCoverageMap): ConstructExamples {
+  const files = fixtureFileMap()
+  const sizes = coverageSizes(coverage)
+  const descriptions = new Map(jsxFixtures.map(f => [f.id, f.description]))
+
+  const exemplarFor = (construct: string, field: 'kinds' | 'axes'): ConstructExample | undefined => {
+    let best: string | undefined
+    for (const [id, c] of Object.entries(coverage.fixtures)) {
+      if (!c[field].includes(construct)) continue
+      // Only fixtures we can both describe and link to are eligible.
+      if (!descriptions.has(id) || !files.has(id)) continue
+      if (
+        best === undefined ||
+        sizes.get(id)! < sizes.get(best)! ||
+        (sizes.get(id) === sizes.get(best) && id < best)
+      ) {
+        best = id
+      }
+    }
+    if (best === undefined) return undefined
+    return {
+      fixture: best,
+      description: descriptions.get(best)!,
+      url: `${GITHUB_BLOB_BASE}/${files.get(best)!}`,
+    }
+  }
+
+  const kinds: Record<string, ConstructExample> = {}
+  const axes: Record<string, ConstructExample> = {}
+  for (const c of Object.keys(coverage.kindCounts)) {
+    const ex = exemplarFor(c, 'kinds')
+    if (ex) kinds[c] = ex
+  }
+  for (const c of Object.keys(coverage.axisCounts)) {
+    const ex = exemplarFor(c, 'axes')
+    if (ex) axes[c] = ex
+  }
+  return { kinds, axes }
+}

--- a/packages/compat/src/construct-examples.ts
+++ b/packages/compat/src/construct-examples.ts
@@ -21,6 +21,7 @@ import { readdirSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import path from 'path'
 import ts from 'typescript'
+import { ARRAY_METHOD_NAMES } from '@barefootjs/jsx'
 import { jsxFixtures } from '../../adapter-tests/fixtures'
 import type { SupportMatrixCoverageMap } from './support-matrix'
 
@@ -36,6 +37,14 @@ export interface ConstructExample {
   description: string
   /** GitHub permalink to the fixture source file. */
   url: string
+  /**
+   * The smallest expression in the exemplar's source matching this
+   * construct (`items.at(-1)`), when one is extractable — see
+   * `extractSnippet`. Omitted for constructs whose matcher is
+   * intentionally undefined (`unsupported`) or when no in-budget match
+   * exists.
+   */
+  code?: string
 }
 
 /**
@@ -80,6 +89,159 @@ function fixtureFileMap(): Map<string, string> {
   return map
 }
 
+const ARRAY_METHOD_SET: ReadonlySet<string> = new Set(ARRAY_METHOD_NAMES)
+
+/** Operators the compiler parses as `logical` (vs plain `binary`). */
+const LOGICAL_OPS = new Set(['&&', '||', '??'])
+
+/**
+ * TS-node predicate for one construct label, mirroring (approximately —
+ * this is documentation, not lowering) how `expression-parser.ts`
+ * classifies expressions. `jsxOnly` restricts ubiquitous constructs
+ * (`identifier`, `literal:*`) to nodes inside a JSX expression
+ * container, so the match is a template expression like `{name}` and
+ * not an import specifier or helper-local. Returns undefined for
+ * constructs with no meaningful snippet (`unsupported` — the fixture
+ * description already says what shape is refused).
+ */
+function matcherFor(construct: string): { test: (n: ts.Node) => boolean; jsxOnly?: boolean } | undefined {
+  const [family, detail] = construct.includes(':')
+    ? [construct.slice(0, construct.indexOf(':')), construct.slice(construct.indexOf(':') + 1)]
+    : [construct, undefined]
+
+  const literalTest = (n: ts.Node, type: string | undefined): boolean => {
+    switch (type) {
+      case 'string':
+        return ts.isStringLiteral(n) || ts.isNoSubstitutionTemplateLiteral(n)
+      case 'number':
+        return ts.isNumericLiteral(n)
+      case 'boolean':
+        return n.kind === ts.SyntaxKind.TrueKeyword || n.kind === ts.SyntaxKind.FalseKeyword
+      case 'null':
+        return n.kind === ts.SyntaxKind.NullKeyword
+      default:
+        return literalTest(n, 'string') || literalTest(n, 'number') || literalTest(n, 'boolean') || literalTest(n, 'null')
+    }
+  }
+
+  switch (family) {
+    case 'identifier':
+      return { test: ts.isIdentifier, jsxOnly: true }
+    case 'literal':
+      return { test: (n) => literalTest(n, detail), jsxOnly: true }
+    case 'call':
+      // Exclude catalogue methods so `count()` wins over `.at(-1)`.
+      return {
+        test: (n) =>
+          ts.isCallExpression(n) &&
+          !(ts.isPropertyAccessExpression(n.expression) && ARRAY_METHOD_SET.has(n.expression.name.text)),
+      }
+    case 'member':
+      if (detail === 'optional')
+        return {
+          test: (n) =>
+            (ts.isPropertyAccessChain(n) || ts.isElementAccessChain(n)) && n.questionDotToken !== undefined,
+        }
+      if (detail === 'computed')
+        return {
+          test: (n) =>
+            ts.isElementAccessExpression(n) &&
+            (ts.isStringLiteral(n.argumentExpression) || ts.isNumericLiteral(n.argumentExpression)),
+        }
+      return { test: ts.isPropertyAccessExpression }
+    case 'index-access':
+      // Non-literal index — the literal case stays a computed `member`.
+      return {
+        test: (n) =>
+          ts.isElementAccessExpression(n) &&
+          !ts.isStringLiteral(n.argumentExpression) &&
+          !ts.isNumericLiteral(n.argumentExpression),
+      }
+    case 'binary':
+      return {
+        test: (n) =>
+          ts.isBinaryExpression(n) &&
+          (detail
+            ? n.operatorToken.getText() === detail
+            : !LOGICAL_OPS.has(n.operatorToken.getText()) && n.operatorToken.kind !== ts.SyntaxKind.EqualsToken),
+      }
+    case 'logical':
+      return {
+        test: (n) =>
+          ts.isBinaryExpression(n) && (detail ? n.operatorToken.getText() === detail : LOGICAL_OPS.has(n.operatorToken.getText())),
+      }
+    case 'unary':
+      return {
+        test: (n) =>
+          (ts.isPrefixUnaryExpression(n) && (!detail || ts.tokenToString(n.operator) === detail)) ||
+          (ts.isTypeOfExpression(n) && (!detail || detail === 'typeof')),
+      }
+    case 'conditional':
+      return { test: ts.isConditionalExpression }
+    case 'template-literal':
+      return { test: ts.isTemplateExpression }
+    case 'arrow':
+      return { test: ts.isArrowFunction }
+    case 'regex':
+      return { test: ts.isRegularExpressionLiteral }
+    case 'array-literal':
+      return { test: ts.isArrayLiteralExpression }
+    case 'object-literal':
+      return { test: ts.isObjectLiteralExpression }
+    case 'array-method':
+      return {
+        test: (n) =>
+          ts.isCallExpression(n) &&
+          ts.isPropertyAccessExpression(n.expression) &&
+          (detail ? n.expression.name.text === detail : ARRAY_METHOD_SET.has(n.expression.name.text)),
+      }
+    default:
+      return undefined
+  }
+}
+
+/** Longest snippet worth putting in a table cell — anything bigger stays behind the fixture link. */
+const SNIPPET_MAX_CHARS = 60
+
+function hasAncestor(node: ts.Node, pred: (n: ts.Node) => boolean): boolean {
+  for (let p = node.parent; p; p = p.parent) if (pred(p)) return true
+  return false
+}
+
+/**
+ * The smallest expression across the fixture's source files matching
+ * the construct, whitespace-collapsed — smallest because the most
+ * focused occurrence reads best in a table cell (`items.at(-1)`, not a
+ * whole ternary that happens to contain the call). Matches inside
+ * import declarations never illustrate a template expression and are
+ * skipped; over-budget matches are dropped rather than truncated
+ * (truncated code misleads — the fixture link has the full context).
+ */
+function extractSnippet(sources: string[], construct: string): string | undefined {
+  const matcher = matcherFor(construct)
+  if (!matcher) return undefined
+
+  let best: string | undefined
+  for (const source of sources) {
+    const sourceFile = ts.createSourceFile('fixture.tsx', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+    const visit = (node: ts.Node): void => {
+      if (
+        matcher.test(node) &&
+        !hasAncestor(node, ts.isImportDeclaration) &&
+        (!matcher.jsxOnly || hasAncestor(node, ts.isJsxExpression))
+      ) {
+        const text = node.getText(sourceFile).replace(/\s+/g, ' ').trim()
+        if (text.length <= SNIPPET_MAX_CHARS && (best === undefined || text.length < best.length)) {
+          best = text
+        }
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(sourceFile)
+  }
+  return best
+}
+
 /** Coverage-set size per fixture id — the exemplar-choice metric (smaller = more targeted). */
 function coverageSizes(coverage: SupportMatrixCoverageMap): Map<string, number> {
   const sizes = new Map<string, number>()
@@ -97,14 +259,14 @@ export interface ConstructExamples {
 export function computeConstructExamples(coverage: SupportMatrixCoverageMap): ConstructExamples {
   const files = fixtureFileMap()
   const sizes = coverageSizes(coverage)
-  const descriptions = new Map(jsxFixtures.map(f => [f.id, f.description]))
+  const byId = new Map(jsxFixtures.map(f => [f.id, f]))
 
   const exemplarFor = (construct: string, field: 'kinds' | 'axes'): ConstructExample | undefined => {
     let best: string | undefined
     for (const [id, c] of Object.entries(coverage.fixtures)) {
       if (!c[field].includes(construct)) continue
       // Only fixtures we can both describe and link to are eligible.
-      if (!descriptions.has(id) || !files.has(id)) continue
+      if (!byId.has(id) || !files.has(id)) continue
       if (
         best === undefined ||
         sizes.get(id)! < sizes.get(best)! ||
@@ -114,11 +276,15 @@ export function computeConstructExamples(coverage: SupportMatrixCoverageMap): Co
       }
     }
     if (best === undefined) return undefined
-    return {
+    const fixture = byId.get(best)!
+    const example: ConstructExample = {
       fixture: best,
-      description: descriptions.get(best)!,
+      description: fixture.description,
       url: `${GITHUB_BLOB_BASE}/${files.get(best)!}`,
     }
+    const code = extractSnippet([fixture.source, ...Object.values(fixture.components ?? {})], construct)
+    if (code) example.code = code
+    return example
   }
 
   const kinds: Record<string, ConstructExample> = {}

--- a/packages/compat/src/construct-source-links.ts
+++ b/packages/compat/src/construct-source-links.ts
@@ -1,0 +1,161 @@
+// GitHub permalinks for each `kind` / `axis` construct shown in the
+// Compatibility Matrix docs page's "Construct Support" section — so a
+// reader looking at e.g. `array-method:at` can jump straight to where
+// that construct is recognised instead of guessing from the label.
+//
+// Links are computed with a TS AST walk (never regex/string matching —
+// see CLAUDE.md's "Never parse imports/TS syntax with regex" rule) over
+// the two files that are already the authoritative registries for these
+// labels:
+//   - `PARSED_EXPR_KINDS` / `ARRAY_METHOD_NAMES` in expression-parser.ts
+//     (each entry sits on its own line, exhaustiveness-pinned already).
+//   - the axis-derivation `switch` in coverage-map.ts's
+//     `collectKindsAndAxes` (one `axes.add(...)` call site per axis
+//     family — `binary:${op}`, `logical:${op}`, `unary:${op}`,
+//     `literal:${literalType}` — plus the two exact `member:optional` /
+//     `member:computed` literals).
+//
+// This module is invoked from `computeSupportMatrix()` on every
+// `support-matrix:lock` regen, and the lock file is drift-checked in CI
+// (support-matrix.test.ts + ci-compat.yml) same as every other field —
+// so a link can never silently go stale. Moving a catalogue entry or a
+// `case` updates the line number the next regen picks up, and CI fails
+// if that regen is forgotten — the same guarantee the existing
+// `compat-issue-freshness` schedule gives the issue-tracking links.
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'path'
+import ts from 'typescript'
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
+const GITHUB_BLOB_BASE = 'https://github.com/piconic-ai/barefootjs/blob/main'
+
+const EXPRESSION_PARSER_FILE = 'packages/jsx/src/expression-parser.ts'
+const COVERAGE_MAP_FILE = 'packages/adapter-tests/src/coverage-map.ts'
+
+export interface SourceLink {
+  /** Repo-relative path, forward-slashed. */
+  file: string
+  /** 1-indexed source line. */
+  line: number
+  /** Ready-to-render GitHub permalink (`blob/main/<file>#L<line>`). */
+  url: string
+}
+
+/** One axis family whose fixture-observed suffix (`===`, `string`, ...) isn't statically enumerable. */
+interface AxisPrefixLink {
+  /** e.g. `'binary:'` — matched with `axis.startsWith(prefix)`. */
+  prefix: string
+  link: SourceLink
+}
+
+/** Backing table for `resolveKindLink` / `resolveAxisLink`. */
+export interface ConstructSourceLinks {
+  kinds: Record<string, SourceLink>
+  /** Exact-match axis labels: `member:optional`, `member:computed`, every `array-method:<method>`. */
+  axisExact: Record<string, SourceLink>
+  /** Family fallback for axes with a non-enumerable suffix: `binary:`, `logical:`, `unary:`, `literal:`. */
+  axisPrefixes: AxisPrefixLink[]
+}
+
+function makeLink(file: string, line: number): SourceLink {
+  return { file, line, url: `${GITHUB_BLOB_BASE}/${file}#L${line}` }
+}
+
+function lineOf(sourceFile: ts.SourceFile, node: ts.Node): number {
+  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1
+}
+
+function parseFile(relPath: string): ts.SourceFile {
+  const abs = path.join(REPO_ROOT, relPath)
+  return ts.createSourceFile(relPath, readFileSync(abs, 'utf8'), ts.ScriptTarget.Latest, true)
+}
+
+function forEachDescendant(node: ts.Node, visit: (n: ts.Node) => void): void {
+  visit(node)
+  ts.forEachChild(node, child => forEachDescendant(child, visit))
+}
+
+/**
+ * String-literal elements of `export const <constName> = [...] as const
+ * satisfies ...` → their 1-indexed line. Walks the whole initializer
+ * subtree (rather than assuming a fixed `as`/`satisfies` wrapper shape)
+ * so it survives the wrapper being reshaped.
+ */
+function arrayLiteralLineMap(sourceFile: ts.SourceFile, constName: string): Map<string, number> {
+  const lines = new Map<string, number>()
+  forEachDescendant(sourceFile, node => {
+    if (!ts.isVariableDeclaration(node) || !ts.isIdentifier(node.name) || node.name.text !== constName) return
+    if (!node.initializer) return
+    forEachDescendant(node.initializer, inner => {
+      if (ts.isStringLiteral(inner)) lines.set(inner.text, lineOf(sourceFile, inner))
+    })
+  })
+  return lines
+}
+
+/** One `axes.add(...)` call site in `collectKindsAndAxes`'s switch. */
+interface AxisAddSite {
+  /** Set when the argument is a plain string literal (`'member:optional'`). */
+  exact?: string
+  /** Set when the argument is a template literal — its text before the first `${` (`'binary:'`). */
+  prefix?: string
+  line: number
+}
+
+function collectAxisAddSites(sourceFile: ts.SourceFile): AxisAddSite[] {
+  const sites: AxisAddSite[] = []
+  forEachDescendant(sourceFile, node => {
+    if (!ts.isCallExpression(node)) return
+    const callee = node.expression
+    if (!ts.isPropertyAccessExpression(callee)) return
+    if (callee.name.text !== 'add') return
+    if (!ts.isIdentifier(callee.expression) || callee.expression.text !== 'axes') return
+    const arg = node.arguments[0]
+    if (!arg) return
+    const line = lineOf(sourceFile, node)
+    if (ts.isStringLiteral(arg)) sites.push({ exact: arg.text, line })
+    else if (ts.isTemplateExpression(arg)) sites.push({ prefix: arg.head.text, line })
+  })
+  return sites
+}
+
+export function computeConstructSourceLinks(): ConstructSourceLinks {
+  const exprParserSource = parseFile(EXPRESSION_PARSER_FILE)
+  const coverageMapSource = parseFile(COVERAGE_MAP_FILE)
+
+  const kindLines = arrayLiteralLineMap(exprParserSource, 'PARSED_EXPR_KINDS')
+  const methodLines = arrayLiteralLineMap(exprParserSource, 'ARRAY_METHOD_NAMES')
+  const axisAddSites = collectAxisAddSites(coverageMapSource)
+
+  const kinds: Record<string, SourceLink> = {}
+  for (const [kind, line] of kindLines) kinds[kind] = makeLink(EXPRESSION_PARSER_FILE, line)
+
+  const axisExact: Record<string, SourceLink> = {}
+  for (const site of axisAddSites) {
+    if (site.exact) axisExact[site.exact] = makeLink(COVERAGE_MAP_FILE, site.line)
+  }
+  // Every `array-method:<method>` points at its own `ARRAY_METHOD_NAMES`
+  // line rather than the one shared `axes.add(`array-method:${rec.method}`)`
+  // call site every method funnels through in coverage-map.ts.
+  for (const [method, line] of methodLines) {
+    axisExact[`array-method:${method}`] = makeLink(EXPRESSION_PARSER_FILE, line)
+  }
+
+  const axisPrefixes: AxisPrefixLink[] = axisAddSites
+    .filter((s): s is AxisAddSite & { prefix: string } => Boolean(s.prefix))
+    .map(s => ({ prefix: s.prefix, link: makeLink(COVERAGE_MAP_FILE, s.line) }))
+
+  return { kinds, axisExact, axisPrefixes }
+}
+
+export function resolveKindLink(kind: string, links: ConstructSourceLinks): SourceLink | undefined {
+  return links.kinds[kind]
+}
+
+export function resolveAxisLink(axis: string, links: ConstructSourceLinks): SourceLink | undefined {
+  const exact = links.axisExact[axis]
+  if (exact) return exact
+  return links.axisPrefixes.find(p => axis.startsWith(p.prefix))?.link
+}

--- a/packages/compat/src/support-matrix.ts
+++ b/packages/compat/src/support-matrix.ts
@@ -29,6 +29,7 @@
 import { PARSED_EXPR_KINDS } from '@barefootjs/jsx'
 import coverageMapJson from '../../adapter-tests/coverage-map.json' with { type: 'json' }
 import { loadCompatAdapters } from './adapter-registry'
+import { computeConstructExamples, type ConstructExample } from './construct-examples'
 import { computeConstructSourceLinks, resolveAxisLink, resolveKindLink, type SourceLink } from './construct-source-links'
 import { compareAdapterIds, KNOWN_LIMITATION_LABEL } from './report'
 
@@ -76,6 +77,8 @@ export interface SupportMatrixConstruct {
   cells: Record<string, SupportMatrixCell>
   /** GitHub permalink to where this construct is recognised, when resolvable (see `construct-source-links.ts`). */
   source?: SourceLink
+  /** Exemplar covering fixture — what the case looks like (see `construct-examples.ts`). */
+  example?: ConstructExample
 }
 
 export interface SupportMatrixReport {
@@ -195,27 +198,34 @@ export function buildSupportMatrix(
  */
 export async function computeSupportMatrix(): Promise<SupportMatrixReport> {
   const { loaded } = await loadCompatAdapters()
-  const report = buildSupportMatrix(coverageMapJson as SupportMatrixCoverageMap, loaded)
-  return attachSourceLinks(report)
+  const coverage = coverageMapJson as SupportMatrixCoverageMap
+  const report = buildSupportMatrix(coverage, loaded)
+  return attachConstructDocs(report, coverage)
 }
 
 /**
- * Attaches a `source` permalink to every resolvable kind/axis row. Kept
- * separate from `buildSupportMatrix` (which stays a pure join over
- * caller-supplied data, per its unit test's synthetic fixtures/adapters)
- * since this reads real source files off disk via
- * `computeConstructSourceLinks()` — there is nothing meaningful to
- * resolve against a synthetic coverage map.
+ * Attaches to every resolvable kind/axis row a `source` definition
+ * permalink and an `example` exemplar fixture (id + description +
+ * fixture-file permalink). Kept separate from `buildSupportMatrix`
+ * (which stays a pure join over caller-supplied data, per its unit
+ * test's synthetic fixtures/adapters) since this reads real source
+ * files off disk — there is nothing meaningful to resolve against a
+ * synthetic coverage map.
  */
-function attachSourceLinks(report: SupportMatrixReport): SupportMatrixReport {
+function attachConstructDocs(report: SupportMatrixReport, coverage: SupportMatrixCoverageMap): SupportMatrixReport {
   const links = computeConstructSourceLinks()
+  const examples = computeConstructExamples(coverage)
   for (const [kind, construct] of Object.entries(report.kinds)) {
     const source = resolveKindLink(kind, links)
     if (source) construct.source = source
+    const example = examples.kinds[kind]
+    if (example) construct.example = example
   }
   for (const [axis, construct] of Object.entries(report.axes)) {
     const source = resolveAxisLink(axis, links)
     if (source) construct.source = source
+    const example = examples.axes[axis]
+    if (example) construct.example = example
   }
   return report
 }

--- a/packages/compat/src/support-matrix.ts
+++ b/packages/compat/src/support-matrix.ts
@@ -29,6 +29,7 @@
 import { PARSED_EXPR_KINDS } from '@barefootjs/jsx'
 import coverageMapJson from '../../adapter-tests/coverage-map.json' with { type: 'json' }
 import { loadCompatAdapters } from './adapter-registry'
+import { computeConstructSourceLinks, resolveAxisLink, resolveKindLink, type SourceLink } from './construct-source-links'
 import { compareAdapterIds, KNOWN_LIMITATION_LABEL } from './report'
 
 export const SUPPORT_MATRIX_NOTE =
@@ -73,6 +74,8 @@ export interface SupportMatrixCell {
 export interface SupportMatrixConstruct {
   total: number
   cells: Record<string, SupportMatrixCell>
+  /** GitHub permalink to where this construct is recognised, when resolvable (see `construct-source-links.ts`). */
+  source?: SourceLink
 }
 
 export interface SupportMatrixReport {
@@ -192,7 +195,29 @@ export function buildSupportMatrix(
  */
 export async function computeSupportMatrix(): Promise<SupportMatrixReport> {
   const { loaded } = await loadCompatAdapters()
-  return buildSupportMatrix(coverageMapJson as SupportMatrixCoverageMap, loaded)
+  const report = buildSupportMatrix(coverageMapJson as SupportMatrixCoverageMap, loaded)
+  return attachSourceLinks(report)
+}
+
+/**
+ * Attaches a `source` permalink to every resolvable kind/axis row. Kept
+ * separate from `buildSupportMatrix` (which stays a pure join over
+ * caller-supplied data, per its unit test's synthetic fixtures/adapters)
+ * since this reads real source files off disk via
+ * `computeConstructSourceLinks()` — there is nothing meaningful to
+ * resolve against a synthetic coverage map.
+ */
+function attachSourceLinks(report: SupportMatrixReport): SupportMatrixReport {
+  const links = computeConstructSourceLinks()
+  for (const [kind, construct] of Object.entries(report.kinds)) {
+    const source = resolveKindLink(kind, links)
+    if (source) construct.source = source
+  }
+  for (const [axis, construct] of Object.entries(report.axes)) {
+    const source = resolveAxisLink(axis, links)
+    if (source) construct.source = source
+  }
+  return report
 }
 
 /** Lock-file JSON: 2-space indent, trailing newline — same contract as `formatCompatJson`. */

--- a/site/core/pages/compat-matrix.tsx
+++ b/site/core/pages/compat-matrix.tsx
@@ -69,9 +69,16 @@ interface SupportMatrixCell {
   gaps?: SupportMatrixGap[]
 }
 
+interface SupportMatrixSourceLink {
+  file: string
+  line: number
+  url: string
+}
+
 interface SupportMatrixConstruct {
   total: number
   cells: Record<string, SupportMatrixCell>
+  source?: SupportMatrixSourceLink
 }
 
 interface SupportMatrixLock {
@@ -274,6 +281,17 @@ function supportCellMarkdown(cell: SupportMatrixCell | undefined): string {
   return `${ratio} (${formatIssueLinks(issues, supportMatrix.knownLimitationLabel)})`
 }
 
+/**
+ * The "Construct" cell: the raw label, linked to where it's recognised
+ * in source when `computeConstructSourceLinks()` (packages/compat) could
+ * resolve one — see the "Data Source" section below for how that stays
+ * in sync as the source moves.
+ */
+function constructLabelMarkdown(name: string, source: SupportMatrixSourceLink | undefined): string {
+  const code = `\`${escapeCell(name)}\``
+  return source ? `[${code}](${source.url})` : code
+}
+
 /** One `construct × adapter` table — shared by the "By kind" and "By axis" tables. */
 function buildSupportTable(records: Record<string, SupportMatrixConstruct>): string {
   const adapters = supportMatrix.adapters
@@ -282,7 +300,7 @@ function buildSupportTable(records: Record<string, SupportMatrixConstruct>): str
   const divider = `| --- | ${adapters.map(() => '---').join(' | ')} |`
   const rows = names.map((name) => {
     const cells = adapters.map((adapter) => supportCellMarkdown(records[name]?.cells[adapter]))
-    return `| \`${escapeCell(name)}\` | ${cells.join(' | ')} |`
+    return `| ${constructLabelMarkdown(name, records[name]?.source)} | ${cells.join(' | ')} |`
   })
   return [header, divider, ...rows].join('\n')
 }
@@ -302,6 +320,8 @@ function buildSupportMatrixSection(): string {
 ${supportMatrix.note}
 
 **Read this as a ratio, not a binary.** \`conformancePins\` and \`renderDivergences\` are attributed to a whole **fixture** (a component), not to the individual construct — a gapped fixture is usually a complex component that happens to exercise many common kinds and axes alongside the one shape it exists to pin down. A construct showing \`137/138\` has exactly one gapped fixture contributing to it, not 137 broken cases. A construct with \`total: 0\` (currently just \`regex\`) has no fixture exercising it yet.
+
+Each construct name links to where it's recognised in source, when resolvable.
 
 ### By kind
 
@@ -342,7 +362,7 @@ ${supportMatrixSection}
 
 This table is generated from the committed [\`ui/compat.lock.json\`](https://github.com/piconic-ai/barefootjs/blob/main/ui/compat.lock.json), regenerated with \`bun run compat:lock\` and drift-checked in CI. Render-level divergences are declared per adapter in \`packages/adapter-*/src/render-divergences.ts\` (each adapter's conformance suite derives its skip list from the same declaration, so this page and the tests cannot drift apart). Tracked limitations carry the [\`known-limitation\`](${compat.knownLimitationLabel}) label.
 
-The construct-support section above is generated from the committed [\`ui/support-matrix.lock.json\`](https://github.com/piconic-ai/barefootjs/blob/main/ui/support-matrix.lock.json), regenerated with \`bun run support-matrix:lock\` and drift-checked in CI alongside the component matrix.
+The construct-support section above is generated from the committed [\`ui/support-matrix.lock.json\`](https://github.com/piconic-ai/barefootjs/blob/main/ui/support-matrix.lock.json), regenerated with \`bun run support-matrix:lock\` and drift-checked in CI alongside the component matrix. Each construct's source link is computed the same way — a TS AST walk over the catalogues that define it ([\`construct-source-links.ts\`](https://github.com/piconic-ai/barefootjs/blob/main/packages/compat/src/construct-source-links.ts)) — so it is regenerated and drift-checked on the same schedule: a link can't silently go stale, because moving the code it points at changes what the next regen commits, and CI fails if that regen was forgotten.
 
 Every issue link on this page is freshness-checked on a schedule (\`bun run compat:issues\`, the [\`compat-issue-freshness\`](https://github.com/piconic-ai/barefootjs/blob/main/.github/workflows/compat-issue-freshness.yml) workflow): if a referenced issue is closed while its pin still points at it, an alert issue is opened automatically so the link is re-pointed or removed — the matrix cannot silently link a live limitation to a completed ticket.
 `

--- a/site/core/pages/compat-matrix.tsx
+++ b/site/core/pages/compat-matrix.tsx
@@ -79,6 +79,7 @@ interface SupportMatrixExample {
   fixture: string
   description: string
   url: string
+  code?: string
 }
 
 interface SupportMatrixConstruct {
@@ -302,11 +303,20 @@ function constructLabelMarkdown(construct: SupportMatrixConstruct | undefined, n
   return url ? `[${code}](${url})` : code
 }
 
-/** The "Example" cell: the exemplar fixture's human-written description. */
+/**
+ * The "Example" cell: the extracted code snippet (when one exists) with
+ * the exemplar fixture's description under it. A snippet containing a
+ * backtick (template literals) uses a double-backtick code span, per
+ * CommonMark.
+ */
 function exampleCellMarkdown(construct: SupportMatrixConstruct | undefined): string {
   const example = construct?.example
   if (!example) return '—'
-  return escapeCell(example.description)
+  const description = escapeCell(example.description)
+  if (!example.code) return description
+  const code = escapeCell(example.code)
+  const span = code.includes('`') ? `\`\` ${code} \`\`` : `\`${code}\``
+  return `${span}<br>${description}`
 }
 
 /** One `construct × adapter` table — shared by the "By kind" and "By axis" tables. */

--- a/site/core/pages/compat-matrix.tsx
+++ b/site/core/pages/compat-matrix.tsx
@@ -75,10 +75,17 @@ interface SupportMatrixSourceLink {
   url: string
 }
 
+interface SupportMatrixExample {
+  fixture: string
+  description: string
+  url: string
+}
+
 interface SupportMatrixConstruct {
   total: number
   cells: Record<string, SupportMatrixCell>
   source?: SupportMatrixSourceLink
+  example?: SupportMatrixExample
 }
 
 interface SupportMatrixLock {
@@ -282,25 +289,35 @@ function supportCellMarkdown(cell: SupportMatrixCell | undefined): string {
 }
 
 /**
- * The "Construct" cell: the raw label, linked to where it's recognised
- * in source when `computeConstructSourceLinks()` (packages/compat) could
- * resolve one — see the "Data Source" section below for how that stays
- * in sync as the source moves.
+ * The "Construct" cell: the label linked to the construct's exemplar
+ * conformance fixture — a small self-contained component showing the
+ * case in real code — falling back to the definition-site permalink
+ * (where the construct is registered in the compiler) for constructs
+ * with no covering fixture yet (`total: 0` rows). See the "Data Source"
+ * section below for how these stay in sync as the source moves.
  */
-function constructLabelMarkdown(name: string, source: SupportMatrixSourceLink | undefined): string {
+function constructLabelMarkdown(construct: SupportMatrixConstruct | undefined, name: string): string {
   const code = `\`${escapeCell(name)}\``
-  return source ? `[${code}](${source.url})` : code
+  const url = construct?.example?.url ?? construct?.source?.url
+  return url ? `[${code}](${url})` : code
+}
+
+/** The "Example" cell: the exemplar fixture's human-written description. */
+function exampleCellMarkdown(construct: SupportMatrixConstruct | undefined): string {
+  const example = construct?.example
+  if (!example) return '—'
+  return escapeCell(example.description)
 }
 
 /** One `construct × adapter` table — shared by the "By kind" and "By axis" tables. */
 function buildSupportTable(records: Record<string, SupportMatrixConstruct>): string {
   const adapters = supportMatrix.adapters
   const names = Object.keys(records).sort()
-  const header = `| Construct | ${adapters.join(' | ')} |`
-  const divider = `| --- | ${adapters.map(() => '---').join(' | ')} |`
+  const header = `| Construct | Example | ${adapters.join(' | ')} |`
+  const divider = `| --- | --- | ${adapters.map(() => '---').join(' | ')} |`
   const rows = names.map((name) => {
     const cells = adapters.map((adapter) => supportCellMarkdown(records[name]?.cells[adapter]))
-    return `| ${constructLabelMarkdown(name, records[name]?.source)} | ${cells.join(' | ')} |`
+    return `| ${constructLabelMarkdown(records[name], name)} | ${exampleCellMarkdown(records[name])} | ${cells.join(' | ')} |`
   })
   return [header, divider, ...rows].join('\n')
 }
@@ -321,7 +338,7 @@ ${supportMatrix.note}
 
 **Read this as a ratio, not a binary.** \`conformancePins\` and \`renderDivergences\` are attributed to a whole **fixture** (a component), not to the individual construct — a gapped fixture is usually a complex component that happens to exercise many common kinds and axes alongside the one shape it exists to pin down. A construct showing \`137/138\` has exactly one gapped fixture contributing to it, not 137 broken cases. A construct with \`total: 0\` (currently just \`regex\`) has no fixture exercising it yet.
 
-Each construct name links to where it's recognised in source, when resolvable.
+Each construct name links to a conformance fixture exercising it — a small self-contained component showing the case in real code — and the **Example** column is that fixture's description. Constructs with no covering fixture yet link to where they're registered in the compiler instead.
 
 ### By kind
 
@@ -362,7 +379,7 @@ ${supportMatrixSection}
 
 This table is generated from the committed [\`ui/compat.lock.json\`](https://github.com/piconic-ai/barefootjs/blob/main/ui/compat.lock.json), regenerated with \`bun run compat:lock\` and drift-checked in CI. Render-level divergences are declared per adapter in \`packages/adapter-*/src/render-divergences.ts\` (each adapter's conformance suite derives its skip list from the same declaration, so this page and the tests cannot drift apart). Tracked limitations carry the [\`known-limitation\`](${compat.knownLimitationLabel}) label.
 
-The construct-support section above is generated from the committed [\`ui/support-matrix.lock.json\`](https://github.com/piconic-ai/barefootjs/blob/main/ui/support-matrix.lock.json), regenerated with \`bun run support-matrix:lock\` and drift-checked in CI alongside the component matrix. Each construct's source link is computed the same way — a TS AST walk over the catalogues that define it ([\`construct-source-links.ts\`](https://github.com/piconic-ai/barefootjs/blob/main/packages/compat/src/construct-source-links.ts)) — so it is regenerated and drift-checked on the same schedule: a link can't silently go stale, because moving the code it points at changes what the next regen commits, and CI fails if that regen was forgotten.
+The construct-support section above is generated from the committed [\`ui/support-matrix.lock.json\`](https://github.com/piconic-ai/barefootjs/blob/main/ui/support-matrix.lock.json), regenerated with \`bun run support-matrix:lock\` and drift-checked in CI alongside the component matrix. Each construct's fixture link and example description are computed the same way — the exemplar is mechanically chosen as the most narrowly targeted covering fixture ([\`construct-examples.ts\`](https://github.com/piconic-ai/barefootjs/blob/main/packages/compat/src/construct-examples.ts)), and definition-site fallback links come from a TS AST walk over the compiler's construct catalogues ([\`construct-source-links.ts\`](https://github.com/piconic-ai/barefootjs/blob/main/packages/compat/src/construct-source-links.ts)) — so they are regenerated and drift-checked on the same schedule: a link can't silently go stale, because moving the code it points at changes what the next regen commits, and CI fails if that regen was forgotten.
 
 Every issue link on this page is freshness-checked on a schedule (\`bun run compat:issues\`, the [\`compat-issue-freshness\`](https://github.com/piconic-ai/barefootjs/blob/main/.github/workflows/compat-issue-freshness.yml) workflow): if a referenced issue is closed while its pin still points at it, an alert issue is opened automatically so the link is re-pointed or removed — the matrix cannot silently link a live limitation to a completed ticket.
 `

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -157,6 +157,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 176,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L176"
+      },
+      "example": {
+        "fixture": "client-only-loop",
+        "description": "Client-only directive suppresses SSR for a bare loop, keeping boundary markers",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/client-only-loop.ts"
       }
     },
     "array-method": {
@@ -203,6 +208,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 178,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L178"
+      },
+      "example": {
+        "fixture": "array-at-default",
+        "description": ".at() with no argument returns the first element",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-at-default.ts"
       }
     },
     "arrow": {
@@ -349,6 +359,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 174,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L174"
+      },
+      "example": {
+        "fixture": "array-sort-field-asc",
+        "description": ".sort((a,b) => a.f - b.f) sorts by field, ascending",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-sort-field-asc.ts"
       }
     },
     "binary": {
@@ -543,6 +558,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 169,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L169"
+      },
+      "example": {
+        "fixture": "array-sort-field-asc",
+        "description": ".sort((a,b) => a.f - b.f) sorts by field, ascending",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-sort-field-asc.ts"
       }
     },
     "call": {
@@ -841,6 +861,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 166,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L166"
+      },
+      "example": {
+        "fixture": "client-only-loop",
+        "description": "Client-only directive suppresses SSR for a bare loop, keeping boundary markers",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/client-only-loop.ts"
       }
     },
     "conditional": {
@@ -887,6 +912,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 171,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L171"
+      },
+      "example": {
+        "fixture": "attr-ternary-title",
+        "description": "Ternary expressions in title and data attribute positions",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/attr-ternary-title.ts"
       }
     },
     "identifier": {
@@ -1185,6 +1215,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 164,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L164"
+      },
+      "example": {
+        "fixture": "array-entries",
+        "description": ".entries().map(([i, v]) => ...) iterates with index and value",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-entries.ts"
       }
     },
     "index-access": {
@@ -1231,6 +1266,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 168,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L168"
+      },
+      "example": {
+        "fixture": "record-index-lookup-via-child-prop",
+        "description": "Object literal indexed by a prop, passed to a child component prop",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/record-index-lookup-via-child-prop.ts"
       }
     },
     "literal": {
@@ -1341,6 +1381,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 165,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L165"
+      },
+      "example": {
+        "fixture": "boolean-attr-literals",
+        "description": "Static boolean attributes: bare, ={true}, and ={false} omission",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/boolean-attr-literals.ts"
       }
     },
     "logical": {
@@ -1451,6 +1496,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 172,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L172"
+      },
+      "example": {
+        "fixture": "logical-and-chain",
+        "description": "Chained a() && b() && <element/> conditional",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/logical-and-chain.ts"
       }
     },
     "member": {
@@ -1749,6 +1799,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 167,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L167"
+      },
+      "example": {
+        "fixture": "grandchild-composition",
+        "description": "Three-level composition threading a prop through each level",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/grandchild-composition.ts"
       }
     },
     "object-literal": {
@@ -1859,6 +1914,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 177,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L177"
+      },
+      "example": {
+        "fixture": "dangerous-inner-html-dynamic",
+        "description": "dangerouslySetInnerHTML with a prop-derived value renders on Hono/CSR, refuses on template adapters",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/dangerous-inner-html-dynamic.ts"
       }
     },
     "regex": {
@@ -1951,6 +2011,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 173,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L173"
+      },
+      "example": {
+        "fixture": "input",
+        "description": "site/ui Input — native text field survives hydration + accepts typing",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/input.ts"
       }
     },
     "unary": {
@@ -2045,6 +2110,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 170,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L170"
+      },
+      "example": {
+        "fixture": "array-at",
+        "description": ".at(-1) returns the last element",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-at.ts"
       }
     },
     "unsupported": {
@@ -2203,6 +2273,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 179,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L179"
+      },
+      "example": {
+        "fixture": "static-array-from-props",
+        "description": "Static-array loop with prop-derived array materialises children on CSR (#1247)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props.ts"
       }
     }
   },
@@ -2251,6 +2326,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 204,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L204"
+      },
+      "example": {
+        "fixture": "array-at-default",
+        "description": ".at() with no argument returns the first element",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-at-default.ts"
       }
     },
     "array-method:concat": {
@@ -2297,6 +2377,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 205,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L205"
+      },
+      "example": {
+        "fixture": "array-concat",
+        "description": ".concat(other) merges two arrays in order",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-concat.ts"
       }
     },
     "array-method:endsWith": {
@@ -2343,6 +2428,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 217,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L217"
+      },
+      "example": {
+        "fixture": "string-endsWith",
+        "description": ".endsWith(suffix) renders the matching branch",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-endsWith.ts"
       }
     },
     "array-method:flat": {
@@ -2389,6 +2479,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 223,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L223"
+      },
+      "example": {
+        "fixture": "array-flat",
+        "description": ".flat() flattens one level",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-flat.ts"
       }
     },
     "array-method:includes": {
@@ -2435,6 +2530,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 201,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L201"
+      },
+      "example": {
+        "fixture": "array-includes",
+        "description": ".includes(x) on an array prop renders the matching branch",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-includes.ts"
       }
     },
     "array-method:indexOf": {
@@ -2481,6 +2581,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 202,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L202"
+      },
+      "example": {
+        "fixture": "array-indexOf",
+        "description": ".indexOf(x) returns the 0-based position",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-indexOf.ts"
       }
     },
     "array-method:join": {
@@ -2527,6 +2632,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 200,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L200"
+      },
+      "example": {
+        "fixture": "array-join-default",
+        "description": ".join() with no argument joins with the default comma",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-join-default.ts"
       }
     },
     "array-method:lastIndexOf": {
@@ -2573,6 +2683,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 203,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L203"
+      },
+      "example": {
+        "fixture": "array-lastIndexOf",
+        "description": ".lastIndexOf(x) returns the position of the last match",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-lastIndexOf.ts"
       }
     },
     "array-method:padEnd": {
@@ -2619,6 +2734,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 222,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L222"
+      },
+      "example": {
+        "fixture": "string-padEnd",
+        "description": ".padEnd(target, pad) right-pads to the target width",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-padEnd.ts"
       }
     },
     "array-method:padStart": {
@@ -2665,6 +2785,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 221,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L221"
+      },
+      "example": {
+        "fixture": "string-padStart",
+        "description": ".padStart(target, pad) left-pads to the target width",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-padStart.ts"
       }
     },
     "array-method:repeat": {
@@ -2711,6 +2836,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 220,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L220"
+      },
+      "example": {
+        "fixture": "string-repeat",
+        "description": ".repeat(n) concatenates the string n times",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-repeat.ts"
       }
     },
     "array-method:replace": {
@@ -2757,6 +2887,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 218,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L218"
+      },
+      "example": {
+        "fixture": "string-replace",
+        "description": ".replace(old, new) swaps the first occurrence",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-replace.ts"
       }
     },
     "array-method:replaceAll": {
@@ -2803,6 +2938,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 219,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L219"
+      },
+      "example": {
+        "fixture": "string-replaceall",
+        "description": ".replaceAll replaces every occurrence, not just the first",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-replaceall.ts"
       }
     },
     "array-method:reverse": {
@@ -2849,6 +2989,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 207,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L207"
+      },
+      "example": {
+        "fixture": "array-reverse",
+        "description": ".reverse() emits the array in reverse order",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-reverse.ts"
       }
     },
     "array-method:slice": {
@@ -2895,6 +3040,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 206,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L206"
+      },
+      "example": {
+        "fixture": "array-slice-copy",
+        "description": ".slice() with no argument copies the whole array",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-slice-copy.ts"
       }
     },
     "array-method:split": {
@@ -2941,6 +3091,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 215,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L215"
+      },
+      "example": {
+        "fixture": "string-split",
+        "description": ".split(sep) splits a string into an array of substrings",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-split.ts"
       }
     },
     "array-method:startsWith": {
@@ -2987,6 +3142,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 216,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L216"
+      },
+      "example": {
+        "fixture": "string-startsWith",
+        "description": ".startsWith(prefix) renders the matching branch",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-startsWith.ts"
       }
     },
     "array-method:toFixed": {
@@ -3033,6 +3193,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 214,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L214"
+      },
+      "example": {
+        "fixture": "number-tofixed",
+        "description": ".toFixed(2) formats a numeric prop with rounding and zero-padding",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/number-tofixed.ts"
       }
     },
     "array-method:toLowerCase": {
@@ -3079,6 +3244,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 209,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L209"
+      },
+      "example": {
+        "fixture": "string-toLowerCase",
+        "description": ".toLowerCase() lowercases the receiver string",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-toLowerCase.ts"
       }
     },
     "array-method:toReversed": {
@@ -3125,6 +3295,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 208,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L208"
+      },
+      "example": {
+        "fixture": "array-toReversed",
+        "description": ".toReversed() emits the array in reverse order",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-toReversed.ts"
       }
     },
     "array-method:toUpperCase": {
@@ -3171,6 +3346,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 210,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L210"
+      },
+      "example": {
+        "fixture": "string-toUpperCase",
+        "description": ".toUpperCase() uppercases the receiver string",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-toUpperCase.ts"
       }
     },
     "array-method:trim": {
@@ -3217,6 +3397,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 211,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L211"
+      },
+      "example": {
+        "fixture": "string-trim",
+        "description": ".trim() strips leading and trailing whitespace",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-trim.ts"
       }
     },
     "array-method:trimEnd": {
@@ -3263,6 +3448,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 213,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L213"
+      },
+      "example": {
+        "fixture": "string-trim-sided",
+        "description": ".trimStart() and .trimEnd() strip only their own side",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-trim-sided.ts"
       }
     },
     "array-method:trimStart": {
@@ -3309,6 +3499,11 @@
         "file": "packages/jsx/src/expression-parser.ts",
         "line": 212,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L212"
+      },
+      "example": {
+        "fixture": "string-trim-sided",
+        "description": ".trimStart() and .trimEnd() strip only their own side",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-trim-sided.ts"
       }
     },
     "binary:!=": {
@@ -3355,6 +3550,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 89,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
+      },
+      "example": {
+        "fixture": "nullish-coalescing-jsx",
+        "description": "Nullish coalescing with JSX fallback in JSX child position",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/nullish-coalescing-jsx.ts"
       }
     },
     "binary:!==": {
@@ -3401,6 +3601,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 89,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
+      },
+      "example": {
+        "fixture": "comparison-ternary-text",
+        "description": "Comparison operators (>=, ===, !==) as ternary conditions",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/comparison-ternary-text.ts"
       }
     },
     "binary:*": {
@@ -3447,6 +3652,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 89,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
+      },
+      "example": {
+        "fixture": "memo",
+        "description": "Derived value with createMemo",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/memo.ts"
       }
     },
     "binary:+": {
@@ -3557,6 +3767,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 89,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
+      },
+      "example": {
+        "fixture": "string-concat-plus",
+        "description": "String concatenation via the + operator",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/string-concat-plus.ts"
       }
     },
     "binary:-": {
@@ -3603,6 +3818,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 89,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
+      },
+      "example": {
+        "fixture": "array-sort-field-asc",
+        "description": ".sort((a,b) => a.f - b.f) sorts by field, ascending",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-sort-field-asc.ts"
       }
     },
     "binary:/": {
@@ -3649,6 +3869,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 89,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
+      },
+      "example": {
+        "fixture": "data-table",
+        "description": "site/ui DataTable demo — keyed-loop reorder on sort: column-header clicks resort the memo and the runtime reorders rows in place",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/data-table.ts"
       }
     },
     "binary:<": {
@@ -3695,6 +3920,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 89,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
+      },
+      "example": {
+        "fixture": "data-table",
+        "description": "site/ui DataTable demo — keyed-loop reorder on sort: column-header clicks resort the memo and the runtime reorders rows in place",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/data-table.ts"
       }
     },
     "binary:===": {
@@ -3841,6 +4071,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 89,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
+      },
+      "example": {
+        "fixture": "nested-ternary",
+        "description": "Nested ternary conditional rendering",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/nested-ternary.ts"
       }
     },
     "binary:>": {
@@ -3887,6 +4122,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 89,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
+      },
+      "example": {
+        "fixture": "top-level-ternary",
+        "description": "Top-level ternary return preserves conditional (#968)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/top-level-ternary.ts"
       }
     },
     "binary:>=": {
@@ -3933,6 +4173,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 89,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
+      },
+      "example": {
+        "fixture": "comparison-ternary-text",
+        "description": "Comparison operators (>=, ===, !==) as ternary conditions",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/comparison-ternary-text.ts"
       }
     },
     "literal:boolean": {
@@ -3979,6 +4224,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 95,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L95"
+      },
+      "example": {
+        "fixture": "boolean-attr-literals",
+        "description": "Static boolean attributes: bare, ={true}, and ={false} omission",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/boolean-attr-literals.ts"
       }
     },
     "literal:null": {
@@ -4025,6 +4275,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 95,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L95"
+      },
+      "example": {
+        "fixture": "adjacent-conditionals",
+        "description": "Two sibling && conditionals with independent signals",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/adjacent-conditionals.ts"
       }
     },
     "literal:number": {
@@ -4071,6 +4326,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 95,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L95"
+      },
+      "example": {
+        "fixture": "svg-icon",
+        "description": "Inline SVG: viewBox casing and camelCase → kebab-case presentation attrs",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/svg-icon.ts"
       }
     },
     "literal:string": {
@@ -4181,6 +4441,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 95,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L95"
+      },
+      "example": {
+        "fixture": "jsx-text-whitespace",
+        "description": "Explicit {\" \"} joiners and multi-line text trimming",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/jsx-text-whitespace.ts"
       }
     },
     "logical:&&": {
@@ -4227,6 +4492,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 86,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L86"
+      },
+      "example": {
+        "fixture": "logical-and-chain",
+        "description": "Chained a() && b() && <element/> conditional",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/logical-and-chain.ts"
       }
     },
     "logical:??": {
@@ -4337,6 +4607,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 86,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L86"
+      },
+      "example": {
+        "fixture": "nullish-coalescing-destructured",
+        "description": "Nullish coalescing over destructured optional props seeds SSR correctly",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/nullish-coalescing-destructured.ts"
       }
     },
     "logical:||": {
@@ -4383,6 +4658,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 86,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L86"
+      },
+      "example": {
+        "fixture": "array-sort-multikey",
+        "description": ".sort((a,b) => a.price - b.price || a.name.localeCompare(b.name)) sorts by price, then name",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-sort-multikey.ts"
       }
     },
     "member:computed": {
@@ -4429,6 +4709,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 102,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L102"
+      },
+      "example": {
+        "fixture": "pagination",
+        "description": "site/ui Pagination demo — one signal drives data-active across seven links; href=\"#\" handlers must preventDefault",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/pagination.ts"
       }
     },
     "member:optional": {
@@ -4475,6 +4760,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 101,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L101"
+      },
+      "example": {
+        "fixture": "optional-chaining-prop",
+        "description": "Optional chaining into an object prop with nullish fallback",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/optional-chaining-prop.ts"
       }
     },
     "unary:!": {
@@ -4569,6 +4859,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 92,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L92"
+      },
+      "example": {
+        "fixture": "form",
+        "description": "Terms-acceptance form — reactive data-state / aria-checked / disabled from one signal",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/form.ts"
       }
     },
     "unary:-": {
@@ -4615,6 +4910,11 @@
         "file": "packages/adapter-tests/src/coverage-map.ts",
         "line": 92,
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L92"
+      },
+      "example": {
+        "fixture": "array-at",
+        "description": ".at(-1) returns the last element",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-at.ts"
       }
     }
   }

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -161,7 +161,8 @@
       "example": {
         "fixture": "client-only-loop",
         "description": "Client-only directive suppresses SSR for a bare loop, keeping boundary markers",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/client-only-loop.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/client-only-loop.ts",
+        "code": "[]"
       }
     },
     "array-method": {
@@ -212,7 +213,8 @@
       "example": {
         "fixture": "array-at-default",
         "description": ".at() with no argument returns the first element",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-at-default.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-at-default.ts",
+        "code": "items.at()"
       }
     },
     "arrow": {
@@ -363,7 +365,8 @@
       "example": {
         "fixture": "array-sort-field-asc",
         "description": ".sort((a,b) => a.f - b.f) sorts by field, ascending",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-sort-field-asc.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-sort-field-asc.ts",
+        "code": "(a, b) => a.price - b.price"
       }
     },
     "binary": {
@@ -562,7 +565,8 @@
       "example": {
         "fixture": "array-sort-field-asc",
         "description": ".sort((a,b) => a.f - b.f) sorts by field, ascending",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-sort-field-asc.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-sort-field-asc.ts",
+        "code": "a.price - b.price"
       }
     },
     "call": {
@@ -865,7 +869,8 @@
       "example": {
         "fixture": "client-only-loop",
         "description": "Client-only directive suppresses SSR for a bare loop, keeping boundary markers",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/client-only-loop.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/client-only-loop.ts",
+        "code": "items()"
       }
     },
     "conditional": {
@@ -916,7 +921,8 @@
       "example": {
         "fixture": "attr-ternary-title",
         "description": "Ternary expressions in title and data attribute positions",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/attr-ternary-title.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/attr-ternary-title.ts",
+        "code": "active() ? 2 : 1"
       }
     },
     "identifier": {
@@ -1219,7 +1225,8 @@
       "example": {
         "fixture": "array-entries",
         "description": ".entries().map(([i, v]) => ...) iterates with index and value",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-entries.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-entries.ts",
+        "code": "i"
       }
     },
     "index-access": {
@@ -1270,7 +1277,8 @@
       "example": {
         "fixture": "record-index-lookup-via-child-prop",
         "description": "Object literal indexed by a prop, passed to a child component prop",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/record-index-lookup-via-child-prop.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/record-index-lookup-via-child-prop.ts",
+        "code": "classes[variant]"
       }
     },
     "literal": {
@@ -1385,7 +1393,8 @@
       "example": {
         "fixture": "boolean-attr-literals",
         "description": "Static boolean attributes: bare, ={true}, and ={false} omission",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/boolean-attr-literals.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/boolean-attr-literals.ts",
+        "code": "true"
       }
     },
     "logical": {
@@ -1500,7 +1509,8 @@
       "example": {
         "fixture": "logical-and-chain",
         "description": "Chained a() && b() && <element/> conditional",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/logical-and-chain.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/logical-and-chain.ts",
+        "code": "ready() && visible()"
       }
     },
     "member": {
@@ -1803,7 +1813,8 @@
       "example": {
         "fixture": "grandchild-composition",
         "description": "Three-level composition threading a prop through each level",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/grandchild-composition.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/grandchild-composition.ts",
+        "code": "props.text"
       }
     },
     "object-literal": {
@@ -1918,7 +1929,8 @@
       "example": {
         "fixture": "dangerous-inner-html-dynamic",
         "description": "dangerouslySetInnerHTML with a prop-derived value renders on Hono/CSR, refuses on template adapters",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/dangerous-inner-html-dynamic.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/dangerous-inner-html-dynamic.ts",
+        "code": "{ __html: html }"
       }
     },
     "regex": {
@@ -2114,7 +2126,8 @@
       "example": {
         "fixture": "array-at",
         "description": ".at(-1) returns the last element",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-at.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-at.ts",
+        "code": "-1"
       }
     },
     "unsupported": {
@@ -2330,7 +2343,8 @@
       "example": {
         "fixture": "array-at-default",
         "description": ".at() with no argument returns the first element",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-at-default.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-at-default.ts",
+        "code": "items.at()"
       }
     },
     "array-method:concat": {
@@ -2381,7 +2395,8 @@
       "example": {
         "fixture": "array-concat",
         "description": ".concat(other) merges two arrays in order",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-concat.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-concat.ts",
+        "code": "left.concat(right)"
       }
     },
     "array-method:endsWith": {
@@ -2432,7 +2447,8 @@
       "example": {
         "fixture": "string-endsWith",
         "description": ".endsWith(suffix) renders the matching branch",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-endsWith.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-endsWith.ts",
+        "code": "value.endsWith(suffix)"
       }
     },
     "array-method:flat": {
@@ -2483,7 +2499,8 @@
       "example": {
         "fixture": "array-flat",
         "description": ".flat() flattens one level",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-flat.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-flat.ts",
+        "code": "rows.flat()"
       }
     },
     "array-method:includes": {
@@ -2534,7 +2551,8 @@
       "example": {
         "fixture": "array-includes",
         "description": ".includes(x) on an array prop renders the matching branch",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-includes.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-includes.ts",
+        "code": "items.includes(target)"
       }
     },
     "array-method:indexOf": {
@@ -2585,7 +2603,8 @@
       "example": {
         "fixture": "array-indexOf",
         "description": ".indexOf(x) returns the 0-based position",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-indexOf.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-indexOf.ts",
+        "code": "items.indexOf(target)"
       }
     },
     "array-method:join": {
@@ -2636,7 +2655,8 @@
       "example": {
         "fixture": "array-join-default",
         "description": ".join() with no argument joins with the default comma",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-join-default.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-join-default.ts",
+        "code": "items.join()"
       }
     },
     "array-method:lastIndexOf": {
@@ -2687,7 +2707,8 @@
       "example": {
         "fixture": "array-lastIndexOf",
         "description": ".lastIndexOf(x) returns the position of the last match",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-lastIndexOf.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-lastIndexOf.ts",
+        "code": "items.lastIndexOf(target)"
       }
     },
     "array-method:padEnd": {
@@ -2738,7 +2759,8 @@
       "example": {
         "fixture": "string-padEnd",
         "description": ".padEnd(target, pad) right-pads to the target width",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-padEnd.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-padEnd.ts",
+        "code": "value.padEnd(5, '.')"
       }
     },
     "array-method:padStart": {
@@ -2789,7 +2811,8 @@
       "example": {
         "fixture": "string-padStart",
         "description": ".padStart(target, pad) left-pads to the target width",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-padStart.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-padStart.ts",
+        "code": "value.padStart(5, '0')"
       }
     },
     "array-method:repeat": {
@@ -2840,7 +2863,8 @@
       "example": {
         "fixture": "string-repeat",
         "description": ".repeat(n) concatenates the string n times",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-repeat.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-repeat.ts",
+        "code": "value.repeat(3)"
       }
     },
     "array-method:replace": {
@@ -2891,7 +2915,8 @@
       "example": {
         "fixture": "string-replace",
         "description": ".replace(old, new) swaps the first occurrence",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-replace.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-replace.ts",
+        "code": "value.replace('o', '0')"
       }
     },
     "array-method:replaceAll": {
@@ -2942,7 +2967,8 @@
       "example": {
         "fixture": "string-replaceall",
         "description": ".replaceAll replaces every occurrence, not just the first",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-replaceall.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-replaceall.ts",
+        "code": "path.replaceAll('/', ' > ')"
       }
     },
     "array-method:reverse": {
@@ -2993,7 +3019,8 @@
       "example": {
         "fixture": "array-reverse",
         "description": ".reverse() emits the array in reverse order",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-reverse.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-reverse.ts",
+        "code": "items.reverse()"
       }
     },
     "array-method:slice": {
@@ -3044,7 +3071,8 @@
       "example": {
         "fixture": "array-slice-copy",
         "description": ".slice() with no argument copies the whole array",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-slice-copy.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-slice-copy.ts",
+        "code": "items.slice()"
       }
     },
     "array-method:split": {
@@ -3095,7 +3123,8 @@
       "example": {
         "fixture": "string-split",
         "description": ".split(sep) splits a string into an array of substrings",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-split.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-split.ts",
+        "code": "value.split(',')"
       }
     },
     "array-method:startsWith": {
@@ -3146,7 +3175,8 @@
       "example": {
         "fixture": "string-startsWith",
         "description": ".startsWith(prefix) renders the matching branch",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-startsWith.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-startsWith.ts",
+        "code": "value.startsWith(prefix)"
       }
     },
     "array-method:toFixed": {
@@ -3197,7 +3227,8 @@
       "example": {
         "fixture": "number-tofixed",
         "description": ".toFixed(2) formats a numeric prop with rounding and zero-padding",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/number-tofixed.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/number-tofixed.ts",
+        "code": "price.toFixed(2)"
       }
     },
     "array-method:toLowerCase": {
@@ -3248,7 +3279,8 @@
       "example": {
         "fixture": "string-toLowerCase",
         "description": ".toLowerCase() lowercases the receiver string",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-toLowerCase.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-toLowerCase.ts",
+        "code": "value.toLowerCase()"
       }
     },
     "array-method:toReversed": {
@@ -3299,7 +3331,8 @@
       "example": {
         "fixture": "array-toReversed",
         "description": ".toReversed() emits the array in reverse order",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-toReversed.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-toReversed.ts",
+        "code": "items.toReversed()"
       }
     },
     "array-method:toUpperCase": {
@@ -3350,7 +3383,8 @@
       "example": {
         "fixture": "string-toUpperCase",
         "description": ".toUpperCase() uppercases the receiver string",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-toUpperCase.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-toUpperCase.ts",
+        "code": "value.toUpperCase()"
       }
     },
     "array-method:trim": {
@@ -3401,7 +3435,8 @@
       "example": {
         "fixture": "string-trim",
         "description": ".trim() strips leading and trailing whitespace",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-trim.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-trim.ts",
+        "code": "value.trim()"
       }
     },
     "array-method:trimEnd": {
@@ -3452,7 +3487,8 @@
       "example": {
         "fixture": "string-trim-sided",
         "description": ".trimStart() and .trimEnd() strip only their own side",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-trim-sided.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-trim-sided.ts",
+        "code": "value.trimEnd()"
       }
     },
     "array-method:trimStart": {
@@ -3503,7 +3539,8 @@
       "example": {
         "fixture": "string-trim-sided",
         "description": ".trimStart() and .trimEnd() strip only their own side",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-trim-sided.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/string-trim-sided.ts",
+        "code": "value.trimStart()"
       }
     },
     "binary:!=": {
@@ -3605,7 +3642,8 @@
       "example": {
         "fixture": "comparison-ternary-text",
         "description": "Comparison operators (>=, ===, !==) as ternary conditions",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/comparison-ternary-text.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/comparison-ternary-text.ts",
+        "code": "n() !== 0"
       }
     },
     "binary:*": {
@@ -3656,7 +3694,8 @@
       "example": {
         "fixture": "memo",
         "description": "Derived value with createMemo",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/memo.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/memo.ts",
+        "code": "count() * 2"
       }
     },
     "binary:+": {
@@ -3771,7 +3810,8 @@
       "example": {
         "fixture": "string-concat-plus",
         "description": "String concatenation via the + operator",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/string-concat-plus.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/string-concat-plus.ts",
+        "code": "'Hello, ' + name"
       }
     },
     "binary:-": {
@@ -3822,7 +3862,8 @@
       "example": {
         "fixture": "array-sort-field-asc",
         "description": ".sort((a,b) => a.f - b.f) sorts by field, ascending",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-sort-field-asc.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-sort-field-asc.ts",
+        "code": "a.price - b.price"
       }
     },
     "binary:/": {
@@ -3873,7 +3914,8 @@
       "example": {
         "fixture": "data-table",
         "description": "site/ui DataTable demo — keyed-loop reorder on sort: column-header clicks resort the memo and the runtime reorders rows in place",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/data-table.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/data-table.ts",
+        "code": "sortedData().length / pageSize"
       }
     },
     "binary:<": {
@@ -3924,7 +3966,8 @@
       "example": {
         "fixture": "data-table",
         "description": "site/ui DataTable demo — keyed-loop reorder on sort: column-header clicks resort the memo and the runtime reorders rows in place",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/data-table.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/data-table.ts",
+        "code": "aStr < bStr"
       }
     },
     "binary:===": {
@@ -4075,7 +4118,8 @@
       "example": {
         "fixture": "nested-ternary",
         "description": "Nested ternary conditional rendering",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/nested-ternary.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/nested-ternary.ts",
+        "code": "status() === 'error'"
       }
     },
     "binary:>": {
@@ -4126,7 +4170,8 @@
       "example": {
         "fixture": "top-level-ternary",
         "description": "Top-level ternary return preserves conditional (#968)",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/top-level-ternary.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/top-level-ternary.ts",
+        "code": "count() > 0"
       }
     },
     "binary:>=": {
@@ -4177,7 +4222,8 @@
       "example": {
         "fixture": "comparison-ternary-text",
         "description": "Comparison operators (>=, ===, !==) as ternary conditions",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/comparison-ternary-text.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/comparison-ternary-text.ts",
+        "code": "n() >= 10"
       }
     },
     "literal:boolean": {
@@ -4228,7 +4274,8 @@
       "example": {
         "fixture": "boolean-attr-literals",
         "description": "Static boolean attributes: bare, ={true}, and ={false} omission",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/boolean-attr-literals.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/boolean-attr-literals.ts",
+        "code": "true"
       }
     },
     "literal:null": {
@@ -4330,7 +4377,8 @@
       "example": {
         "fixture": "svg-icon",
         "description": "Inline SVG: viewBox casing and camelCase → kebab-case presentation attrs",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/svg-icon.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/svg-icon.ts",
+        "code": "2"
       }
     },
     "literal:string": {
@@ -4445,7 +4493,8 @@
       "example": {
         "fixture": "jsx-text-whitespace",
         "description": "Explicit {\" \"} joiners and multi-line text trimming",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/jsx-text-whitespace.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/jsx-text-whitespace.ts",
+        "code": "' '"
       }
     },
     "logical:&&": {
@@ -4496,7 +4545,8 @@
       "example": {
         "fixture": "logical-and-chain",
         "description": "Chained a() && b() && <element/> conditional",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/logical-and-chain.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/logical-and-chain.ts",
+        "code": "ready() && visible()"
       }
     },
     "logical:??": {
@@ -4611,7 +4661,8 @@
       "example": {
         "fixture": "nullish-coalescing-destructured",
         "description": "Nullish coalescing over destructured optional props seeds SSR correctly",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/nullish-coalescing-destructured.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/nullish-coalescing-destructured.ts",
+        "code": "size ?? 1"
       }
     },
     "logical:||": {
@@ -4662,7 +4713,8 @@
       "example": {
         "fixture": "array-sort-multikey",
         "description": ".sort((a,b) => a.price - b.price || a.name.localeCompare(b.name)) sorts by price, then name",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-sort-multikey.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-sort-multikey.ts",
+        "code": "a.price - b.price || a.name.localeCompare(b.name)"
       }
     },
     "member:computed": {
@@ -4713,7 +4765,8 @@
       "example": {
         "fixture": "pagination",
         "description": "site/ui Pagination demo — one signal drives data-active across seven links; href=\"#\" handlers must preventDefault",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/pagination.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/pagination.ts",
+        "code": "strokePaths['x']"
       }
     },
     "member:optional": {
@@ -4764,7 +4817,8 @@
       "example": {
         "fixture": "optional-chaining-prop",
         "description": "Optional chaining into an object prop with nullish fallback",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/optional-chaining-prop.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/optional-chaining-prop.ts",
+        "code": "user?.name"
       }
     },
     "unary:!": {
@@ -4863,7 +4917,8 @@
       "example": {
         "fixture": "form",
         "description": "Terms-acceptance form — reactive data-state / aria-checked / disabled from one signal",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/form.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/form.ts",
+        "code": "!accepted()"
       }
     },
     "unary:-": {
@@ -4914,7 +4969,8 @@
       "example": {
         "fixture": "array-at",
         "description": ".at(-1) returns the last element",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-at.ts"
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-at.ts",
+        "code": "-1"
       }
     }
   }

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -152,6 +152,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 176,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L176"
       }
     },
     "array-method": {
@@ -193,6 +198,11 @@
           "pass": 62,
           "total": 62
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 178,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L178"
       }
     },
     "arrow": {
@@ -334,6 +344,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 174,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L174"
       }
     },
     "binary": {
@@ -523,6 +538,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 169,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L169"
       }
     },
     "call": {
@@ -816,6 +836,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 166,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L166"
       }
     },
     "conditional": {
@@ -857,6 +882,11 @@
           "pass": 19,
           "total": 19
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 171,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L171"
       }
     },
     "identifier": {
@@ -1150,6 +1180,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 164,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L164"
       }
     },
     "index-access": {
@@ -1191,6 +1226,11 @@
           "pass": 12,
           "total": 12
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 168,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L168"
       }
     },
     "literal": {
@@ -1296,6 +1336,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 165,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L165"
       }
     },
     "logical": {
@@ -1401,6 +1446,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 172,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L172"
       }
     },
     "member": {
@@ -1694,6 +1744,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 167,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L167"
       }
     },
     "object-literal": {
@@ -1799,6 +1854,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 177,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L177"
       }
     },
     "regex": {
@@ -1840,6 +1900,11 @@
           "pass": 0,
           "total": 0
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 175,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L175"
       }
     },
     "template-literal": {
@@ -1881,6 +1946,11 @@
           "pass": 27,
           "total": 27
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 173,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L173"
       }
     },
     "unary": {
@@ -1970,6 +2040,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 170,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L170"
       }
     },
     "unsupported": {
@@ -2123,6 +2198,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 179,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L179"
       }
     }
   },
@@ -2166,6 +2246,11 @@
           "pass": 2,
           "total": 2
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 204,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L204"
       }
     },
     "array-method:concat": {
@@ -2207,6 +2292,11 @@
           "pass": 2,
           "total": 2
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 205,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L205"
       }
     },
     "array-method:endsWith": {
@@ -2248,6 +2338,11 @@
           "pass": 2,
           "total": 2
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 217,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L217"
       }
     },
     "array-method:flat": {
@@ -2289,6 +2384,11 @@
           "pass": 4,
           "total": 4
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 223,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L223"
       }
     },
     "array-method:includes": {
@@ -2330,6 +2430,11 @@
           "pass": 12,
           "total": 12
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 201,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L201"
       }
     },
     "array-method:indexOf": {
@@ -2371,6 +2476,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 202,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L202"
       }
     },
     "array-method:join": {
@@ -2412,6 +2522,11 @@
           "pass": 36,
           "total": 36
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 200,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L200"
       }
     },
     "array-method:lastIndexOf": {
@@ -2453,6 +2568,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 203,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L203"
       }
     },
     "array-method:padEnd": {
@@ -2494,6 +2614,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 222,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L222"
       }
     },
     "array-method:padStart": {
@@ -2535,6 +2660,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 221,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L221"
       }
     },
     "array-method:repeat": {
@@ -2576,6 +2706,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 220,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L220"
       }
     },
     "array-method:replace": {
@@ -2617,6 +2752,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 218,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L218"
       }
     },
     "array-method:replaceAll": {
@@ -2658,6 +2798,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 219,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L219"
       }
     },
     "array-method:reverse": {
@@ -2699,6 +2844,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 207,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L207"
       }
     },
     "array-method:slice": {
@@ -2740,6 +2890,11 @@
           "pass": 4,
           "total": 4
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 206,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L206"
       }
     },
     "array-method:split": {
@@ -2781,6 +2936,11 @@
           "pass": 2,
           "total": 2
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 215,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L215"
       }
     },
     "array-method:startsWith": {
@@ -2822,6 +2982,11 @@
           "pass": 3,
           "total": 3
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 216,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L216"
       }
     },
     "array-method:toFixed": {
@@ -2863,6 +3028,11 @@
           "pass": 2,
           "total": 2
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 214,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L214"
       }
     },
     "array-method:toLowerCase": {
@@ -2904,6 +3074,11 @@
           "pass": 4,
           "total": 4
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 209,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L209"
       }
     },
     "array-method:toReversed": {
@@ -2945,6 +3120,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 208,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L208"
       }
     },
     "array-method:toUpperCase": {
@@ -2986,6 +3166,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 210,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L210"
       }
     },
     "array-method:trim": {
@@ -3027,6 +3212,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 211,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L211"
       }
     },
     "array-method:trimEnd": {
@@ -3068,6 +3258,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 213,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L213"
       }
     },
     "array-method:trimStart": {
@@ -3109,6 +3304,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/jsx/src/expression-parser.ts",
+        "line": 212,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L212"
       }
     },
     "binary:!=": {
@@ -3150,6 +3350,11 @@
           "pass": 2,
           "total": 2
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 89,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
       }
     },
     "binary:!==": {
@@ -3191,6 +3396,11 @@
           "pass": 9,
           "total": 9
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 89,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
       }
     },
     "binary:*": {
@@ -3232,6 +3442,11 @@
           "pass": 9,
           "total": 9
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 89,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
       }
     },
     "binary:+": {
@@ -3337,6 +3552,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 89,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
       }
     },
     "binary:-": {
@@ -3378,6 +3598,11 @@
           "pass": 11,
           "total": 11
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 89,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
       }
     },
     "binary:/": {
@@ -3419,6 +3644,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 89,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
       }
     },
     "binary:<": {
@@ -3460,6 +3690,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 89,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
       }
     },
     "binary:===": {
@@ -3601,6 +3836,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 89,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
       }
     },
     "binary:>": {
@@ -3642,6 +3882,11 @@
           "pass": 11,
           "total": 11
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 89,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
       }
     },
     "binary:>=": {
@@ -3683,6 +3928,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 89,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
       }
     },
     "literal:boolean": {
@@ -3724,6 +3974,11 @@
           "pass": 38,
           "total": 38
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 95,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L95"
       }
     },
     "literal:null": {
@@ -3765,6 +4020,11 @@
           "pass": 22,
           "total": 22
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 95,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L95"
       }
     },
     "literal:number": {
@@ -3806,6 +4066,11 @@
           "pass": 86,
           "total": 86
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 95,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L95"
       }
     },
     "literal:string": {
@@ -3911,6 +4176,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 95,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L95"
       }
     },
     "logical:&&": {
@@ -3952,6 +4222,11 @@
           "pass": 7,
           "total": 7
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 86,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L86"
       }
     },
     "logical:??": {
@@ -4057,6 +4332,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 86,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L86"
       }
     },
     "logical:||": {
@@ -4098,6 +4378,11 @@
           "pass": 12,
           "total": 12
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 86,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L86"
       }
     },
     "member:computed": {
@@ -4139,6 +4424,11 @@
           "pass": 8,
           "total": 8
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 102,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L102"
       }
     },
     "member:optional": {
@@ -4180,6 +4470,11 @@
           "pass": 1,
           "total": 1
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 101,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L101"
       }
     },
     "unary:!": {
@@ -4269,6 +4564,11 @@
             }
           ]
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 92,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L92"
       }
     },
     "unary:-": {
@@ -4310,6 +4610,11 @@
           "pass": 11,
           "total": 11
         }
+      },
+      "source": {
+        "file": "packages/adapter-tests/src/coverage-map.ts",
+        "line": 92,
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L92"
       }
     }
   }


### PR DESCRIPTION
## Summary

On the [Compatibility Matrix](https://barefootjs.dev/docs/advanced/compatibility-matrix) docs page, the "Construct Support (kind × axis)" tables list labels like `array-method:at` that aren't self-explanatory in isolation. Each construct row now shows at a glance what the case is, and links to real example code:

- **Construct labels link to an exemplar conformance fixture** — a small self-contained component exercising exactly that construct (e.g. `array-method:at` → [`array-at-default.ts`](https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-at-default.ts)). The exemplar is chosen mechanically: the covering fixture with the smallest total coverage set (= the most narrowly targeted example), tie-broken by id.
- **New "Example" column** renders an extracted code snippet (`items.at()`, `user?.name`, `status() === 'error'`, ...) above the fixture's human-written description. Snippets are the smallest expression in the exemplar's source matching the construct, found with a TS AST matcher mirroring `expression-parser.ts`'s classification (never regex, per `CLAUDE.md`).
- **Definition-site fallback**: constructs with no covering fixture yet (`regex`) link to their entry in the compiler's construct catalogues (`PARSED_EXPR_KINDS` / `ARRAY_METHOD_NAMES` in `expression-parser.ts`, the axis-derivation switch in `coverage-map.ts`), located by AST walk. Constructs exercised only via compiler-synthesized IR (e.g. `binary:!=` from the `??` lowering) or whose smallest match exceeds the cell budget show description-only.

New modules: `packages/compat/src/construct-examples.ts` (exemplar choice + snippet extraction) and `packages/compat/src/construct-source-links.ts` (definition permalinks). Both feed `computeSupportMatrix()` — kept out of the pure `buildSupportMatrix` join so its synthetic-fixture unit test is unaffected — and land in `ui/support-matrix.lock.json`, which `compat-matrix.tsx` renders.

Because all of this is recomputed on every `support-matrix:lock` regen and the lock file is already drift-checked in CI (`support-matrix.test.ts` + `ci-compat.yml`), no link or snippet can silently go stale: moving the code changes what the next regen commits, and CI fails if the regen was forgotten — the same guarantee the existing `compat-issue-freshness` schedule gives the issue-tracking links on this page.

## Test plan

- [x] `bun test packages/compat/__tests__/` — 16 pass (includes the `support-matrix.test.ts` freshness gate against the regenerated lock file)
- [x] `bunx tsc --noEmit -p tsconfig.json` — no errors in changed files
- [x] Reviewed the full extracted-snippet table for all 16 kinds and 45 axes; spot-checked fixture links against source
- [x] Rendered the page locally and verified the By kind / By axis tables (linked labels, Example column, hover state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEJPdLRawQAS1pkKjAQdjj