### PR TITLE
Compatibility Matrix: describe & link component and fixture-corpus rows

### DIFF
--- a/packages/compat/__tests__/component-docs.test.ts
+++ b/packages/compat/__tests__/component-docs.test.ts
@@ -1,0 +1,67 @@
+// Guards the "every Matrix / Render-Conformance row is explained"
+// property the docs page relies on: `computeComponentDocs` /
+// `computeFixtureDocs` must produce a non-empty description and a
+// well-formed GitHub source link for every row the committed
+// `ui/compat.lock.json` renders. CI additionally regenerates the lock
+// and `git diff`s it (`ci-compat.yml`); this in-test check is defense so
+// `bun test` alone catches a component that lost its description (e.g.
+// removed from `ui/registry.json` and missing a JSDoc tagline).
+
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { computeComponentDocs, computeFixtureDocs } from '../src/component-docs'
+
+const LOCK_PATH = resolve(import.meta.dir, '../../../ui/compat.lock.json')
+const lock = JSON.parse(readFileSync(LOCK_PATH, 'utf8')) as {
+  components: Record<string, unknown>
+  componentDocs?: Record<string, { title: string; description: string; url: string }>
+  fixtureDivergences: { fixtures: Record<string, unknown>; docs?: Record<string, { description: string; url: string }> }
+}
+
+const BLOB_PREFIX = 'https://github.com/piconic-ai/barefootjs/blob/main/'
+
+describe('computeComponentDocs', () => {
+  const names = Object.keys(lock.components)
+  const docs = computeComponentDocs(names)
+
+  test('covers every component in the matrix', () => {
+    expect(Object.keys(docs).sort()).toEqual(names.sort())
+  })
+
+  test('every component has a non-empty description and a source link', () => {
+    for (const name of names) {
+      const doc = docs[name]
+      expect(doc.description.length, `${name} has an empty description`).toBeGreaterThan(0)
+      expect(doc.title.length).toBeGreaterThan(0)
+      expect(doc.url).toBe(`${BLOB_PREFIX}ui/components/ui/${name}/index.tsx`)
+    }
+  })
+
+  test('descriptions stay within the table-cell budget', () => {
+    for (const name of names) {
+      // 100-char budget + a 1-char ellipsis when trimmed.
+      expect(docs[name].description.length).toBeLessThanOrEqual(101)
+    }
+  })
+
+  test('matches the committed lock (regen freshness)', () => {
+    expect(docs).toEqual(lock.componentDocs ?? {})
+  })
+})
+
+describe('computeFixtureDocs', () => {
+  const ids = Object.keys(lock.fixtureDivergences.fixtures)
+  const docs = computeFixtureDocs(ids)
+
+  test('every divergent fixture has a description and a source link', () => {
+    for (const id of ids) {
+      expect(docs[id].description.length, `${id} has an empty description`).toBeGreaterThan(0)
+      expect(docs[id].url.startsWith(`${BLOB_PREFIX}packages/adapter-tests/fixtures/`)).toBe(true)
+    }
+  })
+
+  test('matches the committed lock (regen freshness)', () => {
+    expect(docs).toEqual(lock.fixtureDivergences.docs ?? {})
+  })
+})

--- a/packages/compat/src/cli.ts
+++ b/packages/compat/src/cli.ts
@@ -31,6 +31,7 @@ import { glob as fsGlob } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import path from 'path'
 import { loadCompatAdapters } from './adapter-registry'
+import { computeComponentDocs, computeFixtureDocs } from './component-docs'
 import { buildCompatCell, compileForCompat, type CompatCell } from './engine'
 import { buildCompatReport, buildFixtureDivergences, formatCompatJson, formatCompatMarkdown, type CompatReport } from './report'
 
@@ -231,6 +232,18 @@ async function main(): Promise<void> {
   const fixtureDivergences = buildFixtureDivergences(loaded, jsxFixtures.length)
 
   const report = buildCompatReport(cells, fixtureDivergences)
+
+  // Row descriptions + source links for the docs page's two entity
+  // tables (component matrix, render-conformance fixture corpus), so a
+  // reader sees what `accordion` / `filter-nested-callback-predicate`
+  // are without leaving the page. Attached here (not in the pure
+  // `buildCompatReport` / `buildFixtureDivergences`, which stay
+  // synthetic-input-testable) since they read `ui/registry.json`, the
+  // component sources, and the fixture corpus off disk. Committed into
+  // the lock and drift-checked in CI like the rest of it.
+  report.componentDocs = computeComponentDocs(Object.keys(report.components))
+  report.fixtureDivergences.docs = computeFixtureDocs(Object.keys(report.fixtureDivergences.fixtures))
+
   const text = jsonFlag ? formatCompatJson(report) : formatCompatMarkdown(report)
 
   if (outPath) {

--- a/packages/compat/src/component-docs.ts
+++ b/packages/compat/src/component-docs.ts
@@ -1,0 +1,133 @@
+// Human-readable descriptions for the docs Compatibility Matrix page's
+// two entity tables — the component matrix ("Matrix") and the
+// fixture-corpus render-honesty table ("Render Conformance") — so a
+// reader meeting a bare row label like `accordion` or
+// `filter-nested-callback-predicate` sees what it actually is instead
+// of guessing from the id.
+//
+// Sources are the artifacts that already own these descriptions:
+//   - Components: the committed `ui/registry.json` (the public
+//     component catalogue's curated one-liners), falling back to the
+//     component's own JSDoc tagline for anything not in the registry
+//     (`chart`, `icon`). Each label links to the component source.
+//   - Fixtures: the fixture's `description` field (`jsxFixtures`),
+//     linked to its source file (`fixtureFileMap`).
+//
+// Both maps are attached to the lock files at generation time and
+// drift-checked in CI (`ci-compat.yml` regenerates and `git diff
+// --exit-code`s them), so a renamed component or reworded description
+// can't silently rot the page — the next regen picks it up and CI fails
+// if it was forgotten.
+
+import { readFileSync } from 'node:fs'
+import path from 'path'
+import ts from 'typescript'
+import { jsxFixtures } from '../../adapter-tests/fixtures'
+import type { ComponentDoc, FixtureDoc } from './report'
+import { REPO_ROOT, blobUrl, fixtureFileMap } from './repo-links'
+
+const COMPONENTS_DIR = 'ui/components/ui'
+const REGISTRY_FILE = 'ui/registry.json'
+/** A description longer than this is trimmed at a word boundary with an ellipsis (prose, not code — safe to truncate). */
+const DESCRIPTION_MAX_CHARS = 100
+
+interface RegistryItem {
+  name: string
+  title?: string
+  description?: string
+}
+
+function titleCase(name: string): string {
+  return name
+    .split('-')
+    .map(w => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(' ')
+}
+
+function trimToBudget(text: string): string {
+  const clean = text.replace(/\s+/g, ' ').trim()
+  if (clean.length <= DESCRIPTION_MAX_CHARS) return clean
+  const cut = clean.slice(0, DESCRIPTION_MAX_CHARS)
+  const lastSpace = cut.lastIndexOf(' ')
+  return `${(lastSpace > 0 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`
+}
+
+/** name → curated registry entry, from the committed public catalogue. */
+function loadRegistry(): Map<string, RegistryItem> {
+  const raw = JSON.parse(readFileSync(path.join(REPO_ROOT, REGISTRY_FILE), 'utf8')) as { items?: RegistryItem[] }
+  return new Map((raw.items ?? []).map(item => [item.name, item]))
+}
+
+/**
+ * The tagline paragraph of a component's leading JSDoc block: the first
+ * non-empty content line after the title line. The block is located via
+ * the TS AST (not a regex over source — CLAUDE.md): it's the leading
+ * comment of the first real statement, which sits after the
+ * `"use client"` directive prologue every component file opens with (so
+ * a position-0 comment scan would miss it). Used only for components
+ * absent from the registry.
+ */
+function taglineFromSource(name: string): string | undefined {
+  const abs = path.join(REPO_ROOT, COMPONENTS_DIR, name, 'index.tsx')
+  let source: string
+  try {
+    source = readFileSync(abs, 'utf8')
+  } catch {
+    return undefined
+  }
+  const sourceFile = ts.createSourceFile(abs, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  // Skip the `"use client"` directive prologue (a bare string-literal
+  // expression statement); the docstring is the next statement's leading
+  // comment.
+  const firstReal = sourceFile.statements.find(
+    s => !(ts.isExpressionStatement(s) && ts.isStringLiteralLike(s.expression)),
+  )
+  if (!firstReal) return undefined
+  const ranges = ts.getLeadingCommentRanges(source, firstReal.getFullStart()) ?? []
+  const block = ranges.find(r => r.kind === ts.SyntaxKind.MultiLineCommentTrivia)
+  if (!block) return undefined
+  // Strip the `/* … */` fence, then each line's leading ` * ` decoration
+  // with plain string ops (no regex), and read the structure the
+  // component docstrings follow: [title, '', tagline, …].
+  const stripDecoration = (line: string): string => {
+    const t = line.trim()
+    return (t.startsWith('*') ? t.slice(1) : t).trim()
+  }
+  const content = source
+    .slice(block.pos + 2, block.end - 2)
+    .split('\n')
+    .map(stripDecoration)
+    .filter(l => l.length > 0)
+  // content[0] is the title line ("Accordion Components"); the tagline
+  // is the next content line.
+  return content.length >= 2 ? content[1] : undefined
+}
+
+export function computeComponentDocs(names: string[]): Record<string, ComponentDoc> {
+  const registry = loadRegistry()
+  const docs: Record<string, ComponentDoc> = {}
+  for (const name of names) {
+    const item = registry.get(name)
+    const description = item?.description ?? taglineFromSource(name) ?? ''
+    docs[name] = {
+      title: item?.title ?? titleCase(name),
+      description: trimToBudget(description),
+      url: blobUrl(`${COMPONENTS_DIR}/${name}/index.tsx`),
+    }
+  }
+  return docs
+}
+
+export function computeFixtureDocs(fixtureIds: string[]): Record<string, FixtureDoc> {
+  const descriptions = new Map(jsxFixtures.map(f => [f.id, f.description]))
+  const files = fixtureFileMap()
+  const docs: Record<string, FixtureDoc> = {}
+  for (const id of fixtureIds) {
+    const file = files.get(id)
+    docs[id] = {
+      description: trimToBudget(descriptions.get(id) ?? ''),
+      url: file ? blobUrl(file) : blobUrl(''),
+    }
+  }
+  return docs
+}

--- a/packages/compat/src/construct-examples.ts
+++ b/packages/compat/src/construct-examples.ts
@@ -17,17 +17,11 @@
 // the lock file, so the exemplar, its description, and its file link
 // can never silently go stale.
 
-import { readdirSync, readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
-import path from 'path'
 import ts from 'typescript'
 import { ARRAY_METHOD_NAMES } from '@barefootjs/jsx'
 import { jsxFixtures } from '../../adapter-tests/fixtures'
+import { blobUrl, fixtureFileMap } from './repo-links'
 import type { SupportMatrixCoverageMap } from './support-matrix'
-
-const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
-const GITHUB_BLOB_BASE = 'https://github.com/piconic-ai/barefootjs/blob/main'
-const FIXTURES_DIR = 'packages/adapter-tests/fixtures'
 
 /** One construct's exemplar fixture: what the case looks like, in prose and in code. */
 export interface ConstructExample {
@@ -45,48 +39,6 @@ export interface ConstructExample {
    * exists.
    */
   code?: string
-}
-
-/**
- * Fixture id → repo-relative file path, built by AST-walking every
- * `.ts` under the fixtures tree for a string-literal `id:` property
- * (never regex — CLAUDE.md). Fixture files declare their id exactly
- * once (`createFixture({ id: '...' })` or a shared `spec` object), and
- * ids are corpus-unique, so the first declaration wins.
- */
-function fixtureFileMap(): Map<string, string> {
-  const map = new Map<string, string>()
-  const walk = (dir: string): void => {
-    for (const entry of readdirSync(path.join(REPO_ROOT, dir), { withFileTypes: true })) {
-      const rel = `${dir}/${entry.name}`
-      if (entry.isDirectory()) {
-        walk(rel)
-        continue
-      }
-      if (!entry.name.endsWith('.ts')) continue
-      const sourceFile = ts.createSourceFile(
-        rel,
-        readFileSync(path.join(REPO_ROOT, rel), 'utf8'),
-        ts.ScriptTarget.Latest,
-        true,
-      )
-      const visit = (node: ts.Node): void => {
-        if (
-          ts.isPropertyAssignment(node) &&
-          ts.isIdentifier(node.name) &&
-          node.name.text === 'id' &&
-          (ts.isStringLiteral(node.initializer) || ts.isNoSubstitutionTemplateLiteral(node.initializer)) &&
-          !map.has(node.initializer.text)
-        ) {
-          map.set(node.initializer.text, rel)
-        }
-        ts.forEachChild(node, visit)
-      }
-      visit(sourceFile)
-    }
-  }
-  walk(FIXTURES_DIR)
-  return map
 }
 
 const ARRAY_METHOD_SET: ReadonlySet<string> = new Set(ARRAY_METHOD_NAMES)
@@ -280,7 +232,7 @@ export function computeConstructExamples(coverage: SupportMatrixCoverageMap): Co
     const example: ConstructExample = {
       fixture: best,
       description: fixture.description,
-      url: `${GITHUB_BLOB_BASE}/${files.get(best)!}`,
+      url: blobUrl(files.get(best)!),
     }
     const code = extractSnippet([fixture.source, ...Object.values(fixture.components ?? {})], construct)
     if (code) example.code = code

--- a/packages/compat/src/repo-links.ts
+++ b/packages/compat/src/repo-links.ts
@@ -1,0 +1,64 @@
+// Shared GitHub-permalink helpers for the compat lockfile generators.
+// The docs Compatibility Matrix page links each row to the code it
+// stands for; this module centralises the repo constants and the
+// fixture-id → source-file resolution those links need, so
+// `construct-examples.ts` (Construct Support rows) and
+// `component-docs.ts` (component + fixture-corpus rows) build identical
+// URLs from one place.
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'path'
+import ts from 'typescript'
+
+export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
+export const GITHUB_BLOB_BASE = 'https://github.com/piconic-ai/barefootjs/blob/main'
+
+const FIXTURES_DIR = 'packages/adapter-tests/fixtures'
+
+/** `<GITHUB_BLOB_BASE>/<repoRelativePath>` — forward-slashed, no line fragment. */
+export function blobUrl(repoRelativePath: string): string {
+  return `${GITHUB_BLOB_BASE}/${repoRelativePath}`
+}
+
+/**
+ * Fixture id → repo-relative file path, built by AST-walking every
+ * `.ts` under the fixtures tree for a string-literal `id:` property
+ * (never regex — CLAUDE.md). Fixture files declare their id exactly
+ * once (`createFixture({ id: '...' })` or a shared `spec` object), and
+ * ids are corpus-unique, so the first declaration wins.
+ */
+export function fixtureFileMap(): Map<string, string> {
+  const map = new Map<string, string>()
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(path.join(REPO_ROOT, dir), { withFileTypes: true })) {
+      const rel = `${dir}/${entry.name}`
+      if (entry.isDirectory()) {
+        walk(rel)
+        continue
+      }
+      if (!entry.name.endsWith('.ts')) continue
+      const sourceFile = ts.createSourceFile(
+        rel,
+        readFileSync(path.join(REPO_ROOT, rel), 'utf8'),
+        ts.ScriptTarget.Latest,
+        true,
+      )
+      const visit = (node: ts.Node): void => {
+        if (
+          ts.isPropertyAssignment(node) &&
+          ts.isIdentifier(node.name) &&
+          node.name.text === 'id' &&
+          (ts.isStringLiteral(node.initializer) || ts.isNoSubstitutionTemplateLiteral(node.initializer)) &&
+          !map.has(node.initializer.text)
+        ) {
+          map.set(node.initializer.text, rel)
+        }
+        ts.forEachChild(node, visit)
+      }
+      visit(sourceFile)
+    }
+  }
+  walk(FIXTURES_DIR)
+  return map
+}

--- a/packages/compat/src/report.ts
+++ b/packages/compat/src/report.ts
@@ -61,12 +61,32 @@ export const FIXTURE_DIVERGENCES_NOTE =
   'rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance ' +
   'suite until fixed). Fixtures absent from this table render to reference parity on every adapter.'
 
+/** A fixture-corpus row's human-readable description + link to its source file. */
+export interface FixtureDoc {
+  description: string
+  url: string
+}
+
 export interface FixtureDivergences {
   note: string
   /** Total shared-corpus fixture count, for the "N of M clean" summary. */
   totalFixtures: number
   /** Fixture id → adapter id → divergence cell. Clean cells are omitted. */
   fixtures: Record<string, Record<string, FixtureDivergenceCell>>
+  /**
+   * Fixture id → description + source link, for the divergent fixtures
+   * listed above. Populated by the CLI at generation time (see
+   * `component-docs.ts`); absent on reports built without it (the pure
+   * `buildFixtureDivergences` leaves it unset).
+   */
+  docs?: Record<string, FixtureDoc>
+}
+
+/** A component-matrix row's title, description, and link to its source. */
+export interface ComponentDoc {
+  title: string
+  description: string
+  url: string
 }
 
 export interface CompatReport {
@@ -76,6 +96,12 @@ export interface CompatReport {
   adapters: string[]
   /** Component name → adapter id → cell. */
   components: Record<string, Record<string, CompatReportCell>>
+  /**
+   * Component name → title + description + source link. Populated by the
+   * CLI at generation time (see `component-docs.ts`); absent on reports
+   * built without it (the pure `buildCompatReport` leaves it unset).
+   */
+  componentDocs?: Record<string, ComponentDoc>
   /** Fixture-level divergences (build-time refusals + render divergences). */
   fixtureDivergences: FixtureDivergences
 }

--- a/site/core/pages/compat-matrix.tsx
+++ b/site/core/pages/compat-matrix.tsx
@@ -40,10 +40,23 @@ interface FixtureDivergenceCell {
   reason?: string
 }
 
+interface FixtureDoc {
+  description: string
+  url: string
+}
+
 interface FixtureDivergences {
   note: string
   totalFixtures: number
   fixtures: Record<string, Record<string, FixtureDivergenceCell>>
+  /** Optional: fixture id → description + source link (older locks lack it). */
+  docs?: Record<string, FixtureDoc>
+}
+
+interface ComponentDoc {
+  title: string
+  description: string
+  url: string
 }
 
 interface CompatLock {
@@ -51,6 +64,8 @@ interface CompatLock {
   knownLimitationLabel: string
   adapters: string[]
   components: Record<string, Record<string, CompatCell>>
+  /** Optional: component name → title + description + source link (older locks lack it). */
+  componentDocs?: Record<string, ComponentDoc>
   /** Optional: locks generated before #2168's render-honesty section lack it. */
   fixtureDivergences?: FixtureDivergences
 }
@@ -148,14 +163,25 @@ function buildSummary(componentNames: string[]): string {
   return `**${componentNames.length} components × ${adapters.length} adapters — ${okCells} / ${totalCells} cells compile clean**`
 }
 
-/** Build the Markdown table: one row per component, one column per adapter. */
+/**
+ * The "Component" cell: the name linked to its source (`componentDocs`,
+ * generated alongside the lock) when available, else a plain code span.
+ */
+function componentLabelMarkdown(name: string, doc: ComponentDoc | undefined): string {
+  const code = `\`${escapeCell(name)}\``
+  return doc?.url ? `[${code}](${doc.url})` : code
+}
+
+/** Build the Markdown table: one row per component, a description, then one column per adapter. */
 function buildTable(componentNames: string[]): string {
   const adapters = compat.adapters
-  const header = `| Component | ${adapters.join(' | ')} |`
-  const divider = `| --- | ${adapters.map(() => '---').join(' | ')} |`
+  const header = `| Component | Description | ${adapters.join(' | ')} |`
+  const divider = `| --- | --- | ${adapters.map(() => '---').join(' | ')} |`
   const rows = componentNames.map((name) => {
+    const doc = compat.componentDocs?.[name]
+    const description = doc?.description ? escapeCell(doc.description) : '—'
     const cells = adapters.map((adapter) => cellMarkdown(compat.components[name]?.[adapter]))
-    return `| \`${escapeCell(name)}\` | ${cells.join(' | ')} |`
+    return `| ${componentLabelMarkdown(name, doc)} | ${description} | ${cells.join(' | ')} |`
   })
   return [header, divider, ...rows].join('\n')
 }
@@ -233,7 +259,10 @@ function buildFixtureDetails(fd: FixtureDivergences): string {
     const lines = [...byText.entries()].map(
       ([text, adapters]) => `  - ${adapters.map((a) => `\`${a}\``).join(', ')} — ${escapeCell(text)}`,
     )
-    blocks.push(`- **\`${fixtureId}\`**\n${lines.join('\n')}`)
+    const doc = fd.docs?.[fixtureId]
+    const heading = doc?.url ? `**[\`${fixtureId}\`](${doc.url})**` : `**\`${fixtureId}\`**`
+    const summary = doc?.description ? ` — ${escapeCell(doc.description)}` : ''
+    blocks.push(`- ${heading}${summary}\n${lines.join('\n')}`)
   }
   return blocks.join('\n')
 }
@@ -250,8 +279,10 @@ function buildFixtureSection(): string {
   const header = `| Fixture | ${adapters.join(' | ')} |`
   const divider = `| --- | ${adapters.map(() => '---').join(' | ')} |`
   const rows = fixtureIds.map((id) => {
+    const doc = fd.docs?.[id]
+    const label = doc?.url ? `[\`${escapeCell(id)}\`](${doc.url})` : `\`${escapeCell(id)}\``
     const cells = adapters.map((adapter) => fixtureCellMarkdown(fd.fixtures[id]?.[adapter]))
-    return `| \`${escapeCell(id)}\` | ${cells.join(' | ')} |`
+    return `| ${label} | ${cells.join(' | ')} |`
   })
 
   return `
@@ -376,6 +407,8 @@ ${summary}
 
 ## Matrix
 
+Each component name links to its source; the **Description** column says what it is.
+
 ${table}
 
 ## Legend
@@ -388,6 +421,8 @@ ${supportMatrixSection}
 ## Data Source
 
 This table is generated from the committed [\`ui/compat.lock.json\`](https://github.com/piconic-ai/barefootjs/blob/main/ui/compat.lock.json), regenerated with \`bun run compat:lock\` and drift-checked in CI. Render-level divergences are declared per adapter in \`packages/adapter-*/src/render-divergences.ts\` (each adapter's conformance suite derives its skip list from the same declaration, so this page and the tests cannot drift apart). Tracked limitations carry the [\`known-limitation\`](${compat.knownLimitationLabel}) label.
+
+Component and fixture descriptions are computed into the same lock at regen time ([\`component-docs.ts\`](https://github.com/piconic-ai/barefootjs/blob/main/packages/compat/src/component-docs.ts)) — component one-liners from the public catalogue (\`ui/registry.json\`, JSDoc-tagline fallback), fixture descriptions from the corpus itself — so they're drift-checked with everything else and can't go stale independently.
 
 The construct-support section above is generated from the committed [\`ui/support-matrix.lock.json\`](https://github.com/piconic-ai/barefootjs/blob/main/ui/support-matrix.lock.json), regenerated with \`bun run support-matrix:lock\` and drift-checked in CI alongside the component matrix. Each construct's fixture link and example description are computed the same way — the exemplar is mechanically chosen as the most narrowly targeted covering fixture ([\`construct-examples.ts\`](https://github.com/piconic-ai/barefootjs/blob/main/packages/compat/src/construct-examples.ts)), and definition-site fallback links come from a TS AST walk over the compiler's construct catalogues ([\`construct-source-links.ts\`](https://github.com/piconic-ai/barefootjs/blob/main/packages/compat/src/construct-source-links.ts)) — so they are regenerated and drift-checked on the same schedule: a link can't silently go stale, because moving the code it points at changes what the next regen commits, and CI fails if that regen was forgotten.
 

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2177,6 +2177,340 @@
           ]
         }
       }
+    },
+    "docs": {
+      "date-method-uncatalogued": {
+        "description": "Method call on a Date-typed prop refuses with BF021 (no catalogued lowering)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/date-method-uncatalogued.ts"
+      },
+      "filter-nested-callback-predicate": {
+        "description": "Filter predicate containing a nested .some() callback (#2038)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-nested-callback-predicate.ts"
+      },
+      "filter-nested-find-predicate": {
+        "description": "Filter predicate containing a nested .find() callback (#2038)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-nested-find-predicate.ts"
+      },
+      "static-array-from-props": {
+        "description": "Static-array loop with prop-derived array materialises children on CSR (#1247)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props.ts"
+      },
+      "static-array-from-props-with-component": {
+        "description": "Static-array loop with childComponent body materialises rendered children on CSR (#1268)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts"
+      }
+    }
+  },
+  "componentDocs": {
+    "accordion": {
+      "title": "Accordion",
+      "description": "Vertically collapsing content sections",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/accordion/index.tsx"
+    },
+    "alert": {
+      "title": "Alert",
+      "description": "Displays a callout for important content",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/alert/index.tsx"
+    },
+    "alert-dialog": {
+      "title": "Alert Dialog",
+      "description": "A modal dialog that interrupts the user with important content and expects a response",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/alert-dialog/index.tsx"
+    },
+    "aspect-ratio": {
+      "title": "Aspect Ratio",
+      "description": "Displays content within a desired ratio",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/aspect-ratio/index.tsx"
+    },
+    "avatar": {
+      "title": "Avatar",
+      "description": "An image element with a fallback for representing the user",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/avatar/index.tsx"
+    },
+    "badge": {
+      "title": "Badge",
+      "description": "Small status indicator labels",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/badge/index.tsx"
+    },
+    "breadcrumb": {
+      "title": "Breadcrumb",
+      "description": "Displays the path to the current resource using a hierarchy of links",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/breadcrumb/index.tsx"
+    },
+    "button": {
+      "title": "Button",
+      "description": "A button component with variants and sizes",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/button/index.tsx"
+    },
+    "button-group": {
+      "title": "Button Group",
+      "description": "Container for grouping related buttons",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/button-group/index.tsx"
+    },
+    "calendar": {
+      "title": "Calendar",
+      "description": "A date calendar for picking single dates with month navigation",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/calendar/index.tsx"
+    },
+    "card": {
+      "title": "Card",
+      "description": "Container for grouped content",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/card/index.tsx"
+    },
+    "carousel": {
+      "title": "Carousel",
+      "description": "A carousel with motion and swipe built using Embla",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/carousel/index.tsx"
+    },
+    "chart": {
+      "title": "Chart",
+      "description": "Every chart component (containers, primitives, and tooltips) is JSX-native:",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/chart/index.tsx"
+    },
+    "checkbox": {
+      "title": "Checkbox",
+      "description": "A control that allows the user to toggle between checked and not checked",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/checkbox/index.tsx"
+    },
+    "collapsible": {
+      "title": "Collapsible",
+      "description": "An interactive component which expands/collapses a panel",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/collapsible/index.tsx"
+    },
+    "combobox": {
+      "title": "Combobox",
+      "description": "Autocomplete input with searchable dropdown",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/combobox/index.tsx"
+    },
+    "command": {
+      "title": "Command",
+      "description": "A command menu with search, keyboard navigation, and filtering",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/command/index.tsx"
+    },
+    "context-menu": {
+      "title": "Context Menu",
+      "description": "A menu triggered by right-click, displayed at the cursor position",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/context-menu/index.tsx"
+    },
+    "data-table": {
+      "title": "Data Table",
+      "description": "Powerful table with sorting, filtering, and pagination",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/data-table/index.tsx"
+    },
+    "date-picker": {
+      "title": "Date Picker",
+      "description": "A date picker component with calendar popup and range selection",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/date-picker/index.tsx"
+    },
+    "dialog": {
+      "title": "Dialog",
+      "description": "A modal overlay with custom content",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/dialog/index.tsx"
+    },
+    "direction": {
+      "title": "Direction",
+      "description": "A provider for setting text direction (LTR/RTL) on child content",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/direction/index.tsx"
+    },
+    "drawer": {
+      "title": "Drawer",
+      "description": "A draggable panel that slides from the edge of the screen",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/drawer/index.tsx"
+    },
+    "dropdown-menu": {
+      "title": "Dropdown Menu",
+      "description": "An action menu triggered by a button",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/dropdown-menu/index.tsx"
+    },
+    "empty": {
+      "title": "Empty",
+      "description": "Empty state placeholder with icon, title, and action",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/empty/index.tsx"
+    },
+    "field": {
+      "title": "Field",
+      "description": "Form field wrapper with label, description, and error message",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/field/index.tsx"
+    },
+    "hover-card": {
+      "title": "Hover Card",
+      "description": "A floating card that appears on hover to display rich content",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/hover-card/index.tsx"
+    },
+    "icon": {
+      "title": "Icon",
+      "description": "SVG icons based on Lucide icon definitions.",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/icon/index.tsx"
+    },
+    "input": {
+      "title": "Input",
+      "description": "A text input field with error state support",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/input/index.tsx"
+    },
+    "input-group": {
+      "title": "Input Group",
+      "description": "Input with addons, prefixes, and suffixes",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/input-group/index.tsx"
+    },
+    "input-otp": {
+      "title": "Input OTP",
+      "description": "An accessible one-time password input with copy-paste support",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/input-otp/index.tsx"
+    },
+    "item": {
+      "title": "Item",
+      "description": "A generic list/menu item component with composable sub-components",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/item/index.tsx"
+    },
+    "kbd": {
+      "title": "Kbd",
+      "description": "Keyboard key display for showing keyboard shortcuts",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/kbd/index.tsx"
+    },
+    "label": {
+      "title": "Label",
+      "description": "Accessible label for form controls",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/label/index.tsx"
+    },
+    "menubar": {
+      "title": "Menubar",
+      "description": "A visually persistent menu common in desktop applications",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/menubar/index.tsx"
+    },
+    "native-select": {
+      "title": "Native Select",
+      "description": "A styled native HTML select element",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/native-select/index.tsx"
+    },
+    "navigation-menu": {
+      "title": "Navigation Menu",
+      "description": "A collection of links for navigating websites with hover-activated content panels",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/navigation-menu/index.tsx"
+    },
+    "pagination": {
+      "title": "Pagination",
+      "description": "Pagination with page navigation, next and previous links",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/pagination/index.tsx"
+    },
+    "popover": {
+      "title": "Popover",
+      "description": "A floating panel that appears relative to a trigger element",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/popover/index.tsx"
+    },
+    "portal": {
+      "title": "Portal",
+      "description": "Renders content outside the DOM hierarchy",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/portal/index.tsx"
+    },
+    "progress": {
+      "title": "Progress",
+      "description": "Displays an indicator showing the completion progress of a task",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/progress/index.tsx"
+    },
+    "radio-group": {
+      "title": "Radio Group",
+      "description": "A set of checkable buttons where only one can be checked at a time",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/radio-group/index.tsx"
+    },
+    "resizable": {
+      "title": "Resizable",
+      "description": "Accessible resizable panel groups and layouts with drag and keyboard support",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/resizable/index.tsx"
+    },
+    "scroll-area": {
+      "title": "Scroll Area",
+      "description": "Augments native scroll functionality for custom, cross-browser styling",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/scroll-area/index.tsx"
+    },
+    "select": {
+      "title": "Select",
+      "description": "Displays a list of options for the user to pick from",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/select/index.tsx"
+    },
+    "separator": {
+      "title": "Separator",
+      "description": "A visual divider that separates content horizontally or vertically",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/separator/index.tsx"
+    },
+    "sheet": {
+      "title": "Sheet",
+      "description": "A panel that slides in from the edge of the screen",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/sheet/index.tsx"
+    },
+    "sidebar": {
+      "title": "Sidebar",
+      "description": "A composable, collapsible sidebar component with responsive mobile support",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/sidebar/index.tsx"
+    },
+    "skeleton": {
+      "title": "Skeleton",
+      "description": "A placeholder loading indicator with pulse animation",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/skeleton/index.tsx"
+    },
+    "slider": {
+      "title": "Slider",
+      "description": "A range value selector with draggable thumb",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/slider/index.tsx"
+    },
+    "slot": {
+      "title": "Slot",
+      "description": "A polymorphic component that merges props with child element",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/slot/index.tsx"
+    },
+    "spinner": {
+      "title": "Spinner",
+      "description": "An animated loading indicator for async operations",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/spinner/index.tsx"
+    },
+    "switch": {
+      "title": "Switch",
+      "description": "A control that allows the user to toggle between checked and not checked",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/switch/index.tsx"
+    },
+    "table": {
+      "title": "Table",
+      "description": "A responsive table component for displaying structured data",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/table/index.tsx"
+    },
+    "tabs": {
+      "title": "Tabs",
+      "description": "A set of layered sections of content displayed one at a time",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/tabs/index.tsx"
+    },
+    "textarea": {
+      "title": "Textarea",
+      "description": "A multi-line text input field with error state support",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/textarea/index.tsx"
+    },
+    "toast": {
+      "title": "Toast",
+      "description": "A temporary notification message that appears briefly",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/toast/index.tsx"
+    },
+    "toggle": {
+      "title": "Toggle",
+      "description": "A two-state button that can be on or off",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/toggle/index.tsx"
+    },
+    "toggle-group": {
+      "title": "Toggle Group",
+      "description": "A set of two-state buttons that can be toggled on or off",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/toggle-group/index.tsx"
+    },
+    "tooltip": {
+      "title": "Tooltip",
+      "description": "A popup that displays contextual information on hover or focus",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/tooltip/index.tsx"
+    },
+    "typography": {
+      "title": "Typography",
+      "description": "Styled text elements for headings, paragraphs, and prose content",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/typography/index.tsx"
+    },
+    "xyflow": {
+      "title": "xyflow",
+      "description": "Signal-based graph editor — Flow, Background, Controls, MiniMap, Handle, NodeWrapper, SimpleEdge",
+      "url": "https://github.com/piconic-ai/barefootjs/blob/main/ui/components/ui/xyflow/index.tsx"
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2362. On the [Compatibility Matrix](https://barefootjs.dev/docs/advanced/compatibility-matrix) page, the top **Matrix** table and the **Render Conformance (fixture corpus)** table listed bare ids — `accordion`, `filter-nested-callback-predicate` — with no hint of what each one is. This adds that context:

- **Component matrix** gains a **Description** column, and each component name links to its source (`ui/components/ui/<name>/index.tsx`). Descriptions are the curated one-liners from the public component catalogue (`ui/registry.json`); the two components not in the registry (`chart`, `icon`) fall back to their JSDoc tagline, extracted via the TS AST (locating the docstring after the `"use client"` prologue — no regex over source, per `CLAUDE.md`).
- **Render Conformance** fixture ids now link to their source file, and the **Divergence details** list shows each fixture's description (e.g. `date-method-uncatalogued` — "Method call on a Date-typed prop refuses with BF021…").

Both are computed into `ui/compat.lock.json` at generation time by a new `packages/compat/src/component-docs.ts`, wired into the CLI after `buildCompatReport` (kept out of the pure builders so their synthetic-input unit tests are unaffected). Since the lock is regenerated by `bun run compat:lock` and drift-checked in CI (`ci-compat.yml`), a renamed component or reworded description can't silently rot the page — the next regen picks it up and CI fails if it was forgotten. Same guarantee the Construct Support links got in #2362.

Shared fixture-id → source-file resolution is factored out of `construct-examples.ts` into `packages/compat/src/repo-links.ts` and reused here.

## Test plan

- [x] `bun test packages/compat` — 86 pass (new `component-docs.test.ts`: every matrix component + every divergent fixture has a non-empty description, a well-formed source URL, an in-budget length, and matches the committed lock)
- [x] `bunx tsc --noEmit -p tsconfig.json` — no errors in changed files
- [x] `bun run compat --render ui/compat.lock.json` still works (new fields are backward-compatible)
- [x] `ui/support-matrix.lock.json` unchanged by the `construct-examples.ts` refactor (behavior-preserving)
- [x] Rendered the page locally and verified the Matrix Description column, component/fixture source links, and the Divergence details descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEJPdLRawQAS1pkKjAQdjj

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEJPdLRawQAS1pkKjAQdjj)_