### PR TITLE
Add Tetris and Markdown editor integration examples

### DIFF
--- a/integrations/chi/components.go
+++ b/integrations/chi/components.go
@@ -110,6 +110,42 @@ type FormProps struct {
 	Accepted bool `json:"accepted"`
 }
 
+// Seg represents a seg.
+type Seg struct {
+	Bold bool `json:"bold"`
+	Text string `json:"text"`
+}
+
+// Block represents a block.
+type Block struct {
+	Cls string `json:"cls"`
+	Segs []Seg `json:"segs"`
+}
+
+// MarkdownEditorInput is the user-facing input type.
+type MarkdownEditorInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// MarkdownEditorProps is the props type for the MarkdownEditor component.
+type MarkdownEditorProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Text interface{} `json:"text"`
+	Blocks []Block `json:"blocks"`
+	CharCount int `json:"charCount"`
+	WordCount int `json:"wordCount"`
+	LineCount int `json:"lineCount"`
+	ReadMinutes int `json:"readMinutes"`
+}
+
 // ToggleItem represents a toggleitem.
 type ToggleItem struct {
 	ID string `json:"id"`
@@ -267,6 +303,43 @@ type PropsReactivityComparisonProps struct {
 	Count int `json:"count"`
 	PropsStyleChildSlot3 PropsStyleChildProps `json:"-"`
 	DestructuredStyleChildSlot4 DestructuredStyleChildProps `json:"-"`
+}
+
+// Piece represents a piece.
+type Piece struct {
+	Type int `json:"type"`
+	Rot int `json:"rot"`
+	X int `json:"x"`
+	Y int `json:"y"`
+}
+
+// TetrisInput is the user-facing input type.
+type TetrisInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// TetrisProps is the props type for the Tetris component.
+type TetrisProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Board [][]int `json:"board"`
+	Piece interface{} `json:"piece"`
+	NextType int `json:"nextType"`
+	Score int `json:"score"`
+	Lines int `json:"lines"`
+	Level int `json:"level"`
+	Running bool `json:"running"`
+	Paused bool `json:"paused"`
+	GameOver bool `json:"gameOver"`
+	Display [][]int `json:"display"`
+	Preview int `json:"preview"`
 }
 
 // TextEscapeInput is the user-facing input type.
@@ -736,6 +809,26 @@ func NewFormProps(in FormInput) FormProps {
 	}
 }
 
+// NewMarkdownEditorProps creates MarkdownEditorProps from MarkdownEditorInput.
+func NewMarkdownEditorProps(in MarkdownEditorInput) MarkdownEditorProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "MarkdownEditor_" + randomID(6)
+	}
+
+	return MarkdownEditorProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Text: nil,
+		Blocks: nil,
+		CharCount: 0,
+		WordCount: 0,
+		LineCount: 0,
+		ReadMinutes: 0,
+	}
+}
+
 // NewNestedCondToggleListProps creates NestedCondToggleListProps from NestedCondToggleListInput.
 func NewNestedCondToggleListProps(in NestedCondToggleListInput) NestedCondToggleListProps {
 	scopeID := in.ScopeID
@@ -873,6 +966,31 @@ func NewPropsReactivityComparisonProps(in PropsReactivityComparisonInput) PropsR
 			Value: 1,
 			Label: "Destructured",
 		}),
+	}
+}
+
+// NewTetrisProps creates TetrisProps from TetrisInput.
+func NewTetrisProps(in TetrisInput) TetrisProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "Tetris_" + randomID(6)
+	}
+
+	return TetrisProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Board: nil,
+		Piece: nil,
+		NextType: 0,
+		Score: 0,
+		Lines: 0,
+		Level: 1,
+		Running: false,
+		Paused: false,
+		GameOver: false,
+		Display: nil,
+		Preview: 0,
 	}
 }
 

--- a/integrations/echo/components.go
+++ b/integrations/echo/components.go
@@ -110,6 +110,42 @@ type FormProps struct {
 	Accepted bool `json:"accepted"`
 }
 
+// Seg represents a seg.
+type Seg struct {
+	Bold bool `json:"bold"`
+	Text string `json:"text"`
+}
+
+// Block represents a block.
+type Block struct {
+	Cls string `json:"cls"`
+	Segs []Seg `json:"segs"`
+}
+
+// MarkdownEditorInput is the user-facing input type.
+type MarkdownEditorInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// MarkdownEditorProps is the props type for the MarkdownEditor component.
+type MarkdownEditorProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Text interface{} `json:"text"`
+	Blocks []Block `json:"blocks"`
+	CharCount int `json:"charCount"`
+	WordCount int `json:"wordCount"`
+	LineCount int `json:"lineCount"`
+	ReadMinutes int `json:"readMinutes"`
+}
+
 // ToggleItem represents a toggleitem.
 type ToggleItem struct {
 	ID string `json:"id"`
@@ -267,6 +303,43 @@ type PropsReactivityComparisonProps struct {
 	Count int `json:"count"`
 	PropsStyleChildSlot3 PropsStyleChildProps `json:"-"`
 	DestructuredStyleChildSlot4 DestructuredStyleChildProps `json:"-"`
+}
+
+// Piece represents a piece.
+type Piece struct {
+	Type int `json:"type"`
+	Rot int `json:"rot"`
+	X int `json:"x"`
+	Y int `json:"y"`
+}
+
+// TetrisInput is the user-facing input type.
+type TetrisInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// TetrisProps is the props type for the Tetris component.
+type TetrisProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Board [][]int `json:"board"`
+	Piece interface{} `json:"piece"`
+	NextType int `json:"nextType"`
+	Score int `json:"score"`
+	Lines int `json:"lines"`
+	Level int `json:"level"`
+	Running bool `json:"running"`
+	Paused bool `json:"paused"`
+	GameOver bool `json:"gameOver"`
+	Display [][]int `json:"display"`
+	Preview int `json:"preview"`
 }
 
 // TextEscapeInput is the user-facing input type.
@@ -736,6 +809,26 @@ func NewFormProps(in FormInput) FormProps {
 	}
 }
 
+// NewMarkdownEditorProps creates MarkdownEditorProps from MarkdownEditorInput.
+func NewMarkdownEditorProps(in MarkdownEditorInput) MarkdownEditorProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "MarkdownEditor_" + randomID(6)
+	}
+
+	return MarkdownEditorProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Text: nil,
+		Blocks: nil,
+		CharCount: 0,
+		WordCount: 0,
+		LineCount: 0,
+		ReadMinutes: 0,
+	}
+}
+
 // NewNestedCondToggleListProps creates NestedCondToggleListProps from NestedCondToggleListInput.
 func NewNestedCondToggleListProps(in NestedCondToggleListInput) NestedCondToggleListProps {
 	scopeID := in.ScopeID
@@ -873,6 +966,31 @@ func NewPropsReactivityComparisonProps(in PropsReactivityComparisonInput) PropsR
 			Value: 1,
 			Label: "Destructured",
 		}),
+	}
+}
+
+// NewTetrisProps creates TetrisProps from TetrisInput.
+func NewTetrisProps(in TetrisInput) TetrisProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "Tetris_" + randomID(6)
+	}
+
+	return TetrisProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Board: nil,
+		Piece: nil,
+		NextType: 0,
+		Score: 0,
+		Lines: 0,
+		Level: 1,
+		Running: false,
+		Paused: false,
+		GameOver: false,
+		Display: nil,
+		Preview: 0,
 	}
 }
 

--- a/integrations/gin/components.go
+++ b/integrations/gin/components.go
@@ -110,6 +110,42 @@ type FormProps struct {
 	Accepted bool `json:"accepted"`
 }
 
+// Seg represents a seg.
+type Seg struct {
+	Bold bool `json:"bold"`
+	Text string `json:"text"`
+}
+
+// Block represents a block.
+type Block struct {
+	Cls string `json:"cls"`
+	Segs []Seg `json:"segs"`
+}
+
+// MarkdownEditorInput is the user-facing input type.
+type MarkdownEditorInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// MarkdownEditorProps is the props type for the MarkdownEditor component.
+type MarkdownEditorProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Text interface{} `json:"text"`
+	Blocks []Block `json:"blocks"`
+	CharCount int `json:"charCount"`
+	WordCount int `json:"wordCount"`
+	LineCount int `json:"lineCount"`
+	ReadMinutes int `json:"readMinutes"`
+}
+
 // ToggleItem represents a toggleitem.
 type ToggleItem struct {
 	ID string `json:"id"`
@@ -267,6 +303,43 @@ type PropsReactivityComparisonProps struct {
 	Count int `json:"count"`
 	PropsStyleChildSlot3 PropsStyleChildProps `json:"-"`
 	DestructuredStyleChildSlot4 DestructuredStyleChildProps `json:"-"`
+}
+
+// Piece represents a piece.
+type Piece struct {
+	Type int `json:"type"`
+	Rot int `json:"rot"`
+	X int `json:"x"`
+	Y int `json:"y"`
+}
+
+// TetrisInput is the user-facing input type.
+type TetrisInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// TetrisProps is the props type for the Tetris component.
+type TetrisProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Board [][]int `json:"board"`
+	Piece interface{} `json:"piece"`
+	NextType int `json:"nextType"`
+	Score int `json:"score"`
+	Lines int `json:"lines"`
+	Level int `json:"level"`
+	Running bool `json:"running"`
+	Paused bool `json:"paused"`
+	GameOver bool `json:"gameOver"`
+	Display [][]int `json:"display"`
+	Preview int `json:"preview"`
 }
 
 // TextEscapeInput is the user-facing input type.
@@ -736,6 +809,26 @@ func NewFormProps(in FormInput) FormProps {
 	}
 }
 
+// NewMarkdownEditorProps creates MarkdownEditorProps from MarkdownEditorInput.
+func NewMarkdownEditorProps(in MarkdownEditorInput) MarkdownEditorProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "MarkdownEditor_" + randomID(6)
+	}
+
+	return MarkdownEditorProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Text: nil,
+		Blocks: nil,
+		CharCount: 0,
+		WordCount: 0,
+		LineCount: 0,
+		ReadMinutes: 0,
+	}
+}
+
 // NewNestedCondToggleListProps creates NestedCondToggleListProps from NestedCondToggleListInput.
 func NewNestedCondToggleListProps(in NestedCondToggleListInput) NestedCondToggleListProps {
 	scopeID := in.ScopeID
@@ -873,6 +966,31 @@ func NewPropsReactivityComparisonProps(in PropsReactivityComparisonInput) PropsR
 			Value: 1,
 			Label: "Destructured",
 		}),
+	}
+}
+
+// NewTetrisProps creates TetrisProps from TetrisInput.
+func NewTetrisProps(in TetrisInput) TetrisProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "Tetris_" + randomID(6)
+	}
+
+	return TetrisProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Board: nil,
+		Piece: nil,
+		NextType: 0,
+		Score: 0,
+		Lines: 0,
+		Level: 1,
+		Running: false,
+		Paused: false,
+		GameOver: false,
+		Display: nil,
+		Preview: 0,
 	}
 }
 

--- a/integrations/hono/e2e/markdown-editor.spec.ts
+++ b/integrations/hono/e2e/markdown-editor.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Markdown Editor E2E tests for Hono example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { markdownEditorTests } from '../../shared/e2e/markdown-editor.spec'
+
+markdownEditorTests('http://localhost:3001/integrations/hono')

--- a/integrations/hono/e2e/tetris.spec.ts
+++ b/integrations/hono/e2e/tetris.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Tetris E2E tests for Hono example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { tetrisTests } from '../../shared/e2e/tetris.spec'
+
+tetrisTests('http://localhost:3001/integrations/hono')

--- a/integrations/hono/renderer.tsx
+++ b/integrations/hono/renderer.tsx
@@ -51,6 +51,8 @@ export const renderer = jsxRenderer(
           <link rel="stylesheet" href={`${BASE_PATH}/shared/styles/components.css`} />
           <link rel="stylesheet" href={`${BASE_PATH}/shared/styles/todo-app.css`} />
           <link rel="stylesheet" href={`${BASE_PATH}/shared/styles/ai-chat.css`} />
+          <link rel="stylesheet" href={`${BASE_PATH}/shared/styles/tetris.css`} />
+          <link rel="stylesheet" href={`${BASE_PATH}/shared/styles/markdown-editor.css`} />
         </head>
         <body>
           <SiteHeader />

--- a/integrations/hono/server.tsx
+++ b/integrations/hono/server.tsx
@@ -18,6 +18,8 @@ import { ReactiveProps, PropsReactivityComparison } from '@/components/ReactiveP
 import { Form } from '@/components/Form'
 import { PortalExample } from '@/components/PortalExample'
 import ConditionalReturn from '@/components/ConditionalReturn'
+import { Tetris } from '@/components/Tetris'
+import { MarkdownEditor } from '@/components/MarkdownEditor'
 import { AIChatPage } from './components/AIChatPage'
 import { blog } from './blog'
 
@@ -117,6 +119,8 @@ app.get('/', (c) => {
           <li><a href={link('/todos')}>Todo (@client)</a></li>
           <li><a href={link('/todos-ssr')}>Todo (no @client markers)</a></li>
           <li><a href={link('/ai-chat')}>AI Chat (SSE Streaming)</a></li>
+          <li><a href={link('/tetris')}>Tetris (game loop + keyboard)</a></li>
+          <li><a href={link('/editor')}>Markdown Editor (live preview)</a></li>
           <li><a href={link('/blog')}>Blog (@barefootjs/router — partial navigation)</a></li>
         </ul>
       </nav>
@@ -224,6 +228,31 @@ app.get('/conditional-return-link', (c) => {
     <div>
       <h1>Conditional Return Example (Link)</h1>
       <ConditionalReturn variant="link" />
+      <p><a href={link('/')}>← Back</a></p>
+    </div>
+  )
+})
+
+app.get('/tetris', (c) => {
+  return c.render(
+    <div>
+      <h1>Tetris Example</h1>
+      <p>A full game loop driven by BarefootJS signals — keyboard controls, a
+        reactive 10×20 grid, line clears, and scoring. Click Start, then use the
+        arrow keys.</p>
+      <Tetris />
+      <p><a href={link('/')}>← Back</a></p>
+    </div>
+  )
+})
+
+app.get('/editor', (c) => {
+  return c.render(
+    <div>
+      <h1>Markdown Editor Example</h1>
+      <p>Type Markdown on the left; a live preview and word/character counters
+        update on the right — all derived from a single <code>text</code> signal.</p>
+      <MarkdownEditor />
       <p><a href={link('/')}>← Back</a></p>
     </div>
   )

--- a/integrations/nethttp/components.go
+++ b/integrations/nethttp/components.go
@@ -110,6 +110,42 @@ type FormProps struct {
 	Accepted bool `json:"accepted"`
 }
 
+// Seg represents a seg.
+type Seg struct {
+	Bold bool `json:"bold"`
+	Text string `json:"text"`
+}
+
+// Block represents a block.
+type Block struct {
+	Cls string `json:"cls"`
+	Segs []Seg `json:"segs"`
+}
+
+// MarkdownEditorInput is the user-facing input type.
+type MarkdownEditorInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// MarkdownEditorProps is the props type for the MarkdownEditor component.
+type MarkdownEditorProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Text interface{} `json:"text"`
+	Blocks []Block `json:"blocks"`
+	CharCount int `json:"charCount"`
+	WordCount int `json:"wordCount"`
+	LineCount int `json:"lineCount"`
+	ReadMinutes int `json:"readMinutes"`
+}
+
 // ToggleItem represents a toggleitem.
 type ToggleItem struct {
 	ID string `json:"id"`
@@ -267,6 +303,43 @@ type PropsReactivityComparisonProps struct {
 	Count int `json:"count"`
 	PropsStyleChildSlot3 PropsStyleChildProps `json:"-"`
 	DestructuredStyleChildSlot4 DestructuredStyleChildProps `json:"-"`
+}
+
+// Piece represents a piece.
+type Piece struct {
+	Type int `json:"type"`
+	Rot int `json:"rot"`
+	X int `json:"x"`
+	Y int `json:"y"`
+}
+
+// TetrisInput is the user-facing input type.
+type TetrisInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// TetrisProps is the props type for the Tetris component.
+type TetrisProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Board [][]int `json:"board"`
+	Piece interface{} `json:"piece"`
+	NextType int `json:"nextType"`
+	Score int `json:"score"`
+	Lines int `json:"lines"`
+	Level int `json:"level"`
+	Running bool `json:"running"`
+	Paused bool `json:"paused"`
+	GameOver bool `json:"gameOver"`
+	Display [][]int `json:"display"`
+	Preview int `json:"preview"`
 }
 
 // TextEscapeInput is the user-facing input type.
@@ -736,6 +809,26 @@ func NewFormProps(in FormInput) FormProps {
 	}
 }
 
+// NewMarkdownEditorProps creates MarkdownEditorProps from MarkdownEditorInput.
+func NewMarkdownEditorProps(in MarkdownEditorInput) MarkdownEditorProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "MarkdownEditor_" + randomID(6)
+	}
+
+	return MarkdownEditorProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Text: nil,
+		Blocks: nil,
+		CharCount: 0,
+		WordCount: 0,
+		LineCount: 0,
+		ReadMinutes: 0,
+	}
+}
+
 // NewNestedCondToggleListProps creates NestedCondToggleListProps from NestedCondToggleListInput.
 func NewNestedCondToggleListProps(in NestedCondToggleListInput) NestedCondToggleListProps {
 	scopeID := in.ScopeID
@@ -873,6 +966,31 @@ func NewPropsReactivityComparisonProps(in PropsReactivityComparisonInput) PropsR
 			Value: 1,
 			Label: "Destructured",
 		}),
+	}
+}
+
+// NewTetrisProps creates TetrisProps from TetrisInput.
+func NewTetrisProps(in TetrisInput) TetrisProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "Tetris_" + randomID(6)
+	}
+
+	return TetrisProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Board: nil,
+		Piece: nil,
+		NextType: 0,
+		Score: 0,
+		Lines: 0,
+		Level: 1,
+		Running: false,
+		Paused: false,
+		GameOver: false,
+		Display: nil,
+		Preview: 0,
 	}
 }
 

--- a/integrations/shared/components/MarkdownEditor.tsx
+++ b/integrations/shared/components/MarkdownEditor.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+// Live Markdown editor — a compact BarefootJS onboarding showcase.
+//
+// What it demonstrates:
+//   - A single source-of-truth signal (`text`) driving several derived views.
+//   - `createMemo` for parsing + stats that recompute only when `text` changes.
+//   - Reactive list rendering (`blocks().map(...)`) for the live preview, the
+//     same pattern as TodoApp but producing block elements instead of items.
+//   - Plain (non-reactive) event handlers doing textarea manipulation, showing
+//     that heavy imperative logic lives in ordinary functions, not the graph.
+
+import { createSignal, createMemo } from '@barefootjs/client'
+
+type Seg = { bold: boolean; text: string }
+// Every block renders through the SAME shape — a <div> with a precomputed
+// className plus a list of inline segments. Keeping one uniform shape lets the
+// preview map be a single JSX expression (like Tetris's grid), which is the
+// form the compiler lowers cleanly; a map callback with a statement body and
+// several `if`-returns is NOT lowered and emits broken client JS.
+type Block = { cls: string; segs: Seg[] }
+
+// Split a line into alternating plain / bold segments on `**`. Even indices are
+// plain, odd indices are bold — rendered as <strong> in the preview. Segments
+// are precomputed here (in the parser, part of the reactive `blocks` memo) so
+// the preview renders them with a plain nested `.map`, no child component — a
+// prop-driven child would sever reactivity on the client.
+function splitBold(text: string): Seg[] {
+  return text.split('**').map((seg, i) => ({ bold: i % 2 === 1, text: seg }))
+}
+
+// Block-level Markdown parser. Kept deliberately small — no inline HTML, no
+// third-party dependency — so the whole example stays readable end to end.
+function parseBlocks(src: string): Block[] {
+  const out: Block[] = []
+  const lines = src.split('\n')
+  let inCode = false
+  for (const line of lines) {
+    const fence = line.trimStart().startsWith('```')
+    if (fence) {
+      inCode = !inCode
+      continue
+    }
+    if (inCode) {
+      // Preserve the raw line (including leading spaces) as a single segment.
+      out.push({ cls: 'md-blk md-code', segs: [{ bold: false, text: line }] })
+      continue
+    }
+    const trimmed = line.trim()
+    if (trimmed === '') {
+      out.push({ cls: 'md-blk md-gap', segs: [] })
+      continue
+    }
+    const heading = trimmed.match(/^(#{1,6})\s+(.*)$/)
+    if (heading) {
+      out.push({ cls: `md-blk md-h md-h${heading[1].length}`, segs: splitBold(heading[2]) })
+      continue
+    }
+    if (trimmed.startsWith('> ')) {
+      out.push({ cls: 'md-blk md-quote', segs: splitBold(trimmed.slice(2)) })
+      continue
+    }
+    if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
+      out.push({ cls: 'md-blk md-li', segs: splitBold(trimmed.slice(2)) })
+      continue
+    }
+    out.push({ cls: 'md-blk md-p', segs: splitBold(trimmed) })
+  }
+  return out
+}
+
+const SAMPLE = `# BarefootJS Markdown Editor
+
+Type on the **left**, see it rendered on the **right**.
+Everything updates through a single \`text\` signal.
+
+## Features
+
+- Live preview via reactive memos
+- Word, character and line counters
+- **Bold** inline formatting
+- Toolbar shortcuts
+
+> No virtual DOM. Only the nodes that change are touched.
+
+\`\`\`
+const [text, setText] = createSignal(SAMPLE)
+\`\`\`
+`
+
+export function MarkdownEditor() {
+  const [text, setText] = createSignal(SAMPLE)
+
+  const blocks = createMemo(() => parseBlocks(text()))
+  const charCount = createMemo(() => text().length)
+  const wordCount = createMemo(() => {
+    const t = text().trim()
+    return t === '' ? 0 : t.split(/\s+/).length
+  })
+  const lineCount = createMemo(() => text().split('\n').length)
+  const readMinutes = createMemo(() => Math.max(1, Math.ceil(wordCount() / 200)))
+
+  // Insert text around the current textarea selection. Pure imperative DOM work
+  // — it reads/writes the element directly and then syncs the signal.
+  const wrapSelection = (before: string, after: string) => {
+    const el = document.getElementById('md-input') as HTMLTextAreaElement | null
+    if (!el) return
+    const start = el.selectionStart
+    const end = el.selectionEnd
+    const value = el.value
+    const selected = value.slice(start, end)
+    const next = value.slice(0, start) + before + selected + after + value.slice(end)
+    setText(next)
+    el.focus()
+    const caret = start + before.length + selected.length
+    // Restore the caret after the runtime flushes the new value.
+    requestAnimationFrame(() => {
+      el.selectionStart = caret
+      el.selectionEnd = caret
+    })
+  }
+
+  return (
+    <div className="md-editor">
+      <div className="md-toolbar">
+        <button className="md-btn" onClick={() => wrapSelection('**', '**')}>Bold</button>
+        <button className="md-btn" onClick={() => wrapSelection('# ', '')}>H1</button>
+        <button className="md-btn" onClick={() => wrapSelection('## ', '')}>H2</button>
+        <button className="md-btn" onClick={() => wrapSelection('- ', '')}>List</button>
+        <button className="md-btn" onClick={() => wrapSelection('> ', '')}>Quote</button>
+        <button className="md-btn" onClick={() => wrapSelection('`', '`')}>Code</button>
+        <button className="md-btn md-btn-danger" onClick={() => setText('')}>Clear</button>
+      </div>
+
+      <div className="md-panes">
+        <textarea
+          id="md-input"
+          className="md-input"
+          spellcheck={false}
+          value={text()}
+          onInput={(e) => setText(e.target.value)}
+          placeholder="Write some Markdown…"
+        />
+
+        <div className="md-preview">
+          {blocks().map((block, i) => (
+            <div className={block.cls} key={i}>
+              {block.segs.map((seg, j) =>
+                seg.bold ? <strong key={j}>{seg.text}</strong> : <span key={j}>{seg.text}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="md-stats">
+        <span className="md-stat"><strong>{wordCount()}</strong> words</span>
+        <span className="md-stat"><strong>{charCount()}</strong> characters</span>
+        <span className="md-stat"><strong>{lineCount()}</strong> lines</span>
+        <span className="md-stat">~<strong>{readMinutes()}</strong> min read</span>
+      </div>
+    </div>
+  )
+}
+
+export default MarkdownEditor

--- a/integrations/shared/components/Tetris.tsx
+++ b/integrations/shared/components/Tetris.tsx
@@ -1,0 +1,341 @@
+'use client'
+
+// Tetris — the "can a signal framework really drive a game loop?" onboarding
+// showcase for BarefootJS.
+//
+// What it demonstrates:
+//   - A game loop (self-scheduling setTimeout) mutating signals every tick.
+//   - Document-level keyboard handling wired up in `onMount`.
+//   - A derived `display` memo that overlays the falling piece on the settled
+//     board, rendered as a reactive 10×20 grid (nested `.map`).
+//   - All the game rules (collision, rotation, line-clears) live in ordinary
+//     functions — only the JSX reads signals, so the reactive graph stays tiny.
+
+import { createSignal, createMemo, onMount } from '@barefootjs/client'
+
+const COLS = 10
+const ROWS = 20
+
+// Each tetromino is a list of rotation states; a rotation is its 4 filled
+// cells as [col, row] inside a small box. Colours are keyed by piece index + 1
+// (0 means empty) and mapped to `.t-c1`…`.t-c7` classes in the stylesheet.
+type Cell = [number, number]
+const SHAPES: Cell[][][] = [
+  // I
+  [
+    [[0, 1], [1, 1], [2, 1], [3, 1]],
+    [[2, 0], [2, 1], [2, 2], [2, 3]],
+    [[0, 2], [1, 2], [2, 2], [3, 2]],
+    [[1, 0], [1, 1], [1, 2], [1, 3]],
+  ],
+  // J
+  [
+    [[0, 0], [0, 1], [1, 1], [2, 1]],
+    [[1, 0], [2, 0], [1, 1], [1, 2]],
+    [[0, 1], [1, 1], [2, 1], [2, 2]],
+    [[1, 0], [1, 1], [0, 2], [1, 2]],
+  ],
+  // L
+  [
+    [[2, 0], [0, 1], [1, 1], [2, 1]],
+    [[1, 0], [1, 1], [1, 2], [2, 2]],
+    [[0, 1], [1, 1], [2, 1], [0, 2]],
+    [[0, 0], [1, 0], [1, 1], [1, 2]],
+  ],
+  // O
+  [
+    [[1, 0], [2, 0], [1, 1], [2, 1]],
+    [[1, 0], [2, 0], [1, 1], [2, 1]],
+    [[1, 0], [2, 0], [1, 1], [2, 1]],
+    [[1, 0], [2, 0], [1, 1], [2, 1]],
+  ],
+  // S
+  [
+    [[1, 0], [2, 0], [0, 1], [1, 1]],
+    [[1, 0], [1, 1], [2, 1], [2, 2]],
+    [[1, 1], [2, 1], [0, 2], [1, 2]],
+    [[0, 0], [0, 1], [1, 1], [1, 2]],
+  ],
+  // T
+  [
+    [[1, 0], [0, 1], [1, 1], [2, 1]],
+    [[1, 0], [1, 1], [2, 1], [1, 2]],
+    [[0, 1], [1, 1], [2, 1], [1, 2]],
+    [[1, 0], [0, 1], [1, 1], [1, 2]],
+  ],
+  // Z
+  [
+    [[0, 0], [1, 0], [1, 1], [2, 1]],
+    [[2, 0], [1, 1], [2, 1], [1, 2]],
+    [[0, 1], [1, 1], [1, 2], [2, 2]],
+    [[1, 0], [0, 1], [1, 1], [0, 2]],
+  ],
+]
+
+type Piece = { type: number; rot: number; x: number; y: number }
+
+function emptyBoard(): number[][] {
+  return Array.from({ length: ROWS }, () => Array<number>(COLS).fill(0))
+}
+
+function randomType(): number {
+  return Math.floor(Math.random() * SHAPES.length)
+}
+
+export function Tetris() {
+  const [board, setBoard] = createSignal<number[][]>(emptyBoard())
+  const [piece, setPiece] = createSignal<Piece | null>(null)
+  const [nextType, setNextType] = createSignal<number>(randomType())
+  const [score, setScore] = createSignal(0)
+  const [lines, setLines] = createSignal(0)
+  const [level, setLevel] = createSignal(1)
+  const [running, setRunning] = createSignal(false)
+  const [paused, setPaused] = createSignal(false)
+  const [gameOver, setGameOver] = createSignal(false)
+
+  // Instance-scoped loop handle. The component init runs once per mount, so a
+  // plain closure variable is the natural "ref" for the pending timer.
+  let dropTimer: ReturnType<typeof setTimeout> | null = null
+
+  // Collision test for a hypothetical piece placement.
+  const collides = (b: number[][], type: number, rot: number, px: number, py: number): boolean => {
+    for (const [cx, cy] of SHAPES[type][rot]) {
+      const x = px + cx
+      const y = py + cy
+      if (x < 0 || x >= COLS || y >= ROWS) return true
+      if (y >= 0 && b[y][x] !== 0) return true
+    }
+    return false
+  }
+
+  // Display grid = settled board with the active piece painted on top.
+  const display = createMemo(() => {
+    const grid = board().map((row) => row.slice())
+    const p = piece()
+    if (p) {
+      for (const [cx, cy] of SHAPES[p.type][p.rot]) {
+        const x = p.x + cx
+        const y = p.y + cy
+        if (y >= 0 && y < ROWS && x >= 0 && x < COLS) grid[y][x] = p.type + 1
+      }
+    }
+    return grid
+  })
+
+  // Preview grid for the "next" piece, drawn in a fixed 4×4 box.
+  const preview = createMemo(() => {
+    const grid = Array.from({ length: 4 }, () => Array<number>(4).fill(0))
+    for (const [cx, cy] of SHAPES[nextType()][0]) {
+      grid[cy][cx] = nextType() + 1
+    }
+    return grid
+  })
+
+  const spawn = () => {
+    const type = nextType()
+    setNextType(randomType())
+    const p: Piece = { type, rot: 0, x: 3, y: 0 }
+    if (collides(board(), p.type, p.rot, p.x, p.y)) {
+      // No room for a new piece — the stack reached the top.
+      setPiece(null)
+      setRunning(false)
+      setGameOver(true)
+      if (dropTimer) clearTimeout(dropTimer)
+      return
+    }
+    setPiece(p)
+  }
+
+  // Merge the active piece into the board, clear full rows, and score.
+  const lockPiece = () => {
+    const p = piece()
+    if (!p) return
+    const b = board().map((row) => row.slice())
+    for (const [cx, cy] of SHAPES[p.type][p.rot]) {
+      const x = p.x + cx
+      const y = p.y + cy
+      if (y >= 0 && y < ROWS && x >= 0 && x < COLS) b[y][x] = p.type + 1
+    }
+    const kept = b.filter((row) => row.some((c) => c === 0))
+    const cleared = ROWS - kept.length
+    while (kept.length < ROWS) kept.unshift(Array<number>(COLS).fill(0))
+    setBoard(kept)
+    if (cleared > 0) {
+      const points = [0, 100, 300, 500, 800][cleared] * level()
+      const total = lines() + cleared
+      setScore(score() + points)
+      setLines(total)
+      setLevel(Math.floor(total / 10) + 1)
+    }
+    spawn()
+  }
+
+  const tick = () => {
+    const p = piece()
+    if (!p) return
+    if (!collides(board(), p.type, p.rot, p.x, p.y + 1)) {
+      setPiece({ ...p, y: p.y + 1 })
+    } else {
+      lockPiece()
+    }
+  }
+
+  // Self-scheduling loop: reschedules itself at the current level's speed so a
+  // level-up speeds the fall without juggling multiple intervals.
+  const scheduleDrop = () => {
+    if (dropTimer) clearTimeout(dropTimer)
+    if (!running() || paused() || gameOver()) return
+    const speed = Math.max(90, 800 - (level() - 1) * 70)
+    dropTimer = setTimeout(() => {
+      tick()
+      scheduleDrop()
+    }, speed)
+  }
+
+  const move = (dx: number) => {
+    const p = piece()
+    if (!p || paused() || gameOver()) return
+    if (!collides(board(), p.type, p.rot, p.x + dx, p.y)) {
+      setPiece({ ...p, x: p.x + dx })
+    }
+  }
+
+  const softDrop = () => {
+    if (!running() || paused() || gameOver()) return
+    tick()
+    scheduleDrop()
+  }
+
+  const rotate = () => {
+    const p = piece()
+    if (!p || paused() || gameOver()) return
+    const rot = (p.rot + 1) % 4
+    // Basic wall-kick: try in place, then nudged left/right.
+    for (const kick of [0, -1, 1, -2, 2]) {
+      if (!collides(board(), p.type, rot, p.x + kick, p.y)) {
+        setPiece({ ...p, rot, x: p.x + kick })
+        return
+      }
+    }
+  }
+
+  const hardDrop = () => {
+    const p = piece()
+    if (!p || paused() || gameOver()) return
+    let y = p.y
+    while (!collides(board(), p.type, p.rot, p.x, y + 1)) y++
+    setScore(score() + (y - p.y) * 2)
+    setPiece({ ...p, y })
+    lockPiece()
+    scheduleDrop()
+  }
+
+  const start = () => {
+    setBoard(emptyBoard())
+    setScore(0)
+    setLines(0)
+    setLevel(1)
+    setGameOver(false)
+    setPaused(false)
+    setNextType(randomType())
+    setRunning(true)
+    spawn()
+    scheduleDrop()
+  }
+
+  const togglePause = () => {
+    if (!running() || gameOver()) return
+    setPaused(!paused())
+    scheduleDrop()
+  }
+
+  onMount(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!running() || gameOver()) return
+      const k = e.key
+      if (k === 'ArrowLeft') { move(-1); e.preventDefault() }
+      else if (k === 'ArrowRight') { move(1); e.preventDefault() }
+      else if (k === 'ArrowDown') { softDrop(); e.preventDefault() }
+      else if (k === 'ArrowUp') { rotate(); e.preventDefault() }
+      else if (k === ' ') { hardDrop(); e.preventDefault() }
+      else if (k === 'p' || k === 'P') { togglePause() }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      if (dropTimer) clearTimeout(dropTimer)
+    }
+  })
+
+  return (
+    <div className="tetris">
+      <div className="t-main">
+        <div className="t-board">
+          {display().map((row, y) => (
+            <div className="t-row" key={y}>
+              {row.map((cell, x) => (
+                <div className={`t-cell ${cell ? 't-c' + cell : 't-empty'}`} key={x} />
+              ))}
+            </div>
+          ))}
+
+          {gameOver() && (
+            <div className="t-overlay">
+              <p className="t-overlay-title">Game Over</p>
+              <button className="t-btn t-btn-primary" onClick={start}>Play again</button>
+            </div>
+          )}
+          {paused() && !gameOver() && (
+            <div className="t-overlay">
+              <p className="t-overlay-title">Paused</p>
+              <button className="t-btn" onClick={togglePause}>Resume</button>
+            </div>
+          )}
+          {!running() && !gameOver() && (
+            <div className="t-overlay">
+              <p className="t-overlay-title">BarefootJS Tetris</p>
+              <button className="t-btn t-btn-primary" onClick={start}>Start</button>
+            </div>
+          )}
+        </div>
+
+        <aside className="t-side">
+          <div className="t-panel">
+            <span className="t-label">Score</span>
+            <span className="t-value">{score()}</span>
+          </div>
+          <div className="t-panel">
+            <span className="t-label">Lines</span>
+            <span className="t-value">{lines()}</span>
+          </div>
+          <div className="t-panel">
+            <span className="t-label">Level</span>
+            <span className="t-value">{level()}</span>
+          </div>
+          <div className="t-panel">
+            <span className="t-label">Next</span>
+            <div className="t-preview">
+              {preview().map((row, y) => (
+                <div className="t-row" key={y}>
+                  {row.map((cell, x) => (
+                    <div className={`t-mini ${cell ? 't-c' + cell : 't-empty'}`} key={x} />
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="t-controls">
+            <button className="t-btn" onClick={togglePause}>{paused() ? 'Resume' : 'Pause'}</button>
+            <button className="t-btn" onClick={start}>Restart</button>
+          </div>
+        </aside>
+      </div>
+
+      <p className="t-hint">
+        ← → move · ↑ rotate · ↓ soft drop · Space hard drop · P pause
+      </p>
+    </div>
+  )
+}
+
+export default Tetris

--- a/integrations/shared/e2e/markdown-editor.spec.ts
+++ b/integrations/shared/e2e/markdown-editor.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared Markdown Editor Component E2E Tests
+ *
+ * Exports a test function adapter integrations import with their base URL.
+ */
+
+import { test, expect } from '@playwright/test'
+
+export function markdownEditorTests(baseUrl: string) {
+  test.describe('Markdown Editor Component', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`${baseUrl}/editor`)
+    })
+
+    test('renders the sample document in the preview', async ({ page }) => {
+      await expect(
+        page.locator('.md-preview .md-h1').first()
+      ).toContainText('BarefootJS Markdown Editor')
+    })
+
+    test('typing updates the preview live', async ({ page }) => {
+      const input = page.locator('.md-input')
+      await input.fill('# Hello World')
+      await expect(page.locator('.md-preview .md-h1')).toHaveText('Hello World')
+    })
+
+    test('word and character counters react to input', async ({ page }) => {
+      const input = page.locator('.md-input')
+      await input.fill('one two three')
+
+      const stats = page.locator('.md-stats')
+      await expect(stats).toContainText('3 words')
+      await expect(stats).toContainText('13 characters')
+    })
+
+    test('renders bold inline formatting', async ({ page }) => {
+      await page.locator('.md-input').fill('a **bold** word')
+      await expect(page.locator('.md-preview strong')).toHaveText('bold')
+    })
+
+    test('renders list items with bullets', async ({ page }) => {
+      await page.locator('.md-input').fill('- first\n- second')
+      await expect(page.locator('.md-preview .md-li')).toHaveCount(2)
+    })
+
+    test('renders blockquotes', async ({ page }) => {
+      await page.locator('.md-input').fill('> quoted text')
+      await expect(page.locator('.md-preview .md-quote')).toHaveText('quoted text')
+    })
+
+    test('Clear button empties the editor', async ({ page }) => {
+      await page.getByRole('button', { name: 'Clear' }).click()
+      await expect(page.locator('.md-input')).toHaveValue('')
+      await expect(page.locator('.md-stats')).toContainText('0 words')
+    })
+
+    test('Bold toolbar button inserts markers', async ({ page }) => {
+      const input = page.locator('.md-input')
+      await input.fill('')
+      await page.getByRole('button', { name: 'Bold', exact: true }).click()
+      await expect(input).toHaveValue('****')
+    })
+  })
+}

--- a/integrations/shared/e2e/tetris.spec.ts
+++ b/integrations/shared/e2e/tetris.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared Tetris Component E2E Tests
+ *
+ * Exports a test function adapter integrations import with their base URL.
+ */
+
+import { test, expect } from '@playwright/test'
+
+export function tetrisTests(baseUrl: string) {
+  test.describe('Tetris Component', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`${baseUrl}/tetris`)
+    })
+
+    test('renders a 10×20 board grid after hydration', async ({ page }) => {
+      // 20 rows of 10 cells = 200 cells.
+      await expect(page.locator('.t-board .t-cell')).toHaveCount(200)
+    })
+
+    test('shows the start overlay before the game begins', async ({ page }) => {
+      await expect(page.locator('.t-overlay-title')).toHaveText('BarefootJS Tetris')
+    })
+
+    test('starting the game hides the overlay and spawns a piece', async ({ page }) => {
+      await page.getByRole('button', { name: 'Start', exact: true }).click()
+      await expect(page.locator('.t-overlay')).toHaveCount(0)
+      // A spawned piece paints at least one coloured cell (classes t-c1..t-c7).
+      await expect
+        .poll(async () =>
+          page.locator('.t-board .t-cell[class*="t-c"]').count()
+        )
+        .toBeGreaterThan(0)
+    })
+
+    test('a falling piece moves down over time', async ({ page }) => {
+      await page.getByRole('button', { name: 'Start', exact: true }).click()
+
+      // Capture which cells are filled, wait for a tick, and confirm the
+      // filled set changed (the piece descended).
+      const filledSignature = async () =>
+        page.evaluate(() =>
+          Array.from(document.querySelectorAll('.t-board .t-cell'))
+            .map((el, i) => (/t-c[1-7]/.test(el.className) ? i : -1))
+            .filter((i) => i >= 0)
+            .join(',')
+        )
+
+      const before = await filledSignature()
+      await expect.poll(filledSignature, { timeout: 3000 }).not.toBe(before)
+    })
+
+    test('score panel starts at zero', async ({ page }) => {
+      const scorePanel = page.locator('.t-panel', { hasText: 'Score' })
+      await expect(scorePanel.locator('.t-value')).toHaveText('0')
+    })
+
+    test('left/right arrow keys move the active piece horizontally', async ({ page }) => {
+      await page.getByRole('button', { name: 'Start', exact: true }).click()
+
+      // Columns occupied by the active piece (0..9), derived from filled indices.
+      const columns = async () =>
+        page.evaluate(() => {
+          const cells = Array.from(document.querySelectorAll('.t-board .t-cell'))
+          const cols = new Set<number>()
+          cells.forEach((el, i) => {
+            if (/t-c[1-7]/.test(el.className)) cols.add(i % 10)
+          })
+          return [...cols].sort((a, b) => a - b).join(',')
+        })
+
+      const before = await columns()
+      await page.keyboard.press('ArrowRight')
+      await expect.poll(columns).not.toBe(before)
+    })
+
+    test('pause overlay appears and resumes', async ({ page }) => {
+      await page.getByRole('button', { name: 'Start', exact: true }).click()
+      await page.locator('.t-controls').getByRole('button', { name: 'Pause' }).click()
+      await expect(page.locator('.t-overlay-title')).toHaveText('Paused')
+      await page.locator('.t-controls').getByRole('button', { name: 'Resume' }).click()
+      await expect(page.locator('.t-overlay')).toHaveCount(0)
+    })
+  })
+}

--- a/integrations/shared/styles/markdown-editor.css
+++ b/integrations/shared/styles/markdown-editor.css
@@ -1,0 +1,153 @@
+/**
+ * Markdown editor example styles. Theme-aware via tokens.css.
+ */
+
+.md-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 900px;
+  font-family: var(--font-sans);
+  color: var(--foreground);
+}
+
+.md-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.md-btn {
+  padding: 6px 12px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--secondary-foreground);
+  background: var(--secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: filter var(--duration-fast);
+}
+
+.md-btn:hover {
+  filter: brightness(1.1);
+}
+
+.md-btn-danger {
+  margin-left: auto;
+  color: var(--destructive-foreground);
+  background: var(--destructive);
+  border-color: transparent;
+}
+
+.md-panes {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+  min-height: 340px;
+}
+
+@media (max-width: 640px) {
+  .md-panes {
+    grid-template-columns: 1fr;
+  }
+}
+
+.md-input {
+  width: 100%;
+  min-height: 340px;
+  padding: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--foreground);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.md-input:focus {
+  outline: 2px solid var(--ring);
+  outline-offset: -1px;
+}
+
+.md-preview {
+  padding: var(--space-4);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow-y: auto;
+  line-height: 1.6;
+}
+
+/* Every preview block is a `.md-blk` div; the second class selects its look. */
+.md-h {
+  font-weight: 700;
+  letter-spacing: var(--tracking-tight);
+  margin: 0.6em 0 0.3em;
+  line-height: 1.25;
+}
+.md-h1 { font-size: 1.7rem; }
+.md-h2 { font-size: 1.4rem; }
+.md-h3 { font-size: 1.2rem; }
+.md-h4, .md-h5, .md-h6 { font-size: 1.05rem; }
+
+.md-p {
+  margin: 0.4em 0;
+}
+
+.md-li {
+  position: relative;
+  margin: 0.2em 0 0.2em 1.2em;
+}
+
+.md-li::before {
+  content: "•";
+  position: absolute;
+  left: -1.1em;
+  color: var(--gradient-start);
+  font-weight: 700;
+}
+
+.md-quote {
+  margin: 0.5em 0;
+  padding: 0.3em 0.9em;
+  border-left: 3px solid var(--gradient-start);
+  color: var(--muted-foreground);
+  font-style: italic;
+}
+
+.md-code {
+  margin: 0;
+  padding: 0.1em 0.6em;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  background: var(--muted);
+  color: var(--foreground);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.md-gap {
+  height: 0.5em;
+}
+
+.md-preview strong {
+  font-weight: 700;
+}
+
+.md-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  padding: var(--space-2) 0;
+  font-size: 0.85rem;
+  color: var(--muted-foreground);
+}
+
+.md-stat strong {
+  color: var(--foreground);
+  font-family: var(--font-mono);
+}

--- a/integrations/shared/styles/tetris.css
+++ b/integrations/shared/styles/tetris.css
@@ -1,0 +1,164 @@
+/**
+ * Tetris example styles. Colours come from tokens.css so the board works in
+ * both light and dark themes; the seven piece colours are fixed hues.
+ */
+
+.tetris {
+  display: inline-flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  font-family: var(--font-sans);
+  color: var(--foreground);
+}
+
+.t-main {
+  display: flex;
+  gap: var(--space-5);
+  align-items: flex-start;
+}
+
+.t-board {
+  position: relative;
+  display: grid;
+  grid-template-rows: repeat(20, 1fr);
+  gap: 1px;
+  padding: 6px;
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+}
+
+.t-row {
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  gap: 1px;
+}
+
+.t-preview .t-row {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.t-cell {
+  width: 22px;
+  height: 22px;
+  border-radius: 3px;
+}
+
+.t-mini {
+  width: 14px;
+  height: 14px;
+  border-radius: 2px;
+}
+
+.t-empty {
+  background: var(--background);
+  opacity: 0.35;
+}
+
+/* Piece colours — indices match `type + 1` in the component. */
+.t-c1 { background: #22d3ee; } /* I */
+.t-c2 { background: #3b82f6; } /* J */
+.t-c3 { background: #f97316; } /* L */
+.t-c4 { background: #eab308; } /* O */
+.t-c5 { background: #22c55e; } /* S */
+.t-c6 { background: #a855f7; } /* T */
+.t-c7 { background: #ef4444; } /* Z */
+
+.t-cell.t-c1, .t-cell.t-c2, .t-cell.t-c3, .t-cell.t-c4,
+.t-cell.t-c5, .t-cell.t-c6, .t-cell.t-c7 {
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.25),
+              inset 0 -3px 4px rgb(0 0 0 / 0.25);
+}
+
+.t-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-4);
+  background: color-mix(in oklab, var(--background) 82%, transparent);
+  backdrop-filter: blur(2px);
+  border-radius: var(--radius-md);
+}
+
+.t-overlay-title {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+  letter-spacing: var(--tracking-tight);
+}
+
+.t-side {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-width: 140px;
+}
+
+.t-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-3);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.t-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  color: var(--muted-foreground);
+}
+
+.t-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  font-family: var(--font-mono);
+}
+
+.t-preview {
+  display: grid;
+  grid-template-rows: repeat(4, 1fr);
+  gap: 1px;
+  margin-top: 4px;
+}
+
+.t-controls {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.t-btn {
+  flex: 1;
+  padding: 8px 12px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--secondary-foreground);
+  background: var(--secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: filter var(--duration-fast);
+}
+
+.t-btn:hover {
+  filter: brightness(1.1);
+}
+
+.t-btn-primary {
+  color: var(--primary-foreground);
+  background: var(--gradient-start);
+  border-color: transparent;
+}
+
+.t-hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--muted-foreground);
+  text-align: center;
+}


### PR DESCRIPTION
## Summary

Two new onboarding showcases for the shared integration examples, aimed at making BarefootJS's capabilities easier to grasp for newcomers. Both live in `integrations/shared/components` (so every adapter compiles them) and are wired into the Hono example with routes, styles, and e2e coverage.

### 🎮 Tetris — a game loop on signals
`integrations/shared/components/Tetris.tsx`

Demonstrates that signal-based reactivity can drive a real-time game:
- A **self-scheduling `setTimeout` drop loop** that re-arms at the current level's speed.
- **Document-level keyboard controls** wired up in `onMount` (← → move · ↑ rotate · ↓ soft drop · Space hard drop · P pause).
- A derived **`display` memo** that overlays the falling piece on the settled board, rendered as a reactive **10×20 grid** (nested `.map`).
- All game rules (collision, rotation, wall-kicks, line clears, scoring, levels) live in **plain functions** — only the JSX reads signals, so the reactive graph stays small. SSR pre-renders the full board (no hydration layout shift).

### 📝 Markdown editor — one signal, many derived views
`integrations/shared/components/MarkdownEditor.tsx`

Demonstrates fine-grained derivation from a single source of truth:
- A single `text` signal drives a **live block-level preview** plus **word / character / line / read-time** counters, all through `createMemo`.
- The preview is one reactive list of **uniform blocks**, so the map lowers to a single JSX expression; inline **bold** segments render from a nested map over data **precomputed in the parser** (rather than a prop-driven child component, which severs client reactivity).
- Toolbar buttons (Bold / H1 / H2 / List / Quote / Code / Clear) do imperative textarea manipulation, showing heavy logic living outside the reactive graph.

## Testing

- Added shared e2e suites (`integrations/shared/e2e/{tetris,markdown-editor}.spec.ts`) and Hono wiring specs — covering hydration, keyboard input, the game loop / piece movement, live preview, counters, and inline formatting.
- Full Hono e2e suite green (**119/119**, including the 15 new tests).
- Verified the two shared components compile cleanly under the CSR, Go-template (echo), and Perl (mojolicious) adapters in addition to Hono.

## Generated files

Regenerated the four Go integrations' committed `components.go` (`chi`, `echo`, `gin`, `nethttp`) for the two new shared components, to satisfy the Go-template CI drift gate.

## Notes

- No changeset: changes are confined to `integrations/`, not published `packages/*/src`.
- While building the editor I hit a compiler gap worth a follow-up: a `.map()` callback with a **statement body containing multiple `if`-returns of JSX** is not lowered — it emits raw JSX into the client bundle (a runtime `SyntaxError`) instead of erroring at compile time. The examples here use the supported single-JSX-expression form; flagging separately in case it's worth a diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FG9KVo7k7nmVkvpuDXKCaC)_