### PR TITLE
Lower .map() if-chain callbacks to a per-item conditional

### DIFF
--- a/.changeset/bf026-list-callback-block-body.md
+++ b/.changeset/bf026-list-callback-block-body.md
@@ -1,0 +1,19 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Lower `.map()` callbacks with an if-chain of JSX returns to a per-item conditional.
+
+A list-render callback with a statement-block body that returns JSX from multiple branches —
+
+```tsx
+blocks().map((block, i) => {
+  if (block.kind === 'code') return <pre key={i}>{block.text}</pre>
+  if (block.kind === 'quote') return <blockquote key={i}>{block.text}</blockquote>
+  return <p key={i}>{block.text}</p>
+})
+```
+
+— now compiles and runs: the if / else-if / else (or `switch`) chain is lowered into a nested `IRConditional`, the same representation a ternary map body produces, reusing the analyzer's `extractMultiReturnJsxBranches` (already used to inline multi-return JSX helpers) plus a shared `foldMultiReturnBranches` fold. Previously the compiler kept only the single top-level `return` as the per-item template and swept the other `if (...) return <JSX/>` branches into the loop preamble as raw text, leaking JSX into the client bundle (`Unexpected token '<'` at hydrate) with the build still reporting success.
+
+The new `BF026` (`UNSUPPORTED_LIST_CALLBACK_BODY`) diagnostic now fires only for the residual shapes the chain extractor cannot lower — a branching JSX return mixed with a local `const`/`let`, or nested control flow inside a branch — turning what remains of the silent mis-lowering into a loud, actionable compile error (code frame + rewrite guidance) with a benign placeholder so the erroring output never carries raw JSX. Supported single-expression / ternary / logical callback forms, JSX call arguments (`createPortal(<div/>, …)`), and single-return blocks with a non-JSX preamble are unaffected.

--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -98,7 +98,7 @@ export function Counter() {
 
 ---
 
-## JSX Errors (BF021–BF023)
+## JSX Errors (BF021–BF026)
 
 ### BF021 — Unsupported JSX Pattern
 
@@ -217,6 +217,80 @@ backend cannot compute, and dies at render time the same way.
 {items().map(item => <li key={item.id}>{item.name}</li>)}
 ```
 
+### BF026 — Unsupported List-Render Callback Body
+
+A `.map()` callback whose body is an **if / else-if / else (or `switch`) chain
+of direct JSX returns** is lowered to a per-item conditional (the same shape a
+ternary map body produces), so the natural multi-branch form works:
+
+```tsx
+// ✅ if-chain in a .map() callback — lowered to a per-item conditional
+{blocks().map((block, i) => {
+  if (block.kind === 'code') return <pre key={i}>{block.text}</pre>
+  if (block.kind === 'quote') return <blockquote key={i}>{block.text}</blockquote>
+  return <p key={i}>{block.text}</p>
+})}
+
+// ✅ switch with a default also works
+{blocks().map((block, i) => {
+  switch (block.kind) {
+    case 'code': return <pre key={i}>{block.text}</pre>
+    default: return <p key={i}>{block.text}</p>
+  }
+})}
+```
+
+**Trigger:** BF026 fires only when such a body **cannot** be lowered — when the
+branching JSX returns are mixed with a **local variable declaration** or
+**nested control flow** inside a branch. Those can't collapse into a per-item
+conditional, and left alone would leak raw JSX into the client bundle
+(`Unexpected token '<'` at hydrate) while the build still reported success.
+
+```tsx
+// ❌ BF026 — a preamble const alongside branching JSX returns
+{items().map((item, i) => {
+  const label = item.name.toUpperCase()
+  if (item.a) return <li key={i} className="a">{label}</li>
+  return <li key={i}>{label}</li>
+})}
+
+// ❌ BF026 — nested control flow inside a branch
+{items().map((item, i) => {
+  if (item.a) {
+    let n = 0
+    for (const x of item.xs) n += x
+    return <li key={i}>{n}</li>
+  }
+  return <li key={i}>{item.id}</li>
+})}
+```
+
+**Fix:** keep each branch a direct `return <JSX/>` and move per-item
+computation into the array before mapping (or into the returned JSX
+expression):
+
+```tsx
+// ✅ precompute in a memo, then branch on plain fields
+const rows = createMemo(() =>
+  items().map(item => ({ ...item, label: item.name.toUpperCase() }))
+)
+// ...
+{rows().map((row, i) => {
+  if (row.a) return <li key={i} className="a">{row.label}</li>
+  return <li key={i}>{row.label}</li>
+})}
+```
+
+A non-JSX preamble with a *single* return is also fine (no branching):
+
+```tsx
+// ✅ single return with a preamble const compiles
+{items().map((item, i) => {
+  const label = item.toUpperCase()
+  return <li key={i}>{label}</li>
+})}
+```
+
 ---
 
 ## Component Errors (BF043–BF044)
@@ -332,6 +406,7 @@ function Component({ checked }: Props) {
 | BF011 | Error | Module-level reactive declaration without `/* @client */` |
 | BF021 | Error | Unsupported JSX pattern for SSR |
 | BF023 | Error | Missing key in list |
+| BF026 | Error | Unsupported `.map()` callback body (block with branching JSX returns) |
 | BF043 | Warning | Props destructuring breaks reactivity |
 | BF044 | Error | Signal/memo getter passed without calling it |
 | BF054 | Error | Built-in `<Async>` / `<Region>` used without `@barefootjs/client` import |

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2005,6 +2005,27 @@
       "axes": [],
       "contexts": []
     },
+    "if-chain-map": {
+      "kinds": [
+        "array-literal",
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "binary:===",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "condition",
+        "loop",
+        "text"
+      ]
+    },
     "if-statement": {
       "kinds": [
         "binary",
@@ -4202,18 +4223,18 @@
     }
   },
   "kindCounts": {
-    "array-literal": 54,
+    "array-literal": 55,
     "array-method": 62,
     "arrow": 55,
-    "binary": 67,
-    "call": 164,
+    "binary": 68,
+    "call": 165,
     "conditional": 19,
-    "identifier": 244,
+    "identifier": 245,
     "index-access": 12,
-    "literal": 202,
+    "literal": 203,
     "logical": 41,
-    "member": 123,
-    "object-literal": 46,
+    "member": 124,
+    "object-literal": 47,
     "template-literal": 27,
     "unary": 22,
     "unsupported": 21
@@ -4250,13 +4271,13 @@
     "binary:-": 11,
     "binary:/": 1,
     "binary:<": 1,
-    "binary:===": 30,
+    "binary:===": 31,
     "binary:>": 11,
     "binary:>=": 1,
     "literal:boolean": 38,
     "literal:null": 22,
     "literal:number": 86,
-    "literal:string": 145,
+    "literal:string": 146,
     "logical:&&": 7,
     "logical:??": 37,
     "logical:||": 12,

--- a/packages/adapter-tests/fixtures/if-chain-map.ts
+++ b/packages/adapter-tests/fixtures/if-chain-map.ts
@@ -1,0 +1,48 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Array `.map(...)` whose callback is a statement-block if-chain of JSX returns.
+ *
+ * `if (kind==='code') return <pre/>; if (kind==='quote') return <blockquote/>;
+ * return <p/>` is lowered to a nested per-item conditional — the same shape a
+ * ternary map body produces — so the natural multi-branch form renders per
+ * item. Regression coverage for the if-chain→conditional lowering (the subset
+ * widening that flipped BF026 from "reject all if-chains" to "reject only what
+ * the extractor can't lower"). Matrix cell: BlockStatement if-chain × `.map`.
+ */
+export const fixture = createFixture({
+  id: 'if-chain-map',
+  description: '.map callback with an if-chain of JSX returns → per-item conditional',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Block = { kind: string; text: string }
+export function IfChainMap() {
+  const [blocks] = createSignal<Block[]>([
+    { kind: 'code', text: 'x' },
+    { kind: 'quote', text: 'y' },
+    { kind: 'para', text: 'z' },
+  ])
+  return (
+    <ul>
+      {blocks().map((b, i) => {
+        if (b.kind === 'code') return <pre key={i}>{b.text}</pre>
+        if (b.kind === 'quote') return <blockquote key={i}>{b.text}</blockquote>
+        return <p key={i}>{b.text}</p>
+      })}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s5">
+      <pre bf-c="s3" data-key="0"><!--bf:s4-->x<!--/--></pre>
+      <!--bf-cond-start:s3-->
+      <blockquote bf-c="s1" data-key="1"><!--bf:s2-->y<!--/--></blockquote>
+      <!--bf-cond-end:s3-->
+      <!--bf-cond-start:s3-->
+      <p bf-c="s1" data-key="2"><!--bf:s0-->z<!--/--></p>
+      <!--bf-cond-end:s3-->
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -148,6 +148,7 @@ import { fixture as nullishCoalescingJsx } from './nullish-coalescing-jsx'
 import { fixture as logicalOrJsx } from './logical-or-jsx'
 import { fixture as branchSelfClosing } from './branch-self-closing'
 import { fixture as branchMap } from './branch-map'
+import { fixture as ifChainMap } from './if-chain-map'
 import { fixture as branchLocalFilterJoin } from './branch-local-filter-join'
 import { fixture as returnLogicalAnd } from './return-logical-and'
 import { fixture as returnLogicalOr } from './return-logical-or'
@@ -503,6 +504,7 @@ export const jsxFixtures: JSXFixture[] = [
   logicalOrJsx,
   branchSelfClosing,
   branchMap,
+  ifChainMap,
   branchLocalFilterJoin,
   returnLogicalAnd,
   returnLogicalOr,

--- a/packages/jsx/src/__tests__/list-callback-block-body.test.ts
+++ b/packages/jsx/src/__tests__/list-callback-block-body.test.ts
@@ -1,0 +1,291 @@
+/**
+ * `.map()` callbacks with a statement-block body.
+ *
+ * An if/else-if/else (or switch) chain of JSX returns is LOWERED into a nested
+ * conditional — the same representation a ternary map body produces — so the
+ * natural multi-branch form works and runs. BF026
+ * (UNSUPPORTED_LIST_CALLBACK_BODY) remains only for shapes the chain extractor
+ * cannot lower (a preamble `const`/`let` alongside a branching return, or nested
+ * control flow inside a branch); those would otherwise leak raw JSX into the
+ * client bundle (`Unexpected token '<'` at hydrate) with the build still green.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import { ErrorCodes } from '../errors'
+
+const adapter = new TestAdapter()
+
+function compile(source: string, filename = 'Test.tsx') {
+  return compileJSX(source, filename, { adapter })
+}
+
+function errorsFor(code: string, source: string) {
+  return compile(source).errors.filter((e) => e.code === code)
+}
+
+function clientJs(source: string): string {
+  return compile(source).files.find((f) => f.type === 'clientJs')?.content ?? ''
+}
+
+const BF026 = ErrorCodes.UNSUPPORTED_LIST_CALLBACK_BODY
+
+// ---------------------------------------------------------------------------
+// Now lowered — the natural multi-branch form works.
+// ---------------------------------------------------------------------------
+
+describe('.map() if/switch chains lower to a conditional (no BF026)', () => {
+  test('if / if / return chain lowers to a reactive nested conditional', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Block = { kind: string; text: string }
+      export function Preview() {
+        const [blocks] = createSignal<Block[]>([])
+        return (
+          <div>
+            {blocks().map((block, i) => {
+              if (block.kind === 'code') return <pre key={i}>{block.text}</pre>
+              if (block.kind === 'quote') return <blockquote key={i}>{block.text}</blockquote>
+              return <p key={i}>{block.text}</p>
+            })}
+          </div>
+        )
+      }
+    `
+    expect(errorsFor(BF026, source)).toHaveLength(0)
+    const js = clientJs(source)
+    // Reactive conditional inside the loop: the branch condition, every branch
+    // tag, and no raw JSX return leaked into the bundle.
+    expect(js).toContain('mapArray')
+    expect(js).toContain("block().kind === 'code'")
+    expect(js).toContain('<pre')
+    expect(js).toContain('<blockquote')
+    expect(js).toContain('<p')
+    expect(js).not.toMatch(/return <(pre|blockquote|p)\b/)
+  })
+
+  test('explicit if / else-if / else chain lowers, no BF026', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Block = { kind: string; text: string }
+      export function Preview() {
+        const [blocks] = createSignal<Block[]>([])
+        return (
+          <div>
+            {blocks().map((block, i) => {
+              if (block.kind === 'code') {
+                return <pre key={i}>{block.text}</pre>
+              } else if (block.kind === 'quote') {
+                return <blockquote key={i}>{block.text}</blockquote>
+              } else {
+                return <p key={i}>{block.text}</p>
+              }
+            })}
+          </div>
+        )
+      }
+    `
+    expect(errorsFor(BF026, source)).toHaveLength(0)
+    expect(clientJs(source)).not.toMatch(/return <(pre|blockquote|p)\b/)
+  })
+
+  test('if-chain with no trailing return (renders nothing when unmatched) lowers, no BF026', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Block = { kind: string; text: string }
+      export function Preview() {
+        const [blocks] = createSignal<Block[]>([])
+        return (
+          <div>
+            {blocks().map((block, i) => {
+              if (block.kind === 'code') return <pre key={i}>{block.text}</pre>
+              if (block.kind === 'quote') return <blockquote key={i}>{block.text}</blockquote>
+            })}
+          </div>
+        )
+      }
+    `
+    expect(errorsFor(BF026, source)).toHaveLength(0)
+    expect(clientJs(source)).not.toMatch(/return <(pre|blockquote)\b/)
+  })
+
+  test('guard clause (early JSX return + trailing return null) lowers, no BF026', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Row = { hidden: boolean; label: string }
+      export function List() {
+        const [rows] = createSignal<Row[]>([])
+        return (
+          <ul>
+            {rows().map((row, i) => {
+              if (row.hidden) return <li key={i} className="hidden" />
+              return null
+            })}
+          </ul>
+        )
+      }
+    `
+    expect(errorsFor(BF026, source)).toHaveLength(0)
+    expect(clientJs(source)).not.toMatch(/return <li\b/)
+  })
+
+  test('switch with default lowers, no BF026', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Block = { kind: string; text: string }
+      export function Preview() {
+        const [blocks] = createSignal<Block[]>([])
+        return (
+          <div>
+            {blocks().map((block, i) => {
+              switch (block.kind) {
+                case 'code': return <pre key={i}>{block.text}</pre>
+                case 'quote': return <blockquote key={i}>{block.text}</blockquote>
+                default: return <p key={i}>{block.text}</p>
+              }
+            })}
+          </div>
+        )
+      }
+    `
+    expect(errorsFor(BF026, source)).toHaveLength(0)
+    expect(clientJs(source)).not.toMatch(/return <(pre|blockquote|p)\b/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Still rejected — shapes the chain extractor cannot lower.
+// ---------------------------------------------------------------------------
+
+describe('BF026 — shapes the extractor cannot lower still error (no raw JSX leak)', () => {
+  test('a preamble const alongside a branching JSX return raises BF026', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Item = { a: boolean; name: string }
+      export function List() {
+        const [items] = createSignal<Item[]>([])
+        return (
+          <ul>
+            {items().map((item, i) => {
+              const label = item.name.toUpperCase()
+              if (item.a) return <li key={i} className="a">{label}</li>
+              return <li key={i}>{label}</li>
+            })}
+          </ul>
+        )
+      }
+    `
+    const errs = errorsFor(BF026, source)
+    expect(errs).toHaveLength(1)
+    expect(errs[0].severity).toBe('error')
+    expect(clientJs(source)).not.toMatch(/return <li\b/)
+  })
+
+  test('nested control flow inside a branch raises BF026', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Item = { a: boolean; xs: number[]; id: string }
+      export function List() {
+        const [items] = createSignal<Item[]>([])
+        return (
+          <ul>
+            {items().map((item, i) => {
+              if (item.a) {
+                let n = 0
+                for (const x of item.xs) n += x
+                return <li key={i}>{n}</li>
+              }
+              return <li key={i}>{item.id}</li>
+            })}
+          </ul>
+        )
+      }
+    `
+    const errs = errorsFor(BF026, source)
+    expect(errs).toHaveLength(1)
+    expect(clientJs(source)).not.toMatch(/return <li\b/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Supported forms — no false positives.
+// ---------------------------------------------------------------------------
+
+describe('BF026 — supported forms compile clean (no false positives)', () => {
+  test('single JSX expression body — no BF026', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function List() {
+        const [items] = createSignal<string[]>([])
+        return <ul>{items().map((item, i) => <li key={i}>{item}</li>)}</ul>
+      }
+    `
+    expect(errorsFor(BF026, source)).toHaveLength(0)
+  })
+
+  test('ternary body — no BF026', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Item = { done: boolean; id: string }
+      export function List() {
+        const [items] = createSignal<Item[]>([])
+        return (
+          <ul>
+            {items().map((item, i) =>
+              item.done ? <li key={i} className="done">{item.id}</li> : <li key={i}>{item.id}</li>
+            )}
+          </ul>
+        )
+      }
+    `
+    expect(errorsFor(BF026, source)).toHaveLength(0)
+  })
+
+  test('JSX as a call argument (createPortal) in a single-return block — no BF026', () => {
+    const source = `
+      'use client'
+      import { createSignal, createPortal } from '@barefootjs/client'
+      export function Demo() {
+        const [items] = createSignal<{ id: string; body: string }[]>([])
+        return (
+          <ul>
+            {items().map(it => {
+              createPortal(<div>{it.body}</div>, document.body)
+              return <li key={it.id}>{it.id}</li>
+            })}
+          </ul>
+        )
+      }
+    `
+    expect(errorsFor(BF026, source)).toHaveLength(0)
+  })
+
+  test('non-JSX preamble const + single return — no BF026', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function List() {
+        const [items] = createSignal<string[]>([])
+        return (
+          <ul>
+            {items().map((item, i) => {
+              const label = item.toUpperCase()
+              return <li key={i}>{label}</li>
+            })}
+          </ul>
+        )
+      }
+    `
+    expect(errorsFor(BF026, source)).toHaveLength(0)
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -2084,7 +2084,7 @@ type JsxReturnNode = ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment
  * Supports if/else if chains and switch statements where every branch
  * returns JSX or null. Returns null for unsupported patterns.
  */
-function extractMultiReturnJsxBranches(
+export function extractMultiReturnJsxBranches(
   body: ts.Block
 ): { branches: Array<{ condition: ts.Expression; jsxReturn: JsxReturnNode | null }>; fallback: JsxReturnNode | null; switchDiscriminant?: ts.Expression } | null {
   const branches: Array<{ condition: ts.Expression; jsxReturn: JsxReturnNode | null }> = []

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -27,6 +27,16 @@ export const ErrorCodes = {
   MISSING_KEY_IN_LIST: 'BF023',
   MISSING_KEY_IN_NESTED_LIST: 'BF024',
   UNSUPPORTED_DESTRUCTURE_REST: 'BF025',
+  // A `.map()` list-render callback whose body is a statement block
+  // (`(item) => { ... return <jsx> }`) instead of a single JSX expression.
+  // The list-lowering pipeline only builds a per-item template from an
+  // expression body (JSX literal, or a ternary / logical / component call
+  // that resolves to JSX); a block body is not lowered and, before this
+  // diagnostic, leaked the raw JSX return into the emitted client bundle —
+  // an `Unexpected token '<'` SyntaxError at runtime that silently broke
+  // hydration while the build still reported success. Mirrors BF045's
+  // "use a single return statement" stance for local JSX functions.
+  UNSUPPORTED_LIST_CALLBACK_BODY: 'BF026',
 
   // Component errors (BF043-BF049)
   PROPS_DESTRUCTURING: 'BF043',
@@ -115,6 +125,11 @@ const errorMessages: Record<ErrorCode, string> = {
     'Missing key attribute in list rendering. Add a key prop for efficient updates',
   [ErrorCodes.MISSING_KEY_IN_NESTED_LIST]:
     'Nested .map() loop requires key attribute for event delegation. Add a key prop to elements in the inner loop',
+  [ErrorCodes.UNSUPPORTED_LIST_CALLBACK_BODY]:
+    'Unsupported .map() list-render callback. A block-body callback that returns JSX from multiple branches is lowered to a per-item conditional only when the body is a plain if / else-if / else (or switch) chain of direct `return <JSX/>` statements. ' +
+    'This body mixes those branching returns with a local variable declaration or nested control flow, which cannot be lowered — leaving the raw JSX to leak into the client bundle and throw at runtime. ' +
+    'Keep each branch a direct `return <JSX/>` and move any per-item computation into the array before mapping (or into the returned JSX expression); or collapse the branches into a single ternary.',
+
   [ErrorCodes.UNSUPPORTED_DESTRUCTURE_REST]:
     // Despite the legacy `UNSUPPORTED_DESTRUCTURE_REST` name, this code now
     // fires only for shapes that are valid TypeScript but unrepresentable in

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -51,7 +51,7 @@ import { createTemplateAwareStringProtector } from './ir-to-client-js/html-templ
 import { datePlugin, DATE_METHODS } from './date-lowering.ts'
 import { toLocaleDatePlugin, foldedArgToClientJs } from './to-locale-date-lowering.ts'
 import type { LoweringMatcher } from './lowering-registry.ts'
-import { extractFreeIdentifiersFromNode, initializerShapeContainsJsx } from './analyzer.ts'
+import { extractFreeIdentifiersFromNode, initializerShapeContainsJsx, extractMultiReturnJsxBranches } from './analyzer.ts'
 import { iterateJsTokens, replaceInExprContexts } from './scanner/js-scanner.ts'
 import { toHTMLAttrName, decodeEntities } from '@barefootjs/shared'
 
@@ -2087,6 +2087,108 @@ function transformJsxFunctionCall(
   }
 }
 
+/**
+ * Fold an extracted if/else-if/else (or switch) JSX-return chain into a nested
+ * `IRConditional` — `if (c1) return <A/>; if (c2) return <B/>; return <C/>`
+ * becomes `c1 ? <A/> : c2 ? <B/> : <C/>`. Built bottom-up so each branch's
+ * `whenFalse` is the accumulated rest, terminating in the fallback (or a `null`
+ * expression when there is none — i.e. no branch matched renders nothing).
+ *
+ * `getText` extracts condition source: the inlined-helper path passes a
+ * param-substituting variant (and swaps `ctx.getJS` so nested JSX transforms
+ * substitute too); the `.map()`-callback path passes the identity `ctx.getJS`
+ * because the callback's params are the loop params, already in scope.
+ */
+function foldMultiReturnBranches(
+  info: Omit<MultiReturnJsxInfo, 'params'>,
+  ctx: TransformContext,
+  loc: SourceLocation,
+  getText: (node: ts.Node) => string,
+): IRNode {
+  const nullExpr: IRExpression = {
+    type: 'expression',
+    expr: 'null',
+    typeInfo: { kind: 'primitive', raw: 'null', primitive: 'null' },
+    reactive: false,
+    slotId: null,
+    loc,
+    origin: { phase: 'tick', scope: 'template', effect: 'pure', freeRefs: [] },
+  }
+
+  let result: IRNode = info.fallback
+    ? (transformNode(info.fallback, ctx) ?? nullExpr)
+    : nullExpr
+
+  for (let i = info.branches.length - 1; i >= 0; i--) {
+    const branch = info.branches[i]
+
+    let conditionText: string
+    if (info.switchDiscriminant) {
+      conditionText = `${getText(info.switchDiscriminant)} === ${getText(branch.condition)}`
+    } else {
+      conditionText = getText(branch.condition)
+    }
+
+    const env = makeBindingEnv(ctx)
+    const caseFreeRefs = resolveFreeRefs(branch.condition, env)
+    const discFreeRefs = info.switchDiscriminant
+      ? resolveFreeRefs(info.switchDiscriminant, env)
+      : []
+    const conditionOrigin: OriginInfo = {
+      phase: 'tick',
+      scope: 'template',
+      effect: 'pure',
+      freeRefs: [...discFreeRefs, ...caseFreeRefs],
+    }
+    const reactive = isReactiveExpression(conditionText, ctx, branch.condition)
+      || isReactiveOrigin(conditionOrigin)
+    const loopParamReactive = !reactive && referencesLoopParam(conditionText, ctx)
+    const callsReactive = exprCallsReactiveGetters(branch.condition, ctx)
+      || (info.switchDiscriminant ? exprCallsReactiveGetters(info.switchDiscriminant, ctx) : false)
+    const hasCalls = exprHasFunctionCalls(branch.condition)
+      || (info.switchDiscriminant ? exprHasFunctionCalls(info.switchDiscriminant) : false)
+    const needsSlot = reactive || loopParamReactive || callsReactive || hasCalls
+    const slotId = needsSlot ? generateSlotId(ctx) : null
+
+    const whenTrue = branch.jsxReturn
+      ? (transformNode(branch.jsxReturn, ctx) ?? nullExpr)
+      : nullExpr
+
+    let templateCondition: string | undefined
+    if (info.switchDiscriminant) {
+      const discRewritten = rewriteBarePropRefs(
+        getText(info.switchDiscriminant), info.switchDiscriminant, ctx
+      )
+      const caseRewritten = rewriteBarePropRefs(
+        getText(branch.condition), branch.condition, ctx
+      )
+      const discPart = discRewritten ?? getText(info.switchDiscriminant)
+      const casePart = caseRewritten ?? getText(branch.condition)
+      templateCondition = `${discPart} === ${casePart}`
+    } else {
+      templateCondition = rewriteBarePropRefs(conditionText, branch.condition, ctx)
+    }
+
+    const conditional: IRConditional = {
+      type: 'conditional',
+      condition: conditionText,
+      templateCondition,
+      conditionType: null,
+      reactive,
+      whenTrue,
+      whenFalse: result,
+      slotId,
+      callsReactiveGetters: callsReactive || undefined,
+      hasFunctionCalls: hasCalls || undefined,
+      loc,
+      origin: conditionOrigin,
+    }
+    result = conditional
+  }
+
+  return result
+}
+
 function transformMultiReturnJsxFunctionCall(
   callExpr: ts.CallExpression,
   info: MultiReturnJsxInfo,
@@ -2119,96 +2221,9 @@ function transformMultiReturnJsxFunctionCall(
 
   try {
     const loc = getSourceLocation(callExpr, ctx.sourceFile, ctx.filePath)
-    const nullExpr: IRExpression = {
-      type: 'expression',
-      expr: 'null',
-      typeInfo: { kind: 'primitive', raw: 'null', primitive: 'null' },
-      reactive: false,
-      slotId: null,
-      loc,
-      origin: { phase: 'tick', scope: 'template', effect: 'pure', freeRefs: [] },
-    }
-
-    // Build the conditional chain from bottom up (last branch → first branch)
-    let result: IRNode = info.fallback
-      ? (transformNode(info.fallback, ctx) ?? nullExpr)
-      : nullExpr
-
-    for (let i = info.branches.length - 1; i >= 0; i--) {
-      const branch = info.branches[i]
-
-      // Build condition text with param substitution
-      let conditionText: string
-      if (info.switchDiscriminant) {
-        const discText = substitutedGetJS(info.switchDiscriminant)
-        const caseText = substitutedGetJS(branch.condition)
-        conditionText = `${discText} === ${caseText}`
-      } else {
-        conditionText = substitutedGetJS(branch.condition)
-      }
-
-      // For switch-sourced conditions, merge freeRefs/reactivity from
-      // both the discriminant and case expression so prop rewrites and
-      // reactivity detection cover the full `disc === case` condition.
-      const env = makeBindingEnv(ctx)
-      const caseFreeRefs = resolveFreeRefs(branch.condition, env)
-      const discFreeRefs = info.switchDiscriminant
-        ? resolveFreeRefs(info.switchDiscriminant, env)
-        : []
-      const conditionOrigin: OriginInfo = {
-        phase: 'tick',
-        scope: 'template',
-        effect: 'pure',
-        freeRefs: [...discFreeRefs, ...caseFreeRefs],
-      }
-      const reactive = isReactiveExpression(conditionText, ctx, branch.condition)
-        || isReactiveOrigin(conditionOrigin)
-      const loopParamReactive = !reactive && referencesLoopParam(conditionText, ctx)
-      const callsReactive = exprCallsReactiveGetters(branch.condition, ctx)
-        || (info.switchDiscriminant ? exprCallsReactiveGetters(info.switchDiscriminant, ctx) : false)
-      const hasCalls = exprHasFunctionCalls(branch.condition)
-        || (info.switchDiscriminant ? exprHasFunctionCalls(info.switchDiscriminant) : false)
-      const needsSlot = reactive || loopParamReactive || callsReactive || hasCalls
-      const slotId = needsSlot ? generateSlotId(ctx) : null
-
-      const whenTrue = branch.jsxReturn
-        ? (transformNode(branch.jsxReturn, ctx) ?? nullExpr)
-        : nullExpr
-
-      // For switch conditions, build templateCondition from both parts
-      let templateCondition: string | undefined
-      if (info.switchDiscriminant) {
-        const discRewritten = rewriteBarePropRefs(
-          substitutedGetJS(info.switchDiscriminant), info.switchDiscriminant, ctx
-        )
-        const caseRewritten = rewriteBarePropRefs(
-          substitutedGetJS(branch.condition), branch.condition, ctx
-        )
-        const discPart = discRewritten ?? substitutedGetJS(info.switchDiscriminant)
-        const casePart = caseRewritten ?? substitutedGetJS(branch.condition)
-        templateCondition = `${discPart} === ${casePart}`
-      } else {
-        templateCondition = rewriteBarePropRefs(conditionText, branch.condition, ctx)
-      }
-
-      const conditional: IRConditional = {
-        type: 'conditional',
-        condition: conditionText,
-        templateCondition,
-        conditionType: null,
-        reactive,
-        whenTrue,
-        whenFalse: result,
-        slotId,
-        callsReactiveGetters: callsReactive || undefined,
-        hasFunctionCalls: hasCalls || undefined,
-        loc,
-        origin: conditionOrigin,
-      }
-      result = conditional
-    }
-
-    return result
+    // `substitutedGetJS` extracts condition text with param→arg substitution;
+    // `ctx.getJS` is swapped above so nested JSX transforms substitute too.
+    return foldMultiReturnBranches(info, ctx, loc, substitutedGetJS)
   } finally {
     ctx.getJS = originalCtxGetJS
     ctx.analyzer.getJS = originalAnalyzerGetJS
@@ -2321,6 +2336,69 @@ function containsJsxInExpression(node: ts.Node): boolean {
     return true
   }
   return ts.forEachChild(node, containsJsxInExpression) ?? false
+}
+
+/**
+ * Does a `.map()` block-body preamble statement contain a `return` whose value
+ * is JSX? This is the leak that BF026 guards: only the callback's single chosen
+ * return becomes a per-item template, so an earlier `if (...) return <JSX/>`
+ * branch would otherwise be captured as raw text and emitted verbatim into the
+ * client bundle (`Unexpected token '<'` at runtime).
+ *
+ * Crucially this is narrower than "statement contains any JSX": JSX passed as a
+ * function-call argument (`createPortal(<div/>, document.body)`) is lowered by
+ * its own path and must NOT trip BF026. We therefore look specifically for a
+ * `return` of JSX, and do NOT descend into nested function/arrow bodies — a
+ * return inside those belongs to that inner function, not this callback.
+ */
+function preambleStatementReturnsJsx(node: ts.Node): boolean {
+  let found = false
+  const visit = (n: ts.Node): void => {
+    if (found) return
+    // Stop at every function-like boundary — functions, arrows, methods,
+    // accessors, constructors — so a `return <JSX/>` inside a class/object
+    // method declared in the preamble is attributed to that inner scope, not
+    // this map callback (matches the `ts.isFunctionLike` return-scan
+    // convention in analyzer.ts).
+    if (ts.isFunctionLike(n)) return
+    if (ts.isReturnStatement(n) && n.expression && containsJsxInExpression(n.expression)) {
+      found = true
+      return
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(node)
+  return found
+}
+
+/**
+ * The first JSX element/fragment anywhere in a block body (not descending into
+ * nested function-like scopes). Used only to give a BF026-rejected callback a
+ * benign, already-lowered placeholder template so the raw callback text is
+ * never handed to the scalar `.map(...)` fallback (which would re-emit the
+ * invalid JSX). Because `hasStrayJsxReturn` requires a return whose expression
+ * *contains* JSX, this finds a literal even inside a ternary / logical / call
+ * (`return cond ? <A/> : <B/>`), not just a direct JSX return.
+ */
+function firstJsxElementIn(
+  node: ts.Node,
+): ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment | null {
+  let found:
+    | ts.JsxElement
+    | ts.JsxSelfClosingElement
+    | ts.JsxFragment
+    | null = null
+  const visit = (n: ts.Node): void => {
+    if (found) return
+    if (ts.isFunctionLike(n)) return
+    if (ts.isJsxElement(n) || ts.isJsxSelfClosingElement(n) || ts.isJsxFragment(n)) {
+      found = n
+      return
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(node)
+  return found
 }
 
 /**
@@ -3885,6 +3963,10 @@ function transformMapCall(
   let children: IRNode[] = []
   let paramBindings: LoopParamBinding[] | undefined
   let flatMapCallback: FlatMapCallback | undefined
+  // Set when BF026 fires for an unlowerable block-body callback. Suppresses the
+  // downstream key check (BF023/BF024 would be redundant noise on already-
+  // rejected code) and records that children hold only a benign placeholder.
+  let bf026Raised = false
 
   if (ts.isArrowFunction(callback)) {
     // Extract parameter names and type annotations
@@ -4036,7 +4118,66 @@ function transformMapCall(
       const returnStmt = body.statements.find(
         (s): s is ts.ReturnStatement => ts.isReturnStatement(s) && s.expression != null
       )
-      if (returnStmt && returnStmt.expression) {
+
+      // A block body with an if/else-if/else (or switch) chain of JSX returns —
+      //   if (a) return <A/>; if (b) return <B/>; return <C/>
+      // — is lowered into a nested IRConditional (`a ? <A/> : b ? <B/> : <C/>`),
+      // the SAME representation a ternary map body produces, which the loop
+      // machinery already lowers to per-branch templates. So the natural
+      // multi-branch callback form WORKS rather than erroring. Reuses the
+      // analyzer's `extractMultiReturnJsxBranches` (also used for inlined
+      // multi-return JSX helpers) + the shared `foldMultiReturnBranches` fold;
+      // no param substitution here because the callback's params are the loop
+      // params, already registered in `ctx.loopParams`.
+      const multiReturn = extractMultiReturnJsxBranches(body)
+
+      // BF026 remains only for shapes the extractor cannot lower: a branching
+      // JSX return alongside a preamble `const`/`let`, or nested control flow
+      // inside a branch. Those still can't become a single per-item template,
+      // and — left alone — would leak raw JSX into the client bundle (swept into
+      // `mapPreamble`, or via the null → scalar-`.map()`-stringify fallback).
+      // A `return` of JSX passed as a call argument — `createPortal(<div/>,
+      // document.body)` — is not a branch return and is lowered elsewhere, so
+      // it is deliberately spared.
+      const hasStrayJsxReturn = !multiReturn && body.statements.some(
+        (s) => s !== returnStmt && preambleStatementReturnsJsx(s),
+      )
+
+      if (multiReturn && multiReturn.branches.length > 0) {
+        const chainLoc = getSourceLocation(callback.body, ctx.sourceFile, ctx.filePath)
+        children = [foldMultiReturnBranches(multiReturn, ctx, chainLoc, (n) => ctx.getJS(n))]
+      } else if (hasStrayJsxReturn) {
+        bf026Raised = true
+        ctx.analyzer.errors.push(
+          createError(
+            ErrorCodes.UNSUPPORTED_LIST_CALLBACK_BODY,
+            getSourceLocation(callback.body, ctx.sourceFile, ctx.filePath),
+          ),
+        )
+        // Guarantee a non-empty `children` so the raw callback text is never
+        // handed to the scalar `.map()` fallback (which would re-emit the
+        // invalid JSX). Use any JSX literal in the body as a benign, already-
+        // lowered placeholder template — this finds one even inside a ternary /
+        // logical / call return. As a final backstop (transform declines, or —
+        // defensively — no literal is found), fall back to an empty text node.
+        // The build is already failing on BF026, so the placeholder is never
+        // observed; this only keeps the erroring output free of raw JSX. No
+        // preamble is built.
+        const placeholder = firstJsxElementIn(body)
+        if (placeholder) {
+          const transformed = transformNode(placeholder, ctx)
+          if (transformed) children = [transformed]
+        }
+        if (children.length === 0) {
+          children = [
+            {
+              type: 'text',
+              value: '',
+              loc: getSourceLocation(callback.body, ctx.sourceFile, ctx.filePath),
+            },
+          ]
+        }
+      } else if (returnStmt && returnStmt.expression) {
         let returnExpr = returnStmt.expression
         while (ts.isParenthesizedExpression(returnExpr)) {
           returnExpr = returnExpr.expression
@@ -4047,6 +4188,8 @@ function transformMapCall(
             children = [transformed]
           }
         }
+        // Preamble statements here are guaranteed JSX-return-free (the stray
+        // case was handled above), so capturing them verbatim is safe.
         const preambleStmts: string[] = []
         const templatePreambleStmts: string[] = []
         const typedPreambleStmts: string[] = []
@@ -4076,7 +4219,7 @@ function transformMapCall(
 
       // flatMap block body fallback: compile JSX inline when children
       // couldn't be extracted via the standard single-return path.
-      if (method === 'flatMap' && children.length === 0) {
+      if (method === 'flatMap' && children.length === 0 && !bf026Raised) {
         flatMapCallback = buildFlatMapCallback(callback, body, ctx)
       }
     } else {
@@ -4101,8 +4244,10 @@ function transformMapCall(
   }
 
   // Emit BF023 / BF024 if the loop root element lacks a valid key attribute.
-  // Call whenever children were produced (the callback returned JSX).
-  if (ts.isArrowFunction(node.arguments[0]) && children.length > 0) {
+  // Call whenever children were produced (the callback returned JSX). Skip when
+  // BF026 already rejected the callback — the children hold only a benign
+  // placeholder, so a key diagnostic on it would be misleading noise.
+  if (ts.isArrowFunction(node.arguments[0]) && children.length > 0 && !bf026Raised) {
     checkLoopKey(node.arguments[0], ctx, isNested)
   }
 

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 263,
+    "totalFixtures": 264,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 54,
+      "total": 55,
       "cells": {
         "hono": {
-          "pass": 54,
-          "total": 54
+          "pass": 55,
+          "total": 55
         },
         "blade": {
-          "pass": 52,
-          "total": 54,
+          "pass": 53,
+          "total": 55,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -39,8 +39,8 @@
           ]
         },
         "erb": {
-          "pass": 53,
-          "total": 54,
+          "pass": 54,
+          "total": 55,
           "gaps": [
             {
               "fixture": "filter-nested-find-predicate",
@@ -51,8 +51,8 @@
           ]
         },
         "go-template": {
-          "pass": 52,
-          "total": 54,
+          "pass": 53,
+          "total": 55,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -69,8 +69,8 @@
           ]
         },
         "jinja": {
-          "pass": 52,
-          "total": 54,
+          "pass": 53,
+          "total": 55,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -87,8 +87,8 @@
           ]
         },
         "minijinja": {
-          "pass": 52,
-          "total": 54,
+          "pass": 53,
+          "total": 55,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -105,8 +105,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 53,
-          "total": 54,
+          "pass": 54,
+          "total": 55,
           "gaps": [
             {
               "fixture": "filter-nested-find-predicate",
@@ -117,8 +117,8 @@
           ]
         },
         "twig": {
-          "pass": 52,
-          "total": 54,
+          "pass": 53,
+          "total": 55,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -135,8 +135,8 @@
           ]
         },
         "xslate": {
-          "pass": 52,
-          "total": 54,
+          "pass": 53,
+          "total": 55,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -370,15 +370,15 @@
       }
     },
     "binary": {
-      "total": 67,
+      "total": 68,
       "cells": {
         "hono": {
-          "pass": 67,
-          "total": 67
+          "pass": 68,
+          "total": 68
         },
         "blade": {
-          "pass": 64,
-          "total": 67,
+          "pass": 65,
+          "total": 68,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -401,8 +401,8 @@
           ]
         },
         "erb": {
-          "pass": 65,
-          "total": 67,
+          "pass": 66,
+          "total": 68,
           "gaps": [
             {
               "fixture": "filter-nested-find-predicate",
@@ -419,8 +419,8 @@
           ]
         },
         "go-template": {
-          "pass": 64,
-          "total": 67,
+          "pass": 65,
+          "total": 68,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -443,8 +443,8 @@
           ]
         },
         "jinja": {
-          "pass": 64,
-          "total": 67,
+          "pass": 65,
+          "total": 68,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -467,8 +467,8 @@
           ]
         },
         "minijinja": {
-          "pass": 64,
-          "total": 67,
+          "pass": 65,
+          "total": 68,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -491,8 +491,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 65,
-          "total": 67,
+          "pass": 66,
+          "total": 68,
           "gaps": [
             {
               "fixture": "filter-nested-find-predicate",
@@ -509,8 +509,8 @@
           ]
         },
         "twig": {
-          "pass": 64,
-          "total": 67,
+          "pass": 65,
+          "total": 68,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -533,8 +533,8 @@
           ]
         },
         "xslate": {
-          "pass": 64,
-          "total": 67,
+          "pass": 65,
+          "total": 68,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -570,11 +570,11 @@
       }
     },
     "call": {
-      "total": 164,
+      "total": 165,
       "cells": {
         "hono": {
-          "pass": 163,
-          "total": 164,
+          "pass": 164,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -585,8 +585,8 @@
           ]
         },
         "blade": {
-          "pass": 159,
-          "total": 164,
+          "pass": 160,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -621,8 +621,8 @@
           ]
         },
         "erb": {
-          "pass": 160,
-          "total": 164,
+          "pass": 161,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -651,8 +651,8 @@
           ]
         },
         "go-template": {
-          "pass": 159,
-          "total": 164,
+          "pass": 160,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -687,8 +687,8 @@
           ]
         },
         "jinja": {
-          "pass": 159,
-          "total": 164,
+          "pass": 160,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -723,8 +723,8 @@
           ]
         },
         "minijinja": {
-          "pass": 159,
-          "total": 164,
+          "pass": 160,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -759,8 +759,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 160,
-          "total": 164,
+          "pass": 161,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -789,8 +789,8 @@
           ]
         },
         "twig": {
-          "pass": 159,
-          "total": 164,
+          "pass": 160,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -825,8 +825,8 @@
           ]
         },
         "xslate": {
-          "pass": 159,
-          "total": 164,
+          "pass": 160,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -926,11 +926,11 @@
       }
     },
     "identifier": {
-      "total": 244,
+      "total": 245,
       "cells": {
         "hono": {
-          "pass": 243,
-          "total": 244,
+          "pass": 244,
+          "total": 245,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -941,8 +941,8 @@
           ]
         },
         "blade": {
-          "pass": 239,
-          "total": 244,
+          "pass": 240,
+          "total": 245,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -977,8 +977,8 @@
           ]
         },
         "erb": {
-          "pass": 240,
-          "total": 244,
+          "pass": 241,
+          "total": 245,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1007,8 +1007,8 @@
           ]
         },
         "go-template": {
-          "pass": 239,
-          "total": 244,
+          "pass": 240,
+          "total": 245,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1043,8 +1043,8 @@
           ]
         },
         "jinja": {
-          "pass": 239,
-          "total": 244,
+          "pass": 240,
+          "total": 245,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1079,8 +1079,8 @@
           ]
         },
         "minijinja": {
-          "pass": 239,
-          "total": 244,
+          "pass": 240,
+          "total": 245,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1115,8 +1115,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 240,
-          "total": 244,
+          "pass": 241,
+          "total": 245,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1145,8 +1145,8 @@
           ]
         },
         "twig": {
-          "pass": 239,
-          "total": 244,
+          "pass": 240,
+          "total": 245,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1181,8 +1181,8 @@
           ]
         },
         "xslate": {
-          "pass": 239,
-          "total": 244,
+          "pass": 240,
+          "total": 245,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1282,15 +1282,15 @@
       }
     },
     "literal": {
-      "total": 202,
+      "total": 203,
       "cells": {
         "hono": {
-          "pass": 202,
-          "total": 202
+          "pass": 203,
+          "total": 203
         },
         "blade": {
-          "pass": 201,
-          "total": 202,
+          "pass": 202,
+          "total": 203,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1301,8 +1301,8 @@
           ]
         },
         "erb": {
-          "pass": 201,
-          "total": 202,
+          "pass": 202,
+          "total": 203,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1313,8 +1313,8 @@
           ]
         },
         "go-template": {
-          "pass": 201,
-          "total": 202,
+          "pass": 202,
+          "total": 203,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1325,8 +1325,8 @@
           ]
         },
         "jinja": {
-          "pass": 201,
-          "total": 202,
+          "pass": 202,
+          "total": 203,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1337,8 +1337,8 @@
           ]
         },
         "minijinja": {
-          "pass": 201,
-          "total": 202,
+          "pass": 202,
+          "total": 203,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1349,8 +1349,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 201,
-          "total": 202,
+          "pass": 202,
+          "total": 203,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1361,8 +1361,8 @@
           ]
         },
         "twig": {
-          "pass": 201,
-          "total": 202,
+          "pass": 202,
+          "total": 203,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1373,8 +1373,8 @@
           ]
         },
         "xslate": {
-          "pass": 201,
-          "total": 202,
+          "pass": 202,
+          "total": 203,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1514,11 +1514,11 @@
       }
     },
     "member": {
-      "total": 123,
+      "total": 124,
       "cells": {
         "hono": {
-          "pass": 122,
-          "total": 123,
+          "pass": 123,
+          "total": 124,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1529,8 +1529,8 @@
           ]
         },
         "blade": {
-          "pass": 118,
-          "total": 123,
+          "pass": 119,
+          "total": 124,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1565,8 +1565,8 @@
           ]
         },
         "erb": {
-          "pass": 119,
-          "total": 123,
+          "pass": 120,
+          "total": 124,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1595,8 +1595,8 @@
           ]
         },
         "go-template": {
-          "pass": 118,
-          "total": 123,
+          "pass": 119,
+          "total": 124,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1631,8 +1631,8 @@
           ]
         },
         "jinja": {
-          "pass": 118,
-          "total": 123,
+          "pass": 119,
+          "total": 124,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1667,8 +1667,8 @@
           ]
         },
         "minijinja": {
-          "pass": 118,
-          "total": 123,
+          "pass": 119,
+          "total": 124,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1703,8 +1703,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 119,
-          "total": 123,
+          "pass": 120,
+          "total": 124,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1733,8 +1733,8 @@
           ]
         },
         "twig": {
-          "pass": 118,
-          "total": 123,
+          "pass": 119,
+          "total": 124,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1769,8 +1769,8 @@
           ]
         },
         "xslate": {
-          "pass": 118,
-          "total": 123,
+          "pass": 119,
+          "total": 124,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1818,15 +1818,15 @@
       }
     },
     "object-literal": {
-      "total": 46,
+      "total": 47,
       "cells": {
         "hono": {
-          "pass": 46,
-          "total": 46
+          "pass": 47,
+          "total": 47
         },
         "blade": {
-          "pass": 45,
-          "total": 46,
+          "pass": 46,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -1837,8 +1837,8 @@
           ]
         },
         "erb": {
-          "pass": 45,
-          "total": 46,
+          "pass": 46,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -1849,8 +1849,8 @@
           ]
         },
         "go-template": {
-          "pass": 45,
-          "total": 46,
+          "pass": 46,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -1861,8 +1861,8 @@
           ]
         },
         "jinja": {
-          "pass": 45,
-          "total": 46,
+          "pass": 46,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -1873,8 +1873,8 @@
           ]
         },
         "minijinja": {
-          "pass": 45,
-          "total": 46,
+          "pass": 46,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -1885,8 +1885,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 45,
-          "total": 46,
+          "pass": 46,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -1897,8 +1897,8 @@
           ]
         },
         "twig": {
-          "pass": 45,
-          "total": 46,
+          "pass": 46,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -1909,8 +1909,8 @@
           ]
         },
         "xslate": {
-          "pass": 45,
-          "total": 46,
+          "pass": 46,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3971,15 +3971,15 @@
       }
     },
     "binary:===": {
-      "total": 30,
+      "total": 31,
       "cells": {
         "hono": {
-          "pass": 30,
-          "total": 30
+          "pass": 31,
+          "total": 31
         },
         "blade": {
-          "pass": 28,
-          "total": 30,
+          "pass": 29,
+          "total": 31,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -3996,8 +3996,8 @@
           ]
         },
         "erb": {
-          "pass": 29,
-          "total": 30,
+          "pass": 30,
+          "total": 31,
           "gaps": [
             {
               "fixture": "filter-nested-find-predicate",
@@ -4008,8 +4008,8 @@
           ]
         },
         "go-template": {
-          "pass": 28,
-          "total": 30,
+          "pass": 29,
+          "total": 31,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4026,8 +4026,8 @@
           ]
         },
         "jinja": {
-          "pass": 28,
-          "total": 30,
+          "pass": 29,
+          "total": 31,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4044,8 +4044,8 @@
           ]
         },
         "minijinja": {
-          "pass": 28,
-          "total": 30,
+          "pass": 29,
+          "total": 31,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4062,8 +4062,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 29,
-          "total": 30,
+          "pass": 30,
+          "total": 31,
           "gaps": [
             {
               "fixture": "filter-nested-find-predicate",
@@ -4074,8 +4074,8 @@
           ]
         },
         "twig": {
-          "pass": 28,
-          "total": 30,
+          "pass": 29,
+          "total": 31,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4092,8 +4092,8 @@
           ]
         },
         "xslate": {
-          "pass": 28,
-          "total": 30,
+          "pass": 29,
+          "total": 31,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4382,15 +4382,15 @@
       }
     },
     "literal:string": {
-      "total": 145,
+      "total": 146,
       "cells": {
         "hono": {
-          "pass": 145,
-          "total": 145
+          "pass": 146,
+          "total": 146
         },
         "blade": {
-          "pass": 144,
-          "total": 145,
+          "pass": 145,
+          "total": 146,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -4401,8 +4401,8 @@
           ]
         },
         "erb": {
-          "pass": 144,
-          "total": 145,
+          "pass": 145,
+          "total": 146,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -4413,8 +4413,8 @@
           ]
         },
         "go-template": {
-          "pass": 144,
-          "total": 145,
+          "pass": 145,
+          "total": 146,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -4425,8 +4425,8 @@
           ]
         },
         "jinja": {
-          "pass": 144,
-          "total": 145,
+          "pass": 145,
+          "total": 146,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -4437,8 +4437,8 @@
           ]
         },
         "minijinja": {
-          "pass": 144,
-          "total": 145,
+          "pass": 145,
+          "total": 146,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -4449,8 +4449,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 144,
-          "total": 145,
+          "pass": 145,
+          "total": 146,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -4461,8 +4461,8 @@
           ]
         },
         "twig": {
-          "pass": 144,
-          "total": 145,
+          "pass": 145,
+          "total": 146,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -4473,8 +4473,8 @@
           ]
         },
         "xslate": {
-          "pass": 144,
-          "total": 145,
+          "pass": 145,
+          "total": 146,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",


### PR DESCRIPTION
## Summary

Makes the natural multi-branch `.map()` callback **compile and run**. A callback whose block body returns JSX from several branches — an `if / else-if / else` or `switch` chain — is now lowered to a per-item conditional and rendered correctly per item.

```tsx
// ✅ compiles and runs — lowered to a per-item conditional
{blocks().map((block, i) => {
  if (block.kind === 'code')  return <pre key={i}>{block.text}</pre>
  if (block.kind === 'quote') return <blockquote key={i}>{block.text}</blockquote>
  return <p key={i}>{block.text}</p>
})}
```

This is a natural, readable way to render a list whose items vary by shape, and it should just work — so now it does. Previously the compiler kept only the single top-level `return` as the per-item template and swept the other `if (...) return <JSX/>` branches into the loop preamble as raw text, leaking JSX into the client bundle (`Uncaught SyntaxError: Unexpected token '<'`, breaking hydration) while `bf build` reported `0 errors`. That silent mis-lowering is gone.

## How

The machinery already existed — it just wasn't wired to `.map()`:

- `extractMultiReturnJsxBranches` (analyzer) turns an `if/else-if/else` or `switch` chain of JSX returns into `{branches, fallback}`.
- The bottom-up fold (previously private to `transformMultiReturnJsxFunctionCall`) builds a nested `IRConditional` — `a ? <A/> : b ? <B/> : <C/>` — the **same representation a ternary map body produces**.

These powered inlined multi-return JSX helpers and component-level early returns. This PR:

- Exports the extractor and factors the pure branches→`IRConditional` fold into a shared `foldMultiReturnBranches` (no param substitution for the map path — a callback's params are the loop params, already in `ctx.loopParams`).
- Routes the `.map()` block body through extract+fold, so it reuses the **existing, proven** ternary-in-map lowering: reactive branch conditions (`() => block().kind === 'code'` inside `insert()`), reactive branch text, and `key` preserved per branch. A chain with no trailing `return` correctly renders nothing when unmatched; `switch` with a `default` works too.

Because it's the same `IRConditional` a ternary yields, per-item conditionals, keys, and cross-adapter rendering are all handled by code that already exists — no new rendering path.

## The remaining edge: BF026

A couple of shapes still can't be represented as a per-item conditional today: a branching JSX return mixed with a preamble `const`/`let`, or nested control flow (a `for`/`while`/inner block) inside a branch. For those — and only those — the compiler raises `BF026 (UNSUPPORTED_LIST_CALLBACK_BODY)` with a code frame and a concrete rewrite (lift the computation into the array, keep each branch a direct `return <JSX/>`), and emits a benign placeholder so the erroring output never carries raw JSX.

This is a **reluctant last resort, not the goal** — a strict improvement over the previous silent runtime break, and a candidate to lower in a future pass (e.g. by threading branch-local declarations the way component early-returns already do). The point of this PR is that the common, natural form now works; the error only covers what the lowering can't yet express.

Untouched: single-expression / ternary / logical callback forms, JSX as a call argument (`createPortal(<div/>, …)`), and single-return blocks with a non-JSX preamble. The return-scan stops at every `ts.isFunctionLike` boundary so a `return <JSX/>` inside a class/object method isn't misattributed.

## Testing

- `packages/jsx/src/__tests__/list-callback-block-body.test.ts` — 11 cases: `if` / `else-if` / `switch` / guard-clause / no-trailing-return chains lower and run (no BF026); the two not-yet-representable shapes error without leaking raw JSX; supported forms clean.
- New CSR conformance fixture `if-chain-map` — pins per-item branch rendering (`<pre>x</pre>`, `<blockquote>y</blockquote>`, `<p>z</p>`); green on CSR + cross-adapter render + SSR-hydration contracts across all 9 adapters. `coverage-map.json`, `ui/support-matrix.lock.json`, and `ui/compat.lock.json` regenerated (the new construct now compiles on every backend — each construct total ticks up by one).
- Full `packages/jsx` suite **2614 pass / 0 fail**; compat suite **64 pass / 0 fail**. The shared-fold refactor is covered by the 141 existing helper-inlining + conditional tests.

## Notes

- Supersedes the earlier diagnose-only revision of this PR (its two Copilot review rounds are addressed in-thread; that diagnostic path is retained only for the not-yet-representable shapes).
- The original Tetris / Markdown-editor examples (closed #2370) written with the natural if-chain form would now compile and run as-is — the div-unification workaround there is no longer needed, and they can re-land in their natural form as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)