### PR TITLE
Stage 1: adapter-gate off-subset filter/sort predicates (callback-body fidelity)

### DIFF
--- a/.changeset/adapter-gate-callback-body-fidelity.md
+++ b/.changeset/adapter-gate-callback-body-fidelity.md
@@ -1,0 +1,20 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/blade": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/rust": patch
+"@barefootjs/twig": patch
+"@barefootjs/xslate": patch
+---
+
+Adapter-gate the Phase-1 `BF021` refusal for off-subset `filter` predicates and `sort` comparators (callback-body fidelity, Stage 1 of `spec/callback-fidelity.md`).
+
+An off-catalogue `filter` predicate or `sort` comparator (`typeof`, a function call, a nested higher-order method, …) previously raised `BF021` in Phase 1 — before any adapter was consulted — rejecting the code for every target, including JS runtimes whose template engine could run the callback verbatim. The refusal is now adapter-conditional via a new `acceptsCallbackBody` capability on `TemplateAdapter`:
+
+- JS-runtime adapters (`JsxAdapter` — Hono, CSR) accept any `filter`/`sort` callback body and run it as written.
+- DSL adapters keep the `BF021` refusal and the explicit `/* @client */` escape to defer the shape to client-only rendering.
+
+SSR/CSR parity is unchanged: per-backend fidelity means per-backend SSR coverage, with the browser as the common fully-faithful floor. Each DSL adapter declares the expected diagnostic for the new `filter-typeof-predicate` conformance fixture via its `conformancePins`.

--- a/docs/core/rendering/jsx-compatibility.md
+++ b/docs/core/rendering/jsx-compatibility.md
@@ -184,7 +184,7 @@ Only a genuinely imperative comparator — one that re-assigns a local, loops, o
 `break`s — has no value-position lowering and errors:
 
 ```tsx
-// ❌ BF021 (all adapters)
+// ❌ BF021 on Go/Mojo — a JS-runtime target (Hono, CSR) runs the comparator
 {items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map(item => (
   <Item key={item.id} item={item} />
 ))}
@@ -201,7 +201,7 @@ compiles (see the "Sort comparators" section above); an **imported** or
 only one binding, so it can't see through a re-export or `const c2 = c1`:
 
 ```tsx
-// ❌ BF021 — `byPrice` is imported, not declared in this file
+// ❌ BF021 on Go/Mojo — `byPrice` is imported, not declared in this file
 import { byPrice } from './comparators'
 function SortedList({ items }: { items: Item[] }) {
   return <ul>{items.sort(byPrice).map((item) => <li key={item.id}>{item.name}</li>)}</ul>

--- a/docs/core/rendering/jsx-compatibility.md
+++ b/docs/core/rendering/jsx-compatibility.md
@@ -108,11 +108,11 @@ Some JavaScript expressions cannot be translated into marked template syntax. Wh
 | `.reduce()`, `.forEach()`, `.flatMap()` | works | **BF101** |
 | Nested `.filter()` / `.map()` in a filter predicate (`x => x.tags.filter(...).length > 0`) | works | works |
 | Nested `.some()` / `.find()` / `.reduce()` in a filter predicate | works | **BF101** |
-| Sort comparator that's a multi-statement block body or `localeCompare(b, locale, opts)` | **BF021** (all adapters) | **BF021** |
-| Sort comparator that's a function reference to an imported/prop identifier, or an alias chain (`const c2 = c1`) | **BF021** (all adapters) | **BF021** |
-| `typeof` in a filter predicate | **BF021** (all adapters) | **BF021** |
+| Sort comparator that's a multi-statement block body or `localeCompare(b, locale, opts)` | works (runs as JS) | **BF021** |
+| Sort comparator that's a function reference to an imported/prop identifier, or an alias chain (`const c2 = c1`) | works (runs as JS) | **BF021** |
+| `typeof` in a filter predicate | works (runs as JS) | **BF021** |
 
-`BF021` is raised at the IR layer and applies to every adapter. `BF101` is raised by adapters that can't lower the expression to their template language. Either way, add [`/* @client */`](./client-directive.md) to opt into client-only evaluation and suppress the error.
+An off-subset `filter` predicate or `sort` comparator (`typeof`, an imperative block body, an imported/aliased comparator reference, …) is raised as `BF021` only on non-JS template adapters — a JS-runtime adapter (Hono, CSR) executes the callback body verbatim at SSR, so it compiles there. `BF101` is raised by adapters that can't lower the expression to their template language. Either way, add [`/* @client */`](./client-directive.md) on a DSL backend to defer the shape to client-only evaluation and suppress the error.
 
 ### Patterns that error on Go / Mojo
 
@@ -165,9 +165,9 @@ A nested `.some()` / `.find()` / `.reduce()` still has no faithful Go/Mojo lower
 {items().filter(x => x.done)}
 ```
 
-### Patterns that error on all adapters
+### Sort comparators that error on Go / Mojo
 
-**Unsupported sort comparators** (imperative block bodies, unresolved function references):
+**Unsupported sort comparators** (imperative block bodies, unresolved function references) — a JS-runtime adapter (Hono, CSR) runs any of these verbatim; only non-JS template backends refuse them:
 
 A value-producing block body normalizes to an expression — pure `const`
 bindings inline (let-inline) and a value-producing `if` / early `return`
@@ -181,7 +181,7 @@ becomes a ternary — so it lowers on all adapters just like the expression form
 ```
 
 Only a genuinely imperative comparator — one that re-assigns a local, loops, or
-`break`s — has no value-position lowering and errors:
+`break`s — has no value-position lowering and errors on Go / Mojo:
 
 ```tsx
 // ❌ BF021 on Go/Mojo — a JS-runtime target (Hono, CSR) runs the comparator

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -11,6 +11,10 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // Off-subset filter predicate (`typeof`) the compiler can't lower; a
+  // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -12,6 +12,10 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // Off-subset filter predicate (`typeof`) the compiler can't lower; a
+  // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -11,6 +11,10 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // Off-subset filter predicate (`typeof`) the compiler can't lower; a
+  // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   // `style-object-dynamic` / `style-3-signals` no longer pinned — a
   // `style={{ … }}` object literal now lowers to a CSS string with dynamic
   // values interpolated (`background-color:{{.Color}};padding:8px`) via

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -11,6 +11,10 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // Off-subset filter predicate (`typeof`) the compiler can't lower; a
+  // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -9,6 +9,10 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // Off-subset filter predicate (`typeof`) the compiler can't lower; a
+  // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -12,6 +12,10 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // Off-subset filter predicate (`typeof`) the compiler can't lower; a
+  // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1888,6 +1888,48 @@
         "text"
       ]
     },
+    "filter-typeof-predicate": {
+      "kinds": [
+        "array-literal",
+        "arrow",
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "unsupported"
+      ],
+      "axes": [
+        "binary:===",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "filter-typeof-predicate-client": {
+      "kinds": [
+        "array-literal",
+        "arrow",
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "unsupported"
+      ],
+      "axes": [
+        "binary:===",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "filter-wrapper-props-reachable": {
       "kinds": [
         "array-literal",
@@ -4202,21 +4244,21 @@
     }
   },
   "kindCounts": {
-    "array-literal": 54,
+    "array-literal": 56,
     "array-method": 62,
-    "arrow": 55,
-    "binary": 67,
-    "call": 164,
+    "arrow": 57,
+    "binary": 69,
+    "call": 166,
     "conditional": 19,
-    "identifier": 244,
+    "identifier": 246,
     "index-access": 12,
-    "literal": 202,
+    "literal": 204,
     "logical": 41,
-    "member": 123,
+    "member": 125,
     "object-literal": 46,
     "template-literal": 27,
     "unary": 22,
-    "unsupported": 21
+    "unsupported": 23
   },
   "axisCounts": {
     "array-method:at": 2,
@@ -4250,13 +4292,13 @@
     "binary:-": 11,
     "binary:/": 1,
     "binary:<": 1,
-    "binary:===": 30,
+    "binary:===": 32,
     "binary:>": 11,
     "binary:>=": 1,
     "literal:boolean": 38,
     "literal:null": 22,
     "literal:number": 86,
-    "literal:string": 145,
+    "literal:string": 147,
     "logical:&&": 7,
     "logical:??": 37,
     "logical:||": 12,

--- a/packages/adapter-tests/fixtures/filter-typeof-predicate-client.ts
+++ b/packages/adapter-tests/fixtures/filter-typeof-predicate-client.ts
@@ -1,0 +1,24 @@
+import { createFixture } from '../src/types'
+
+/**
+ * The `/* @client *\/` twin of `filter-typeof-predicate`. Marking the chain
+ * client-only suppresses the SSR diagnostic on every backend — the loop
+ * renders empty at SSR and the browser (always JS) runs the `typeof` predicate.
+ * No conformance pin: this must compile clean on all adapters, asserting the
+ * `/* @client *\/` escape works. See `spec/callback-fidelity.md`.
+ */
+export const fixture = createFixture({
+  id: 'filter-typeof-predicate-client',
+  description: 'Off-subset filter predicate deferred to the client via /* @client */',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function TypeofPredicateClient() {
+  const [items, setItems] = createSignal<unknown[]>([])
+  return <ul>{/* @client */ items().filter(t => typeof t === 'string').map((t, i) => <li key={i}>{String(t)}</li>)}</ul>
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s1"></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/filter-typeof-predicate.ts
+++ b/packages/adapter-tests/fixtures/filter-typeof-predicate.ts
@@ -1,0 +1,34 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Filter predicate the compiler can't lower to a template / ParsedExpr subtree
+ * at all — a `typeof` guard (`t => typeof t === 'string'`). This is the
+ * *not-parseable* off-subset path (a Phase-1 refusal), as opposed to the
+ * *parseable-but-evaluator-refuses* nested-callback path
+ * (`filter-nested-callback-predicate`, which surfaces BF101 at emit time).
+ *
+ * Per `spec/callback-fidelity.md` the diagnostic is adapter-gated:
+ *   - Hono / CSR run the predicate verbatim (JS runtime) and render the chain
+ *     faithfully — the callback stays in the array string for the runtime.
+ *   - DSL adapters (Go, Perl, Ruby, PHP, Rust, Python) can't run it at SSR and
+ *     surface BF021 with a `/* @client *\/` escape (declared via each adapter's
+ *     `conformancePins`). The user opts that piece into client-only rendering.
+ *
+ * The `/* @client *\/` twin (`filter-typeof-predicate-client`) has no pin —
+ * it must render clean on every adapter, asserting the suppression contract.
+ */
+export const fixture = createFixture({
+  id: 'filter-typeof-predicate',
+  description: 'Off-subset filter predicate (typeof) — JS-runtime faithful, DSL diagnostic',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function TypeofPredicate() {
+  const [items, setItems] = createSignal<unknown[]>([])
+  return <ul>{items().filter(t => typeof t === 'string').map((t, i) => <li key={i}>{String(t)}</li>)}</ul>
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s1"></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -117,6 +117,8 @@ import { fixture as mapWithIndex } from './map-with-index'
 import { fixture as filterSimple } from './filter-simple'
 import { fixture as filterNestedCallbackPredicate } from './filter-nested-callback-predicate'
 import { fixture as filterNestedCallbackPredicateClient } from './filter-nested-callback-predicate-client'
+import { fixture as filterTypeofPredicate } from './filter-typeof-predicate'
+import { fixture as filterTypeofPredicateClient } from './filter-typeof-predicate-client'
 import { fixture as filterNestedFindPredicate } from './filter-nested-find-predicate'
 import { fixture as sortSimple } from './sort-simple'
 import { fixture as filterSortChain } from './filter-sort-chain'
@@ -472,6 +474,8 @@ export const jsxFixtures: JSXFixture[] = [
   filterSimple,
   filterNestedCallbackPredicate,
   filterNestedCallbackPredicateClient,
+  filterTypeofPredicate,
+  filterTypeofPredicateClient,
   filterNestedFindPredicate,
   sortSimple,
   filterSortChain,

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -18,6 +18,13 @@ import {
 import { mkdir, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
+// The CSR runtime is a JS engine, so — like Hono / any `JsxAdapter` — it runs
+// an off-subset callback body (`filter`/`sort` predicate the compiler can't
+// lower) verbatim. Model that capability here so the CSR harness compiles such
+// a predicate instead of tripping the DSL-only BF021. See
+// `spec/callback-fidelity.md`.
+const csrAcceptsCallbackBody = () => true
+
 const CSR_TEMP_DIR = resolve(import.meta.dir, '../.csr-render-temp')
 
 export interface CsrRenderOptions {
@@ -52,7 +59,7 @@ function compileToClientJs(source: string, filePath: string): string {
   if (componentNames.length === 0) {
     // Fall back to default-export resolution (preserves prior behaviour for
     // sources where `listComponentFunctions` returns nothing).
-    const ctx = analyzeComponent(source, filePath)
+    const ctx = analyzeComponent(source, filePath, undefined, undefined, csrAcceptsCallbackBody)
     if (!ctx.jsxReturn) {
       throwIfErrors(ctx, filePath)
       return ''
@@ -72,7 +79,7 @@ function compileToClientJs(source: string, filePath: string): string {
 
   const outputs: string[] = []
   for (const componentName of componentNames) {
-    const ctx = analyzeComponent(source, filePath, componentName)
+    const ctx = analyzeComponent(source, filePath, componentName, undefined, csrAcceptsCallbackBody)
     if (!ctx.jsxReturn) {
       throwIfErrors(ctx, filePath)
       continue

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -11,6 +11,10 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // Off-subset filter predicate (`typeof`) the compiler can't lower; a
+  // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -9,6 +9,10 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // Off-subset filter predicate (`typeof`) the compiler can't lower; a
+  // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -5548,3 +5548,97 @@ export function initCounter(__scope, _p = {}) {
 hydrate('Counter', { init: initCounter, template: (_p) => \`<button bf="s1"> Count: <!--bf:s0-->\${escapeText((0))}<!--/--></button>\` })
 export function Counter(_p, __bfKey) { return createComponent('Counter', _p, __bfKey) }"
 `;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L188 — ❌ BF021 on Go/Mojo — a JS-runtime target (Hono, CSR) runs the comparator 1`] = `
+"import { $, $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  let __anchor_s0 = _s0
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __anchor_s0 = __bfText(__anchor_s0, __val)
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\` })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  let __anchor_s0 = _s0
+  createEffect(() => {
+    const __val = String(_p.item)
+    __anchor_s0 = __bfText(__anchor_s0, __val)
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\` })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\` })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const children = _p.children
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L205 — ❌ BF021 on Go/Mojo — \`byPrice\` is imported, not declared in this file 1`] = `
+"import { $, $t, createComponent, createEffect, escapeText, hydrate, mapArray, tAfter } from '@barefootjs/client/runtime'
+import { byPrice } from './comparators'
+
+
+export function initSortedList(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const items = _p.items
+
+  const [_s1] = $(__scope, 's1')
+
+  const __tpl_l0 = document.createElement('template')
+  __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
+  mapArray(() => items.sort(byPrice), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
+    const __p = __existing ? null : [__el.firstChild]
+    { const __rt_s0 = __p ? tAfter(__p[0]) : $t(__el, 's0')[0]
+    if (__rt_s0) createEffect(() => { __rt_s0.textContent = String(item().name) }) }
+    return __el
+  }, 'l0')
+
+}
+
+hydrate('SortedList__b3c36eee', { init: initSortedList, template: (_p) => \`<ul bf="s1"><!--bf-loop:l0-->\${_p.items.sort(byPrice).map((item) => \`<li data-key="\${item.id}"><!--bf:s0-->\${escapeText(item.name)}<!--/--></li>\`).join('')}<!--bf-/loop:l0--></ul>\` })
+export function SortedList(_p, __bfKey) { return createComponent('SortedList__b3c36eee', _p, __bfKey) }"
+`;

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -1203,6 +1203,71 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L188 — ❌ BF021 on Go/Mojo — a JS-runtime target (Hono, CSR) runs the comparator 1`] = `
+"import { $, $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  let __anchor_s0 = _s0
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __anchor_s0 = __bfText(__anchor_s0, __val)
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\` })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  let __anchor_s0 = _s0
+  createEffect(() => {
+    const __val = String(_p.item)
+    __anchor_s0 = __bfText(__anchor_s0, __val)
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\` })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\` })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const children = _p.children
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
 exports[`docs/core/rendering/jsx-compatibility.md doc-examples L193 — ✅ Use /* @client */ 1`] = `
 "import { $, $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
 
@@ -1266,6 +1331,35 @@ export function initExample(__scope, _p = {}) {
 
 hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L205 — ❌ BF021 on Go/Mojo — \`byPrice\` is imported, not declared in this file 1`] = `
+"import { $, $t, createComponent, createEffect, escapeText, hydrate, mapArray, tAfter } from '@barefootjs/client/runtime'
+import { byPrice } from './comparators'
+
+
+export function initSortedList(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const items = _p.items
+
+  const [_s1] = $(__scope, 's1')
+
+  const __tpl_l0 = document.createElement('template')
+  __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
+  mapArray(() => items.sort(byPrice), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
+    const __p = __existing ? null : [__el.firstChild]
+    { const __rt_s0 = __p ? tAfter(__p[0]) : $t(__el, 's0')[0]
+    if (__rt_s0) createEffect(() => { __rt_s0.textContent = String(item().name) }) }
+    return __el
+  }, 'l0')
+
+}
+
+hydrate('SortedList__b3c36eee', { init: initSortedList, template: (_p) => \`<ul bf="s1"><!--bf-loop:l0-->\${_p.items.sort(byPrice).map((item) => \`<li data-key="\${item.id}"><!--bf:s0-->\${escapeText(item.name)}<!--/--></li>\`).join('')}<!--bf-/loop:l0--></ul>\` })
+export function SortedList(_p, __bfKey) { return createComponent('SortedList__b3c36eee', _p, __bfKey) }"
 `;
 
 exports[`docs/core/rendering/jsx-compatibility.md doc-examples L211 — ✅ Use /* @client */, or inline / re-declare the comparator locally 1`] = `
@@ -5547,98 +5641,4 @@ export function initCounter(__scope, _p = {}) {
 
 hydrate('Counter', { init: initCounter, template: (_p) => \`<button bf="s1"> Count: <!--bf:s0-->\${escapeText((0))}<!--/--></button>\` })
 export function Counter(_p, __bfKey) { return createComponent('Counter', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L188 — ❌ BF021 on Go/Mojo — a JS-runtime target (Hono, CSR) runs the comparator 1`] = `
-"import { $, $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const [_s0] = $t(__scope, 's0')
-
-  let __anchor_s0 = _s0
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __anchor_s0 = __bfText(__anchor_s0, __val)
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\` })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const [_s0] = $t(__scope, 's0')
-
-  let __anchor_s0 = _s0
-  createEffect(() => {
-    const __val = String(_p.item)
-    __anchor_s0 = __bfText(__anchor_s0, __val)
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\` })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\` })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const children = _p.children
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const [_s1] = $(__scope, 's1')
-
-  mapArray(() => items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
-    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
-  }, 'l0')
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L205 — ❌ BF021 on Go/Mojo — \`byPrice\` is imported, not declared in this file 1`] = `
-"import { $, $t, createComponent, createEffect, escapeText, hydrate, mapArray, tAfter } from '@barefootjs/client/runtime'
-import { byPrice } from './comparators'
-
-
-export function initSortedList(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const items = _p.items
-
-  const [_s1] = $(__scope, 's1')
-
-  const __tpl_l0 = document.createElement('template')
-  __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
-  mapArray(() => items.sort(byPrice), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
-    const __p = __existing ? null : [__el.firstChild]
-    { const __rt_s0 = __p ? tAfter(__p[0]) : $t(__el, 's0')[0]
-    if (__rt_s0) createEffect(() => { __rt_s0.textContent = String(item().name) }) }
-    return __el
-  }, 'l0')
-
-}
-
-hydrate('SortedList__b3c36eee', { init: initSortedList, template: (_p) => \`<ul bf="s1"><!--bf-loop:l0-->\${_p.items.sort(byPrice).map((item) => \`<li data-key="\${item.id}"><!--bf:s0-->\${escapeText(item.name)}<!--/--></li>\`).join('')}<!--bf-/loop:l0--></ul>\` })
-export function SortedList(_p, __bfKey) { return createComponent('SortedList__b3c36eee', _p, __bfKey) }"
 `;

--- a/packages/jsx/src/__tests__/unsupported-expression.test.ts
+++ b/packages/jsx/src/__tests__/unsupported-expression.test.ts
@@ -125,13 +125,28 @@ describe('Unsupported Expression Error (BF021)', () => {
     expect(ir!.type).toBe('element')
   })
 
-  test('compileJSX includes IR-phase BF021 errors in result', () => {
-    const result = compileJSX(unsupportedSource, 'TodoList.tsx', { adapter })
+  test('compileJSX surfaces IR-phase BF021 for a DSL target (no acceptsCallbackBody)', () => {
+    // Model a DSL adapter: its template runtime can't run an off-subset
+    // predicate verbatim, so the Phase-1 diagnostic must surface in the result.
+    const dslAdapter = new TestAdapter()
+    ;(dslAdapter as { acceptsCallbackBody?: unknown }).acceptsCallbackBody = undefined
+    const result = compileJSX(unsupportedSource, 'TodoList.tsx', { adapter: dslAdapter })
     const bf021 = result.errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
 
     expect(bf021).toHaveLength(1)
     expect(bf021[0].severity).toBe('error')
     expect(bf021[0].message).toContain('Expression cannot be compiled to marked template')
+    expect(bf021[0].suggestion?.message).toContain('@client')
+  })
+
+  test('compileJSX does NOT raise BF021 for a JS-runtime target (fidelity)', () => {
+    // A JS runtime (Hono / CSR — the default TestAdapter, extending JsxAdapter)
+    // runs the predicate verbatim, so an off-subset body is not a universal
+    // error. It stays in the array string for the runtime to evaluate.
+    // See spec/callback-fidelity.md.
+    const result = compileJSX(unsupportedSource, 'TodoList.tsx', { adapter })
+    const bf021 = result.errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021).toHaveLength(0)
   })
 })
 

--- a/packages/jsx/src/__tests__/unsupported-expression.test.ts
+++ b/packages/jsx/src/__tests__/unsupported-expression.test.ts
@@ -128,8 +128,11 @@ describe('Unsupported Expression Error (BF021)', () => {
   test('compileJSX surfaces IR-phase BF021 for a DSL target (no acceptsCallbackBody)', () => {
     // Model a DSL adapter: its template runtime can't run an off-subset
     // predicate verbatim, so the Phase-1 diagnostic must surface in the result.
+    // Real DSL adapters leave `acceptsCallbackBody` unset; the gate
+    // (`?.(kind) ?? false`) treats unset and a false-returning predicate
+    // identically, so override it to decline every callback kind.
     const dslAdapter = new TestAdapter()
-    ;(dslAdapter as { acceptsCallbackBody?: unknown }).acceptsCallbackBody = undefined
+    dslAdapter.acceptsCallbackBody = () => false
     const result = compileJSX(unsupportedSource, 'TodoList.tsx', { adapter: dslAdapter })
     const bf021 = result.errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
 

--- a/packages/jsx/src/adapters/interface.ts
+++ b/packages/jsx/src/adapters/interface.ts
@@ -130,6 +130,37 @@ export type TemplatePrimitiveRegistry = Record<string, TemplatePrimitiveEmit>
  */
 export type TemplateCallAcceptor = (calleeName: string) => boolean
 
+/**
+ * The collection-method callbacks whose body the compiler may hand to a
+ * backend to run. Used by {@link CallbackBodyAcceptor}. See
+ * `spec/callback-fidelity.md`.
+ */
+export type CallbackBodyKind =
+  | 'filter'
+  | 'sort'
+  | 'map'
+  | 'flatMap'
+  | 'find'
+  | 'some'
+  | 'every'
+  | 'reduce'
+
+/**
+ * Predicate: can this adapter's runtime render an *off-subset* callback body
+ * of the given kind verbatim? A callback whose body the compiler can't express
+ * as a template / ParsedExpr subtree is only renderable at SSR by a backend
+ * whose template runtime is a full JS engine.
+ *
+ * JS-runtime adapters (Hono SSR, CSR — anything extending `JsxAdapter`) return
+ * true, so the compiler keeps the callback inlined for the runtime to execute
+ * instead of raising a universal Phase-1 diagnostic. DSL adapters (Go, Perl,
+ * …) leave this undefined; an off-subset body then raises the usual diagnostic
+ * with the `/* @client *\/` escape, and the user opts that piece into
+ * client-only rendering. Granular by kind so a DSL adapter may later accept a
+ * subset (e.g. `filter` but not `sort`). See `spec/callback-fidelity.md`.
+ */
+export type CallbackBodyAcceptor = (kind: CallbackBodyKind) => boolean
+
 export interface TemplateAdapter {
   name: string
   extension: string
@@ -200,6 +231,15 @@ export interface TemplateAdapter {
    * and rely on the explicit `templatePrimitives` map.
    */
   acceptsTemplateCall?: TemplateCallAcceptor
+
+  /**
+   * Whether this adapter's runtime can render an off-subset callback body
+   * (`filter`/`sort`/`find`/… predicate or comparator the compiler can't
+   * lower to a template / ParsedExpr) verbatim. JS-runtime adapters set this
+   * (via `JsxAdapter`); DSL adapters leave it undefined and instead surface
+   * the diagnostic + `/* @client *\/` escape. See `spec/callback-fidelity.md`.
+   */
+  acceptsCallbackBody?: CallbackBodyAcceptor
 
   // Main entry point - generates complete template from IR
   generate(ir: ComponentIR, options?: AdapterGenerateOptions): AdapterOutput

--- a/packages/jsx/src/adapters/jsx-adapter.ts
+++ b/packages/jsx/src/adapters/jsx-adapter.ts
@@ -12,6 +12,7 @@ import type {
 } from '../types.ts'
 import { BF_SCOPE, BF_SLOT, BF_COND } from '@barefootjs/shared'
 import { BaseAdapter } from './interface.ts'
+import type { CallbackBodyAcceptor } from './interface.ts'
 import { ENV_SIGNAL_CLIENT_FACTORY } from './env-signal.ts'
 import { formatParamWithType, findReachableNames } from '../module-exports.ts'
 
@@ -25,6 +26,15 @@ export abstract class JsxAdapter extends BaseAdapter {
 
   /** Subclasses define whether to use typed values for type-safe output */
   protected abstract jsxConfig: JsxAdapterConfig
+
+  /**
+   * JS-runtime adapters (Hono SSR, CSR, the test adapter) render an off-subset
+   * callback body by running it verbatim, so the compiler need not raise a
+   * universal Phase-1 diagnostic for a `filter`/`sort`/… body it can't lower.
+   * DSL adapters extend `BaseAdapter` and leave this undefined.
+   * See `spec/callback-fidelity.md`.
+   */
+  acceptsCallbackBody: CallbackBodyAcceptor = () => true
 
   // ===========================================================================
   // Import Formatting

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -25,6 +25,7 @@ import type {
   DeclinedReactiveFactory,
 } from './types.ts'
 import { type ExcludeRange, collectAllTypeRanges, reconstructWithoutTypes } from './strip-types.ts'
+import type { CallbackBodyAcceptor } from './adapters/interface.ts'
 
 /**
  * Deferred info for BF043 (props destructuring warning).
@@ -199,6 +200,15 @@ export interface AnalyzerContext {
 
   // Errors
   errors: CompilerError[]
+  /**
+   * Capability of the adapter this component is being compiled for: can its
+   * runtime render an off-subset callback body (`filter`/`sort`/… predicate)
+   * verbatim? Set from `TemplateAdapter.acceptsCallbackBody`; undefined for
+   * direct analyzer callers (no adapter) and DSL adapters. Consulted at the
+   * Phase-1 callback-lowering sites so a JS-runtime target isn't rejected for
+   * a body it could run. See `spec/callback-fidelity.md`.
+   */
+  acceptsCallbackBody?: CallbackBodyAcceptor
 
   // Directive
   hasUseClientDirective: boolean
@@ -232,11 +242,13 @@ export interface AnalyzerContext {
 
 export function createAnalyzerContext(
   sourceFile: ts.SourceFile,
-  filePath: string
+  filePath: string,
+  acceptsCallbackBody?: CallbackBodyAcceptor
 ): AnalyzerContext {
   return {
     sourceFile,
     filePath,
+    acceptsCallbackBody,
 
     componentName: null,
     componentNode: null,

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -9,6 +9,7 @@
 import ts from 'typescript'
 import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo, DeclinedReactiveFactory, RequiredFactoryImport, FactoryRenameSite, SourceLocation } from './types.ts'
 import { parseExpression, parseBlockBodyTolerant, foldBlockToExpr } from './expression-parser.ts'
+import type { CallbackBodyAcceptor } from './adapters/interface.ts'
 import { rewriteBarePropRefs } from './prop-rewrite.ts'
 import { incrementCounter } from './instrumentation.ts'
 import {
@@ -158,7 +159,8 @@ export function analyzeComponent(
   source: string,
   filePath: string,
   targetComponentName?: string,
-  program?: ts.Program
+  program?: ts.Program,
+  acceptsCallbackBody?: CallbackBodyAcceptor
 ): AnalyzerContext {
   incrementCounter('filesAnalyzed')
   // Track whether the caller supplied a shared ts.Program. Used downstream
@@ -229,7 +231,7 @@ export function analyzeComponent(
     }
   }
 
-  const ctx = createAnalyzerContext(sourceFile, filePath)
+  const ctx = createAnalyzerContext(sourceFile, filePath, acceptsCallbackBody)
   ctx.checker = checker
 
   // Reactive-factory prescan results (#931, #2325 cross-file + object-

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -119,7 +119,7 @@ function compileMultipleComponents(
   const program = options.program ?? (needsTypeBasedDetection(source) ? createProgramForFile(source, filePath)?.program : undefined)
 
   for (const componentName of componentNames) {
-    const ctx = analyzeComponent(source, filePath, componentName, program)
+    const ctx = analyzeComponent(source, filePath, componentName, program, adapter.acceptsCallbackBody)
 
     if (!ctx.jsxReturn) {
       errors.push(...ctx.errors)
@@ -556,7 +556,7 @@ export function compileJSX(
   }
 
   // Single component flow
-  const ctx = analyzeComponent(compileSource, filePath, undefined, options.program)
+  const ctx = analyzeComponent(compileSource, filePath, undefined, options.program, options.adapter.acceptsCallbackBody)
 
   if (!ctx.jsxReturn) {
     errors.push(...ctx.errors)

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -3761,7 +3761,12 @@ function transformMapCall(
     // Handle sort comparator extraction
     const sortExtraction = extractSortComparator(sortInfo.callback, sortInfo.method, ctx)
     if (isClientOnly || !sortExtraction.result) {
-      if (!isClientOnly && sortExtraction.unsupportedReason) {
+      // Off-subset comparator: keep it in the array string for client / SSR
+      // evaluation. Only raise the diagnostic when the target adapter's runtime
+      // can't run the comparator body verbatim (DSL); a JS-runtime adapter runs
+      // it, so rejecting it would be a universal error for a DSL-only limit.
+      // See spec/callback-fidelity.md.
+      if (!isClientOnly && sortExtraction.unsupportedReason && !(ctx.analyzer.acceptsCallbackBody?.('sort') ?? false)) {
         ctx.analyzer.errors.push(
           createError(ErrorCodes.UNSUPPORTED_JSX_PATTERN,
             getSourceLocation(sortInfo.callback, ctx.sourceFile, ctx.filePath),
@@ -3784,7 +3789,11 @@ function transformMapCall(
         chainOrder = 'filter-sort'
         const filterExtraction = extractFilterPredicate(innerFilter.callback, ctx)
         if (isClientOnly || !filterExtraction.result) {
-          if (!isClientOnly && filterExtraction.unsupportedReason) {
+          // Off-subset predicate: keep it in the array string for client / SSR
+      // evaluation. Only raise the diagnostic when the target adapter's runtime
+      // can't run the predicate body verbatim (DSL); a JS-runtime adapter runs
+      // it. See spec/callback-fidelity.md.
+      if (!isClientOnly && filterExtraction.unsupportedReason && !(ctx.analyzer.acceptsCallbackBody?.('filter') ?? false)) {
             ctx.analyzer.errors.push(
               createError(ErrorCodes.UNSUPPORTED_JSX_PATTERN,
                 getSourceLocation(innerFilter.callback, ctx.sourceFile, ctx.filePath),
@@ -3818,7 +3827,11 @@ function transformMapCall(
     const filterExtraction = extractFilterPredicate(filterInfo.callback, ctx)
 
     if (isClientOnly || !filterExtraction.result) {
-      if (!isClientOnly && filterExtraction.unsupportedReason) {
+      // Off-subset predicate: keep it in the array string for client / SSR
+      // evaluation. Only raise the diagnostic when the target adapter's runtime
+      // can't run the predicate body verbatim (DSL); a JS-runtime adapter runs
+      // it. See spec/callback-fidelity.md.
+      if (!isClientOnly && filterExtraction.unsupportedReason && !(ctx.analyzer.acceptsCallbackBody?.('filter') ?? false)) {
         ctx.analyzer.errors.push(
           createError(ErrorCodes.UNSUPPORTED_JSX_PATTERN,
             getSourceLocation(filterInfo.callback, ctx.sourceFile, ctx.filePath),
@@ -3841,7 +3854,12 @@ function transformMapCall(
         chainOrder = 'sort-filter'
         const sortExtraction = extractSortComparator(innerSort.callback, innerSort.method, ctx)
         if (isClientOnly || !sortExtraction.result) {
-          if (!isClientOnly && sortExtraction.unsupportedReason) {
+          // Off-subset comparator: keep it in the array string for client / SSR
+      // evaluation. Only raise the diagnostic when the target adapter's runtime
+      // can't run the comparator body verbatim (DSL); a JS-runtime adapter runs
+      // it, so rejecting it would be a universal error for a DSL-only limit.
+      // See spec/callback-fidelity.md.
+      if (!isClientOnly && sortExtraction.unsupportedReason && !(ctx.analyzer.acceptsCallbackBody?.('sort') ?? false)) {
             ctx.analyzer.errors.push(
               createError(ErrorCodes.UNSUPPORTED_JSX_PATTERN,
                 getSourceLocation(innerSort.callback, ctx.sourceFile, ctx.filePath),

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -3790,10 +3790,10 @@ function transformMapCall(
         const filterExtraction = extractFilterPredicate(innerFilter.callback, ctx)
         if (isClientOnly || !filterExtraction.result) {
           // Off-subset predicate: keep it in the array string for client / SSR
-      // evaluation. Only raise the diagnostic when the target adapter's runtime
-      // can't run the predicate body verbatim (DSL); a JS-runtime adapter runs
-      // it. See spec/callback-fidelity.md.
-      if (!isClientOnly && filterExtraction.unsupportedReason && !(ctx.analyzer.acceptsCallbackBody?.('filter') ?? false)) {
+          // evaluation. Only raise the diagnostic when the target adapter's runtime
+          // can't run the predicate body verbatim (DSL); a JS-runtime adapter runs
+          // it. See spec/callback-fidelity.md.
+          if (!isClientOnly && filterExtraction.unsupportedReason && !(ctx.analyzer.acceptsCallbackBody?.('filter') ?? false)) {
             ctx.analyzer.errors.push(
               createError(ErrorCodes.UNSUPPORTED_JSX_PATTERN,
                 getSourceLocation(innerFilter.callback, ctx.sourceFile, ctx.filePath),
@@ -3855,11 +3855,11 @@ function transformMapCall(
         const sortExtraction = extractSortComparator(innerSort.callback, innerSort.method, ctx)
         if (isClientOnly || !sortExtraction.result) {
           // Off-subset comparator: keep it in the array string for client / SSR
-      // evaluation. Only raise the diagnostic when the target adapter's runtime
-      // can't run the comparator body verbatim (DSL); a JS-runtime adapter runs
-      // it, so rejecting it would be a universal error for a DSL-only limit.
-      // See spec/callback-fidelity.md.
-      if (!isClientOnly && sortExtraction.unsupportedReason && !(ctx.analyzer.acceptsCallbackBody?.('sort') ?? false)) {
+          // evaluation. Only raise the diagnostic when the target adapter's runtime
+          // can't run the comparator body verbatim (DSL); a JS-runtime adapter runs
+          // it, so rejecting it would be a universal error for a DSL-only limit.
+          // See spec/callback-fidelity.md.
+          if (!isClientOnly && sortExtraction.unsupportedReason && !(ctx.analyzer.acceptsCallbackBody?.('sort') ?? false)) {
             ctx.analyzer.errors.push(
               createError(ErrorCodes.UNSUPPORTED_JSX_PATTERN,
                 getSourceLocation(innerSort.callback, ctx.sourceFile, ctx.filePath),

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2029,6 +2029,56 @@
           ]
         }
       },
+      "filter-typeof-predicate": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        }
+      },
       "static-array-from-props": {
         "blade": {
           "kind": "refusal",
@@ -2190,6 +2240,10 @@
       "filter-nested-find-predicate": {
         "description": "Filter predicate containing a nested .find() callback (#2038)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-nested-find-predicate.ts"
+      },
+      "filter-typeof-predicate": {
+        "description": "Off-subset filter predicate (typeof) — JS-runtime faithful, DSL diagnostic",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-typeof-predicate.ts"
       },
       "static-array-from-props": {
         "description": "Static-array loop with prop-derived array materialises children on CSR (#1247)",

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 263,
+    "totalFixtures": 265,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -21,7 +21,7 @@
           "total": 56
         },
         "blade": {
-          "pass": 54,
+          "pass": 53,
           "total": 56,
           "gaps": [
             {
@@ -35,11 +35,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "erb": {
-          "pass": 55,
+          "pass": 54,
           "total": 56,
           "gaps": [
             {
@@ -47,11 +51,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "go-template": {
-          "pass": 54,
+          "pass": 53,
           "total": 56,
           "gaps": [
             {
@@ -65,11 +73,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 54,
+          "pass": 53,
           "total": 56,
           "gaps": [
             {
@@ -83,11 +95,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "minijinja": {
-          "pass": 54,
+          "pass": 53,
           "total": 56,
           "gaps": [
             {
@@ -101,11 +117,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "mojolicious": {
-          "pass": 55,
+          "pass": 54,
           "total": 56,
           "gaps": [
             {
@@ -113,11 +133,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "twig": {
-          "pass": 54,
+          "pass": 53,
           "total": 56,
           "gaps": [
             {
@@ -131,11 +155,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "xslate": {
-          "pass": 54,
+          "pass": 53,
           "total": 56,
           "gaps": [
             {
@@ -149,6 +177,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         }
@@ -225,7 +257,7 @@
           "total": 57
         },
         "blade": {
-          "pass": 55,
+          "pass": 54,
           "total": 57,
           "gaps": [
             {
@@ -239,11 +271,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "erb": {
-          "pass": 56,
+          "pass": 55,
           "total": 57,
           "gaps": [
             {
@@ -251,11 +287,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "go-template": {
-          "pass": 55,
+          "pass": 54,
           "total": 57,
           "gaps": [
             {
@@ -269,11 +309,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 55,
+          "pass": 54,
           "total": 57,
           "gaps": [
             {
@@ -287,11 +331,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "minijinja": {
-          "pass": 55,
+          "pass": 54,
           "total": 57,
           "gaps": [
             {
@@ -305,11 +353,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "mojolicious": {
-          "pass": 56,
+          "pass": 55,
           "total": 57,
           "gaps": [
             {
@@ -317,11 +369,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "twig": {
-          "pass": 55,
+          "pass": 54,
           "total": 57,
           "gaps": [
             {
@@ -335,11 +391,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "xslate": {
-          "pass": 55,
+          "pass": 54,
           "total": 57,
           "gaps": [
             {
@@ -353,6 +413,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         }
@@ -377,7 +441,7 @@
           "total": 69
         },
         "blade": {
-          "pass": 66,
+          "pass": 65,
           "total": 69,
           "gaps": [
             {
@@ -391,6 +455,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props-with-component",
@@ -401,7 +469,7 @@
           ]
         },
         "erb": {
-          "pass": 67,
+          "pass": 66,
           "total": 69,
           "gaps": [
             {
@@ -409,6 +477,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props-with-component",
@@ -419,7 +491,7 @@
           ]
         },
         "go-template": {
-          "pass": 66,
+          "pass": 65,
           "total": 69,
           "gaps": [
             {
@@ -433,6 +505,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props-with-component",
@@ -443,7 +519,7 @@
           ]
         },
         "jinja": {
-          "pass": 66,
+          "pass": 65,
           "total": 69,
           "gaps": [
             {
@@ -457,6 +533,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props-with-component",
@@ -467,7 +547,7 @@
           ]
         },
         "minijinja": {
-          "pass": 66,
+          "pass": 65,
           "total": 69,
           "gaps": [
             {
@@ -481,6 +561,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props-with-component",
@@ -491,7 +575,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 67,
+          "pass": 66,
           "total": 69,
           "gaps": [
             {
@@ -499,6 +583,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props-with-component",
@@ -509,7 +597,7 @@
           ]
         },
         "twig": {
-          "pass": 66,
+          "pass": 65,
           "total": 69,
           "gaps": [
             {
@@ -523,6 +611,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props-with-component",
@@ -533,7 +625,7 @@
           ]
         },
         "xslate": {
-          "pass": 66,
+          "pass": 65,
           "total": 69,
           "gaps": [
             {
@@ -547,6 +639,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props-with-component",
@@ -585,7 +681,7 @@
           ]
         },
         "blade": {
-          "pass": 161,
+          "pass": 160,
           "total": 166,
           "gaps": [
             {
@@ -605,6 +701,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -621,7 +721,7 @@
           ]
         },
         "erb": {
-          "pass": 162,
+          "pass": 161,
           "total": 166,
           "gaps": [
             {
@@ -635,6 +735,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -651,7 +755,7 @@
           ]
         },
         "go-template": {
-          "pass": 161,
+          "pass": 160,
           "total": 166,
           "gaps": [
             {
@@ -671,6 +775,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -687,7 +795,7 @@
           ]
         },
         "jinja": {
-          "pass": 161,
+          "pass": 160,
           "total": 166,
           "gaps": [
             {
@@ -707,6 +815,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -723,7 +835,7 @@
           ]
         },
         "minijinja": {
-          "pass": 161,
+          "pass": 160,
           "total": 166,
           "gaps": [
             {
@@ -743,6 +855,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -759,7 +875,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 162,
+          "pass": 161,
           "total": 166,
           "gaps": [
             {
@@ -773,6 +889,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -789,7 +909,7 @@
           ]
         },
         "twig": {
-          "pass": 161,
+          "pass": 160,
           "total": 166,
           "gaps": [
             {
@@ -809,6 +929,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -825,7 +949,7 @@
           ]
         },
         "xslate": {
-          "pass": 161,
+          "pass": 160,
           "total": 166,
           "gaps": [
             {
@@ -845,6 +969,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -941,7 +1069,7 @@
           ]
         },
         "blade": {
-          "pass": 241,
+          "pass": 240,
           "total": 246,
           "gaps": [
             {
@@ -961,6 +1089,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -977,7 +1109,7 @@
           ]
         },
         "erb": {
-          "pass": 242,
+          "pass": 241,
           "total": 246,
           "gaps": [
             {
@@ -991,6 +1123,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1007,7 +1143,7 @@
           ]
         },
         "go-template": {
-          "pass": 241,
+          "pass": 240,
           "total": 246,
           "gaps": [
             {
@@ -1027,6 +1163,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1043,7 +1183,7 @@
           ]
         },
         "jinja": {
-          "pass": 241,
+          "pass": 240,
           "total": 246,
           "gaps": [
             {
@@ -1063,6 +1203,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1079,7 +1223,7 @@
           ]
         },
         "minijinja": {
-          "pass": 241,
+          "pass": 240,
           "total": 246,
           "gaps": [
             {
@@ -1099,6 +1243,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1115,7 +1263,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 242,
+          "pass": 241,
           "total": 246,
           "gaps": [
             {
@@ -1129,6 +1277,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1145,7 +1297,7 @@
           ]
         },
         "twig": {
-          "pass": 241,
+          "pass": 240,
           "total": 246,
           "gaps": [
             {
@@ -1165,6 +1317,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1181,7 +1337,7 @@
           ]
         },
         "xslate": {
-          "pass": 241,
+          "pass": 240,
           "total": 246,
           "gaps": [
             {
@@ -1201,6 +1357,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1289,9 +1449,13 @@
           "total": 204
         },
         "blade": {
-          "pass": 203,
+          "pass": 202,
           "total": 204,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -1301,9 +1465,13 @@
           ]
         },
         "erb": {
-          "pass": 203,
+          "pass": 202,
           "total": 204,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -1313,9 +1481,13 @@
           ]
         },
         "go-template": {
-          "pass": 203,
+          "pass": 202,
           "total": 204,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -1325,9 +1497,13 @@
           ]
         },
         "jinja": {
-          "pass": 203,
+          "pass": 202,
           "total": 204,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -1337,9 +1513,13 @@
           ]
         },
         "minijinja": {
-          "pass": 203,
+          "pass": 202,
           "total": 204,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -1349,9 +1529,13 @@
           ]
         },
         "mojolicious": {
-          "pass": 203,
+          "pass": 202,
           "total": 204,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -1361,9 +1545,13 @@
           ]
         },
         "twig": {
-          "pass": 203,
+          "pass": 202,
           "total": 204,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -1373,9 +1561,13 @@
           ]
         },
         "xslate": {
-          "pass": 203,
+          "pass": 202,
           "total": 204,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -1529,7 +1721,7 @@
           ]
         },
         "blade": {
-          "pass": 120,
+          "pass": 119,
           "total": 125,
           "gaps": [
             {
@@ -1549,6 +1741,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1565,7 +1761,7 @@
           ]
         },
         "erb": {
-          "pass": 121,
+          "pass": 120,
           "total": 125,
           "gaps": [
             {
@@ -1579,6 +1775,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1595,7 +1795,7 @@
           ]
         },
         "go-template": {
-          "pass": 120,
+          "pass": 119,
           "total": 125,
           "gaps": [
             {
@@ -1615,6 +1815,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1631,7 +1835,7 @@
           ]
         },
         "jinja": {
-          "pass": 120,
+          "pass": 119,
           "total": 125,
           "gaps": [
             {
@@ -1651,6 +1855,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1667,7 +1875,7 @@
           ]
         },
         "minijinja": {
-          "pass": 120,
+          "pass": 119,
           "total": 125,
           "gaps": [
             {
@@ -1687,6 +1895,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1703,7 +1915,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 121,
+          "pass": 120,
           "total": 125,
           "gaps": [
             {
@@ -1717,6 +1929,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1733,7 +1949,7 @@
           ]
         },
         "twig": {
-          "pass": 120,
+          "pass": 119,
           "total": 125,
           "gaps": [
             {
@@ -1753,6 +1969,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1769,7 +1989,7 @@
           ]
         },
         "xslate": {
-          "pass": 120,
+          "pass": 119,
           "total": 125,
           "gaps": [
             {
@@ -1789,6 +2009,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -2138,9 +2362,13 @@
           "total": 23
         },
         "blade": {
-          "pass": 21,
+          "pass": 20,
           "total": 23,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -2156,9 +2384,13 @@
           ]
         },
         "erb": {
-          "pass": 21,
+          "pass": 20,
           "total": 23,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -2174,9 +2406,13 @@
           ]
         },
         "go-template": {
-          "pass": 21,
+          "pass": 20,
           "total": 23,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -2192,9 +2428,13 @@
           ]
         },
         "jinja": {
-          "pass": 21,
+          "pass": 20,
           "total": 23,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -2210,9 +2450,13 @@
           ]
         },
         "minijinja": {
-          "pass": 21,
+          "pass": 20,
           "total": 23,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -2228,9 +2472,13 @@
           ]
         },
         "mojolicious": {
-          "pass": 21,
+          "pass": 20,
           "total": 23,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -2246,9 +2494,13 @@
           ]
         },
         "twig": {
-          "pass": 21,
+          "pass": 20,
           "total": 23,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -2264,9 +2516,13 @@
           ]
         },
         "xslate": {
-          "pass": 21,
+          "pass": 20,
           "total": 23,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3978,7 +4234,7 @@
           "total": 32
         },
         "blade": {
-          "pass": 30,
+          "pass": 29,
           "total": 32,
           "gaps": [
             {
@@ -3992,11 +4248,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "erb": {
-          "pass": 31,
+          "pass": 30,
           "total": 32,
           "gaps": [
             {
@@ -4004,11 +4264,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "go-template": {
-          "pass": 30,
+          "pass": 29,
           "total": 32,
           "gaps": [
             {
@@ -4022,11 +4286,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 30,
+          "pass": 29,
           "total": 32,
           "gaps": [
             {
@@ -4040,11 +4308,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "minijinja": {
-          "pass": 30,
+          "pass": 29,
           "total": 32,
           "gaps": [
             {
@@ -4058,11 +4330,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "mojolicious": {
-          "pass": 31,
+          "pass": 30,
           "total": 32,
           "gaps": [
             {
@@ -4070,11 +4346,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "twig": {
-          "pass": 30,
+          "pass": 29,
           "total": 32,
           "gaps": [
             {
@@ -4088,11 +4368,15 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         },
         "xslate": {
-          "pass": 30,
+          "pass": 29,
           "total": 32,
           "gaps": [
             {
@@ -4106,6 +4390,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
             }
           ]
         }
@@ -4389,9 +4677,13 @@
           "total": 147
         },
         "blade": {
-          "pass": 146,
+          "pass": 145,
           "total": 147,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -4401,9 +4693,13 @@
           ]
         },
         "erb": {
-          "pass": 146,
+          "pass": 145,
           "total": 147,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -4413,9 +4709,13 @@
           ]
         },
         "go-template": {
-          "pass": 146,
+          "pass": 145,
           "total": 147,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -4425,9 +4725,13 @@
           ]
         },
         "jinja": {
-          "pass": 146,
+          "pass": 145,
           "total": 147,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -4437,9 +4741,13 @@
           ]
         },
         "minijinja": {
-          "pass": 146,
+          "pass": 145,
           "total": 147,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -4449,9 +4757,13 @@
           ]
         },
         "mojolicious": {
-          "pass": 146,
+          "pass": 145,
           "total": 147,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -4461,9 +4773,13 @@
           ]
         },
         "twig": {
-          "pass": 146,
+          "pass": 145,
           "total": 147,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -4473,9 +4789,13 @@
           ]
         },
         "xslate": {
-          "pass": 146,
+          "pass": 145,
           "total": 147,
           "gaps": [
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 54,
+      "total": 56,
       "cells": {
         "hono": {
-          "pass": 54,
-          "total": 54
+          "pass": 56,
+          "total": 56
         },
         "blade": {
-          "pass": 52,
-          "total": 54,
+          "pass": 54,
+          "total": 56,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -39,8 +39,8 @@
           ]
         },
         "erb": {
-          "pass": 53,
-          "total": 54,
+          "pass": 55,
+          "total": 56,
           "gaps": [
             {
               "fixture": "filter-nested-find-predicate",
@@ -51,8 +51,8 @@
           ]
         },
         "go-template": {
-          "pass": 52,
-          "total": 54,
+          "pass": 54,
+          "total": 56,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -69,8 +69,8 @@
           ]
         },
         "jinja": {
-          "pass": 52,
-          "total": 54,
+          "pass": 54,
+          "total": 56,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -87,8 +87,8 @@
           ]
         },
         "minijinja": {
-          "pass": 52,
-          "total": 54,
+          "pass": 54,
+          "total": 56,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -105,8 +105,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 53,
-          "total": 54,
+          "pass": 55,
+          "total": 56,
           "gaps": [
             {
               "fixture": "filter-nested-find-predicate",
@@ -117,8 +117,8 @@
           ]
         },
         "twig": {
-          "pass": 52,
-          "total": 54,
+          "pass": 54,
+          "total": 56,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -135,8 +135,8 @@
           ]
         },
         "xslate": {
-          "pass": 52,
-          "total": 54,
+          "pass": 54,
+          "total": 56,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -218,15 +218,15 @@
       }
     },
     "arrow": {
-      "total": 55,
+      "total": 57,
       "cells": {
         "hono": {
-          "pass": 55,
-          "total": 55
+          "pass": 57,
+          "total": 57
         },
         "blade": {
-          "pass": 53,
-          "total": 55,
+          "pass": 55,
+          "total": 57,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -243,8 +243,8 @@
           ]
         },
         "erb": {
-          "pass": 54,
-          "total": 55,
+          "pass": 56,
+          "total": 57,
           "gaps": [
             {
               "fixture": "filter-nested-find-predicate",
@@ -255,8 +255,8 @@
           ]
         },
         "go-template": {
-          "pass": 53,
-          "total": 55,
+          "pass": 55,
+          "total": 57,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -273,8 +273,8 @@
           ]
         },
         "jinja": {
-          "pass": 53,
-          "total": 55,
+          "pass": 55,
+          "total": 57,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -291,8 +291,8 @@
           ]
         },
         "minijinja": {
-          "pass": 53,
-          "total": 55,
+          "pass": 55,
+          "total": 57,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -309,8 +309,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 54,
-          "total": 55,
+          "pass": 56,
+          "total": 57,
           "gaps": [
             {
               "fixture": "filter-nested-find-predicate",
@@ -321,8 +321,8 @@
           ]
         },
         "twig": {
-          "pass": 53,
-          "total": 55,
+          "pass": 55,
+          "total": 57,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -339,8 +339,8 @@
           ]
         },
         "xslate": {
-          "pass": 53,
-          "total": 55,
+          "pass": 55,
+          "total": 57,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -370,15 +370,15 @@
       }
     },
     "binary": {
-      "total": 67,
+      "total": 69,
       "cells": {
         "hono": {
-          "pass": 67,
-          "total": 67
+          "pass": 69,
+          "total": 69
         },
         "blade": {
-          "pass": 64,
-          "total": 67,
+          "pass": 66,
+          "total": 69,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -401,8 +401,8 @@
           ]
         },
         "erb": {
-          "pass": 65,
-          "total": 67,
+          "pass": 67,
+          "total": 69,
           "gaps": [
             {
               "fixture": "filter-nested-find-predicate",
@@ -419,8 +419,8 @@
           ]
         },
         "go-template": {
-          "pass": 64,
-          "total": 67,
+          "pass": 66,
+          "total": 69,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -443,8 +443,8 @@
           ]
         },
         "jinja": {
-          "pass": 64,
-          "total": 67,
+          "pass": 66,
+          "total": 69,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -467,8 +467,8 @@
           ]
         },
         "minijinja": {
-          "pass": 64,
-          "total": 67,
+          "pass": 66,
+          "total": 69,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -491,8 +491,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 65,
-          "total": 67,
+          "pass": 67,
+          "total": 69,
           "gaps": [
             {
               "fixture": "filter-nested-find-predicate",
@@ -509,8 +509,8 @@
           ]
         },
         "twig": {
-          "pass": 64,
-          "total": 67,
+          "pass": 66,
+          "total": 69,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -533,8 +533,8 @@
           ]
         },
         "xslate": {
-          "pass": 64,
-          "total": 67,
+          "pass": 66,
+          "total": 69,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -570,11 +570,11 @@
       }
     },
     "call": {
-      "total": 164,
+      "total": 166,
       "cells": {
         "hono": {
-          "pass": 163,
-          "total": 164,
+          "pass": 165,
+          "total": 166,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -585,8 +585,8 @@
           ]
         },
         "blade": {
-          "pass": 159,
-          "total": 164,
+          "pass": 161,
+          "total": 166,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -621,8 +621,8 @@
           ]
         },
         "erb": {
-          "pass": 160,
-          "total": 164,
+          "pass": 162,
+          "total": 166,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -651,8 +651,8 @@
           ]
         },
         "go-template": {
-          "pass": 159,
-          "total": 164,
+          "pass": 161,
+          "total": 166,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -687,8 +687,8 @@
           ]
         },
         "jinja": {
-          "pass": 159,
-          "total": 164,
+          "pass": 161,
+          "total": 166,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -723,8 +723,8 @@
           ]
         },
         "minijinja": {
-          "pass": 159,
-          "total": 164,
+          "pass": 161,
+          "total": 166,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -759,8 +759,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 160,
-          "total": 164,
+          "pass": 162,
+          "total": 166,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -789,8 +789,8 @@
           ]
         },
         "twig": {
-          "pass": 159,
-          "total": 164,
+          "pass": 161,
+          "total": 166,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -825,8 +825,8 @@
           ]
         },
         "xslate": {
-          "pass": 159,
-          "total": 164,
+          "pass": 161,
+          "total": 166,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -926,11 +926,11 @@
       }
     },
     "identifier": {
-      "total": 244,
+      "total": 246,
       "cells": {
         "hono": {
-          "pass": 243,
-          "total": 244,
+          "pass": 245,
+          "total": 246,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -941,8 +941,8 @@
           ]
         },
         "blade": {
-          "pass": 239,
-          "total": 244,
+          "pass": 241,
+          "total": 246,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -977,8 +977,8 @@
           ]
         },
         "erb": {
-          "pass": 240,
-          "total": 244,
+          "pass": 242,
+          "total": 246,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1007,8 +1007,8 @@
           ]
         },
         "go-template": {
-          "pass": 239,
-          "total": 244,
+          "pass": 241,
+          "total": 246,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1043,8 +1043,8 @@
           ]
         },
         "jinja": {
-          "pass": 239,
-          "total": 244,
+          "pass": 241,
+          "total": 246,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1079,8 +1079,8 @@
           ]
         },
         "minijinja": {
-          "pass": 239,
-          "total": 244,
+          "pass": 241,
+          "total": 246,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1115,8 +1115,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 240,
-          "total": 244,
+          "pass": 242,
+          "total": 246,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1145,8 +1145,8 @@
           ]
         },
         "twig": {
-          "pass": 239,
-          "total": 244,
+          "pass": 241,
+          "total": 246,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1181,8 +1181,8 @@
           ]
         },
         "xslate": {
-          "pass": 239,
-          "total": 244,
+          "pass": 241,
+          "total": 246,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1282,15 +1282,15 @@
       }
     },
     "literal": {
-      "total": 202,
+      "total": 204,
       "cells": {
         "hono": {
-          "pass": 202,
-          "total": 202
+          "pass": 204,
+          "total": 204
         },
         "blade": {
-          "pass": 201,
-          "total": 202,
+          "pass": 203,
+          "total": 204,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1301,8 +1301,8 @@
           ]
         },
         "erb": {
-          "pass": 201,
-          "total": 202,
+          "pass": 203,
+          "total": 204,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1313,8 +1313,8 @@
           ]
         },
         "go-template": {
-          "pass": 201,
-          "total": 202,
+          "pass": 203,
+          "total": 204,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1325,8 +1325,8 @@
           ]
         },
         "jinja": {
-          "pass": 201,
-          "total": 202,
+          "pass": 203,
+          "total": 204,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1337,8 +1337,8 @@
           ]
         },
         "minijinja": {
-          "pass": 201,
-          "total": 202,
+          "pass": 203,
+          "total": 204,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1349,8 +1349,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 201,
-          "total": 202,
+          "pass": 203,
+          "total": 204,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1361,8 +1361,8 @@
           ]
         },
         "twig": {
-          "pass": 201,
-          "total": 202,
+          "pass": 203,
+          "total": 204,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1373,8 +1373,8 @@
           ]
         },
         "xslate": {
-          "pass": 201,
-          "total": 202,
+          "pass": 203,
+          "total": 204,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1514,11 +1514,11 @@
       }
     },
     "member": {
-      "total": 123,
+      "total": 125,
       "cells": {
         "hono": {
-          "pass": 122,
-          "total": 123,
+          "pass": 124,
+          "total": 125,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1529,8 +1529,8 @@
           ]
         },
         "blade": {
-          "pass": 118,
-          "total": 123,
+          "pass": 120,
+          "total": 125,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1565,8 +1565,8 @@
           ]
         },
         "erb": {
-          "pass": 119,
-          "total": 123,
+          "pass": 121,
+          "total": 125,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1595,8 +1595,8 @@
           ]
         },
         "go-template": {
-          "pass": 118,
-          "total": 123,
+          "pass": 120,
+          "total": 125,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1631,8 +1631,8 @@
           ]
         },
         "jinja": {
-          "pass": 118,
-          "total": 123,
+          "pass": 120,
+          "total": 125,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1667,8 +1667,8 @@
           ]
         },
         "minijinja": {
-          "pass": 118,
-          "total": 123,
+          "pass": 120,
+          "total": 125,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1703,8 +1703,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 119,
-          "total": 123,
+          "pass": 121,
+          "total": 125,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1733,8 +1733,8 @@
           ]
         },
         "twig": {
-          "pass": 118,
-          "total": 123,
+          "pass": 120,
+          "total": 125,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1769,8 +1769,8 @@
           ]
         },
         "xslate": {
-          "pass": 118,
-          "total": 123,
+          "pass": 120,
+          "total": 125,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2131,15 +2131,15 @@
       }
     },
     "unsupported": {
-      "total": 21,
+      "total": 23,
       "cells": {
         "hono": {
-          "pass": 21,
-          "total": 21
+          "pass": 23,
+          "total": 23
         },
         "blade": {
-          "pass": 19,
-          "total": 21,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2156,8 +2156,8 @@
           ]
         },
         "erb": {
-          "pass": 19,
-          "total": 21,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2174,8 +2174,8 @@
           ]
         },
         "go-template": {
-          "pass": 19,
-          "total": 21,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2192,8 +2192,8 @@
           ]
         },
         "jinja": {
-          "pass": 19,
-          "total": 21,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2210,8 +2210,8 @@
           ]
         },
         "minijinja": {
-          "pass": 19,
-          "total": 21,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2228,8 +2228,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 19,
-          "total": 21,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2246,8 +2246,8 @@
           ]
         },
         "twig": {
-          "pass": 19,
-          "total": 21,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2264,8 +2264,8 @@
           ]
         },
         "xslate": {
-          "pass": 19,
-          "total": 21,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3971,15 +3971,15 @@
       }
     },
     "binary:===": {
-      "total": 30,
+      "total": 32,
       "cells": {
         "hono": {
-          "pass": 30,
-          "total": 30
+          "pass": 32,
+          "total": 32
         },
         "blade": {
-          "pass": 28,
-          "total": 30,
+          "pass": 30,
+          "total": 32,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -3996,8 +3996,8 @@
           ]
         },
         "erb": {
-          "pass": 29,
-          "total": 30,
+          "pass": 31,
+          "total": 32,
           "gaps": [
             {
               "fixture": "filter-nested-find-predicate",
@@ -4008,8 +4008,8 @@
           ]
         },
         "go-template": {
-          "pass": 28,
-          "total": 30,
+          "pass": 30,
+          "total": 32,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4026,8 +4026,8 @@
           ]
         },
         "jinja": {
-          "pass": 28,
-          "total": 30,
+          "pass": 30,
+          "total": 32,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4044,8 +4044,8 @@
           ]
         },
         "minijinja": {
-          "pass": 28,
-          "total": 30,
+          "pass": 30,
+          "total": 32,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4062,8 +4062,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 29,
-          "total": 30,
+          "pass": 31,
+          "total": 32,
           "gaps": [
             {
               "fixture": "filter-nested-find-predicate",
@@ -4074,8 +4074,8 @@
           ]
         },
         "twig": {
-          "pass": 28,
-          "total": 30,
+          "pass": 30,
+          "total": 32,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4092,8 +4092,8 @@
           ]
         },
         "xslate": {
-          "pass": 28,
-          "total": 30,
+          "pass": 30,
+          "total": 32,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4382,15 +4382,15 @@
       }
     },
     "literal:string": {
-      "total": 145,
+      "total": 147,
       "cells": {
         "hono": {
-          "pass": 145,
-          "total": 145
+          "pass": 147,
+          "total": 147
         },
         "blade": {
-          "pass": 144,
-          "total": 145,
+          "pass": 146,
+          "total": 147,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -4401,8 +4401,8 @@
           ]
         },
         "erb": {
-          "pass": 144,
-          "total": 145,
+          "pass": 146,
+          "total": 147,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -4413,8 +4413,8 @@
           ]
         },
         "go-template": {
-          "pass": 144,
-          "total": 145,
+          "pass": 146,
+          "total": 147,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -4425,8 +4425,8 @@
           ]
         },
         "jinja": {
-          "pass": 144,
-          "total": 145,
+          "pass": 146,
+          "total": 147,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -4437,8 +4437,8 @@
           ]
         },
         "minijinja": {
-          "pass": 144,
-          "total": 145,
+          "pass": 146,
+          "total": 147,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -4449,8 +4449,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 144,
-          "total": 145,
+          "pass": 146,
+          "total": 147,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -4461,8 +4461,8 @@
           ]
         },
         "twig": {
-          "pass": 144,
-          "total": 145,
+          "pass": 146,
+          "total": 147,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -4473,8 +4473,8 @@
           ]
         },
         "xslate": {
-          "pass": 144,
-          "total": 145,
+          "pass": 146,
+          "total": 147,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",


### PR DESCRIPTION
## Summary

Stage 1 of the [Callback-Body Fidelity RFC](../blob/main/spec/callback-fidelity.md) (`spec/callback-fidelity.md`, merged in #2372).

Until now, an off-catalogue `filter` predicate or `sort` comparator (`typeof`, a function call, a nested higher-order method, …) raised **BF021 in Phase 1**, before any adapter was consulted — so the code was rejected for *every* target, including JS runtimes (browser CSR always; Hono/H3/Elysia SSR) whose template runtime is a full JS engine that would run the callback verbatim. That's friction with no user benefit: the majority target is clamped to the least-capable template language.

This PR makes the Phase-1 BF021 gate for value-callbacks **adapter-conditional**:

- **JS-runtime adapters** (`JsxAdapter` — Hono, CSR, TestAdapter) accept any `filter`/`sort` callback body and run it as written. **Full fidelity.**
- **DSL adapters** (Go, ERB, Rust, Blade, Jinja, Twig, Xslate, Mojolicious) keep the honest BF021 refusal, and the user reaches for the existing explicit `/* @client */` escape to defer that piece to client-only rendering — not a silent auto-fallback, not a project-wide failure that also punishes JS targets.

The **SSR/CSR parity invariant is unchanged**: per-backend fidelity means per-backend SSR *coverage*, with the browser as the common fully-faithful floor.

## How

- New `CallbackBodyKind` / `CallbackBodyAcceptor` type and an optional `acceptsCallbackBody` capability on `TemplateAdapter` (`packages/jsx/src/adapters/interface.ts`). `JsxAdapter` sets `acceptsCallbackBody = () => true`; DSL adapters leave it unset (default-refuse).
- The capability threads through `compiler.ts` → `analyzeComponent` → `AnalyzerContext`, so Phase 1 (`jsx-to-ir.ts`) can consult the target adapter. The 4 BF021 gate sites in `transformMapCall` (2 sort, 2 filter) now skip the refusal when the adapter accepts that callback kind.
- CSR is a JS runtime: `csr-render.ts` passes `() => true` so the client conformance harness compiles off-subset predicates the same way the browser runs them.

## Tests

- **Compiler unit** (`unsupported-expression.test.ts`): split into a DSL-modelled adapter asserting BF021 + `/* @client */`, and default TestAdapter asserting 0 BF021.
- **Cross-adapter conformance**: new `filter-typeof-predicate` fixture (JS-runtime faithful / DSL-diagnostic via `conformancePins` on all 8 DSL adapters) and its `/* @client */` twin `filter-typeof-predicate-client` (must render clean on every adapter — asserts the suppression contract).
- Regenerated `coverage-map.json`, `support-matrix.lock.json`, `compat.lock.json` for the two new fixtures.
- Docs (`jsx-compatibility.md`) re-marked from `❌ BF021 (all adapters)` to `❌ BF021 on Go/Mojo`.

Full suites green: **jsx 2602/0 · adapter-tests 1361/0 · compat 87/0**.

## Scope / follow-ups

This first Stage-1 PR covers `filter` and `sort`. Remaining Stage-1 items per the RFC (`find`/`some`/`every`/`reduce`/`flatMap` predicates, the latent `fill` gap, the stale `reduce` comment) follow in subsequent PRs. Stage 2+ (JSX-`map` fold to neutral IR, verbatim `/* @client */` for the rest, examples re-land) are separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FG9KVo7k7nmVkvpuDXKCaC)_