### PR TITLE
Stage 1: gate `.fill()` on DSL adapters; fix stale reduce/higher-order comments

### DIFF
--- a/.changeset/gate-fill-and-fix-stale-reduce-comments.md
+++ b/.changeset/gate-fill-and-fix-stale-reduce-comments.md
@@ -1,0 +1,17 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/blade": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/rust": patch
+"@barefootjs/twig": patch
+"@barefootjs/xslate": patch
+---
+
+Close the latent `.fill()` gap and correct stale `reduce` documentation (callback-body fidelity, Stage 1 of `spec/callback-fidelity.md`).
+
+`Array.prototype.fill(value)` had no template lowering on any DSL adapter but was reported "supported" by `isSupported`, so the DSL adapters emitted a raw `.fill(...)` method call with no build diagnostic — a silent footgun that only surfaced as a crash at template-render time. `fill` is now in the `UNSUPPORTED_METHODS` gate, so a DSL build fails loudly with BF101 and points at the `/* @client */` escape; a JS-runtime adapter (Hono, CSR) still runs it verbatim, since those skip `isSupported`. Covered by the `fill-unsupported` conformance fixture (JS-runtime faithful / DSL-diagnostic, pinned BF101 on every DSL adapter).
+
+Also corrects two stale comments in `expression-parser.ts` (the claim that `find`/`some`/`every`/… are "intercepted as `higher-order` IR", and that `reduce` folds into a structured `ReduceOp` before the gate — neither is true; both flow through the runtime evaluator as a generic `call`) and removes the dead, never-referenced `ReduceMethod` type from `parsed-expr-emitter.ts`.

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -15,6 +15,10 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // `.fill(value)` mutates the receiver in place — no template lowering
+  // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
+  // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.
+  'fill-unsupported': [{ code: 'BF101', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -16,6 +16,10 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // `.fill(value)` mutates the receiver in place — no template lowering
+  // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
+  // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.
+  'fill-unsupported': [{ code: 'BF101', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -15,6 +15,10 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // `.fill(value)` mutates the receiver in place — no template lowering
+  // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
+  // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.
+  'fill-unsupported': [{ code: 'BF101', severity: 'error' }],
   // `style-object-dynamic` / `style-3-signals` no longer pinned — a
   // `style={{ … }}` object literal now lowers to a CSS string with dynamic
   // values interpolated (`background-color:{{.Color}};padding:8px`) via

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -15,6 +15,10 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // `.fill(value)` mutates the receiver in place — no template lowering
+  // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
+  // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.
+  'fill-unsupported': [{ code: 'BF101', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -13,6 +13,10 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // `.fill(value)` mutates the receiver in place — no template lowering
+  // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
+  // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.
+  'fill-unsupported': [{ code: 'BF101', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -16,6 +16,10 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // `.fill(value)` mutates the receiver in place — no template lowering
+  // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
+  // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.
+  'fill-unsupported': [{ code: 'BF101', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1775,6 +1775,24 @@
         "text"
       ]
     },
+    "fill-unsupported": {
+      "kinds": [
+        "array-literal",
+        "array-method",
+        "call",
+        "identifier",
+        "literal",
+        "member"
+      ],
+      "axes": [
+        "array-method:join",
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "filter-nested-callback-predicate": {
       "kinds": [
         "array-literal",
@@ -4244,17 +4262,17 @@
     }
   },
   "kindCounts": {
-    "array-literal": 56,
-    "array-method": 62,
+    "array-literal": 57,
+    "array-method": 63,
     "arrow": 57,
     "binary": 69,
-    "call": 166,
+    "call": 167,
     "conditional": 19,
-    "identifier": 246,
+    "identifier": 247,
     "index-access": 12,
-    "literal": 204,
+    "literal": 205,
     "logical": 41,
-    "member": 125,
+    "member": 126,
     "object-literal": 46,
     "template-literal": 27,
     "unary": 22,
@@ -4267,7 +4285,7 @@
     "array-method:flat": 4,
     "array-method:includes": 12,
     "array-method:indexOf": 1,
-    "array-method:join": 36,
+    "array-method:join": 37,
     "array-method:lastIndexOf": 1,
     "array-method:padEnd": 1,
     "array-method:padStart": 1,
@@ -4297,8 +4315,8 @@
     "binary:>=": 1,
     "literal:boolean": 38,
     "literal:null": 22,
-    "literal:number": 86,
-    "literal:string": 147,
+    "literal:number": 87,
+    "literal:string": 148,
     "logical:&&": 7,
     "logical:??": 37,
     "logical:||": 12,

--- a/packages/adapter-tests/fixtures/fill-unsupported.ts
+++ b/packages/adapter-tests/fixtures/fill-unsupported.ts
@@ -1,0 +1,33 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `Array.prototype.fill(value)` — a mutating array method with no template
+ * lowering on any DSL adapter (it fills the receiver in place and returns
+ * it; there is no ParsedExpr / evaluator form). Before `fill` was gated it
+ * was reported "supported" by `isSupported` and the DSL adapters emitted a
+ * raw `.fill(...)` method call with no build diagnostic — a silent footgun
+ * that only surfaced as a crash at template-render time.
+ *
+ * Per `spec/callback-fidelity.md` the diagnostic is adapter-gated:
+ *   - Hono / CSR run `.fill()` verbatim (JS runtime) and render faithfully.
+ *   - DSL adapters (Go, Perl, Ruby, PHP, Rust, Python) can't lower it at SSR
+ *     and surface BF101 with a `/* @client *\/` escape (declared via each
+ *     adapter's `conformancePins`). Marking the expression `/* @client *\/`
+ *     defers it to client-only rendering — the method-agnostic suppression
+ *     contract is already covered by the `filter-*-client` twins.
+ */
+export const fixture = createFixture({
+  id: 'fill-unsupported',
+  description: 'Off-subset array method `.fill()` — JS-runtime faithful, DSL diagnostic',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function FillUnsupported() {
+  const [items, setItems] = createSignal<number[]>([])
+  return <div>{items().fill(0).join(',')}</div>
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0--><!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -120,6 +120,7 @@ import { fixture as filterNestedCallbackPredicateClient } from './filter-nested-
 import { fixture as filterTypeofPredicate } from './filter-typeof-predicate'
 import { fixture as filterTypeofPredicateClient } from './filter-typeof-predicate-client'
 import { fixture as filterNestedFindPredicate } from './filter-nested-find-predicate'
+import { fixture as fillUnsupported } from './fill-unsupported'
 import { fixture as sortSimple } from './sort-simple'
 import { fixture as filterSortChain } from './filter-sort-chain'
 import { fixture as mapNested } from './map-nested'
@@ -477,6 +478,7 @@ export const jsxFixtures: JSXFixture[] = [
   filterTypeofPredicate,
   filterTypeofPredicateClient,
   filterNestedFindPredicate,
+  fillUnsupported,
   sortSimple,
   filterSortChain,
   mapNested,

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -15,6 +15,10 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // `.fill(value)` mutates the receiver in place — no template lowering
+  // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
+  // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.
+  'fill-unsupported': [{ code: 'BF101', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -13,6 +13,10 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // `.fill(value)` mutates the receiver in place — no template lowering
+  // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
+  // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.
+  'fill-unsupported': [{ code: 'BF101', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -87,16 +87,11 @@ export type ArrayMethod =
  */
 export type SortMethod = 'sort' | 'toSorted'
 
-/**
- * `reduce` / `reduceRight` are handled by the dedicated `reduceMethod()`
- * dispatcher arm (#1448 Tier C) for the same reason sort is: they carry
- * a structured `ReduceOp` (the parsed arithmetic-fold spec) rather than
- * a `ParsedExpr[]` args list, so folding them into `arrayMethod()` would
- * force a spec-or-args runtime check at every call site. The method name
- * is threaded through so adapters can pick the fold direction (left for
- * `reduce`, right for `reduceRight`).
- */
-export type ReduceMethod = 'reduce' | 'reduceRight'
+// NB: there is no structured `reduce` / `reduceRight` emitter type here.
+// #2018 P5 removed the folded `ReduceOp` form — a `.reduce(fn, init)` now
+// arrives as a generic `call` whose reducer body + initial value serialize
+// to the runtime evaluator, so no dedicated `reduceMethod()` dispatcher (or
+// `ReduceMethod` type) exists.
 
 export type LiteralType = 'string' | 'number' | 'boolean' | 'null'
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -364,25 +364,22 @@ export interface SupportResult {
 // evaluate JS at runtime via hono/jsx) so this set only constrains
 // the template-language adapters.
 const UNSUPPORTED_METHODS = new Set([
-  // Higher-order array methods. Seven of these (`filter`, `every`,
-  // `some`, `find`, `findIndex`, `findLast`, `findLastIndex`) are
-  // intercepted as `higher-order` IR before reaching this gate.
-  // `map` is intercepted as an IRLoop when its callback returns JSX,
-  // and as a `CALLBACK_METHODS` evaluator lowering (`map_eval`, #2073)
-  // when it returns a value — it stays listed here so the fall-throughs
-  // (a bare `arr.map` reference, a function-reference callback) still
-  // refuse loudly. `reduce` / `reduceRight` stay
-  // listed here so the shapes the Tier C catalogue can't lower still
-  // refuse loudly: the `convertNode` call branch intercepts a matching
-  // `.reduce(fn, init)` / `.reduceRight(fn, init)` into the structured
-  // `array-method` + `ReduceOp` form *before* this gate (returning
-  // early), so only the unlowerable fall-throughs (a `.reduce(fn)` with
-  // no initial value, or a bare method reference) reach the gate and
-  // refuse. A 2-arg call whose reducer/init shape is off-catalogue
-  // returns an explicit `unsupported` from the call branch with a richer
-  // message. The rest stay refused — see #1448 Tier C for the design
-  // questions. `forEach` carries a tailored reason (see
-  // `UNSUPPORTED_METHOD_REASONS`).
+  // Higher-order array methods. `filter`, `every`, `some`, `find`,
+  // `findIndex`, `findLast`, `findLastIndex`, `reduce`, `reduceRight`
+  // and `flatMap` *with an arrow-callback argument* are recognized by
+  // `asCallbackMethodCall` and lower via the runtime evaluator
+  // (`serializeParsedExpr`) in the `call` arm ABOVE this gate — an
+  // off-subset callback body refuses there with a "complex callback"
+  // reason, not here. They stay listed in this set so the shapes that
+  // recognition can't catch — a BARE method reference (`arr.filter`
+  // uncalled) or a function-reference callback (no arrow) — still refuse
+  // loudly. (`reduce` / `reduceRight` are NOT folded into a structured
+  // `array-method` / `ReduceOp` form: #2018 P5 leaves them as a generic
+  // `call` whose reducer body + initial value serialize to the
+  // evaluator.) `map` is intercepted as an IRLoop when its callback
+  // returns JSX, and as a `CALLBACK_METHODS` evaluator lowering
+  // (`map_eval`, #2073) when it returns a value. `forEach` carries a
+  // tailored reason (see `UNSUPPORTED_METHOD_REASONS`).
   // `flat` is no longer here — `.flat(depth?)` lowers via the
   // `array-method` IR (structured `FlatDepth`) + `bf_flat` (Go) /
   // `bf->flat` (Mojo). `flatMap` stays listed as a fallback: the
@@ -395,6 +392,17 @@ const UNSUPPORTED_METHODS = new Set([
   // `IRLoop` upstream. See #1448.
   'filter', 'map', 'reduce', 'reduceRight', 'every', 'some',
   'forEach', 'flatMap',
+  // `fill` has no template lowering on any DSL adapter (it mutates the
+  // receiver in place and returns it — no ParsedExpr / evaluator form).
+  // Before it was listed here `isSupported` reported it "supported" and
+  // the adapters emitted a raw `.fill(...)` method call with no build
+  // diagnostic — the same silent footgun the string methods below
+  // documented before they were gated: it only surfaced as a crash at
+  // template-render time. Listing it makes the build fail loudly with
+  // BF101, pointing users at the `/* @client */` escape (a JS-runtime
+  // adapter still runs it verbatim, since those skip `isSupported`).
+  // See spec/callback-fidelity.md.
+  'fill',
   // #1448 Tier A — Array methods. Each method PR adds the lowering
   // (typically a new `array-method` variant or runtime helper) and
   // removes its row here. See packages/adapter-tests/fixtures/methods/.

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 265,
+    "totalFixtures": 266,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -1896,6 +1896,56 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2356"
+          ]
+        }
+      },
+      "fill-unsupported": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
           ]
         }
       },
@@ -2232,6 +2282,10 @@
       "date-method-uncatalogued": {
         "description": "Method call on a Date-typed prop refuses with BF021 (no catalogued lowering)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/date-method-uncatalogued.ts"
+      },
+      "fill-unsupported": {
+        "description": "Off-subset array method `.fill()` — JS-runtime faithful, DSL diagnostic",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/fill-unsupported.ts"
       },
       "filter-nested-callback-predicate": {
         "description": "Filter predicate containing a nested .some() callback (#2038)",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,16 +14,20 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 56,
+      "total": 57,
       "cells": {
         "hono": {
-          "pass": 56,
-          "total": 56
+          "pass": 57,
+          "total": 57
         },
         "blade": {
           "pass": 53,
-          "total": 56,
+          "total": 57,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
@@ -44,8 +48,12 @@
         },
         "erb": {
           "pass": 54,
-          "total": 56,
+          "total": 57,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
@@ -60,8 +68,12 @@
         },
         "go-template": {
           "pass": 53,
-          "total": 56,
+          "total": 57,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
@@ -82,8 +94,12 @@
         },
         "jinja": {
           "pass": 53,
-          "total": 56,
+          "total": 57,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
@@ -104,8 +120,12 @@
         },
         "minijinja": {
           "pass": 53,
-          "total": 56,
+          "total": 57,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
@@ -126,8 +146,12 @@
         },
         "mojolicious": {
           "pass": 54,
-          "total": 56,
+          "total": 57,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
@@ -142,8 +166,12 @@
         },
         "twig": {
           "pass": 53,
-          "total": 56,
+          "total": 57,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
@@ -164,8 +192,12 @@
         },
         "xslate": {
           "pass": 53,
-          "total": 56,
+          "total": 57,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
@@ -198,43 +230,91 @@
       }
     },
     "array-method": {
-      "total": 62,
+      "total": 63,
       "cells": {
         "hono": {
-          "pass": 62,
-          "total": 62
+          "pass": 63,
+          "total": 63
         },
         "blade": {
           "pass": 62,
-          "total": 62
+          "total": 63,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "erb": {
           "pass": 62,
-          "total": 62
+          "total": 63,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "go-template": {
           "pass": 62,
-          "total": 62
+          "total": 63,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "jinja": {
           "pass": 62,
-          "total": 62
+          "total": 63,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "minijinja": {
           "pass": 62,
-          "total": 62
+          "total": 63,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "mojolicious": {
           "pass": 62,
-          "total": 62
+          "total": 63,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "twig": {
           "pass": 62,
-          "total": 62
+          "total": 63,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "xslate": {
           "pass": 62,
-          "total": 62
+          "total": 63,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         }
       },
       "source": {
@@ -666,11 +746,11 @@
       }
     },
     "call": {
-      "total": 166,
+      "total": 167,
       "cells": {
         "hono": {
-          "pass": 165,
-          "total": 166,
+          "pass": 166,
+          "total": 167,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -682,13 +762,17 @@
         },
         "blade": {
           "pass": 160,
-          "total": 166,
+          "total": 167,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -722,13 +806,17 @@
         },
         "erb": {
           "pass": 161,
-          "total": 166,
+          "total": 167,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-find-predicate",
@@ -756,13 +844,17 @@
         },
         "go-template": {
           "pass": 160,
-          "total": 166,
+          "total": 167,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -796,13 +888,17 @@
         },
         "jinja": {
           "pass": 160,
-          "total": 166,
+          "total": 167,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -836,13 +932,17 @@
         },
         "minijinja": {
           "pass": 160,
-          "total": 166,
+          "total": 167,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -876,13 +976,17 @@
         },
         "mojolicious": {
           "pass": 161,
-          "total": 166,
+          "total": 167,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-find-predicate",
@@ -910,13 +1014,17 @@
         },
         "twig": {
           "pass": 160,
-          "total": 166,
+          "total": 167,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -950,13 +1058,17 @@
         },
         "xslate": {
           "pass": 160,
-          "total": 166,
+          "total": 167,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -1054,11 +1166,11 @@
       }
     },
     "identifier": {
-      "total": 246,
+      "total": 247,
       "cells": {
         "hono": {
-          "pass": 245,
-          "total": 246,
+          "pass": 246,
+          "total": 247,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1070,13 +1182,17 @@
         },
         "blade": {
           "pass": 240,
-          "total": 246,
+          "total": 247,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -1110,13 +1226,17 @@
         },
         "erb": {
           "pass": 241,
-          "total": 246,
+          "total": 247,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-find-predicate",
@@ -1144,13 +1264,17 @@
         },
         "go-template": {
           "pass": 240,
-          "total": 246,
+          "total": 247,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -1184,13 +1308,17 @@
         },
         "jinja": {
           "pass": 240,
-          "total": 246,
+          "total": 247,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -1224,13 +1352,17 @@
         },
         "minijinja": {
           "pass": 240,
-          "total": 246,
+          "total": 247,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -1264,13 +1396,17 @@
         },
         "mojolicious": {
           "pass": 241,
-          "total": 246,
+          "total": 247,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-find-predicate",
@@ -1298,13 +1434,17 @@
         },
         "twig": {
           "pass": 240,
-          "total": 246,
+          "total": 247,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -1338,13 +1478,17 @@
         },
         "xslate": {
           "pass": 240,
-          "total": 246,
+          "total": 247,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -1442,16 +1586,20 @@
       }
     },
     "literal": {
-      "total": 204,
+      "total": 205,
       "cells": {
         "hono": {
-          "pass": 204,
-          "total": 204
+          "pass": 205,
+          "total": 205
         },
         "blade": {
           "pass": 202,
-          "total": 204,
+          "total": 205,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -1466,8 +1614,12 @@
         },
         "erb": {
           "pass": 202,
-          "total": 204,
+          "total": 205,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -1482,8 +1634,12 @@
         },
         "go-template": {
           "pass": 202,
-          "total": 204,
+          "total": 205,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -1498,8 +1654,12 @@
         },
         "jinja": {
           "pass": 202,
-          "total": 204,
+          "total": 205,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -1514,8 +1674,12 @@
         },
         "minijinja": {
           "pass": 202,
-          "total": 204,
+          "total": 205,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -1530,8 +1694,12 @@
         },
         "mojolicious": {
           "pass": 202,
-          "total": 204,
+          "total": 205,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -1546,8 +1714,12 @@
         },
         "twig": {
           "pass": 202,
-          "total": 204,
+          "total": 205,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -1562,8 +1734,12 @@
         },
         "xslate": {
           "pass": 202,
-          "total": 204,
+          "total": 205,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -1706,11 +1882,11 @@
       }
     },
     "member": {
-      "total": 125,
+      "total": 126,
       "cells": {
         "hono": {
-          "pass": 124,
-          "total": 125,
+          "pass": 125,
+          "total": 126,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1722,13 +1898,17 @@
         },
         "blade": {
           "pass": 119,
-          "total": 125,
+          "total": 126,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -1762,13 +1942,17 @@
         },
         "erb": {
           "pass": 120,
-          "total": 125,
+          "total": 126,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-find-predicate",
@@ -1796,13 +1980,17 @@
         },
         "go-template": {
           "pass": 119,
-          "total": 125,
+          "total": 126,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -1836,13 +2024,17 @@
         },
         "jinja": {
           "pass": 119,
-          "total": 125,
+          "total": 126,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -1876,13 +2068,17 @@
         },
         "minijinja": {
           "pass": 119,
-          "total": 125,
+          "total": 126,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -1916,13 +2112,17 @@
         },
         "mojolicious": {
           "pass": 120,
-          "total": 125,
+          "total": 126,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-find-predicate",
@@ -1950,13 +2150,17 @@
         },
         "twig": {
           "pass": 119,
-          "total": 125,
+          "total": 126,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -1990,13 +2194,17 @@
         },
         "xslate": {
           "pass": 119,
-          "total": 125,
+          "total": 126,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
             },
             {
               "fixture": "filter-nested-callback-predicate",
@@ -2864,43 +3072,91 @@
       }
     },
     "array-method:join": {
-      "total": 36,
+      "total": 37,
       "cells": {
         "hono": {
-          "pass": 36,
-          "total": 36
+          "pass": 37,
+          "total": 37
         },
         "blade": {
           "pass": 36,
-          "total": 36
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "erb": {
           "pass": 36,
-          "total": 36
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "go-template": {
           "pass": 36,
-          "total": 36
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "jinja": {
           "pass": 36,
-          "total": 36
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "minijinja": {
           "pass": 36,
-          "total": 36
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "mojolicious": {
           "pass": 36,
-          "total": 36
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "twig": {
           "pass": 36,
-          "total": 36
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "xslate": {
           "pass": 36,
-          "total": 36
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         }
       },
       "source": {
@@ -4618,43 +4874,91 @@
       }
     },
     "literal:number": {
-      "total": 86,
+      "total": 87,
       "cells": {
         "hono": {
-          "pass": 86,
-          "total": 86
+          "pass": 87,
+          "total": 87
         },
         "blade": {
           "pass": 86,
-          "total": 86
+          "total": 87,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "erb": {
           "pass": 86,
-          "total": 86
+          "total": 87,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "go-template": {
           "pass": 86,
-          "total": 86
+          "total": 87,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "jinja": {
           "pass": 86,
-          "total": 86
+          "total": 87,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "minijinja": {
           "pass": 86,
-          "total": 86
+          "total": 87,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "mojolicious": {
           "pass": 86,
-          "total": 86
+          "total": 87,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "twig": {
           "pass": 86,
-          "total": 86
+          "total": 87,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         },
         "xslate": {
           "pass": 86,
-          "total": 86
+          "total": 87,
+          "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            }
+          ]
         }
       },
       "source": {
@@ -4670,16 +4974,20 @@
       }
     },
     "literal:string": {
-      "total": 147,
+      "total": 148,
       "cells": {
         "hono": {
-          "pass": 147,
-          "total": 147
+          "pass": 148,
+          "total": 148
         },
         "blade": {
           "pass": 145,
-          "total": 147,
+          "total": 148,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -4694,8 +5002,12 @@
         },
         "erb": {
           "pass": 145,
-          "total": 147,
+          "total": 148,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -4710,8 +5022,12 @@
         },
         "go-template": {
           "pass": 145,
-          "total": 147,
+          "total": 148,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -4726,8 +5042,12 @@
         },
         "jinja": {
           "pass": 145,
-          "total": 147,
+          "total": 148,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -4742,8 +5062,12 @@
         },
         "minijinja": {
           "pass": 145,
-          "total": 147,
+          "total": 148,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -4758,8 +5082,12 @@
         },
         "mojolicious": {
           "pass": 145,
-          "total": 147,
+          "total": 148,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -4774,8 +5102,12 @@
         },
         "twig": {
           "pass": 145,
-          "total": 147,
+          "total": 148,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []
@@ -4790,8 +5122,12 @@
         },
         "xslate": {
           "pass": 145,
-          "total": 147,
+          "total": 148,
           "gaps": [
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
             {
               "fixture": "filter-typeof-predicate",
               "issues": []


### PR DESCRIPTION
## Summary

Stage 1 of the [Callback-Body Fidelity RFC](../blob/main/spec/callback-fidelity.md), continuing after #2373 (filter/sort). This is **PR 1 of a 3-PR stack**; PRs 2–3 add off-subset conformance coverage for the remaining callback methods.

Two things, both grounded in an empirical audit of how the remaining callback-taking array methods refuse today:

### 1. Close the latent `.fill()` gap (real behavior change)

`Array.prototype.fill(value)` mutates its receiver in place and has **no template lowering on any DSL adapter**, but `isSupported` reported it *supported* — so Go/ERB/Blade/… emitted a raw `.fill(...)` method call with **no build diagnostic**, a silent footgun that only surfaced as a crash at template-render time (exactly the failure mode the string methods documented before they were gated).

`fill` is now in the `UNSUPPORTED_METHODS` gate:
- **DSL adapters** fail loudly with **BF101** and name the `/* @client */` escape.
- **JS-runtime adapters** (Hono, CSR) still run it verbatim — they skip `isSupported`.

Covered by the new `fill-unsupported` conformance fixture (JS-runtime faithful / DSL-diagnostic), pinned BF101 on all eight DSL adapters.

### 2. Correct stale documentation (no behavior change)

The audit surfaced two comments in `expression-parser.ts` that no longer match the code:
- The claim that `find`/`some`/`every`/… are *"intercepted as `higher-order` IR before reaching this gate"* — there is no `higher-order` ParsedExpr kind; they're recognized by `asCallbackMethodCall` and lower via the runtime evaluator.
- The claim that `reduce`/`reduceRight` fold into a structured `ReduceOp` before the gate — #2018 P5 removed that; they flow through as a generic `call`.

Both are rewritten to match reality, and the dead, never-referenced `ReduceMethod` type is removed from `parsed-expr-emitter.ts`.

## Context: the remaining callback methods are already correctly split

An empirical check confirms `find`/`findIndex`/`findLast`/`findLastIndex`/`some`/`every`/`reduce`/`reduceRight`/`flatMap` with an off-subset body **already** render verbatim on JS runtimes and raise BF101/BF102 (with the `@client` option) on DSL adapters — they never reached the Phase-1 BF021 path that `filter`/`sort` needed gating for, so no `acceptsCallbackBody` gate is required for them. The follow-up PRs lock that split with conformance fixtures; this PR only fixes the one method (`fill`) that was genuinely mis-handled, plus the stale docs.

## Tests

Full suites green: **jsx 2643/0 · adapter-tests 1366/0 · compat 103/0** (includes the support-matrix / compat / coverage-map freshness gates, regenerated for the new fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FG9KVo7k7nmVkvpuDXKCaC)_