### PR TITLE
Stage 2: fold if/else-if & switch .map() bodies to neutral IR

### DIFF
--- a/.changeset/fold-if-chain-switch-map-bodies.md
+++ b/.changeset/fold-if-chain-switch-map-bodies.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fold if/else-if chain and `switch` `.map()` callback bodies to neutral IR (callback-body fidelity, Stage 2 of `spec/callback-fidelity.md`).
+
+A `.map()` whose callback body is a block with an if/else-if chain (or a `switch` with a `default`) returning a different element per branch now folds into a nested `IRConditional` — the same neutral IR a ternary map body already produces — instead of silently leaking: previously the leading `if (...) return <A/>` was emitted uncompiled into the map callback (a `ReferenceError` at hydration) while only the trailing `return <fallback/>` was templatized. All backends gain SSR fidelity for these shapes; no `/* @client */` is needed. The branch-fold core is shared with the multi-return JSX helper-function inliner. Preamble-const, switch-fallthrough, and statement-level nested-loop bodies are not yet folded and remain unchanged (follow-up).

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2468,6 +2468,24 @@
         "text"
       ]
     },
+    "map-if-chain-body": {
+      "kinds": [
+        "binary",
+        "identifier",
+        "literal",
+        "member"
+      ],
+      "axes": [
+        "binary:===",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "condition",
+        "loop",
+        "text"
+      ]
+    },
     "map-index-handler": {
       "kinds": [
         "array-literal",
@@ -4376,14 +4394,14 @@
     "array-literal": 63,
     "array-method": 64,
     "arrow": 61,
-    "binary": 73,
+    "binary": 74,
     "call": 173,
     "conditional": 20,
-    "identifier": 253,
+    "identifier": 254,
     "index-access": 12,
-    "literal": 211,
+    "literal": 212,
     "logical": 41,
-    "member": 132,
+    "member": 133,
     "object-literal": 46,
     "template-literal": 27,
     "unary": 22,
@@ -4421,13 +4439,13 @@
     "binary:-": 11,
     "binary:/": 1,
     "binary:<": 1,
-    "binary:===": 36,
+    "binary:===": 37,
     "binary:>": 11,
     "binary:>=": 1,
     "literal:boolean": 38,
     "literal:null": 22,
     "literal:number": 89,
-    "literal:string": 152,
+    "literal:string": 153,
     "logical:&&": 7,
     "logical:??": 37,
     "logical:||": 12,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -127,6 +127,7 @@ import { fixture as everyTypeofPredicate } from './every-typeof-predicate'
 import { fixture as reduceTypeofBody } from './reduce-typeof-body'
 import { fixture as reduceRightTypeofBody } from './reduce-right-typeof-body'
 import { fixture as flatMapTypeofProjection } from './flatmap-typeof-projection'
+import { fixture as mapIfChainBody } from './map-if-chain-body'
 import { fixture as sortSimple } from './sort-simple'
 import { fixture as filterSortChain } from './filter-sort-chain'
 import { fixture as mapNested } from './map-nested'
@@ -491,6 +492,7 @@ export const jsxFixtures: JSXFixture[] = [
   reduceTypeofBody,
   reduceRightTypeofBody,
   flatMapTypeofProjection,
+  mapIfChainBody,
   sortSimple,
   filterSortChain,
   mapNested,

--- a/packages/adapter-tests/fixtures/map-if-chain-body.ts
+++ b/packages/adapter-tests/fixtures/map-if-chain-body.ts
@@ -1,0 +1,34 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A `.map()` callback whose body is an **if / else-if chain** returning a
+ * different element per branch. Before Stage 2 of `spec/callback-fidelity.md`
+ * this fell through the block-body arm's single-return path: the trailing
+ * `return <C/>` claimed the loop body and the leading `if (...) return <A/>`
+ * leaked verbatim into the map callback (uncompiled JSX / ReferenceError at
+ * hydration). It now folds to a nested `IRConditional` — neutral IR that
+ * renders on **every** backend (no `/* @client *\/` needed), so this is a
+ * positive cross-adapter fixture with no `conformancePins`.
+ */
+export const fixture = createFixture({
+  id: 'map-if-chain-body',
+  description: 'if/else-if chain as a .map() callback body folds to nested IRConditional',
+  source: `
+function MapIfChain({ items }: { items: { id: string; kind: string }[] }) {
+  return (
+    <ul>
+      {items.map((it) => {
+        if (it.kind === 'a') return <li key={it.id}>A:{it.id}</li>
+        else if (it.kind === 'b') return <li key={it.id}>B:{it.id}</li>
+        return <li key={it.id}>C:{it.id}</li>
+      })}
+    </ul>
+  )
+}
+export { MapIfChain }
+`,
+  props: { items: [{ id: '1', kind: 'a' }, { id: '2', kind: 'b' }, { id: '3', kind: 'z' }] },
+  expectedHtml: `
+    <ul bf-s="test" bf="s5"><!--bf-loop:l0--><li bf-c="s3" data-key="1">A:<!--bf:s4-->1<!--/--></li><!--bf-cond-start:s3--><li bf-c="s1" data-key="2">B:<!--bf:s2-->2<!--/--></li><!--bf-cond-end:s3--><!--bf-cond-start:s3--><li bf-c="s1" data-key="3">C:<!--bf:s0-->3<!--/--></li><!--bf-cond-end:s3--><!--bf-/loop:l0--></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/map-if-chain-body.ts
+++ b/packages/adapter-tests/fixtures/map-if-chain-body.ts
@@ -29,6 +29,14 @@ export { MapIfChain }
 `,
   props: { items: [{ id: '1', kind: 'a' }, { id: '2', kind: 'b' }, { id: '3', kind: 'z' }] },
   expectedHtml: `
-    <ul bf-s="test" bf="s5"><!--bf-loop:l0--><li bf-c="s3" data-key="1">A:<!--bf:s4-->1<!--/--></li><!--bf-cond-start:s3--><li bf-c="s1" data-key="2">B:<!--bf:s2-->2<!--/--></li><!--bf-cond-end:s3--><!--bf-cond-start:s3--><li bf-c="s1" data-key="3">C:<!--bf:s0-->3<!--/--></li><!--bf-cond-end:s3--><!--bf-/loop:l0--></ul>
+    <ul bf-s="test" bf="s5">
+      <li bf-c="s3" data-key="1">A:<!--bf:s4-->1<!--/--></li>
+      <!--bf-cond-start:s3-->
+      <li bf-c="s1" data-key="2">B:<!--bf:s2-->2<!--/--></li>
+      <!--bf-cond-end:s3-->
+      <!--bf-cond-start:s3-->
+      <li bf-c="s1" data-key="3">C:<!--bf:s0-->3<!--/--></li>
+      <!--bf-cond-end:s3-->
+    </ul>
   `,
 })

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -2079,16 +2079,27 @@ function extractSingleJsxReturn(
   return jsxReturn
 }
 
-type JsxReturnNode = ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment
+export type JsxReturnNode = ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment
+
+/**
+ * The branch structure extracted from a multi-return JSX body — an if/else-if
+ * chain or a `switch`. Shared by the helper-function fold and (Stage 2 of
+ * `spec/callback-fidelity.md`) the `.map()` callback-body fold.
+ */
+export interface MultiReturnJsxBranches {
+  branches: Array<{ condition: ts.Expression; jsxReturn: JsxReturnNode | null }>
+  fallback: JsxReturnNode | null
+  switchDiscriminant?: ts.Expression
+}
 
 /**
  * Extract conditional branches from a multi-return JSX helper function body.
  * Supports if/else if chains and switch statements where every branch
  * returns JSX or null. Returns null for unsupported patterns.
  */
-function extractMultiReturnJsxBranches(
+export function extractMultiReturnJsxBranches(
   body: ts.Block
-): { branches: Array<{ condition: ts.Expression; jsxReturn: JsxReturnNode | null }>; fallback: JsxReturnNode | null; switchDiscriminant?: ts.Expression } | null {
+): MultiReturnJsxBranches | null {
   const branches: Array<{ condition: ts.Expression; jsxReturn: JsxReturnNode | null }> = []
   let fallback: JsxReturnNode | null = null
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -51,7 +51,7 @@ import { createTemplateAwareStringProtector } from './ir-to-client-js/html-templ
 import { datePlugin, DATE_METHODS } from './date-lowering.ts'
 import { toLocaleDatePlugin, foldedArgToClientJs } from './to-locale-date-lowering.ts'
 import type { LoweringMatcher } from './lowering-registry.ts'
-import { extractFreeIdentifiersFromNode, initializerShapeContainsJsx } from './analyzer.ts'
+import { extractFreeIdentifiersFromNode, initializerShapeContainsJsx, extractMultiReturnJsxBranches, type MultiReturnJsxBranches } from './analyzer.ts'
 import { iterateJsTokens, replaceInExprContexts } from './scanner/js-scanner.ts'
 import { toHTMLAttrName, decodeEntities } from '@barefootjs/shared'
 
@@ -2119,100 +2119,123 @@ function transformMultiReturnJsxFunctionCall(
 
   try {
     const loc = getSourceLocation(callExpr, ctx.sourceFile, ctx.filePath)
-    const nullExpr: IRExpression = {
-      type: 'expression',
-      expr: 'null',
-      typeInfo: { kind: 'primitive', raw: 'null', primitive: 'null' },
-      reactive: false,
-      slotId: null,
-      loc,
-      origin: { phase: 'tick', scope: 'template', effect: 'pure', freeRefs: [] },
-    }
-
-    // Build the conditional chain from bottom up (last branch → first branch)
-    let result: IRNode = info.fallback
-      ? (transformNode(info.fallback, ctx) ?? nullExpr)
-      : nullExpr
-
-    for (let i = info.branches.length - 1; i >= 0; i--) {
-      const branch = info.branches[i]
-
-      // Build condition text with param substitution
-      let conditionText: string
-      if (info.switchDiscriminant) {
-        const discText = substitutedGetJS(info.switchDiscriminant)
-        const caseText = substitutedGetJS(branch.condition)
-        conditionText = `${discText} === ${caseText}`
-      } else {
-        conditionText = substitutedGetJS(branch.condition)
-      }
-
-      // For switch-sourced conditions, merge freeRefs/reactivity from
-      // both the discriminant and case expression so prop rewrites and
-      // reactivity detection cover the full `disc === case` condition.
-      const env = makeBindingEnv(ctx)
-      const caseFreeRefs = resolveFreeRefs(branch.condition, env)
-      const discFreeRefs = info.switchDiscriminant
-        ? resolveFreeRefs(info.switchDiscriminant, env)
-        : []
-      const conditionOrigin: OriginInfo = {
-        phase: 'tick',
-        scope: 'template',
-        effect: 'pure',
-        freeRefs: [...discFreeRefs, ...caseFreeRefs],
-      }
-      const reactive = isReactiveExpression(conditionText, ctx, branch.condition)
-        || isReactiveOrigin(conditionOrigin)
-      const loopParamReactive = !reactive && referencesLoopParam(conditionText, ctx)
-      const callsReactive = exprCallsReactiveGetters(branch.condition, ctx)
-        || (info.switchDiscriminant ? exprCallsReactiveGetters(info.switchDiscriminant, ctx) : false)
-      const hasCalls = exprHasFunctionCalls(branch.condition)
-        || (info.switchDiscriminant ? exprHasFunctionCalls(info.switchDiscriminant) : false)
-      const needsSlot = reactive || loopParamReactive || callsReactive || hasCalls
-      const slotId = needsSlot ? generateSlotId(ctx) : null
-
-      const whenTrue = branch.jsxReturn
-        ? (transformNode(branch.jsxReturn, ctx) ?? nullExpr)
-        : nullExpr
-
-      // For switch conditions, build templateCondition from both parts
-      let templateCondition: string | undefined
-      if (info.switchDiscriminant) {
-        const discRewritten = rewriteBarePropRefs(
-          substitutedGetJS(info.switchDiscriminant), info.switchDiscriminant, ctx
-        )
-        const caseRewritten = rewriteBarePropRefs(
-          substitutedGetJS(branch.condition), branch.condition, ctx
-        )
-        const discPart = discRewritten ?? substitutedGetJS(info.switchDiscriminant)
-        const casePart = caseRewritten ?? substitutedGetJS(branch.condition)
-        templateCondition = `${discPart} === ${casePart}`
-      } else {
-        templateCondition = rewriteBarePropRefs(conditionText, branch.condition, ctx)
-      }
-
-      const conditional: IRConditional = {
-        type: 'conditional',
-        condition: conditionText,
-        templateCondition,
-        conditionType: null,
-        reactive,
-        whenTrue,
-        whenFalse: result,
-        slotId,
-        callsReactiveGetters: callsReactive || undefined,
-        hasFunctionCalls: hasCalls || undefined,
-        loc,
-        origin: conditionOrigin,
-      }
-      result = conditional
-    }
-
-    return result
+    return foldMultiReturnBranches(info, ctx, loc, substitutedGetJS)
   } finally {
     ctx.getJS = originalCtxGetJS
     ctx.analyzer.getJS = originalAnalyzerGetJS
   }
+}
+
+/**
+ * Fold an extracted multi-return branch structure (if/else-if chain or switch)
+ * into a right-nested chain of `IRConditional` nodes, terminating in the
+ * fallback (or `null`). Shared by the helper-function inliner
+ * (`transformMultiReturnJsxFunctionCall`, which swaps `ctx.getJS` for a
+ * param-substituting variant first) and the `.map()` callback-body fold
+ * (Stage 2 of `spec/callback-fidelity.md`), which folds branches in the
+ * loop-body context where the item binding is already in scope — no
+ * substitution. `getText` stringifies condition / discriminant expressions
+ * (the substituting variant for the former, `ctx.getJS` for the latter);
+ * branch JSX is transformed via `transformNode`, which reads the (possibly
+ * swapped) `ctx.getJS`.
+ */
+function foldMultiReturnBranches(
+  info: MultiReturnJsxBranches,
+  ctx: TransformContext,
+  loc: SourceLocation,
+  getText: (node: ts.Node) => string,
+): IRNode {
+  const nullExpr: IRExpression = {
+    type: 'expression',
+    expr: 'null',
+    typeInfo: { kind: 'primitive', raw: 'null', primitive: 'null' },
+    reactive: false,
+    slotId: null,
+    loc,
+    origin: { phase: 'tick', scope: 'template', effect: 'pure', freeRefs: [] },
+  }
+
+  // Build the conditional chain from bottom up (last branch → first branch)
+  let result: IRNode = info.fallback
+    ? (transformNode(info.fallback, ctx) ?? nullExpr)
+    : nullExpr
+
+  for (let i = info.branches.length - 1; i >= 0; i--) {
+    const branch = info.branches[i]
+
+    // Build condition text (`getText` applies param substitution when the
+    // helper-function inliner supplies a substituting variant).
+    let conditionText: string
+    if (info.switchDiscriminant) {
+      const discText = getText(info.switchDiscriminant)
+      const caseText = getText(branch.condition)
+      conditionText = `${discText} === ${caseText}`
+    } else {
+      conditionText = getText(branch.condition)
+    }
+
+    // For switch-sourced conditions, merge freeRefs/reactivity from
+    // both the discriminant and case expression so prop rewrites and
+    // reactivity detection cover the full `disc === case` condition.
+    const env = makeBindingEnv(ctx)
+    const caseFreeRefs = resolveFreeRefs(branch.condition, env)
+    const discFreeRefs = info.switchDiscriminant
+      ? resolveFreeRefs(info.switchDiscriminant, env)
+      : []
+    const conditionOrigin: OriginInfo = {
+      phase: 'tick',
+      scope: 'template',
+      effect: 'pure',
+      freeRefs: [...discFreeRefs, ...caseFreeRefs],
+    }
+    const reactive = isReactiveExpression(conditionText, ctx, branch.condition)
+      || isReactiveOrigin(conditionOrigin)
+    const loopParamReactive = !reactive && referencesLoopParam(conditionText, ctx)
+    const callsReactive = exprCallsReactiveGetters(branch.condition, ctx)
+      || (info.switchDiscriminant ? exprCallsReactiveGetters(info.switchDiscriminant, ctx) : false)
+    const hasCalls = exprHasFunctionCalls(branch.condition)
+      || (info.switchDiscriminant ? exprHasFunctionCalls(info.switchDiscriminant) : false)
+    const needsSlot = reactive || loopParamReactive || callsReactive || hasCalls
+    const slotId = needsSlot ? generateSlotId(ctx) : null
+
+    const whenTrue = branch.jsxReturn
+      ? (transformNode(branch.jsxReturn, ctx) ?? nullExpr)
+      : nullExpr
+
+    // For switch conditions, build templateCondition from both parts
+    let templateCondition: string | undefined
+    if (info.switchDiscriminant) {
+      const discRewritten = rewriteBarePropRefs(
+        getText(info.switchDiscriminant), info.switchDiscriminant, ctx
+      )
+      const caseRewritten = rewriteBarePropRefs(
+        getText(branch.condition), branch.condition, ctx
+      )
+      const discPart = discRewritten ?? getText(info.switchDiscriminant)
+      const casePart = caseRewritten ?? getText(branch.condition)
+      templateCondition = `${discPart} === ${casePart}`
+    } else {
+      templateCondition = rewriteBarePropRefs(conditionText, branch.condition, ctx)
+    }
+
+    const conditional: IRConditional = {
+      type: 'conditional',
+      condition: conditionText,
+      templateCondition,
+      conditionType: null,
+      reactive,
+      whenTrue,
+      whenFalse: result,
+      slotId,
+      callsReactiveGetters: callsReactive || undefined,
+      hasFunctionCalls: hasCalls || undefined,
+      loc,
+      origin: conditionOrigin,
+    }
+    result = conditional
+  }
+
+  return result
 }
 
 function transformConditional(
@@ -4050,10 +4073,27 @@ function transformMapCall(
       // flatMap arrow with array literal: items.flatMap(item => [<A/>, <B/>])
       children = transformArrayLiteralChildren(body, ctx)
     } else if (ts.isBlock(body)) {
+      // Multi-return JSX block body (if/else-if chain or switch) — fold to a
+      // nested IRConditional so the loop renders each branch's compiled
+      // template. Tried BEFORE the single-return path: otherwise the trailing
+      // `return <fallback/>` would claim the single-return arm and the leading
+      // `if (...) return <A/>` would leak verbatim into the map preamble (the
+      // silent-verbatim-leak this fixes). Stage 2 of spec/callback-fidelity.md.
+      // Preamble-const / switch-fallthrough / nested-loop shapes are not yet
+      // extracted (extractMultiReturnJsxBranches returns null) and fall through
+      // to the single-return path below.
+      const multiReturn = method !== 'flatMap' ? extractMultiReturnJsxBranches(body) : null
+      if (multiReturn && multiReturn.branches.length > 0) {
+        const loc = getSourceLocation(body, ctx.sourceFile, ctx.filePath)
+        children = [foldMultiReturnBranches(multiReturn, ctx, loc, ctx.getJS)]
+      }
+
       // Block body: (item) => { const label = ...; return <div>{label}</div> }
-      const returnStmt = body.statements.find(
-        (s): s is ts.ReturnStatement => ts.isReturnStatement(s) && s.expression != null
-      )
+      const returnStmt = children.length === 0
+        ? body.statements.find(
+            (s): s is ts.ReturnStatement => ts.isReturnStatement(s) && s.expression != null
+          )
+        : undefined
       if (returnStmt && returnStmt.expression) {
         let returnExpr = returnStmt.expression
         while (ts.isParenthesizedExpression(returnExpr)) {

--- a/spec/callback-fidelity.md
+++ b/spec/callback-fidelity.md
@@ -1,10 +1,16 @@
 # Callback-Body Fidelity Across Backends (RFC / Draft)
 
-> **Status:** RFC / Draft. Supersedes the diagnose-first
+> **Status:** Accepted; landing in stages. Supersedes the diagnose-first
 > [#2371](https://github.com/piconic-ai/barefootjs/pull/2371) (closed "to
 > restart from a design-first footing"). Records the principle, the target
 > fidelity model, and a staged plan; adjusted as the work lands (same
 > convention as `spec/subset-conformance.md`).
+>
+> **Progress:** Stage 0 (this doc) and Stage 1 have landed — `#2373`
+> (adapter-gate the Phase-1 `filter`/`sort` constraint), `#2374` (close the
+> `fill` gap + doc/comment cleanup), `#2375` (find/some/every off-subset
+> conformance), `#2376` (reduce/reduceRight/flatMap off-subset conformance).
+> Stage 2 is in progress.
 
 ## Vision
 
@@ -246,17 +252,21 @@ Each stage is independently shippable, tested, and PR-sized. Value/risk-ordered.
 
 - **Stage 0 — This RFC.** Agree the model, the `keyFn` contract (D5), and the
   capability-predicate granularity (D1). *Deliverable: this doc, merged.*
-- **Stage 1 — Adapter-gate the value-callback constraints (D1 + D2).** The
-  biggest immediate win: `filter` / `sort` / `find` / `some` / `every` /
-  `reduce` with *any* predicate/comparator compile on JS runtimes; DSL keeps the
-  error + `/* @client */`. Also fixes the latent `fill` gap (silently emitted, no
-  `BF101` today) and the stale `reduce` comment. *Tests: compiler-unit
-  (adapter-conditional BF021), CSR conformance, DSL conformance/divergence,
-  coverage/support-matrix. PRs: ~2–3.*
-- **Stage 2 — Generalize the JSX-`map` fold to neutral IR (D3).** Re-lands the
-  #2371 if-chain fold, reframed, plus preamble-const branches and nested loops.
-  All backends gain SSR fidelity. *Tests: compiler-unit, CSR + cross-adapter +
-  hydration conformance (new fixtures), coverage. PRs: ~2–3.*
+- **Stage 1 — Adapter-gate the value-callback constraints (D1 + D2).** ✅
+  *Landed (#2373–#2376).* The biggest immediate win: `filter` / `sort` / `find`
+  / `some` / `every` / `reduce` with *any* predicate/comparator compile on JS
+  runtimes; DSL keeps the error + `/* @client */`. The survey found the
+  value-callback methods beyond `filter`/`sort` already split correctly (they
+  refuse only at adapter emit — BF101/BF102 — which JS adapters skip), so #2373
+  gated the one Phase-1 `filter`/`sort` `BF021` site and #2375–#2376 locked the
+  rest with off-subset conformance fixtures. #2374 also closed the latent `fill`
+  gap (silently emitted, no `BF101`) and corrected the stale `reduce` /
+  higher-order comments. *Tests: compiler-unit (adapter-conditional BF021), CSR
+  conformance, DSL conformance/divergence, coverage/support-matrix.*
+- **Stage 2 — Generalize the JSX-`map` fold to neutral IR (D3).** *In progress.*
+  Re-lands the #2371 if-chain fold, reframed, plus preamble-const branches and
+  nested loops. All backends gain SSR fidelity. *Tests: compiler-unit, CSR +
+  cross-adapter + hydration conformance (new fixtures), coverage. PRs: ~2–3.*
 - **Stage 3 — JS-runtime verbatim + `/* @client */` for the rest (D4 + D5).**
   Reaches the fidelity ceiling for JSX-`map`. Requires the Stage-0 `keyFn`
   decision. *Tests: runtime-unit (key contract), CSR conformance, E2E

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 272,
+    "totalFixtures": 273,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -866,15 +866,15 @@
       }
     },
     "binary": {
-      "total": 73,
+      "total": 74,
       "cells": {
         "hono": {
-          "pass": 73,
-          "total": 73
+          "pass": 74,
+          "total": 74
         },
         "blade": {
-          "pass": 65,
-          "total": 73,
+          "pass": 66,
+          "total": 74,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -917,8 +917,8 @@
           ]
         },
         "erb": {
-          "pass": 66,
-          "total": 73,
+          "pass": 67,
+          "total": 74,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -955,8 +955,8 @@
           ]
         },
         "go-template": {
-          "pass": 65,
-          "total": 73,
+          "pass": 66,
+          "total": 74,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -999,8 +999,8 @@
           ]
         },
         "jinja": {
-          "pass": 65,
-          "total": 73,
+          "pass": 66,
+          "total": 74,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1043,8 +1043,8 @@
           ]
         },
         "minijinja": {
-          "pass": 65,
-          "total": 73,
+          "pass": 66,
+          "total": 74,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1087,8 +1087,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 66,
-          "total": 73,
+          "pass": 67,
+          "total": 74,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1125,8 +1125,8 @@
           ]
         },
         "twig": {
-          "pass": 65,
-          "total": 73,
+          "pass": 66,
+          "total": 74,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1169,8 +1169,8 @@
           ]
         },
         "xslate": {
-          "pass": 65,
-          "total": 73,
+          "pass": 66,
+          "total": 74,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1886,11 +1886,11 @@
       }
     },
     "identifier": {
-      "total": 253,
+      "total": 254,
       "cells": {
         "hono": {
-          "pass": 252,
-          "total": 253,
+          "pass": 253,
+          "total": 254,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1901,8 +1901,8 @@
           ]
         },
         "blade": {
-          "pass": 240,
-          "total": 253,
+          "pass": 241,
+          "total": 254,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1969,8 +1969,8 @@
           ]
         },
         "erb": {
-          "pass": 241,
-          "total": 253,
+          "pass": 242,
+          "total": 254,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2031,8 +2031,8 @@
           ]
         },
         "go-template": {
-          "pass": 240,
-          "total": 253,
+          "pass": 241,
+          "total": 254,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2099,8 +2099,8 @@
           ]
         },
         "jinja": {
-          "pass": 240,
-          "total": 253,
+          "pass": 241,
+          "total": 254,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2167,8 +2167,8 @@
           ]
         },
         "minijinja": {
-          "pass": 240,
-          "total": 253,
+          "pass": 241,
+          "total": 254,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2235,8 +2235,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 241,
-          "total": 253,
+          "pass": 242,
+          "total": 254,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2297,8 +2297,8 @@
           ]
         },
         "twig": {
-          "pass": 240,
-          "total": 253,
+          "pass": 241,
+          "total": 254,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2365,8 +2365,8 @@
           ]
         },
         "xslate": {
-          "pass": 240,
-          "total": 253,
+          "pass": 241,
+          "total": 254,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2498,15 +2498,15 @@
       }
     },
     "literal": {
-      "total": 211,
+      "total": 212,
       "cells": {
         "hono": {
-          "pass": 211,
-          "total": 211
+          "pass": 212,
+          "total": 212
         },
         "blade": {
-          "pass": 202,
-          "total": 211,
+          "pass": 203,
+          "total": 212,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2549,8 +2549,8 @@
           ]
         },
         "erb": {
-          "pass": 202,
-          "total": 211,
+          "pass": 203,
+          "total": 212,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2593,8 +2593,8 @@
           ]
         },
         "go-template": {
-          "pass": 202,
-          "total": 211,
+          "pass": 203,
+          "total": 212,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2637,8 +2637,8 @@
           ]
         },
         "jinja": {
-          "pass": 202,
-          "total": 211,
+          "pass": 203,
+          "total": 212,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2681,8 +2681,8 @@
           ]
         },
         "minijinja": {
-          "pass": 202,
-          "total": 211,
+          "pass": 203,
+          "total": 212,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2725,8 +2725,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 202,
-          "total": 211,
+          "pass": 203,
+          "total": 212,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2769,8 +2769,8 @@
           ]
         },
         "twig": {
-          "pass": 202,
-          "total": 211,
+          "pass": 203,
+          "total": 212,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2813,8 +2813,8 @@
           ]
         },
         "xslate": {
-          "pass": 202,
-          "total": 211,
+          "pass": 203,
+          "total": 212,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2986,11 +2986,11 @@
       }
     },
     "member": {
-      "total": 132,
+      "total": 133,
       "cells": {
         "hono": {
-          "pass": 131,
-          "total": 132,
+          "pass": 132,
+          "total": 133,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3001,8 +3001,8 @@
           ]
         },
         "blade": {
-          "pass": 119,
-          "total": 132,
+          "pass": 120,
+          "total": 133,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3069,8 +3069,8 @@
           ]
         },
         "erb": {
-          "pass": 120,
-          "total": 132,
+          "pass": 121,
+          "total": 133,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3131,8 +3131,8 @@
           ]
         },
         "go-template": {
-          "pass": 119,
-          "total": 132,
+          "pass": 120,
+          "total": 133,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3199,8 +3199,8 @@
           ]
         },
         "jinja": {
-          "pass": 119,
-          "total": 132,
+          "pass": 120,
+          "total": 133,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3267,8 +3267,8 @@
           ]
         },
         "minijinja": {
-          "pass": 119,
-          "total": 132,
+          "pass": 120,
+          "total": 133,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3335,8 +3335,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 120,
-          "total": 132,
+          "pass": 121,
+          "total": 133,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3397,8 +3397,8 @@
           ]
         },
         "twig": {
-          "pass": 119,
-          "total": 132,
+          "pass": 120,
+          "total": 133,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3465,8 +3465,8 @@
           ]
         },
         "xslate": {
-          "pass": 119,
-          "total": 132,
+          "pass": 120,
+          "total": 133,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -6003,15 +6003,15 @@
       }
     },
     "binary:===": {
-      "total": 36,
+      "total": 37,
       "cells": {
         "hono": {
-          "pass": 36,
-          "total": 36
+          "pass": 37,
+          "total": 37
         },
         "blade": {
-          "pass": 29,
-          "total": 36,
+          "pass": 30,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6048,8 +6048,8 @@
           ]
         },
         "erb": {
-          "pass": 30,
-          "total": 36,
+          "pass": 31,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6080,8 +6080,8 @@
           ]
         },
         "go-template": {
-          "pass": 29,
-          "total": 36,
+          "pass": 30,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6118,8 +6118,8 @@
           ]
         },
         "jinja": {
-          "pass": 29,
-          "total": 36,
+          "pass": 30,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6156,8 +6156,8 @@
           ]
         },
         "minijinja": {
-          "pass": 29,
-          "total": 36,
+          "pass": 30,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6194,8 +6194,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 30,
-          "total": 36,
+          "pass": 31,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6226,8 +6226,8 @@
           ]
         },
         "twig": {
-          "pass": 29,
-          "total": 36,
+          "pass": 30,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6264,8 +6264,8 @@
           ]
         },
         "xslate": {
-          "pass": 29,
-          "total": 36,
+          "pass": 30,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6308,10 +6308,10 @@
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
       },
       "example": {
-        "fixture": "nested-ternary",
-        "description": "Nested ternary conditional rendering",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/nested-ternary.ts",
-        "code": "status() === 'error'"
+        "fixture": "map-if-chain-body",
+        "description": "if/else-if chain as a .map() callback body folds to nested IRConditional",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/map-if-chain-body.ts",
+        "code": "it.kind === 'a'"
       }
     },
     "binary:>": {
@@ -6686,15 +6686,15 @@
       }
     },
     "literal:string": {
-      "total": 152,
+      "total": 153,
       "cells": {
         "hono": {
-          "pass": 152,
-          "total": 152
+          "pass": 153,
+          "total": 153
         },
         "blade": {
-          "pass": 145,
-          "total": 152,
+          "pass": 146,
+          "total": 153,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6729,8 +6729,8 @@
           ]
         },
         "erb": {
-          "pass": 145,
-          "total": 152,
+          "pass": 146,
+          "total": 153,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6765,8 +6765,8 @@
           ]
         },
         "go-template": {
-          "pass": 145,
-          "total": 152,
+          "pass": 146,
+          "total": 153,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6801,8 +6801,8 @@
           ]
         },
         "jinja": {
-          "pass": 145,
-          "total": 152,
+          "pass": 146,
+          "total": 153,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6837,8 +6837,8 @@
           ]
         },
         "minijinja": {
-          "pass": 145,
-          "total": 152,
+          "pass": 146,
+          "total": 153,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6873,8 +6873,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 145,
-          "total": 152,
+          "pass": 146,
+          "total": 153,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6909,8 +6909,8 @@
           ]
         },
         "twig": {
-          "pass": 145,
-          "total": 152,
+          "pass": 146,
+          "total": 153,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6945,8 +6945,8 @@
           ]
         },
         "xslate": {
-          "pass": 145,
-          "total": 152,
+          "pass": 146,
+          "total": 153,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",


### PR DESCRIPTION
## Summary

Stage 2 of the [Callback-Body Fidelity RFC](../blob/main/spec/callback-fidelity.md) (D3). Stage 1 (#2373–#2376) is merged; this is the first Stage 2 PR.

**The friction this removes** — the original Tetris / Markdown-editor onboarding problem. A `.map()` whose callback body is a **block with an if/else-if chain** (or a `switch` with `default`) returning a different element per branch was **silently mis-compiled**: the trailing `return <fallback/>` claimed the loop body, the leading `if (...) return <A/>` leaked *verbatim and uncompiled* into the map callback (raw JSX in emitted JS → `ReferenceError` at hydration), and only the fallback branch got a template. No error, no `/* @client */` hint — just broken output.

It now **folds into a nested `IRConditional`** — the exact neutral IR a ternary map body already produces — so **every backend** (JS runtime *and* DSL) renders each branch's compiled template at SSR. No `/* @client */` needed.

```tsx
// Before: leaked; only <C/> templatized.   After: folds to nested IRConditional.
items.map((it) => {
  if (it.kind === 'a') return <li key={it.id}>A</li>
  else if (it.kind === 'b') return <li key={it.id}>B</li>
  return <li key={it.id}>C</li>
})
```

## How

- Extracted the branch-fold core of `transformMultiReturnJsxFunctionCall` (the multi-return JSX **helper-function** inliner) into a reusable **`foldMultiReturnBranches`**. The helper path keeps its param-substitution wrapper; the map-body path folds in the loop-body context where the item binding is already in scope (no substitution), passing `ctx.getJS` as the condition stringifier.
- Exported **`extractMultiReturnJsxBranches`** (+ its `MultiReturnJsxBranches` type) from the analyzer and try it **first** in `transformMapCall`'s block arm, before the single-return path — otherwise the trailing return claims the body and the leading `if` leaks into the preamble.
- Key extraction across branches already works: the loop `keyFn` is lifted from each branch's root the same way as for a ternary body, so `mapArray(..., (it) => String(it.id), ...)` is emitted correctly. No runtime change.

## Scope / follow-ups

This PR folds **if/else-if chains and `switch`-with-`default`** (no fallthrough). Per the RFC, **preamble-`const` branches**, **switch fallthrough**, and **statement-level nested loops** are not yet extracted (`extractMultiReturnJsxBranches` returns null) and still fall through unchanged — follow-up Stage 2 PRs. This PR also carries the spec status update (Stage 1 marked landed, Stage 2 in progress).

## Tests

- New cross-adapter conformance fixture `map-if-chain-body` (renders on all 9 adapters as neutral IR — **no `conformancePins`**), verified against the SSR-hydration contract (markers ↔ client JS).
- Full suites green: **jsx 2643/0 · adapter-tests 1401/0 · compat 151/0** (freshness gates regenerated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FG9KVo7k7nmVkvpuDXKCaC)_