### PR TITLE
Stage 2: fold switch fallthrough; harden map-body fold against silent drops

### DIFF
--- a/.changeset/fold-switch-fallthrough-map-bodies.md
+++ b/.changeset/fold-switch-fallthrough-map-bodies.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fold `switch` fallthrough in `.map()` bodies and harden the multi-return fold against silent drops (callback-body fidelity, Stage 2 of `spec/callback-fidelity.md`; follow-up to #2377).
+
+- **Switch fallthrough:** an empty `case` label that falls through to the next clause's body (`case 'a': case 'b': return <b/>`) now folds — `extractMultiReturnJsxBranches` accumulates the fallthrough labels and the fold OR-joins them into `disc === 'a' || disc === 'b'`, so both `a` and `b` render the same element. Previously the empty fallthrough clause made extraction bail and the whole `switch` map body leaked verbatim.
+- **No silent drops (fix, #2377 review):** a branch-local `const`/`let` (`if (c) { const x = …; return <A>{x}</A> }`, or a `switch` case with an extra statement) was accepted by the extractor but dropped by the fold, rendering the local `undefined` (ReferenceError at SSR/hydration). `isDirectReturnBlock` and the switch case validation now reject any non-return statement, so these shapes bail conservatively instead of folding-and-dropping.
+- **Switch precedence (fix, #2377 review):** the generated `disc === case` condition now parenthesizes both operands (`(disc) === (case)`) so a low-precedence case (`case a ?? b:`, a ternary) keeps strict-equality semantics.

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2535,6 +2535,25 @@
         "text"
       ]
     },
+    "map-switch-fallthrough-body": {
+      "kinds": [
+        "binary",
+        "identifier",
+        "literal",
+        "logical",
+        "member"
+      ],
+      "axes": [
+        "binary:===",
+        "literal:string",
+        "logical:||"
+      ],
+      "contexts": [
+        "attribute",
+        "condition",
+        "loop"
+      ]
+    },
     "map-with-index": {
       "kinds": [
         "array-literal",
@@ -4394,14 +4413,14 @@
     "array-literal": 63,
     "array-method": 64,
     "arrow": 61,
-    "binary": 74,
+    "binary": 75,
     "call": 173,
     "conditional": 20,
-    "identifier": 254,
+    "identifier": 255,
     "index-access": 12,
-    "literal": 212,
-    "logical": 41,
-    "member": 133,
+    "literal": 213,
+    "logical": 42,
+    "member": 134,
     "object-literal": 46,
     "template-literal": 27,
     "unary": 22,
@@ -4439,16 +4458,16 @@
     "binary:-": 11,
     "binary:/": 1,
     "binary:<": 1,
-    "binary:===": 37,
+    "binary:===": 38,
     "binary:>": 11,
     "binary:>=": 1,
     "literal:boolean": 38,
     "literal:null": 22,
     "literal:number": 89,
-    "literal:string": 153,
+    "literal:string": 154,
     "logical:&&": 7,
     "logical:??": 37,
-    "logical:||": 12,
+    "logical:||": 13,
     "member:computed": 8,
     "member:optional": 1,
     "unary:!": 14,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -128,6 +128,7 @@ import { fixture as reduceTypeofBody } from './reduce-typeof-body'
 import { fixture as reduceRightTypeofBody } from './reduce-right-typeof-body'
 import { fixture as flatMapTypeofProjection } from './flatmap-typeof-projection'
 import { fixture as mapIfChainBody } from './map-if-chain-body'
+import { fixture as mapSwitchFallthroughBody } from './map-switch-fallthrough-body'
 import { fixture as sortSimple } from './sort-simple'
 import { fixture as filterSortChain } from './filter-sort-chain'
 import { fixture as mapNested } from './map-nested'
@@ -493,6 +494,7 @@ export const jsxFixtures: JSXFixture[] = [
   reduceRightTypeofBody,
   flatMapTypeofProjection,
   mapIfChainBody,
+  mapSwitchFallthroughBody,
   sortSimple,
   filterSortChain,
   mapNested,

--- a/packages/adapter-tests/fixtures/map-switch-fallthrough-body.ts
+++ b/packages/adapter-tests/fixtures/map-switch-fallthrough-body.ts
@@ -1,0 +1,39 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A `.map()` callback body that is a `switch` with **fallthrough** — empty
+ * `case` labels that share the next clause's return (`case 'a': case 'b':
+ * return <b/>`). Stage 2 of `spec/callback-fidelity.md` accumulates the
+ * fallthrough labels and folds the shared branch into a nested `IRConditional`
+ * whose condition OR-joins the labels (`disc === 'a' || disc === 'b'`), so
+ * both `a` and `b` render the same element.
+ *
+ * Neutral IR that renders on every backend — a positive cross-adapter fixture
+ * with no `conformancePins`.
+ */
+export const fixture = createFixture({
+  id: 'map-switch-fallthrough-body',
+  description: 'switch with fallthrough case labels as a .map() body folds with an OR condition',
+  source: `
+function MapSwitchFallthrough({ items }: { items: { id: string; kind: string }[] }) {
+  return (
+    <ul>
+      {items.map((it) => {
+        switch (it.kind) {
+          case 'a':
+          case 'b':
+            return <b key={it.id}>AB</b>
+          default:
+            return <span key={it.id}>D</span>
+        }
+      })}
+    </ul>
+  )
+}
+export { MapSwitchFallthrough }
+`,
+  props: { items: [{ id: '1', kind: 'a' }, { id: '2', kind: 'b' }, { id: '3', kind: 'z' }] },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1"><!--bf-loop:l0--><b bf-c="s0" data-key="1">AB</b><b bf-c="s0" data-key="2">AB</b><span bf-c="s0" data-key="3">D</span><!--bf-/loop:l0--></ul>
+  `,
+})

--- a/packages/jsx/src/__tests__/map-multi-return-body.test.ts
+++ b/packages/jsx/src/__tests__/map-multi-return-body.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Stage 2 of spec/callback-fidelity.md — folding a `.map()` callback whose
+ * body is an if/else-if chain or `switch` (optionally preceded by a
+ * `const`/`let` preamble) into a nested `IRConditional`, instead of the prior
+ * silent verbatim leak. Also pins the conservative bail for shapes the fold
+ * can't yet carry (branch-local locals), so nothing is dropped silently.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { extractMultiReturnJsxBranches } from '../analyzer'
+import { TestAdapter } from '../adapters/test-adapter'
+import * as ts from 'typescript'
+
+const adapter = new TestAdapter()
+
+function clientJs(source: string): string {
+  const result = compileJSX(source, 'List.tsx', { adapter })
+  expect(result.errors).toHaveLength(0)
+  const cj = result.files.find(f => f.type === 'clientJs')
+  expect(cj).toBeDefined()
+  return cj!.content
+}
+
+const wrap = (body: string) => `
+function List({ items }: { items: { id: string; on: boolean; kind: string }[] }) {
+  return <ul>{items.map((it) => ${body})}</ul>
+}
+export { List }
+`
+
+describe('.map() multi-return body fold (Stage 2)', () => {
+  test('if/else-if chain folds to a conditional — no raw JSX leak', () => {
+    const js = clientJs(wrap(`{
+      if (it.kind === 'a') return <li key={it.id}>A</li>
+      else if (it.kind === 'b') return <li key={it.id}>B</li>
+      return <li key={it.id}>C</li>
+    }`))
+    // The raw \`if (...) return <li ...>\` must not survive into the callback.
+    expect(js).not.toMatch(/return <li/)
+    // A ternary chain over the branch conditions is emitted instead.
+    expect(js).toMatch(/kind === 'a'/)
+    expect(js).toMatch(/kind === 'b'/)
+  })
+
+  test('switch (with default) folds with a parenthesized strict-equality condition', () => {
+    const js = clientJs(wrap(`{
+      switch (it.kind) {
+        case 'a': return <b key={it.id}>A</b>
+        default: return <span key={it.id}>D</span>
+      }
+    }`))
+    expect(js).not.toMatch(/switch\s*\(/)
+    // Both operands parenthesized so a low-precedence case keeps === semantics.
+    expect(js).toMatch(/\(it\(\)\.kind\) === \('a'\)/)
+  })
+
+  test('switch with fallthrough case labels folds with an OR condition', () => {
+    const js = clientJs(wrap(`{
+      switch (it.kind) {
+        case 'a':
+        case 'b':
+          return <b key={it.id}>AB</b>
+        default:
+          return <span key={it.id}>D</span>
+      }
+    }`))
+    expect(js).not.toMatch(/switch\s*\(/)
+    expect(js).not.toMatch(/return <(b|span)/)
+    // Both fallthrough labels OR-joined into one branch condition.
+    expect(js).toMatch(/=== \('a'\)/)
+    expect(js).toMatch(/=== \('b'\)/)
+    expect(js).toMatch(/\|\|/)
+  })
+
+  describe('conservative bail — no silent drop', () => {
+    function extract(body: string) {
+      const sf = ts.createSourceFile('t.tsx', `const f = (it: any) => ${body}`, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+      let block: ts.Block | undefined
+      const visit = (n: ts.Node) => {
+        if (ts.isArrowFunction(n) && ts.isBlock(n.body)) block = n.body
+        ts.forEachChild(n, visit)
+      }
+      visit(sf)
+      return extractMultiReturnJsxBranches(block!)
+    }
+
+    test('a branch-local const bails (would otherwise be dropped)', () => {
+      const r = extract(`{ if (it.on) { const x = it.kind; return <b>{x}</b> } return <span>Z</span> }`)
+      expect(r).toBeNull()
+    })
+
+    test('a switch case with an extra statement bails', () => {
+      const r = extract(`{ switch (it.kind) { case 'a': { const y = it.id; return <b>{y}</b> } default: return <span>D</span> } }`)
+      expect(r).toBeNull()
+    })
+
+    test('a leading const preamble bails (deferred — DSL cannot carry the local)', () => {
+      const body = `{ const label = it.kind; if (it.on) return <b>{label}</b>; return <span>{label}</span> }`
+      expect(extract(body)).toBeNull()
+    })
+  })
+})

--- a/packages/jsx/src/__tests__/map-multi-return-body.test.ts
+++ b/packages/jsx/src/__tests__/map-multi-return-body.test.ts
@@ -1,9 +1,10 @@
 /**
  * Stage 2 of spec/callback-fidelity.md — folding a `.map()` callback whose
- * body is an if/else-if chain or `switch` (optionally preceded by a
- * `const`/`let` preamble) into a nested `IRConditional`, instead of the prior
- * silent verbatim leak. Also pins the conservative bail for shapes the fold
- * can't yet carry (branch-local locals), so nothing is dropped silently.
+ * body is an if/else-if chain or `switch` (including fallthrough case labels)
+ * into a nested `IRConditional`, instead of the prior silent verbatim leak.
+ * Also pins the conservative bail for shapes the fold can't carry — a
+ * branch-local local, or a leading-`const` preamble (deferred; a following PR
+ * adds an adapter-gated preamble fold) — so nothing is dropped silently.
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -92,6 +93,14 @@ describe('.map() multi-return body fold (Stage 2)', () => {
 
     test('a switch case with an extra statement bails', () => {
       const r = extract(`{ switch (it.kind) { case 'a': { const y = it.id; return <b>{y}</b> } default: return <span>D</span> } }`)
+      expect(r).toBeNull()
+    })
+
+    test('a switch case with a break before the return bails (return unreachable)', () => {
+      // `case 'a': break; return <A/>` — the break makes the return
+      // unreachable at runtime (the case exits to undefined), so it must not
+      // fold as if it rendered <A/>. (#2378 review.)
+      const r = extract(`{ switch (it.kind) { case 'a': break; return <b>A</b>; default: return <span>D</span> } }`)
       expect(r).toBeNull()
     })
 

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -2087,7 +2087,17 @@ export type JsxReturnNode = ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFra
  * `spec/callback-fidelity.md`) the `.map()` callback-body fold.
  */
 export interface MultiReturnJsxBranches {
-  branches: Array<{ condition: ts.Expression; jsxReturn: JsxReturnNode | null }>
+  branches: Array<{
+    condition: ts.Expression
+    jsxReturn: JsxReturnNode | null
+    /**
+     * For a `switch` with fallthrough (`case 'a': case 'b': return X`), the
+     * additional case expressions that share this branch's return. The fold
+     * OR-joins them with `condition` into `disc === a || disc === b`. Only set
+     * on switch-sourced branches.
+     */
+    extraCaseConditions?: ts.Expression[]
+  }>
   fallback: JsxReturnNode | null
   switchDiscriminant?: ts.Expression
 }
@@ -2100,7 +2110,11 @@ export interface MultiReturnJsxBranches {
 export function extractMultiReturnJsxBranches(
   body: ts.Block
 ): MultiReturnJsxBranches | null {
-  const branches: Array<{ condition: ts.Expression; jsxReturn: JsxReturnNode | null }> = []
+  const branches: Array<{
+    condition: ts.Expression
+    jsxReturn: JsxReturnNode | null
+    extraCaseConditions?: ts.Expression[]
+  }> = []
   let fallback: JsxReturnNode | null = null
 
   const stmts = body.statements
@@ -2164,20 +2178,45 @@ export function extractMultiReturnJsxBranches(
       const hasDefault = stmt.caseBlock.clauses.some(c => ts.isDefaultClause(c))
       if (!hasDefault) return null
 
+      // Case labels that fall through to the next clause's body — an empty
+      // `case 'a':` immediately before `case 'b': return X` — share that
+      // return. Accumulate their expressions and attach them to the branch of
+      // the clause that finally carries the body. Stage 2 of
+      // spec/callback-fidelity.md.
+      let pendingCases: ts.Expression[] = []
       for (const clause of stmt.caseBlock.clauses) {
+        if (ts.isCaseClause(clause) && clause.statements.length === 0) {
+          pendingCases.push(clause.expression)
+          continue
+        }
+
         const jsxReturn = findJsxReturnInCaseClause(clause)
         const nullReturn = findNullReturnInCaseClause(clause)
         if (!jsxReturn && !nullReturn) return null
+        // Reject clauses that carry extra statements around the return (a
+        // local `const`, an expression statement, …): folding drops them, the
+        // same branch-local-preamble gap as `isDirectReturnBlock`. A bare
+        // `break` is fine. (#2377 review.)
+        if (!caseClauseIsDirectReturn(clause)) return null
 
         if (ts.isCaseClause(clause)) {
           branches.push({
             condition: clause.expression,
             jsxReturn: jsxReturn ?? null,
+            extraCaseConditions: pendingCases.length > 0 ? pendingCases : undefined,
           })
+          pendingCases = []
         } else {
+          // `default`. A fallthrough INTO default (`case 'a': default:`) would
+          // need the accumulated cases to also hit the default body — an
+          // unusual shape; bail rather than guess.
+          if (pendingCases.length > 0) return null
           fallback = jsxReturn ?? null
         }
       }
+      // Trailing empty case labels with no following body (`case 'z':` last,
+      // no return anywhere after) — nothing to attach them to; bail.
+      if (pendingCases.length > 0) return null
 
       if (branches.length === 0) return null
       return { branches, fallback, switchDiscriminant: stmt.expression }
@@ -2197,7 +2236,10 @@ export function extractMultiReturnJsxBranches(
     }
 
     // Reject bodies with variable declarations — locals referenced in
-    // conditions or JSX would become undefined after inlining.
+    // conditions or JSX would become undefined after inlining. (A leading-const
+    // preamble fold was tried but silently diverged on DSL adapters, which
+    // can't carry a loop-local into a conditional branch template; deferred
+    // pending a per-backend refuse/render story. See spec/callback-fidelity.md.)
     if (ts.isVariableStatement(stmt)) return null
 
     // Any other statement type → unsupported pattern
@@ -2221,18 +2263,17 @@ function isDirectReturnBlock(node: ts.Statement): boolean {
     for (const stmt of node.statements) {
       if (ts.isReturnStatement(stmt)) {
         returnCount++
-      } else if (
-        ts.isIfStatement(stmt) ||
-        ts.isSwitchStatement(stmt) ||
-        ts.isForStatement(stmt) ||
-        ts.isForOfStatement(stmt) ||
-        ts.isForInStatement(stmt) ||
-        ts.isWhileStatement(stmt) ||
-        ts.isDoStatement(stmt) ||
-        ts.isTryStatement(stmt)
-      ) {
-        return false
+        continue
       }
+      // Any non-return statement — a local `const`/`let`, an expression
+      // statement, or nested control flow (if/switch/for/while/try) — means
+      // this is not a *direct* return block. Folding it into an
+      // `IRConditional` branch would silently DROP the statement: the neutral
+      // IR has no per-branch carrier for a local, so a branch-local
+      // `const x = …; return <A>{x}</A>` renders `x` undefined (ReferenceError
+      // at SSR/hydration). Bail so the caller falls back conservatively.
+      // (#2377 review; Stage 2 of spec/callback-fidelity.md.)
+      return false
     }
     return returnCount === 1
   }
@@ -2264,6 +2305,27 @@ function findJsxReturnInCaseClause(
     }
   }
   return null
+}
+
+/**
+ * True when a `switch` case/default clause contains exactly one `return` and
+ * nothing else that would be dropped by the fold (a trailing `break` is
+ * allowed). Rejects clauses with a local `const`/`let`, an expression
+ * statement, or nested control flow — those have no per-branch preamble
+ * carrier in the folded `IRConditional`. (#2377 review; Stage 2 of
+ * spec/callback-fidelity.md.)
+ */
+function caseClauseIsDirectReturn(clause: ts.CaseClause | ts.DefaultClause): boolean {
+  let returnCount = 0
+  for (const stmt of clause.statements) {
+    if (ts.isReturnStatement(stmt)) {
+      returnCount++
+      continue
+    }
+    if (ts.isBreakStatement(stmt)) continue
+    return false
+  }
+  return returnCount === 1
 }
 
 function findNullReturnInCaseClause(

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -2317,12 +2317,22 @@ function findJsxReturnInCaseClause(
  */
 function caseClauseIsDirectReturn(clause: ts.CaseClause | ts.DefaultClause): boolean {
   let returnCount = 0
+  let seenReturn = false
   for (const stmt of clause.statements) {
     if (ts.isReturnStatement(stmt)) {
       returnCount++
+      seenReturn = true
       continue
     }
-    if (ts.isBreakStatement(stmt)) continue
+    if (ts.isBreakStatement(stmt)) {
+      // A `break` BEFORE the return makes the return unreachable — at runtime
+      // the case exits and the callback falls through to `undefined`, so
+      // folding it as if it returned JSX would render the wrong branch. Only a
+      // trailing break (after the return; dead but harmless) is allowed.
+      // (#2378 review.)
+      if (!seenReturn) return false
+      continue
+    }
     return false
   }
   return returnCount === 1

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -2163,22 +2163,31 @@ function foldMultiReturnBranches(
   for (let i = info.branches.length - 1; i >= 0; i--) {
     const branch = info.branches[i]
 
+    // A switch fallthrough (`case 'a': case 'b': return X`) yields one branch
+    // covering several case labels — OR-join them into `disc === a ||
+    // disc === b`. A plain if-branch or a single case is just `[condition]`.
+    const caseConds = info.switchDiscriminant
+      ? [branch.condition, ...(branch.extraCaseConditions ?? [])]
+      : [branch.condition]
+
     // Build condition text (`getText` applies param substitution when the
     // helper-function inliner supplies a substituting variant).
     let conditionText: string
     if (info.switchDiscriminant) {
       const discText = getText(info.switchDiscriminant)
-      const caseText = getText(branch.condition)
-      conditionText = `${discText} === ${caseText}`
+      // Parenthesize both operands so a low-precedence case expression
+      // (`case a ?? b:`, a ternary, …) keeps strict-equality semantics rather
+      // than binding as `(disc === a) ?? b`. (#2377 review.)
+      conditionText = caseConds.map(c => `(${discText}) === (${getText(c)})`).join(' || ')
     } else {
       conditionText = getText(branch.condition)
     }
 
-    // For switch-sourced conditions, merge freeRefs/reactivity from
-    // both the discriminant and case expression so prop rewrites and
-    // reactivity detection cover the full `disc === case` condition.
+    // For switch-sourced conditions, merge freeRefs/reactivity from the
+    // discriminant and every case expression so prop rewrites and reactivity
+    // detection cover the full `disc === a || disc === b` condition.
     const env = makeBindingEnv(ctx)
-    const caseFreeRefs = resolveFreeRefs(branch.condition, env)
+    const caseFreeRefs = caseConds.flatMap(c => resolveFreeRefs(c, env))
     const discFreeRefs = info.switchDiscriminant
       ? resolveFreeRefs(info.switchDiscriminant, env)
       : []
@@ -2191,9 +2200,9 @@ function foldMultiReturnBranches(
     const reactive = isReactiveExpression(conditionText, ctx, branch.condition)
       || isReactiveOrigin(conditionOrigin)
     const loopParamReactive = !reactive && referencesLoopParam(conditionText, ctx)
-    const callsReactive = exprCallsReactiveGetters(branch.condition, ctx)
+    const callsReactive = caseConds.some(c => exprCallsReactiveGetters(c, ctx))
       || (info.switchDiscriminant ? exprCallsReactiveGetters(info.switchDiscriminant, ctx) : false)
-    const hasCalls = exprHasFunctionCalls(branch.condition)
+    const hasCalls = caseConds.some(c => exprHasFunctionCalls(c))
       || (info.switchDiscriminant ? exprHasFunctionCalls(info.switchDiscriminant) : false)
     const needsSlot = reactive || loopParamReactive || callsReactive || hasCalls
     const slotId = needsSlot ? generateSlotId(ctx) : null
@@ -2202,18 +2211,18 @@ function foldMultiReturnBranches(
       ? (transformNode(branch.jsxReturn, ctx) ?? nullExpr)
       : nullExpr
 
-    // For switch conditions, build templateCondition from both parts
+    // For switch conditions, build templateCondition from the discriminant and
+    // every (prop-rewritten) case label, OR-joined for fallthrough.
     let templateCondition: string | undefined
     if (info.switchDiscriminant) {
       const discRewritten = rewriteBarePropRefs(
         getText(info.switchDiscriminant), info.switchDiscriminant, ctx
       )
-      const caseRewritten = rewriteBarePropRefs(
-        getText(branch.condition), branch.condition, ctx
-      )
       const discPart = discRewritten ?? getText(info.switchDiscriminant)
-      const casePart = caseRewritten ?? getText(branch.condition)
-      templateCondition = `${discPart} === ${casePart}`
+      templateCondition = caseConds.map(c => {
+        const casePart = rewriteBarePropRefs(getText(c), c, ctx) ?? getText(c)
+        return `(${discPart}) === (${casePart})`
+      }).join(' || ')
     } else {
       templateCondition = rewriteBarePropRefs(conditionText, branch.condition, ctx)
     }
@@ -4073,15 +4082,15 @@ function transformMapCall(
       // flatMap arrow with array literal: items.flatMap(item => [<A/>, <B/>])
       children = transformArrayLiteralChildren(body, ctx)
     } else if (ts.isBlock(body)) {
-      // Multi-return JSX block body (if/else-if chain or switch) — fold to a
-      // nested IRConditional so the loop renders each branch's compiled
-      // template. Tried BEFORE the single-return path: otherwise the trailing
-      // `return <fallback/>` would claim the single-return arm and the leading
-      // `if (...) return <A/>` would leak verbatim into the map preamble (the
-      // silent-verbatim-leak this fixes). Stage 2 of spec/callback-fidelity.md.
-      // Preamble-const / switch-fallthrough / nested-loop shapes are not yet
-      // extracted (extractMultiReturnJsxBranches returns null) and fall through
-      // to the single-return path below.
+      // Multi-return JSX block body (if/else-if chain or a `switch`, including
+      // fallthrough case labels) — fold to a nested IRConditional so the loop
+      // renders each branch's compiled template. Tried BEFORE the single-return
+      // path: otherwise the trailing `return <fallback/>` would claim the
+      // single-return arm and the leading `if (...) return <A/>` would leak
+      // verbatim into the map preamble (the silent-verbatim-leak this fixes).
+      // Stage 2 of spec/callback-fidelity.md. Bodies with a preamble/branch-local
+      // `const`, or a statement-level nested loop, are not folded
+      // (extractMultiReturnJsxBranches returns null) and fall through below.
       const multiReturn = method !== 'flatMap' ? extractMultiReturnJsxBranches(body) : null
       if (multiReturn && multiReturn.branches.length > 0) {
         const loc = getSourceLocation(body, ctx.sourceFile, ctx.filePath)

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 273,
+    "totalFixtures": 274,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -866,15 +866,15 @@
       }
     },
     "binary": {
-      "total": 74,
+      "total": 75,
       "cells": {
         "hono": {
-          "pass": 74,
-          "total": 74
+          "pass": 75,
+          "total": 75
         },
         "blade": {
-          "pass": 66,
-          "total": 74,
+          "pass": 67,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -917,8 +917,8 @@
           ]
         },
         "erb": {
-          "pass": 67,
-          "total": 74,
+          "pass": 68,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -955,8 +955,8 @@
           ]
         },
         "go-template": {
-          "pass": 66,
-          "total": 74,
+          "pass": 67,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -999,8 +999,8 @@
           ]
         },
         "jinja": {
-          "pass": 66,
-          "total": 74,
+          "pass": 67,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1043,8 +1043,8 @@
           ]
         },
         "minijinja": {
-          "pass": 66,
-          "total": 74,
+          "pass": 67,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1087,8 +1087,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 67,
-          "total": 74,
+          "pass": 68,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1125,8 +1125,8 @@
           ]
         },
         "twig": {
-          "pass": 66,
-          "total": 74,
+          "pass": 67,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1169,8 +1169,8 @@
           ]
         },
         "xslate": {
-          "pass": 66,
-          "total": 74,
+          "pass": 67,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1886,11 +1886,11 @@
       }
     },
     "identifier": {
-      "total": 254,
+      "total": 255,
       "cells": {
         "hono": {
-          "pass": 253,
-          "total": 254,
+          "pass": 254,
+          "total": 255,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1901,8 +1901,8 @@
           ]
         },
         "blade": {
-          "pass": 241,
-          "total": 254,
+          "pass": 242,
+          "total": 255,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1969,8 +1969,8 @@
           ]
         },
         "erb": {
-          "pass": 242,
-          "total": 254,
+          "pass": 243,
+          "total": 255,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2031,8 +2031,8 @@
           ]
         },
         "go-template": {
-          "pass": 241,
-          "total": 254,
+          "pass": 242,
+          "total": 255,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2099,8 +2099,8 @@
           ]
         },
         "jinja": {
-          "pass": 241,
-          "total": 254,
+          "pass": 242,
+          "total": 255,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2167,8 +2167,8 @@
           ]
         },
         "minijinja": {
-          "pass": 241,
-          "total": 254,
+          "pass": 242,
+          "total": 255,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2235,8 +2235,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 242,
-          "total": 254,
+          "pass": 243,
+          "total": 255,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2297,8 +2297,8 @@
           ]
         },
         "twig": {
-          "pass": 241,
-          "total": 254,
+          "pass": 242,
+          "total": 255,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2365,8 +2365,8 @@
           ]
         },
         "xslate": {
-          "pass": 241,
-          "total": 254,
+          "pass": 242,
+          "total": 255,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2498,15 +2498,15 @@
       }
     },
     "literal": {
-      "total": 212,
+      "total": 213,
       "cells": {
         "hono": {
-          "pass": 212,
-          "total": 212
+          "pass": 213,
+          "total": 213
         },
         "blade": {
-          "pass": 203,
-          "total": 212,
+          "pass": 204,
+          "total": 213,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2549,8 +2549,8 @@
           ]
         },
         "erb": {
-          "pass": 203,
-          "total": 212,
+          "pass": 204,
+          "total": 213,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2593,8 +2593,8 @@
           ]
         },
         "go-template": {
-          "pass": 203,
-          "total": 212,
+          "pass": 204,
+          "total": 213,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2637,8 +2637,8 @@
           ]
         },
         "jinja": {
-          "pass": 203,
-          "total": 212,
+          "pass": 204,
+          "total": 213,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2681,8 +2681,8 @@
           ]
         },
         "minijinja": {
-          "pass": 203,
-          "total": 212,
+          "pass": 204,
+          "total": 213,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2725,8 +2725,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 203,
-          "total": 212,
+          "pass": 204,
+          "total": 213,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2769,8 +2769,8 @@
           ]
         },
         "twig": {
-          "pass": 203,
-          "total": 212,
+          "pass": 204,
+          "total": 213,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2813,8 +2813,8 @@
           ]
         },
         "xslate": {
-          "pass": 203,
-          "total": 212,
+          "pass": 204,
+          "total": 213,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2870,15 +2870,15 @@
       }
     },
     "logical": {
-      "total": 41,
+      "total": 42,
       "cells": {
         "hono": {
-          "pass": 41,
-          "total": 41
+          "pass": 42,
+          "total": 42
         },
         "blade": {
-          "pass": 40,
-          "total": 41,
+          "pass": 41,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2889,8 +2889,8 @@
           ]
         },
         "erb": {
-          "pass": 40,
-          "total": 41,
+          "pass": 41,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2901,8 +2901,8 @@
           ]
         },
         "go-template": {
-          "pass": 40,
-          "total": 41,
+          "pass": 41,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2913,8 +2913,8 @@
           ]
         },
         "jinja": {
-          "pass": 40,
-          "total": 41,
+          "pass": 41,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2925,8 +2925,8 @@
           ]
         },
         "minijinja": {
-          "pass": 40,
-          "total": 41,
+          "pass": 41,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2937,8 +2937,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 40,
-          "total": 41,
+          "pass": 41,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2949,8 +2949,8 @@
           ]
         },
         "twig": {
-          "pass": 40,
-          "total": 41,
+          "pass": 41,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2961,8 +2961,8 @@
           ]
         },
         "xslate": {
-          "pass": 40,
-          "total": 41,
+          "pass": 41,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -2986,11 +2986,11 @@
       }
     },
     "member": {
-      "total": 133,
+      "total": 134,
       "cells": {
         "hono": {
-          "pass": 132,
-          "total": 133,
+          "pass": 133,
+          "total": 134,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3001,8 +3001,8 @@
           ]
         },
         "blade": {
-          "pass": 120,
-          "total": 133,
+          "pass": 121,
+          "total": 134,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3069,8 +3069,8 @@
           ]
         },
         "erb": {
-          "pass": 121,
-          "total": 133,
+          "pass": 122,
+          "total": 134,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3131,8 +3131,8 @@
           ]
         },
         "go-template": {
-          "pass": 120,
-          "total": 133,
+          "pass": 121,
+          "total": 134,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3199,8 +3199,8 @@
           ]
         },
         "jinja": {
-          "pass": 120,
-          "total": 133,
+          "pass": 121,
+          "total": 134,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3267,8 +3267,8 @@
           ]
         },
         "minijinja": {
-          "pass": 120,
-          "total": 133,
+          "pass": 121,
+          "total": 134,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3335,8 +3335,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 121,
-          "total": 133,
+          "pass": 122,
+          "total": 134,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3397,8 +3397,8 @@
           ]
         },
         "twig": {
-          "pass": 120,
-          "total": 133,
+          "pass": 121,
+          "total": 134,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3465,8 +3465,8 @@
           ]
         },
         "xslate": {
-          "pass": 120,
-          "total": 133,
+          "pass": 121,
+          "total": 134,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -6003,15 +6003,15 @@
       }
     },
     "binary:===": {
-      "total": 37,
+      "total": 38,
       "cells": {
         "hono": {
-          "pass": 37,
-          "total": 37
+          "pass": 38,
+          "total": 38
         },
         "blade": {
-          "pass": 30,
-          "total": 37,
+          "pass": 31,
+          "total": 38,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6048,8 +6048,8 @@
           ]
         },
         "erb": {
-          "pass": 31,
-          "total": 37,
+          "pass": 32,
+          "total": 38,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6080,8 +6080,8 @@
           ]
         },
         "go-template": {
-          "pass": 30,
-          "total": 37,
+          "pass": 31,
+          "total": 38,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6118,8 +6118,8 @@
           ]
         },
         "jinja": {
-          "pass": 30,
-          "total": 37,
+          "pass": 31,
+          "total": 38,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6156,8 +6156,8 @@
           ]
         },
         "minijinja": {
-          "pass": 30,
-          "total": 37,
+          "pass": 31,
+          "total": 38,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6194,8 +6194,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 31,
-          "total": 37,
+          "pass": 32,
+          "total": 38,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6226,8 +6226,8 @@
           ]
         },
         "twig": {
-          "pass": 30,
-          "total": 37,
+          "pass": 31,
+          "total": 38,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6264,8 +6264,8 @@
           ]
         },
         "xslate": {
-          "pass": 30,
-          "total": 37,
+          "pass": 31,
+          "total": 38,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6686,15 +6686,15 @@
       }
     },
     "literal:string": {
-      "total": 153,
+      "total": 154,
       "cells": {
         "hono": {
-          "pass": 153,
-          "total": 153
+          "pass": 154,
+          "total": 154
         },
         "blade": {
-          "pass": 146,
-          "total": 153,
+          "pass": 147,
+          "total": 154,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6729,8 +6729,8 @@
           ]
         },
         "erb": {
-          "pass": 146,
-          "total": 153,
+          "pass": 147,
+          "total": 154,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6765,8 +6765,8 @@
           ]
         },
         "go-template": {
-          "pass": 146,
-          "total": 153,
+          "pass": 147,
+          "total": 154,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6801,8 +6801,8 @@
           ]
         },
         "jinja": {
-          "pass": 146,
-          "total": 153,
+          "pass": 147,
+          "total": 154,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6837,8 +6837,8 @@
           ]
         },
         "minijinja": {
-          "pass": 146,
-          "total": 153,
+          "pass": 147,
+          "total": 154,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6873,8 +6873,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 146,
-          "total": 153,
+          "pass": 147,
+          "total": 154,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6909,8 +6909,8 @@
           ]
         },
         "twig": {
-          "pass": 146,
-          "total": 153,
+          "pass": 147,
+          "total": 154,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6945,8 +6945,8 @@
           ]
         },
         "xslate": {
-          "pass": 146,
-          "total": 153,
+          "pass": 147,
+          "total": 154,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7162,43 +7162,43 @@
       }
     },
     "logical:||": {
-      "total": 12,
+      "total": 13,
       "cells": {
         "hono": {
-          "pass": 12,
-          "total": 12
+          "pass": 13,
+          "total": 13
         },
         "blade": {
-          "pass": 12,
-          "total": 12
+          "pass": 13,
+          "total": 13
         },
         "erb": {
-          "pass": 12,
-          "total": 12
+          "pass": 13,
+          "total": 13
         },
         "go-template": {
-          "pass": 12,
-          "total": 12
+          "pass": 13,
+          "total": 13
         },
         "jinja": {
-          "pass": 12,
-          "total": 12
+          "pass": 13,
+          "total": 13
         },
         "minijinja": {
-          "pass": 12,
-          "total": 12
+          "pass": 13,
+          "total": 13
         },
         "mojolicious": {
-          "pass": 12,
-          "total": 12
+          "pass": 13,
+          "total": 13
         },
         "twig": {
-          "pass": 12,
-          "total": 12
+          "pass": 13,
+          "total": 13
         },
         "xslate": {
-          "pass": 12,
-          "total": 12
+          "pass": 13,
+          "total": 13
         }
       },
       "source": {


### PR DESCRIPTION
## Summary

Stage 2 of the [Callback-Body Fidelity RFC](../blob/main/spec/callback-fidelity.md), stacked on #2377 (base branch `claude/barefoot-onboarding-ybwugc-mapfold`). Extends the `.map()` multi-return body fold with `switch` fallthrough, and **addresses #2377's Copilot review** (two findings, both verified as real bugs).

> **Note:** an earlier revision of this PR added leading-`const` preamble folding. That was dropped — it silently **diverged on DSL adapters** (Jinja rendered `<b></b>` because a loop-local `const` can't be carried into a conditional branch template on template backends), which violates the RFC's rule that a DSL must render faithfully *or refuse*, never emit wrong output. Preamble-const (and statement-level nested loops) are deferred pending a per-backend refuse/render story.

### 1. Switch fallthrough (new shape)
An empty `case` label that falls through to the next clause's body now folds:
```tsx
items.map((it) => {
  switch (it.kind) {
    case 'a':
    case 'b':
      return <b key={it.id}>AB</b>
    default:
      return <span key={it.id}>D</span>
  }
})
```
`extractMultiReturnJsxBranches` accumulates the fallthrough labels and the fold OR-joins them into `disc === 'a' || disc === 'b'`, so both `a` and `b` render the same element. Previously the empty fallthrough clause made extraction bail and the whole `switch` map body leaked verbatim.

### 2. No silent drops (fix — #2377 review)
A **branch-local** `const`/`let` (`if (c) { const x = …; return <A>{x}</A> }`, or a `switch` case with an extra statement) was accepted by the extractor but **dropped** by the fold, rendering the local `undefined` (`ReferenceError` at SSR/hydration — confirmed: `${x}` emitted with no `const x`). `isDirectReturnBlock` and the switch case validation now reject any non-return statement, so these shapes **bail conservatively** instead of folding-and-dropping.

### 3. Switch precedence (fix — #2377 review)
The generated `disc === case` condition now parenthesizes both operands (`(disc) === (case)`) so a low-precedence case (`case a ?? b:`, a ternary) keeps strict-equality semantics.

## Tests

- `map-switch-fallthrough-body` cross-adapter conformance fixture (renders on all 9 adapters as neutral IR — no pins), verified against the SSR-hydration contract.
- `map-multi-return-body` compiler-unit test extended: fallthrough OR-condition + conservative-bail pins (branch-local const → `null`, switch-case-with-statement → `null`, leading-const preamble → `null`).
- Green: **jsx 2649/0 · hono conformance 964/0 · jinja conformance 908/0 · compat 151/0**. (DSL adapters that shell out to external runtimes are verified by CI.)

## Stack

- #2377 — Stage 2 core (if/else-if & switch fold)
- **this PR** — switch fallthrough + fold hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)