### PR TITLE
Stage 2: fold leading-const preamble map bodies, adapter-gated (BF021 on DSL)

### DIFF
--- a/.changeset/fold-preamble-const-adapter-gated.md
+++ b/.changeset/fold-preamble-const-adapter-gated.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/blade": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/rust": patch
+"@barefootjs/twig": patch
+"@barefootjs/xslate": patch
+---
+
+Fold `.map()` bodies with a leading `const`/`let` preamble, adapter-gated (callback-body fidelity, Stage 2 of `spec/callback-fidelity.md`).
+
+A `.map()` callback body with a leading `const` before an if/else-if chain or `switch` (`{ const label = fmt(it); if (it.on) return <b/>; return <span/> }`) now folds into a nested `IRConditional` with the declarations emitted once per iteration, so the local is in scope in every branch. Because a DSL backend can't carry a loop-local into a conditional branch template, the fold is adapter-gated like the off-subset filter/sort predicates: a JS-runtime adapter (Hono, CSR) folds and runs it, while a DSL adapter refuses with `BF021` + the `/* @client */` escape rather than rendering the local `undefined` (a silent divergence). Covered by the `map-preamble-branch-body` conformance fixture (JS-runtime faithful, pinned BF021 on every DSL adapter) and the `map-multi-return-body` compiler-unit test (fold / refuse / `@client`-escape). A branch-local `const` (inside a branch block or case) and statement-level imperative nested loops remain unfolded — the latter is Stage 3's verbatim-JS territory.

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -15,6 +15,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // A `.map()` body with a `const`/`let` preamble before its branches:
+  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
+  // conditional branch template, so it refuses with BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -16,6 +16,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // A `.map()` body with a `const`/`let` preamble before its branches:
+  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
+  // conditional branch template, so it refuses with BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -15,6 +15,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // A `.map()` body with a `const`/`let` preamble before its branches:
+  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
+  // conditional branch template, so it refuses with BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -15,6 +15,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // A `.map()` body with a `const`/`let` preamble before its branches:
+  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
+  // conditional branch template, so it refuses with BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -13,6 +13,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // A `.map()` body with a `const`/`let` preamble before its branches:
+  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
+  // conditional branch template, so it refuses with BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -16,6 +16,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // A `.map()` body with a `const`/`let` preamble before its branches:
+  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
+  // conditional branch template, so it refuses with BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2535,6 +2535,19 @@
         "text"
       ]
     },
+    "map-preamble-branch-body": {
+      "kinds": [
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "condition",
+        "loop",
+        "text"
+      ]
+    },
     "map-switch-fallthrough-body": {
       "kinds": [
         "binary",
@@ -4416,11 +4429,11 @@
     "binary": 75,
     "call": 173,
     "conditional": 20,
-    "identifier": 255,
+    "identifier": 256,
     "index-access": 12,
     "literal": 213,
     "logical": 42,
-    "member": 134,
+    "member": 135,
     "object-literal": 46,
     "template-literal": 27,
     "unary": 22,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -129,6 +129,7 @@ import { fixture as reduceRightTypeofBody } from './reduce-right-typeof-body'
 import { fixture as flatMapTypeofProjection } from './flatmap-typeof-projection'
 import { fixture as mapIfChainBody } from './map-if-chain-body'
 import { fixture as mapSwitchFallthroughBody } from './map-switch-fallthrough-body'
+import { fixture as mapPreambleBranchBody } from './map-preamble-branch-body'
 import { fixture as sortSimple } from './sort-simple'
 import { fixture as filterSortChain } from './filter-sort-chain'
 import { fixture as mapNested } from './map-nested'
@@ -495,6 +496,7 @@ export const jsxFixtures: JSXFixture[] = [
   flatMapTypeofProjection,
   mapIfChainBody,
   mapSwitchFallthroughBody,
+  mapPreambleBranchBody,
   sortSimple,
   filterSortChain,
   mapNested,

--- a/packages/adapter-tests/fixtures/map-preamble-branch-body.ts
+++ b/packages/adapter-tests/fixtures/map-preamble-branch-body.ts
@@ -1,0 +1,42 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A `.map()` callback body with a leading `const` preamble before an if/else
+ * branch — `{ const label = fmt(it); if (it.on) return <b/>; return <span/> }`.
+ * Stage 2 of `spec/callback-fidelity.md`: a JS-runtime adapter folds this into
+ * a nested `IRConditional` and emits the preamble once per iteration, so the
+ * local is in scope in both branches; a DSL adapter can't carry a loop-local
+ * into a conditional branch template, so it refuses (BF021) rather than render
+ * the local `undefined` (a silent divergence).
+ *
+ * Adapter-gated, like the off-subset filter/sort predicates:
+ *   - Hono / CSR fold and run it; the reference `expectedHtml` renders the
+ *     labels faithfully.
+ *   - DSL adapters (Go, Perl, Ruby, PHP, Rust, Python) surface BF021 with the
+ *     `/* @client *\/` escape (declared via each adapter's `conformancePins`);
+ *     marking the map client-only defers the whole loop to the browser, which
+ *     runs the preamble. (The `/* @client *\/` escape is exercised in the
+ *     `map-multi-return-body` compiler-unit test.)
+ */
+export const fixture = createFixture({
+  id: 'map-preamble-branch-body',
+  description: 'const preamble + if/else as a .map() body — JS-runtime folds, DSL refuses (BF021)',
+  source: `
+function MapPreambleBranch({ items }: { items: { id: string; on: boolean; kind: string }[] }) {
+  return (
+    <ul>
+      {items.map((it) => {
+        const label = it.kind.toUpperCase()
+        if (it.on) return <b key={it.id}>{label}</b>
+        return <span key={it.id}>{label}</span>
+      })}
+    </ul>
+  )
+}
+export { MapPreambleBranch }
+`,
+  props: { items: [{ id: '1', on: true, kind: 'a' }, { id: '2', on: false, kind: 'b' }] },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1"><!--bf-loop:l0--><b bf-c="s0" data-key="1">A</b><span bf-c="s0" data-key="2">B</span><!--bf-/loop:l0--></ul>
+  `,
+})

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -15,6 +15,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // A `.map()` body with a `const`/`let` preamble before its branches:
+  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
+  // conditional branch template, so it refuses with BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -13,6 +13,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
+  // A `.map()` body with a `const`/`let` preamble before its branches:
+  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
+  // conditional branch template, so it refuses with BF021 + `/* @client */`.
+  // See spec/callback-fidelity.md.
+  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/jsx/src/__tests__/map-multi-return-body.test.ts
+++ b/packages/jsx/src/__tests__/map-multi-return-body.test.ts
@@ -1,10 +1,12 @@
 /**
  * Stage 2 of spec/callback-fidelity.md — folding a `.map()` callback whose
- * body is an if/else-if chain or `switch` (including fallthrough case labels)
- * into a nested `IRConditional`, instead of the prior silent verbatim leak.
- * Also pins the conservative bail for shapes the fold can't carry — a
- * branch-local local, or a leading-`const` preamble (deferred; a following PR
- * adds an adapter-gated preamble fold) — so nothing is dropped silently.
+ * body is an if/else-if chain or `switch` (including fallthrough case labels),
+ * optionally preceded by a leading-`const`/`let` preamble, into a nested
+ * `IRConditional`, instead of the prior silent verbatim leak. The preamble
+ * fold is adapter-gated: a JS runtime folds it, a DSL adapter refuses (BF021 +
+ * `/* @client */`). Also pins the conservative bail for shapes the fold can't
+ * carry — a branch-local local, or a preamble with a null-returning branch —
+ * so nothing is dropped silently.
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -75,7 +77,7 @@ describe('.map() multi-return body fold (Stage 2)', () => {
   })
 
   describe('conservative bail — no silent drop', () => {
-    function extract(body: string) {
+    function extract(body: string, allowPreamble = false) {
       const sf = ts.createSourceFile('t.tsx', `const f = (it: any) => ${body}`, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
       let block: ts.Block | undefined
       const visit = (n: ts.Node) => {
@@ -83,7 +85,7 @@ describe('.map() multi-return body fold (Stage 2)', () => {
         ts.forEachChild(n, visit)
       }
       visit(sf)
-      return extractMultiReturnJsxBranches(block!)
+      return extractMultiReturnJsxBranches(block!, allowPreamble)
     }
 
     test('a branch-local const bails (would otherwise be dropped)', () => {
@@ -104,9 +106,51 @@ describe('.map() multi-return body fold (Stage 2)', () => {
       expect(r).toBeNull()
     })
 
-    test('a leading const preamble bails (deferred — DSL cannot carry the local)', () => {
+    test('a leading const is a preamble only when allowPreamble is set', () => {
       const body = `{ const label = it.kind; if (it.on) return <b>{label}</b>; return <span>{label}</span> }`
+      // The helper-function inliner passes no allowPreamble — bails.
       expect(extract(body)).toBeNull()
+      // The .map() body fold opts in — collects the leading const as a preamble.
+      const r = extract(body, true)
+      expect(r).not.toBeNull()
+      expect(r!.preamble?.length).toBe(1)
+    })
+  })
+
+  describe('leading-const preamble is adapter-gated (JS folds, DSL refuses)', () => {
+    const preambleBody = `{
+      const label = it.kind.toUpperCase()
+      if (it.on) return <b key={it.id}>{label}</b>
+      return <span key={it.id}>{label}</span>
+    }`
+
+    function compileWith(source: string, dsl: boolean) {
+      const a = new TestAdapter()
+      // Model a DSL adapter: its template runtime can't run a callback body
+      // verbatim, so `acceptsCallbackBody` reports false for every kind.
+      if (dsl) a.acceptsCallbackBody = () => false
+      return compileJSX(source, 'List.tsx', { adapter: a })
+    }
+
+    test('a JS-runtime adapter folds the preamble (const emitted, no error)', () => {
+      const r = compileWith(wrap(preambleBody), false)
+      expect(r.errors).toHaveLength(0)
+      const cj = r.files.find(f => f.type === 'clientJs')!
+      expect(cj.content).toMatch(/const label\b/)
+      expect(cj.content).not.toMatch(/return <(b|span)/)
+    })
+
+    test('a DSL adapter refuses with BF021 + the /* @client */ escape', () => {
+      const r = compileWith(wrap(preambleBody), true)
+      const bf021 = r.errors.filter(e => e.code === 'BF021')
+      expect(bf021).toHaveLength(1)
+      expect(bf021[0].suggestion?.message).toContain('@client')
+    })
+
+    test('/* @client */ suppresses the DSL refusal', () => {
+      const clientSource = wrap(preambleBody).replace('items.map', '/* @client */ items.map')
+      const r = compileWith(clientSource, true)
+      expect(r.errors.filter(e => e.code === 'BF021')).toHaveLength(0)
     })
   })
 })

--- a/packages/jsx/src/__tests__/map-multi-return-body.test.ts
+++ b/packages/jsx/src/__tests__/map-multi-return-body.test.ts
@@ -115,6 +115,15 @@ describe('.map() multi-return body fold (Stage 2)', () => {
       expect(r).not.toBeNull()
       expect(r!.preamble?.length).toBe(1)
     })
+
+    test('a preamble with a null-returning branch bails (mapArrayAnchored hazard)', () => {
+      // `const f = …; if (!f) return null; return <div key={fid}>…</div>` — the
+      // null early-return routes the loop through the anchored conditional-item
+      // runtime, where a preamble local breaks keyed reactivity (the
+      // pivot-table demo shape). Fold only the all-JSX preamble case.
+      const body = `{ const f = it.field; if (!f) return null; return <div key={it.id}>{f}</div> }`
+      expect(extract(body, true)).toBeNull()
+    })
   })
 
   describe('leading-const preamble is adapter-gated (JS folds, DSL refuses)', () => {

--- a/packages/jsx/src/__tests__/map-multi-return-body.test.ts
+++ b/packages/jsx/src/__tests__/map-multi-return-body.test.ts
@@ -4,7 +4,7 @@
  * optionally preceded by a leading-`const`/`let` preamble, into a nested
  * `IRConditional`, instead of the prior silent verbatim leak. The preamble
  * fold is adapter-gated: a JS runtime folds it, a DSL adapter refuses (BF021 +
- * `/* @client */`). Also pins the conservative bail for shapes the fold can't
+ * `/* @client *\/`). Also pins the conservative bail for shapes the fold can't
  * carry — a branch-local local, or a preamble with a null-returning branch —
  * so nothing is dropped silently.
  */
@@ -114,6 +114,13 @@ describe('.map() multi-return body fold (Stage 2)', () => {
       const r = extract(body, true)
       expect(r).not.toBeNull()
       expect(r!.preamble?.length).toBe(1)
+    })
+
+    test('a leading `var` preamble is not collected (var hoisting semantics)', () => {
+      // Only `const`/`let` are collectable; `var` hoists differently, so the
+      // per-iteration preamble emit wouldn't preserve semantics. (#2379 review.)
+      const body = `{ var label = it.kind; if (it.on) return <b>{label}</b>; return <span>{label}</span> }`
+      expect(extract(body, true)).toBeNull()
     })
 
     test('a preamble with a null-returning branch bails (mapArrayAnchored hazard)', () => {

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -2100,6 +2100,17 @@ export interface MultiReturnJsxBranches {
   }>
   fallback: JsxReturnNode | null
   switchDiscriminant?: ts.Expression
+  /**
+   * Leading `const` / `let` declarations before the branches, collected only
+   * when the caller passes `allowPreamble` (the `.map()` body fold — Stage 2 of
+   * `spec/callback-fidelity.md`). A JS-runtime adapter folds them into a
+   * per-iteration preamble; a DSL adapter can't carry a loop-local into a
+   * conditional branch template, so the `.map()` lowering refuses (BF021 +
+   * `/* @client *\/`) rather than render wrong output. Empty for the
+   * helper-function inliner, which passes no `allowPreamble` and still bails on
+   * any variable statement.
+   */
+  preamble?: ts.VariableStatement[]
 }
 
 /**
@@ -2108,7 +2119,8 @@ export interface MultiReturnJsxBranches {
  * returns JSX or null. Returns null for unsupported patterns.
  */
 export function extractMultiReturnJsxBranches(
-  body: ts.Block
+  body: ts.Block,
+  allowPreamble = false,
 ): MultiReturnJsxBranches | null {
   const branches: Array<{
     condition: ts.Expression
@@ -2116,6 +2128,7 @@ export function extractMultiReturnJsxBranches(
     extraCaseConditions?: ts.Expression[]
   }> = []
   let fallback: JsxReturnNode | null = null
+  const preamble: ts.VariableStatement[] = []
 
   const stmts = body.statements
   for (let i = 0; i < stmts.length; i++) {
@@ -2152,7 +2165,7 @@ export function extractMultiReturnJsxBranches(
             return null
           }
           if (branches.length === 0) return null
-          return { branches, fallback }
+          return { branches, fallback, preamble }
         }
         break
       }
@@ -2219,7 +2232,7 @@ export function extractMultiReturnJsxBranches(
       if (pendingCases.length > 0) return null
 
       if (branches.length === 0) return null
-      return { branches, fallback, switchDiscriminant: stmt.expression }
+      return { branches, fallback, switchDiscriminant: stmt.expression, preamble }
     }
 
     // Trailing return <jsx> or return null — this is the fallback
@@ -2235,19 +2248,28 @@ export function extractMultiReturnJsxBranches(
       continue
     }
 
-    // Reject bodies with variable declarations — locals referenced in
-    // conditions or JSX would become undefined after inlining. (A leading-const
-    // preamble fold was tried but silently diverged on DSL adapters, which
-    // can't carry a loop-local into a conditional branch template; deferred
-    // pending a per-backend refuse/render story. See spec/callback-fidelity.md.)
-    if (ts.isVariableStatement(stmt)) return null
+    // Leading `const`/`let` before any branch — collected as a preamble when
+    // the caller allows it (the `.map()` body fold; Stage 2 of
+    // spec/callback-fidelity.md). The JS-runtime fold emits it once per
+    // iteration ahead of the conditional; a DSL target refuses (BF021 +
+    // `/* @client */`) since it can't carry the loop-local into a branch
+    // template. Without `allowPreamble`, or once branches have started, reject:
+    // the helper-function inliner has no place to emit it, and a mid-chain
+    // local referenced in a later condition/JSX would become undefined.
+    if (ts.isVariableStatement(stmt)) {
+      if (allowPreamble && branches.length === 0 && fallback === null) {
+        preamble.push(stmt)
+        continue
+      }
+      return null
+    }
 
     // Any other statement type → unsupported pattern
     return null
   }
 
   if (branches.length === 0) return null
-  return { branches, fallback }
+  return { branches, fallback, preamble }
 }
 
 /**

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -2114,6 +2114,27 @@ export interface MultiReturnJsxBranches {
 }
 
 /**
+ * A leading-`const` preamble is only safe to fold when every branch (and the
+ * fallback) returns real JSX. If any returns `null`, the loop item can be null
+ * and the compiler routes the loop through the anchored conditional-item
+ * runtime (`mapArrayAnchored`), where a preamble local computed before the
+ * conditional interacts badly with the per-item hydration anchor — observed as
+ * a keyed-reactivity break on a real component (the pivot-table demo, whose
+ * `.map()` body is `const f = …; if (!f) return null; return <div key={fid}>`
+ * and which carries a workaround note about exactly this compiler behavior).
+ * When unsafe, bail so the body falls through to the single-return path
+ * unchanged. Stage 2 of `spec/callback-fidelity.md`.
+ */
+function preambleUnsafe(
+  preamble: ts.VariableStatement[],
+  branches: Array<{ jsxReturn: JsxReturnNode | null }>,
+  fallback: JsxReturnNode | null,
+): boolean {
+  if (preamble.length === 0) return false
+  return fallback === null || branches.some(b => b.jsxReturn === null)
+}
+
+/**
  * Extract conditional branches from a multi-return JSX helper function body.
  * Supports if/else if chains and switch statements where every branch
  * returns JSX or null. Returns null for unsupported patterns.
@@ -2165,6 +2186,7 @@ export function extractMultiReturnJsxBranches(
             return null
           }
           if (branches.length === 0) return null
+          if (preambleUnsafe(preamble, branches, fallback)) return null
           return { branches, fallback, preamble }
         }
         break
@@ -2232,6 +2254,7 @@ export function extractMultiReturnJsxBranches(
       if (pendingCases.length > 0) return null
 
       if (branches.length === 0) return null
+      if (preambleUnsafe(preamble, branches, fallback)) return null
       return { branches, fallback, switchDiscriminant: stmt.expression, preamble }
     }
 
@@ -2269,6 +2292,7 @@ export function extractMultiReturnJsxBranches(
   }
 
   if (branches.length === 0) return null
+  if (preambleUnsafe(preamble, branches, fallback)) return null
   return { branches, fallback, preamble }
 }
 

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -2280,7 +2280,14 @@ export function extractMultiReturnJsxBranches(
     // the helper-function inliner has no place to emit it, and a mid-chain
     // local referenced in a later condition/JSX would become undefined.
     if (ts.isVariableStatement(stmt)) {
-      if (allowPreamble && branches.length === 0 && fallback === null) {
+      // Only `const` / `let` are collectable — a `var` hoists to the enclosing
+      // function scope with different (redeclaration / TDZ-free) semantics that
+      // the per-iteration preamble emit wouldn't preserve, so reject it.
+      // (#2379 review.)
+      const declFlags = stmt.declarationList.flags
+      const isConstOrLet =
+        (declFlags & ts.NodeFlags.Const) !== 0 || (declFlags & ts.NodeFlags.Let) !== 0
+      if (allowPreamble && isConstOrLet && branches.length === 0 && fallback === null) {
         preamble.push(stmt)
         continue
       }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -4083,18 +4083,66 @@ function transformMapCall(
       children = transformArrayLiteralChildren(body, ctx)
     } else if (ts.isBlock(body)) {
       // Multi-return JSX block body (if/else-if chain or a `switch`, including
-      // fallthrough case labels) — fold to a nested IRConditional so the loop
-      // renders each branch's compiled template. Tried BEFORE the single-return
-      // path: otherwise the trailing `return <fallback/>` would claim the
+      // fallthrough case labels, optionally preceded by a `const`/`let`
+      // preamble) — fold to a nested IRConditional so the loop renders each
+      // branch's compiled template. Tried BEFORE the single-return path:
+      // otherwise the trailing `return <fallback/>` would claim the
       // single-return arm and the leading `if (...) return <A/>` would leak
       // verbatim into the map preamble (the silent-verbatim-leak this fixes).
-      // Stage 2 of spec/callback-fidelity.md. Bodies with a preamble/branch-local
-      // `const`, or a statement-level nested loop, are not folded
-      // (extractMultiReturnJsxBranches returns null) and fall through below.
-      const multiReturn = method !== 'flatMap' ? extractMultiReturnJsxBranches(body) : null
+      // Stage 2 of spec/callback-fidelity.md. A branch-local `const` (inside a
+      // branch block/case) or a statement-level nested loop is not folded
+      // (extractMultiReturnJsxBranches returns null) and falls through below.
+      const multiReturn = method !== 'flatMap' ? extractMultiReturnJsxBranches(body, true) : null
       if (multiReturn && multiReturn.branches.length > 0) {
         const loc = getSourceLocation(body, ctx.sourceFile, ctx.filePath)
         children = [foldMultiReturnBranches(multiReturn, ctx, loc, ctx.getJS)]
+
+        const pre = multiReturn.preamble ?? []
+        if (pre.length > 0) {
+          // Emit the leading const/let preamble once per iteration, ahead of
+          // the conditional — the same carrier the single-return path uses. A
+          // JS-runtime adapter (and the browser under /* @client */) runs it
+          // verbatim.
+          const jsStmts: string[] = []
+          const tplStmts: string[] = []
+          const typedStmts: string[] = []
+          let tplDiff = false
+          let typeDiff = false
+          for (const stmt of pre) {
+            const js = ctx.getJS(stmt)
+            const tjs = ctx.getTemplateJS(stmt)
+            const raw = stmt.getText(ctx.sourceFile)
+            jsStmts.push(js.endsWith(';') ? js : js + ';')
+            tplStmts.push(tjs.endsWith(';') ? tjs : tjs + ';')
+            typedStmts.push(raw.endsWith(';') ? raw : raw + ';')
+            if (js !== raw) typeDiff = true
+            if (js !== tjs) tplDiff = true
+          }
+          mapPreamble = jsStmts.join(' ')
+          if (tplDiff) templateMapPreamble = tplStmts.join(' ')
+          if (typeDiff) typedMapPreamble = typedStmts.join(' ')
+
+          // A DSL adapter can't carry a loop-local `const` into a conditional
+          // branch template, so it would render the branches with the local
+          // undefined (silent divergence). Refuse instead — adapter-gated like
+          // the filter/sort sites: a JS-runtime target folds and runs it, a DSL
+          // target errors with the /* @client */ escape (which renders the map
+          // client-only, where the browser runs the preamble). Stage 2 of
+          // spec/callback-fidelity.md.
+          if (!isClientOnly && !(ctx.analyzer.acceptsCallbackBody?.('map') ?? false)) {
+            ctx.analyzer.errors.push(
+              createError(ErrorCodes.UNSUPPORTED_JSX_PATTERN, loc, {
+                message:
+                  'A .map() callback body with a `const`/`let` preamble before its ' +
+                  'branches cannot be lowered to a template: the loop-local binding ' +
+                  'cannot be carried into a conditional branch on this backend.',
+                suggestion: {
+                  message: 'Add /* @client */ to evaluate this expression on the client only',
+                },
+              })
+            )
+          }
+        }
       }
 
       // Block body: (item) => { const label = ...; return <div>{label}</div> }

--- a/spec/callback-fidelity.md
+++ b/spec/callback-fidelity.md
@@ -263,10 +263,21 @@ Each stage is independently shippable, tested, and PR-sized. Value/risk-ordered.
   gap (silently emitted, no `BF101`) and corrected the stale `reduce` /
   higher-order comments. *Tests: compiler-unit (adapter-conditional BF021), CSR
   conformance, DSL conformance/divergence, coverage/support-matrix.*
-- **Stage 2 — Generalize the JSX-`map` fold to neutral IR (D3).** *In progress.*
-  Re-lands the #2371 if-chain fold, reframed, plus preamble-const branches and
-  nested loops. All backends gain SSR fidelity. *Tests: compiler-unit, CSR +
-  cross-adapter + hydration conformance (new fixtures), coverage. PRs: ~2–3.*
+- **Stage 2 — Generalize the JSX-`map` fold to neutral IR (D3).** ✅
+  *Landed (#2377, #2378, and follow-up).* A `.map()` block body that is an
+  if/else-if chain or a `switch` (including fallthrough case labels) now folds
+  into a nested `IRConditional` — the neutral IR a ternary map body already
+  produces — instead of silently leaking the raw `if`/`switch` into the
+  callback. All backends gain SSR fidelity for these shapes. A **leading
+  `const`/`let` preamble** folds on JS-runtime adapters and, since a DSL
+  backend can't carry a loop-local into a conditional branch template, is
+  adapter-gated: a DSL target refuses with `BF021` + `/* @client */` (never
+  silent divergence). Two shapes are deliberately **not** folded and bail
+  conservatively: a *branch-local* `const` (inside a branch block / case), and
+  a **statement-level nested loop** (an imperative `for`-with-`push` that builds
+  a JSX array) — the latter is an arbitrary imperative body handled by Stage 3's
+  verbatim-JS path, not the neutral-IR fold. *Tests: compiler-unit, CSR +
+  cross-adapter + hydration conformance (new fixtures), coverage.*
 - **Stage 3 — JS-runtime verbatim + `/* @client */` for the rest (D4 + D5).**
   Reaches the fidelity ceiling for JSX-`map`. Requires the Stage-0 `keyFn`
   decision. *Tests: runtime-unit (key contract), CSR conformance, E2E

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 274,
+    "totalFixtures": 275,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -2279,6 +2279,56 @@
           ]
         }
       },
+      "map-preamble-branch-body": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        }
+      },
       "reduce-right-typeof-body": {
         "blade": {
           "kind": "refusal",
@@ -2610,6 +2660,10 @@
       "flatmap-typeof-projection": {
         "description": "Off-subset `.flatMap()` projection (typeof) — JS-runtime faithful, DSL diagnostic",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/flatmap-typeof-projection.ts"
+      },
+      "map-preamble-branch-body": {
+        "description": "const preamble + if/else as a .map() body — JS-runtime folds, DSL refuses (BF021)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/map-preamble-branch-body.ts"
       },
       "reduce-right-typeof-body": {
         "description": "Off-subset `.reduceRight()` body (typeof) — JS-runtime faithful, DSL diagnostic",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1886,11 +1886,11 @@
       }
     },
     "identifier": {
-      "total": 255,
+      "total": 256,
       "cells": {
         "hono": {
-          "pass": 254,
-          "total": 255,
+          "pass": 255,
+          "total": 256,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1902,7 +1902,7 @@
         },
         "blade": {
           "pass": 242,
-          "total": 255,
+          "total": 256,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1940,6 +1940,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -1970,7 +1974,7 @@
         },
         "erb": {
           "pass": 243,
-          "total": 255,
+          "total": 256,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2002,6 +2006,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -2032,7 +2040,7 @@
         },
         "go-template": {
           "pass": 242,
-          "total": 255,
+          "total": 256,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2070,6 +2078,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -2100,7 +2112,7 @@
         },
         "jinja": {
           "pass": 242,
-          "total": 255,
+          "total": 256,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2138,6 +2150,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -2168,7 +2184,7 @@
         },
         "minijinja": {
           "pass": 242,
-          "total": 255,
+          "total": 256,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2206,6 +2222,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -2236,7 +2256,7 @@
         },
         "mojolicious": {
           "pass": 243,
-          "total": 255,
+          "total": 256,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2268,6 +2288,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -2298,7 +2322,7 @@
         },
         "twig": {
           "pass": 242,
-          "total": 255,
+          "total": 256,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2336,6 +2360,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -2366,7 +2394,7 @@
         },
         "xslate": {
           "pass": 242,
-          "total": 255,
+          "total": 256,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2404,6 +2432,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -2986,11 +3018,11 @@
       }
     },
     "member": {
-      "total": 134,
+      "total": 135,
       "cells": {
         "hono": {
-          "pass": 133,
-          "total": 134,
+          "pass": 134,
+          "total": 135,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3002,7 +3034,7 @@
         },
         "blade": {
           "pass": 121,
-          "total": 134,
+          "total": 135,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3040,6 +3072,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -3070,7 +3106,7 @@
         },
         "erb": {
           "pass": 122,
-          "total": 134,
+          "total": 135,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3102,6 +3138,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -3132,7 +3172,7 @@
         },
         "go-template": {
           "pass": 121,
-          "total": 134,
+          "total": 135,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3170,6 +3210,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -3200,7 +3244,7 @@
         },
         "jinja": {
           "pass": 121,
-          "total": 134,
+          "total": 135,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3238,6 +3282,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -3268,7 +3316,7 @@
         },
         "minijinja": {
           "pass": 121,
-          "total": 134,
+          "total": 135,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3306,6 +3354,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -3336,7 +3388,7 @@
         },
         "mojolicious": {
           "pass": 122,
-          "total": 134,
+          "total": 135,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3368,6 +3420,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -3398,7 +3454,7 @@
         },
         "twig": {
           "pass": 121,
-          "total": 134,
+          "total": 135,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3436,6 +3492,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -3466,7 +3526,7 @@
         },
         "xslate": {
           "pass": 121,
-          "total": 134,
+          "total": 135,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3504,6 +3564,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {


### PR DESCRIPTION
## Summary

Stage 2 of the [Callback-Body Fidelity RFC](../blob/main/spec/callback-fidelity.md), stacked on #2378. Completes Stage 2's foldable shapes by adding **leading-`const` preamble** support with the correct **per-backend model**.

```tsx
items.map((it) => {
  const label = fmt(it)          // ← leading preamble
  if (it.on) return <b key={it.id}>{label}</b>
  return <span key={it.id}>{label}</span>
})
```

The body folds into a nested `IRConditional` with the `const` emitted once per iteration, so the local is in scope in both branches.

**Why adapter-gated:** a DSL backend can't carry a loop-local into a conditional branch template — an earlier attempt (in the first revision of #2378) rendered `<b></b>` on Jinja (the local `undefined`), a **silent divergence** that violates the RFC. So the preamble fold is gated exactly like the off-subset filter/sort predicates:

- **JS-runtime adapters** (Hono, CSR) fold and run it — full SSR fidelity.
- **DSL adapters** refuse with **BF021 + the `/* @client */` escape** (never silent wrong output); marking the map `/* @client */` defers the whole loop to the browser, which runs the preamble.

## Tests

- `map-preamble-branch-body` conformance fixture: JS-runtime-faithful (`expectedHtml` renders the labels), **BF021 pinned on all eight DSL adapters** (a compile-time diagnostic — no external runtime needed).
- `map-multi-return-body` compiler-unit test extended: JS folds (const emitted), DSL refuses (BF021 + `@client`), `/* @client */` suppresses the refusal.
- Green: **jsx 2652/0 · hydration-contract 747/0 · compat 159/0 · jinja 910/0 · hono 966/0 · unit 9/0**.

## Stage 2 completeness

With #2377 (if/else-if & switch), #2378 (fallthrough + hardening), and this PR (preamble-const), Stage 2's neutral-IR fold is complete. Two shapes intentionally stay unfolded and bail conservatively: a **branch-local** `const` (inside a branch block/case), and a **statement-level imperative nested loop** (`for`-with-`push` building a JSX array) — the latter is an arbitrary imperative body handled by **Stage 3**'s verbatim-JS path, not the neutral-IR fold. The spec is updated to reflect this.

## Stack

- #2377 — if/else-if & switch fold
- #2378 — switch fallthrough + fold hardening
- **this PR** — leading-const preamble (adapter-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FG9KVo7k7nmVkvpuDXKCaC)_