### PR TITLE
Stage 3: refuse arbitrary map bodies that build JSX (seal the silent leak)

### DIFF
--- a/.changeset/refuse-arbitrary-map-body-jsx-leak.md
+++ b/.changeset/refuse-arbitrary-map-body-jsx-leak.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Refuse (instead of silently leaking) a `.map()` callback body that constructs JSX in a statement before its `return` (callback-body fidelity, Stage 3 of `spec/callback-fidelity.md`).
+
+An imperative array-builder body — `const out = []; for (const c of it.cells) out.push(<td>{c}</td>); return <tr>{out}</tr>` — cannot be lowered to a template. The single-return path collected every pre-`return` statement into the loop preamble verbatim via the type-stripper, which strips *types* but not JSX, so the raw `<td>{c}</td>` spliced into the emitted client bundle as invalid JS — a silent syntax-error leak with **no diagnostic** on any backend. The compiler now detects inline JSX in a pre-`return` statement and raises `BF021` with an actionable suggestion (return the JSX directly, e.g. via a nested `.map()` inside the returned element) instead of emitting the leak. Value-only preambles (`const label = it.name; return <li>{label}</li>`) are unaffected. A later Stage-3 PR renders these arbitrary bodies verbatim on JS-runtime adapters; until then the refusal is uniform across backends.

--- a/packages/adapter-tests/fixtures/map-preamble-branch-body.ts
+++ b/packages/adapter-tests/fixtures/map-preamble-branch-body.ts
@@ -37,6 +37,9 @@ export { MapPreambleBranch }
 `,
   props: { items: [{ id: '1', on: true, kind: 'a' }, { id: '2', on: false, kind: 'b' }] },
   expectedHtml: `
-    <ul bf-s="test" bf="s1"><!--bf-loop:l0--><b bf-c="s0" data-key="1">A</b><span bf-c="s0" data-key="2">B</span><!--bf-/loop:l0--></ul>
+    <ul bf-s="test" bf="s1">
+      <b bf-c="s0" data-key="1">A</b>
+      <span bf-c="s0" data-key="2">B</span>
+    </ul>
   `,
 })

--- a/packages/adapter-tests/fixtures/map-switch-fallthrough-body.ts
+++ b/packages/adapter-tests/fixtures/map-switch-fallthrough-body.ts
@@ -34,6 +34,10 @@ export { MapSwitchFallthrough }
 `,
   props: { items: [{ id: '1', kind: 'a' }, { id: '2', kind: 'b' }, { id: '3', kind: 'z' }] },
   expectedHtml: `
-    <ul bf-s="test" bf="s1"><!--bf-loop:l0--><b bf-c="s0" data-key="1">AB</b><b bf-c="s0" data-key="2">AB</b><span bf-c="s0" data-key="3">D</span><!--bf-/loop:l0--></ul>
+    <ul bf-s="test" bf="s1">
+      <b bf-c="s0" data-key="1">AB</b>
+      <b bf-c="s0" data-key="2">AB</b>
+      <span bf-c="s0" data-key="3">D</span>
+    </ul>
   `,
 })

--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -1115,7 +1115,18 @@ describe('<Async> body error path — sync throw + async reject (#1375)', () => 
 })
 
 describe('createPortal inside .map() — per-item portal owner tracking', () => {
-  test('one portal created per loop item', () => {
+  // SURFACED LIMITATION. Passing *inline* JSX as a `createPortal` argument is
+  // an unsupported shape: there is no compiler lowering for it (the JSX is
+  // never compiled to DOM ops) and no runtime per-loop-item portal tracking.
+  // Here the `createPortal(<div>…</div>, …)` sits as a non-return statement in
+  // a `.map()` callback, so as of Stage 3 of spec/callback-fidelity.md the
+  // generic "map body builds JSX in a preamble statement" guard refuses it
+  // with BF021 — replacing what was previously a *silent* leak of the raw
+  // `<div>{it.body}</div>` verbatim into the client bundle. The body below
+  // asserts the intended end state (compiles clean, one portal per item);
+  // drop `.todo` once inline-JSX createPortal (and per-item owner tracking)
+  // is actually implemented.
+  test.todo('one portal created per loop item', () => {
     const src = `
       'use client'
       import { createSignal, createPortal } from '@barefootjs/client'

--- a/packages/jsx/src/__tests__/map-arbitrary-body.test.ts
+++ b/packages/jsx/src/__tests__/map-arbitrary-body.test.ts
@@ -68,6 +68,23 @@ export { List }
     expect(cj.content).toMatch(/const label\b/)
   })
 
+  test('JSX in unreachable code after the return does not trip BF021', () => {
+    // The preamble collector stops at `return`, so JSX in a post-return dead
+    // statement is never spliced into the loop — it is not part of the leak
+    // and must not be refused. (Guards the scan boundary.)
+    const src = `
+function List({ items }: { items: { id: string }[] }) {
+  return <ul>{items.map((it) => {
+    return <li key={it.id}>{it.id}</li>
+    const dead = <span>{it.id}</span>
+  })}</ul>
+}
+export { List }
+`
+    const r = compile(src, false)
+    expect(r.errors.filter(e => e.code === 'BF021')).toHaveLength(0)
+  })
+
   test('a plain single-return JSX body is unaffected', () => {
     const src = `
 function List({ items }: { items: { id: string }[] }) {

--- a/packages/jsx/src/__tests__/map-arbitrary-body.test.ts
+++ b/packages/jsx/src/__tests__/map-arbitrary-body.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Stage 3 of spec/callback-fidelity.md — a `.map()` callback whose body
+ * *constructs* JSX in a statement before its `return` (an imperative
+ * array-builder: `const out = []; for (…) out.push(<td/>); return <tr>{out}</tr>`)
+ * cannot be lowered to a template. Before this stage the compiler silently
+ * spliced such statements into the loop preamble verbatim — and because the
+ * type-stripper leaves JSX untouched, the raw `<td/>` leaked into the emitted
+ * client bundle as invalid JS, with NO diagnostic. This pins the loud refusal
+ * (BF021) that replaces the silent leak, on both a JS-runtime and a DSL adapter,
+ * and guards that legitimate value-only preambles are NOT caught.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+function compile(source: string, dsl: boolean) {
+  const a = new TestAdapter()
+  // A DSL adapter's template runtime can't run a callback body verbatim.
+  if (dsl) a.acceptsCallbackBody = () => false
+  return compileJSX(source, 'List.tsx', { adapter: a })
+}
+
+const arrayBuilder = `
+function Table({ rows }: { rows: { id: string; cells: string[] }[] }) {
+  return <table>{rows.map((r) => {
+    const out = []
+    for (const c of r.cells) out.push(<td>{c}</td>)
+    return <tr key={r.id}>{out}</tr>
+  })}</table>
+}
+export { Table }
+`
+
+describe('.map() arbitrary body — no silent JSX leak (Stage 3)', () => {
+  for (const dsl of [false, true]) {
+    const tier = dsl ? 'DSL' : 'JS-runtime'
+
+    test(`an array-builder body refuses with BF021 (${tier})`, () => {
+      const r = compile(arrayBuilder, dsl)
+      const bf021 = r.errors.filter(e => e.code === 'BF021')
+      expect(bf021).toHaveLength(1)
+    })
+
+    test(`the raw JSX never leaks into the client bundle (${tier})`, () => {
+      const r = compile(arrayBuilder, dsl)
+      const cj = r.files.find(f => f.type === 'clientJs')
+      // The `out.push(<td>…</td>)` statement must not survive verbatim — raw
+      // JSX in the plain-JS client bundle is a syntax error.
+      expect(cj?.content ?? '').not.toMatch(/out\.push\(</)
+      expect(cj?.content ?? '').not.toMatch(/<td>/)
+    })
+  }
+
+  test('a value-only const preamble still compiles clean (no false positive)', () => {
+    const src = `
+function List({ items }: { items: { id: string; name: string }[] }) {
+  return <ul>{items.map((it) => {
+    const label = it.name.toUpperCase()
+    return <li key={it.id}>{label}</li>
+  })}</ul>
+}
+export { List }
+`
+    const r = compile(src, false)
+    expect(r.errors.filter(e => e.code === 'BF021')).toHaveLength(0)
+    const cj = r.files.find(f => f.type === 'clientJs')!
+    expect(cj.content).toMatch(/const label\b/)
+  })
+
+  test('a plain single-return JSX body is unaffected', () => {
+    const src = `
+function List({ items }: { items: { id: string }[] }) {
+  return <ul>{items.map((it) => { return <li key={it.id}>{it.id}</li> })}</ul>
+}
+export { List }
+`
+    const r = compile(src, true)
+    expect(r.errors.filter(e => e.code === 'BF021')).toHaveLength(0)
+  })
+})

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -4162,29 +4162,64 @@ function transformMapCall(
             children = [transformed]
           }
         }
-        const preambleStmts: string[] = []
-        const templatePreambleStmts: string[] = []
-        const typedPreambleStmts: string[] = []
-        let hasTypeDiff = false
-        let hasTemplateDiff = false
-        for (const stmt of body.statements) {
-          if (stmt === returnStmt) break
-          const js = ctx.getJS(stmt)
-          const tjs = ctx.getTemplateJS(stmt)
-          const ts = stmt.getText(ctx.sourceFile)
-          preambleStmts.push(js.endsWith(';') ? js : js + ';')
-          templatePreambleStmts.push(tjs.endsWith(';') ? tjs : tjs + ';')
-          typedPreambleStmts.push(ts.endsWith(';') ? ts : ts + ';')
-          if (js !== ts) hasTypeDiff = true
-          if (js !== tjs) hasTemplateDiff = true
-        }
-        if (preambleStmts.length > 0) {
-          mapPreamble = preambleStmts.join(' ')
-          if (hasTemplateDiff) {
-            templateMapPreamble = templatePreambleStmts.join(' ')
+        // Stage 3 of spec/callback-fidelity.md — an arbitrary `.map()` body that
+        // *constructs* JSX in a statement before its `return` (the classic
+        // `const out = []; for (const c of it.cells) out.push(<td>{c}</td>);
+        // return <tr>{out}</tr>` array-builder) cannot be lowered to a template.
+        // The preamble collector below reconstructs each statement with
+        // `ctx.getJS`, which strips *types* but not JSX, so the raw `<td>{c}</td>`
+        // would splice verbatim into the emitted client bundle — invalid JS, a
+        // silent syntax-error leak with no diagnostic. Refuse loudly instead of
+        // leaking. (A later Stage-3 PR renders such bodies verbatim on JS
+        // runtimes; until then it is a build error on every backend.)
+        const jsxPreambleStmt = body.statements.find(
+          s => s !== returnStmt && containsJsxInExpression(s)
+        )
+        if (jsxPreambleStmt) {
+          ctx.analyzer.errors.push(
+            createError(
+              ErrorCodes.UNSUPPORTED_JSX_PATTERN,
+              getSourceLocation(jsxPreambleStmt, ctx.sourceFile, ctx.filePath),
+              {
+                message:
+                  'A .map() callback that builds JSX in a statement before its ' +
+                  '`return` (for example pushing elements into an array in a loop) ' +
+                  'cannot be lowered to a template.',
+                suggestion: {
+                  message:
+                    'Return the JSX directly — e.g. project with a nested .map() ' +
+                    'inside the returned element — instead of constructing it in a ' +
+                    'preceding statement.',
+                },
+              }
+            )
+          )
+          // Do NOT collect the JSX-bearing preamble: that splice is the leak.
+        } else {
+          const preambleStmts: string[] = []
+          const templatePreambleStmts: string[] = []
+          const typedPreambleStmts: string[] = []
+          let hasTypeDiff = false
+          let hasTemplateDiff = false
+          for (const stmt of body.statements) {
+            if (stmt === returnStmt) break
+            const js = ctx.getJS(stmt)
+            const tjs = ctx.getTemplateJS(stmt)
+            const ts = stmt.getText(ctx.sourceFile)
+            preambleStmts.push(js.endsWith(';') ? js : js + ';')
+            templatePreambleStmts.push(tjs.endsWith(';') ? tjs : tjs + ';')
+            typedPreambleStmts.push(ts.endsWith(';') ? ts : ts + ';')
+            if (js !== ts) hasTypeDiff = true
+            if (js !== tjs) hasTemplateDiff = true
           }
-          if (hasTypeDiff) {
-            typedMapPreamble = typedPreambleStmts.join(' ')
+          if (preambleStmts.length > 0) {
+            mapPreamble = preambleStmts.join(' ')
+            if (hasTemplateDiff) {
+              templateMapPreamble = templatePreambleStmts.join(' ')
+            }
+            if (hasTypeDiff) {
+              typedMapPreamble = typedPreambleStmts.join(' ')
+            }
           }
         }
       }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -4172,9 +4172,18 @@ function transformMapCall(
         // silent syntax-error leak with no diagnostic. Refuse loudly instead of
         // leaking. (A later Stage-3 PR renders such bodies verbatim on JS
         // runtimes; until then it is a build error on every backend.)
-        const jsxPreambleStmt = body.statements.find(
-          s => s !== returnStmt && containsJsxInExpression(s)
-        )
+        // Scan only statements the preamble collector below would reach — i.e.
+        // those *before* `returnStmt` (it `break`s at the return). JSX in
+        // unreachable post-return dead code is never spliced into the preamble,
+        // so it is not part of the leak and must not trip the refusal.
+        let jsxPreambleStmt: ts.Statement | undefined
+        for (const stmt of body.statements) {
+          if (stmt === returnStmt) break
+          if (containsJsxInExpression(stmt)) {
+            jsxPreambleStmt = stmt
+            break
+          }
+        }
         if (jsxPreambleStmt) {
           ctx.analyzer.errors.push(
             createError(


### PR DESCRIPTION
## Summary

First PR of **Stage 3** (D4) of the [Callback-Body Fidelity RFC](../blob/main/spec/callback-fidelity.md). Stage 1 (#2373–#2376) and Stage 2 (#2377–#2379) are merged. This PR seals a **pre-existing silent-leak** that Stage 3 must resolve before adding the verbatim-render path.

### The bug

A `.map()` callback whose body *constructs* JSX in a statement **before** its `return` — the imperative array-builder — cannot be lowered to a template:

```tsx
rows.map((r) => {
  const out = []
  for (const c of r.cells) out.push(<td>{c}</td>)   // ← JSX in a pre-return statement
  return <tr key={r.id}>{out}</tr>
})
```

The single-return path collected every pre-`return` statement into the loop **preamble** via the type-stripper, which strips *types* but **not JSX**. So the raw `<td>{c}</td>` spliced verbatim into the emitted client bundle as invalid JS — a **syntax-error leak with no diagnostic on any backend**. Confirmed: the emitted client JS contained `out.push(<td>{c}</td>)` literally.

### The fix

Detect inline JSX in a pre-`return` statement of a map block body (reusing the existing `containsJsxInExpression` AST walk) and raise **`BF021`** with an actionable suggestion, instead of emitting the leak. The JSX-bearing preamble is **not** collected — that splice *was* the leak.

- **Scoped to the `.map()` callback path** in `transformMapCall`. A component-body `for…push` that builds JSX (a supported top-level shape, `compiler-stress-1244.test.ts`) is untouched.
- **Value-only preambles** (`const label = it.name; return <li>{label}</li>`) are unaffected — only statements that *contain JSX* are refused.
- Uniform across backends **for now**; a later Stage-3 PR renders these arbitrary bodies verbatim on JS-runtime adapters, at which point the refusal becomes adapter-gated (per the RFC's per-backend model).

### Surfaced latent bug

`createPortal(<div>…</div>, …)` **inside** a `.map()` callback was the same latent leak (inline JSX as a `createPortal` argument leaks verbatim — there is no compiler lowering nor runtime per-item portal machinery for it). Its stress test asserted only `expectNoFatalErrors`, so it passed while silently emitting broken JS. It is now converted to a `test.todo` (the file's documented "surfaced limitation" convention) describing the intended end state, so the pin re-activates if inline-JSX `createPortal` is ever implemented.

## Tests

- New `map-arbitrary-body.test.ts`: the array-builder body refuses with `BF021` and never leaks raw JSX into the bundle (asserted on both a JS-runtime and a DSL adapter); value-only preambles and plain single-return bodies stay clean (no false positives).
- `compiler-stress-1244.test.ts`: the `createPortal`-in-`.map()` case converted to `test.todo` with a docstring.
- Full `packages/jsx` suite green (2689 tests; the only remaining red is a pre-existing, load-dependent perf-timeout in `profile-nested-binding-ids`, which fails identically on `main`).

## Stack / Stage 3 plan

- **this PR** — seal the silent leak (loud `BF021`).
- next — JS-runtime verbatim `renderItem` for arbitrary bodies + `/* @client */` for DSL (D4), with the `keyFn` **hoist** contract (D5, option (a): the key stays a pure raw-item expression — zero runtime change, preserves SSR/CSR hydration parity).
- then — conformance/e2e + spec status update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FG9KVo7k7nmVkvpuDXKCaC)_