### PR TITLE
feat(jsx): render arbitrary array-builder .map() bodies verbatim on JS runtimes (Stage 3 / D4+D5)

### DIFF
--- a/.changeset/map-array-builder-verbatim.md
+++ b/.changeset/map-array-builder-verbatim.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/blade": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/rust": patch
+"@barefootjs/twig": patch
+"@barefootjs/xslate": patch
+---
+
+Render arbitrary array-builder `.map()` bodies verbatim on JS-runtime adapters (callback-body fidelity, Stage 3 / D4 + D5 of `spec/callback-fidelity.md`).
+
+A `.map()` callback that constructs JSX in a statement before its `return` — the imperative array-builder `{ const out = []; for (const c of r.cells) out.push(<td>{c}</td>); return <tr key={r.id}>{out}</tr> }` — previously refused on every backend (it would otherwise leak raw JSX into the plain-JS bundle). On a JS-runtime adapter it now renders verbatim: each JSX leaf lowers to a template-literal HTML string (reusing the flatMap-callback fragment mechanism), the imperative control flow runs as-is, and the `{out}` element-array child is joined into the row so SSR, hydration, and CSR all render identical markup. The loop key is hoisted (D5): it is derived from the raw item and evaluated before the body runs, so a key that reads a preamble-computed local is refused rather than compiled to an unbound `keyFn`. A leaf that carries an event handler, a component, a nested loop, a reactive expression, or a spread is refused loudly (no silent divergence). A DSL adapter refuses the whole shape with `BF021` + the `/* @client */` escape (which renders the loop client-only, where the browser runs the same verbatim body). Covered by the `map-array-builder-body` conformance fixture (JS-runtime faithful, pinned BF021 on every DSL adapter) and the rewritten `map-arbitrary-body` compiler-unit test (verbatim lowering, `{out}` join, keyFn hoist, key-derivability and leaf-scope refusals). Also fixes a latent bug where `TestAdapter.renderLoop` dropped the `.map()` preamble entirely.

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -20,6 +20,7 @@ export const conformancePins: ConformancePins = {
   // conditional branch template, so it refuses with BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -21,6 +21,7 @@ export const conformancePins: ConformancePins = {
   // conditional branch template, so it refuses with BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -20,6 +20,7 @@ export const conformancePins: ConformancePins = {
   // conditional branch template, so it refuses with BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -20,6 +20,7 @@ export const conformancePins: ConformancePins = {
   // conditional branch template, so it refuses with BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -18,6 +18,7 @@ export const conformancePins: ConformancePins = {
   // conditional branch template, so it refuses with BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -21,6 +21,7 @@ export const conformancePins: ConformancePins = {
   // conditional branch template, so it refuses with BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2440,6 +2440,18 @@
         "text"
       ]
     },
+    "map-array-builder-body": {
+      "kinds": [
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "map-basic": {
       "kinds": [
         "array-literal",
@@ -4429,11 +4441,11 @@
     "binary": 75,
     "call": 173,
     "conditional": 20,
-    "identifier": 256,
+    "identifier": 257,
     "index-access": 12,
     "literal": 213,
     "logical": 42,
-    "member": 135,
+    "member": 136,
     "object-literal": 46,
     "template-literal": 27,
     "unary": 22,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -130,6 +130,7 @@ import { fixture as flatMapTypeofProjection } from './flatmap-typeof-projection'
 import { fixture as mapIfChainBody } from './map-if-chain-body'
 import { fixture as mapSwitchFallthroughBody } from './map-switch-fallthrough-body'
 import { fixture as mapPreambleBranchBody } from './map-preamble-branch-body'
+import { fixture as mapArrayBuilderBody } from './map-array-builder-body'
 import { fixture as sortSimple } from './sort-simple'
 import { fixture as filterSortChain } from './filter-sort-chain'
 import { fixture as mapNested } from './map-nested'
@@ -497,6 +498,7 @@ export const jsxFixtures: JSXFixture[] = [
   mapIfChainBody,
   mapSwitchFallthroughBody,
   mapPreambleBranchBody,
+  mapArrayBuilderBody,
   sortSimple,
   filterSortChain,
   mapNested,

--- a/packages/adapter-tests/fixtures/map-array-builder-body.ts
+++ b/packages/adapter-tests/fixtures/map-array-builder-body.ts
@@ -1,0 +1,44 @@
+import { createFixture } from '../src/types'
+
+/**
+ * An imperative array-builder `.map()` body — `{ const out = []; for (const c
+ * of r.cells) out.push(<td>{c}</td>); return <tr key={r.id}>{out}</tr> }`.
+ * Stage 3 / D4 of `spec/callback-fidelity.md`: a JS-runtime adapter runs the
+ * callback body verbatim — each JSX leaf lowers to a template-literal HTML
+ * string, the imperative control flow runs as-is, and the `{out}` element-array
+ * child is joined into the row — so SSR, hydration, and CSR all render the cells
+ * faithfully. The loop key is hoisted (D5): `key={r.id}` is derived from the raw
+ * item, evaluated before the body runs.
+ *
+ * Adapter-gated, like the const-preamble branch body and the off-subset
+ * filter/sort predicates:
+ *   - Hono / CSR run it; the reference `expectedHtml` renders the cells.
+ *   - DSL adapters (Go, Perl, Ruby, PHP, Rust, Python) surface BF021 with the
+ *     `/* @client *\/` escape (declared via each adapter's `conformancePins`);
+ *     marking the map client-only defers the whole loop to the browser, which
+ *     runs the same verbatim body.
+ */
+export const fixture = createFixture({
+  id: 'map-array-builder-body',
+  description: 'imperative array-builder .map() body — JS-runtime verbatim, DSL refuses (BF021)',
+  source: `
+function TableBuilder({ rows }: { rows: { id: string; cells: string[] }[] }) {
+  return (
+    <table>
+      <tbody>
+        {rows.map((r) => {
+          const out = []
+          for (const c of r.cells) out.push(<td>{c}</td>)
+          return <tr key={r.id}>{out}</tr>
+        })}
+      </tbody>
+    </table>
+  )
+}
+export { TableBuilder }
+`,
+  props: { rows: [{ id: '1', cells: ['a', 'b'] }, { id: '2', cells: ['c', 'd'] }] },
+  expectedHtml: `
+    <table bf-s="test"><tbody bf="s0"><tr data-key="1"><td>a</td><td>b</td></tr><tr data-key="2"><td>c</td><td>d</td></tr></tbody></table>
+  `,
+})

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -20,6 +20,7 @@ export const conformancePins: ConformancePins = {
   // conditional branch template, so it refuses with BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -18,6 +18,7 @@ export const conformancePins: ConformancePins = {
   // conditional branch template, so it refuses with BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/jsx/src/__tests__/map-arbitrary-body.test.ts
+++ b/packages/jsx/src/__tests__/map-arbitrary-body.test.ts
@@ -95,6 +95,28 @@ export { Table }
   })
 })
 
+describe('.map() array-builder — {out} join is scoped to the bare identifier', () => {
+  test('only the bare {out} child joins; a property access on it does not', () => {
+    // `{out}` is the element-array child and must join; `{out.length}` is a
+    // number and must NOT get the array-join coercion (which would also
+    // double-read the expression).
+    const src = `
+function T({ rows }: { rows: { id: string; cells: string[] }[] }) {
+  return <table><tbody>{rows.map((r) => {
+    const out = []
+    for (const c of r.cells) out.push(<td>{c}</td>)
+    return <tr key={r.id}>{out}<td>{out.length}</td></tr>
+  })}</tbody></table>
+}
+export { T }
+`
+    const r = compile(src, false)
+    const cj = r.files.find(f => f.type === 'clientJs')!.content
+    expect(cj).toMatch(/Array\.isArray\(out\)\s*\?\s*out\.join\(''\)/)
+    expect(cj).not.toMatch(/Array\.isArray\(out\.length\)/)
+  })
+})
+
 describe('.map() array-builder — D5 keyFn hoist contract', () => {
   test('a key derived from a preamble-computed local is refused', () => {
     // `k` is computed in the body; the key runs *before* the body, so it cannot
@@ -103,6 +125,24 @@ describe('.map() array-builder — D5 keyFn hoist contract', () => {
 function T({ rows }: { rows: { id: string; cells: string[] }[] }) {
   return <table><tbody>{rows.map((r) => {
     const k = r.id + '-row'
+    const out = []
+    for (const c of r.cells) out.push(<td>{c}</td>)
+    return <tr key={k}>{out}</tr>
+  })}</tbody></table>
+}
+export { T }
+`
+    const r = compile(src, false)
+    expect(r.errors.filter(e => e.code === 'BF021')).toHaveLength(1)
+  })
+
+  test('a key derived from a destructured preamble local is refused', () => {
+    // The guard must see `k` even when it is bound via destructuring — else it
+    // would compile to a keyFn referencing an unbound `k`.
+    const src = `
+function T({ rows }: { rows: { meta: { id: string }; cells: string[] }[] }) {
+  return <table><tbody>{rows.map((r) => {
+    const { id: k } = r.meta
     const out = []
     for (const c of r.cells) out.push(<td>{c}</td>)
     return <tr key={k}>{out}</tr>

--- a/packages/jsx/src/__tests__/map-arbitrary-body.test.ts
+++ b/packages/jsx/src/__tests__/map-arbitrary-body.test.ts
@@ -1,13 +1,19 @@
 /**
- * Stage 3 of spec/callback-fidelity.md — a `.map()` callback whose body
- * *constructs* JSX in a statement before its `return` (an imperative
- * array-builder: `const out = []; for (…) out.push(<td/>); return <tr>{out}</tr>`)
- * cannot be lowered to a template. Before this stage the compiler silently
- * spliced such statements into the loop preamble verbatim — and because the
- * type-stripper leaves JSX untouched, the raw `<td/>` leaked into the emitted
- * client bundle as invalid JS, with NO diagnostic. This pins the loud refusal
- * (BF021) that replaces the silent leak, on both a JS-runtime and a DSL adapter,
- * and guards that legitimate value-only preambles are NOT caught.
+ * Stage 3 (D4 + D5) of spec/callback-fidelity.md — a `.map()` callback whose
+ * body *constructs* JSX in a statement before its `return` (an imperative
+ * array-builder: `const out = []; for (…) out.push(<td/>); return <tr>{out}</tr>`).
+ *
+ * On a **JS-runtime** adapter (`acceptsCallbackBody() => true`) the body is now
+ * rendered verbatim: each JSX leaf lowers to a template-literal HTML string, the
+ * imperative control flow runs as-is, and the `{out}` element-array child is
+ * joined into the row's innerHTML. No raw JSX leaks into the plain-JS bundle.
+ *
+ * On a **DSL** adapter (whose template runtime can't run a callback body) it
+ * still refuses with BF021, always naming the `/* @client *\/` escape.
+ *
+ * D5 (keyFn = hoist): the loop key is evaluated before the body runs, so it must
+ * be derivable from the raw item — a key that reads a preamble-computed local is
+ * refused (it would compile to an unbound keyFn).
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -23,35 +29,110 @@ function compile(source: string, dsl: boolean) {
 
 const arrayBuilder = `
 function Table({ rows }: { rows: { id: string; cells: string[] }[] }) {
-  return <table>{rows.map((r) => {
+  return <table><tbody>{rows.map((r) => {
     const out = []
     for (const c of r.cells) out.push(<td>{c}</td>)
     return <tr key={r.id}>{out}</tr>
-  })}</table>
+  })}</tbody></table>
 }
 export { Table }
 `
 
-describe('.map() arbitrary body — no silent JSX leak (Stage 3)', () => {
-  for (const dsl of [false, true]) {
-    const tier = dsl ? 'DSL' : 'JS-runtime'
+describe('.map() array-builder body — JS-runtime verbatim (Stage 3 / D4)', () => {
+  test('compiles with no BF021 on a JS-runtime adapter', () => {
+    const r = compile(arrayBuilder, false)
+    expect(r.errors.filter(e => e.code === 'BF021')).toHaveLength(0)
+  })
 
-    test(`an array-builder body refuses with BF021 (${tier})`, () => {
-      const r = compile(arrayBuilder, dsl)
-      const bf021 = r.errors.filter(e => e.code === 'BF021')
-      expect(bf021).toHaveLength(1)
-    })
+  test('no raw JSX leaks into the client bundle; the leaf is a lowered string', () => {
+    const r = compile(arrayBuilder, false)
+    const cj = r.files.find(f => f.type === 'clientJs')!.content
+    // The raw `out.push(<td>…)` must not survive — raw JSX is invalid plain JS.
+    expect(cj).not.toMatch(/out\.push\(</)
+    // …it lowers to a template-literal HTML string instead.
+    expect(cj).toMatch(/out\.push\(`<td>/)
+  })
 
-    test(`the raw JSX never leaks into the client bundle (${tier})`, () => {
-      const r = compile(arrayBuilder, dsl)
-      const cj = r.files.find(f => f.type === 'clientJs')
-      // The `out.push(<td>…</td>)` statement must not survive verbatim — raw
-      // JSX in the plain-JS client bundle is a syntax error.
-      expect(cj?.content ?? '').not.toMatch(/out\.push\(</)
-      expect(cj?.content ?? '').not.toMatch(/<td>/)
-    })
-  }
+  test('the element-array child {out} is joined into the row', () => {
+    const r = compile(arrayBuilder, false)
+    const cj = r.files.find(f => f.type === 'clientJs')!.content
+    // `out` is an array of HTML strings; the child interpolation must join it,
+    // not `String([])`-comma-collapse it.
+    expect(cj).toMatch(/Array\.isArray\(out\)\s*\?\s*out\.join\(''\)/)
+  })
 
+  test('keyFn is hoisted from the returned root and derived from the raw item', () => {
+    const r = compile(arrayBuilder, false)
+    const cj = r.files.find(f => f.type === 'clientJs')!.content
+    expect(cj).toMatch(/\(r\)\s*=>\s*String\(r\.id\)/)
+  })
+
+  test('DSL adapter refuses with BF021 naming the /* @client */ escape', () => {
+    const r = compile(arrayBuilder, true)
+    const bf021 = r.errors.filter(e => e.code === 'BF021')
+    expect(bf021).toHaveLength(1)
+    expect(bf021[0].suggestion?.message ?? '').toMatch(/@client/)
+  })
+
+  test('a /* @client */-marked array-builder compiles clean on a DSL adapter', () => {
+    // The escape: the loop renders client-only (the DSL SSR adapter emits
+    // markers, the browser runs the verbatim body), so the DSL refusal lifts.
+    const src = `
+function Table({ rows }: { rows: { id: string; cells: string[] }[] }) {
+  return <table><tbody>{/* @client */ rows.map((r) => {
+    const out = []
+    for (const c of r.cells) out.push(<td>{c}</td>)
+    return <tr key={r.id}>{out}</tr>
+  })}</tbody></table>
+}
+export { Table }
+`
+    const r = compile(src, true)
+    expect(r.errors.filter(e => e.code === 'BF021')).toHaveLength(0)
+    const cj = r.files.find(f => f.type === 'clientJs')!.content
+    // The browser still runs the verbatim body — the leaf is a lowered string.
+    expect(cj).toMatch(/out\.push\(`<td>/)
+  })
+})
+
+describe('.map() array-builder — D5 keyFn hoist contract', () => {
+  test('a key derived from a preamble-computed local is refused', () => {
+    // `k` is computed in the body; the key runs *before* the body, so it cannot
+    // reference `k`. Refuse rather than emit an unbound keyFn.
+    const src = `
+function T({ rows }: { rows: { id: string; cells: string[] }[] }) {
+  return <table><tbody>{rows.map((r) => {
+    const k = r.id + '-row'
+    const out = []
+    for (const c of r.cells) out.push(<td>{c}</td>)
+    return <tr key={k}>{out}</tr>
+  })}</tbody></table>
+}
+export { T }
+`
+    const r = compile(src, false)
+    expect(r.errors.filter(e => e.code === 'BF021')).toHaveLength(1)
+  })
+})
+
+describe('.map() array-builder — leaf scope (D-E: refuse what cannot be wired)', () => {
+  test('a leaf with an event handler is refused (no silent divergence)', () => {
+    const src = `
+function T({ rows }: { rows: { id: string; cells: string[] }[] }) {
+  return <table><tbody>{rows.map((r) => {
+    const out = []
+    for (const c of r.cells) out.push(<td onClick={() => console.log(c)}>{c}</td>)
+    return <tr key={r.id}>{out}</tr>
+  })}</tbody></table>
+}
+export { T }
+`
+    const r = compile(src, false)
+    expect(r.errors.filter(e => e.code === 'BF021')).toHaveLength(1)
+  })
+})
+
+describe('.map() arbitrary body — regression guards (unchanged)', () => {
   test('a value-only const preamble still compiles clean (no false positive)', () => {
     const src = `
 function List({ items }: { items: { id: string; name: string }[] }) {
@@ -69,9 +150,6 @@ export { List }
   })
 
   test('JSX in unreachable code after the return does not trip BF021', () => {
-    // The preamble collector stops at `return`, so JSX in a post-return dead
-    // statement is never spliced into the loop — it is not part of the leak
-    // and must not be refused. (Guards the scan boundary.)
     const src = `
 function List({ items }: { items: { id: string }[] }) {
   return <ul>{items.map((it) => {
@@ -85,7 +163,7 @@ export { List }
     expect(r.errors.filter(e => e.code === 'BF021')).toHaveLength(0)
   })
 
-  test('a plain single-return JSX body is unaffected', () => {
+  test('a plain single-return JSX body is unaffected on a DSL adapter', () => {
     const src = `
 function List({ items }: { items: { id: string }[] }) {
   return <ul>{items.map((it) => { return <li key={it.id}>{it.id}</li> })}</ul>

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -253,6 +253,16 @@ export class TestAdapter extends JsxAdapter {
     // parsed as a block statement (matches hono-adapter behavior).
     const safeChildren = children.startsWith('{') ? `<>${children}</>` : children
 
+    // A `.map()` callback preamble (a Stage-2 value-only `const`, or a Stage-3
+    // arbitrary array-builder) runs verbatim in the block body. Use the typed
+    // carrier so raw JSX leaves stay intact for the JSX runtime; `{out}`-style
+    // element-array children render natively. (Without this the preamble was
+    // dropped and its identifiers rendered unbound.)
+    const preamble = loop.typedMapPreamble ?? loop.mapPreamble
+    if (preamble) {
+      return `{${loop.array}.map((${loop.param}${indexParam}) => { ${preamble} return ${safeChildren} })}`
+    }
+
     return `{${loop.array}.map((${loop.param}${indexParam}) => ${safeChildren})}`
   }
 

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -777,6 +777,7 @@ export function collectElements(
         } : undefined,
         chainOrder: l.chainOrder,
         mapPreamble: l.mapPreamble,
+        preambleFragments: l.preambleFragments,
       })
       // Don't descend — loop-scoped variables are only available inside the iteration.
     },

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
@@ -39,6 +39,7 @@ import {
 import { buildLoopReactiveEffectsPlan } from './build-reactive-effects.ts'
 import { buildComponentLoopPlan } from './build-component-loop.ts'
 import { buildTopLevelCompositePlan } from './build-composite-loop.ts'
+import { substituteJsxFragments, irToHtmlTemplate } from '../../html-template.ts'
 import type {
   LoopPlan,
   PlainLoopPlan,
@@ -100,7 +101,17 @@ export function buildPlainLoopPlan(elem: TopLevelLoop, profileComponentName?: st
     paramHead,
     paramUnwrap,
     indexParam: elem.index || '__idx',
-    mapPreambleWrapped: elem.mapPreamble ? wrap(elem.mapPreamble) : '',
+    // Stage 3 / D4 — wrap the loop-param accessors first (placeholders are inert
+    // identifiers `wrap` won't touch), then substitute each JSX leaf with its
+    // rendered HTML-string template. The fragment renders under this loop's param
+    // context so a leaf that reads the item (`r`) becomes `r()`.
+    mapPreambleWrapped: elem.mapPreamble
+      ? substituteJsxFragments(
+          wrap(elem.mapPreamble),
+          elem.preambleFragments,
+          (ir) => irToHtmlTemplate(ir, undefined, 1, [{ param: elem.param, bindings: elem.paramBindings }], undefined, true),
+        )
+      : '',
     template: elem.template,
     skeletonTemplate: elem.skeletonTemplate,
     skeletonPaths: elem.skeletonPaths,

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -2,7 +2,7 @@
  * IR → HTML template string generation and validation.
  */
 
-import type { AttrValue, IRAttribute, IRNode, IRProp } from '../types.ts'
+import type { AttrValue, IRAttribute, IRNode, IRProp, FlatMapJsxFragment } from '../types.ts'
 import { isBooleanAttr } from '../html-constants.ts'
 import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, loopStartMarker, loopEndMarker, loopItemMarker, freeIdsFromRefs, setIntersects, wrapExprWithLoopParams } from './utils.ts'
 import type { LoopParamSpec } from './utils.ts'
@@ -556,6 +556,28 @@ function itemAnchorTemplate(keyExpr: string): string {
   return `<!--${loopItemMarker('${' + keyExpr + '}')}-->`
 }
 
+/**
+ * Stage 3 / D4 (spec/callback-fidelity.md) — substitute each `__BF_JSX_N__`
+ * placeholder in an arbitrary `.map()` preamble with a template-literal HTML
+ * string built from the leaf's compiled IR. Mirrors the flatMap-callback
+ * substitution but is shared across the client-JS and hydrate-template splice
+ * sites. Uses a function replacement so `$`-sequences in the rendered HTML
+ * (`${...}`) are never reinterpreted by `String.replace`.
+ */
+export function substituteJsxFragments(
+  text: string,
+  fragments: ReadonlyArray<FlatMapJsxFragment> | undefined,
+  renderFragment: (ir: IRNode) => string,
+): string {
+  if (!fragments || fragments.length === 0) return text
+  let result = text
+  for (const frag of fragments) {
+    const rendered = renderFragment(frag.ir)
+    result = result.replace(frag.placeholder, () => '`' + rendered + '`')
+  }
+  return result
+}
+
 export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0, loopParams?: ReadonlyArray<string | LoopParamSpec>, branchSlotsVar?: string, insideLoop = false, inHoistedChildren = false): string {
   const recurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth, loopParams, branchSlotsVar, insideLoop, inHoistedChildren)
   const wrapExpr = (expr: string) => wrapExprWithLoopParams(expr, loopParams)
@@ -624,20 +646,29 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
       // as HTML (template.innerHTML), so re-escape for the HTML parser.
       return escapeHtml(node.value)
 
-    case 'expression':
+    case 'expression': {
       if (node.expr === 'null' || node.expr === 'undefined') return ''
+      const inner = wrapInterpolation(wrapExpr(node.expr))
+      // Stage 3 / D4 — an element-array child ({out}) built by an arbitrary
+      // .map() preamble is an array of HTML strings; join it rather than let
+      // `${[...]}` `String`-comma-collapse it. Only reached on a JS-runtime
+      // adapter (the flag is set in Phase 1 only there); a plain local can be
+      // read twice safely.
+      const valueExpr = node.joinArrayChild
+        ? `Array.isArray(${inner}) ? ${inner}.join('') : (${inner} ?? '')`
+        : inner
       if (node.slotId) {
-        const inner = wrapInterpolation(wrapExpr(node.expr))
         // In branch-slot context `wrapInterpolation` routes the value
         // through `__bfSlot`, which returns raw `<!--bf-slot:N-->` markers
         // for live `Node` values (spliced back by `insert()`). Escaping
         // would corrupt those markers and drop slotted content (#1694
         // regression). `__bfSlot` owns coercion of its own value, so the
         // text-escape applies only to the non-slot (plain text) form.
-        const slotted = branchSlotsVar ? inner : escapeTextSlotExpr(inner)
+        const slotted = branchSlotsVar || node.joinArrayChild ? valueExpr : escapeTextSlotExpr(valueExpr)
         return `<!--bf:${node.slotId}-->\${${slotted}}<!--/-->`
       }
-      return `\${${wrapInterpolation(wrapExpr(node.expr))}}`
+      return `\${${valueExpr}}`
+    }
 
     case 'conditional': {
       const trueBranch = recurse(node.whenTrue)
@@ -748,7 +779,10 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
         }
         mapExpr = `\${${wrappedArray}.flatMap(${node.flatMapCallback.params} => ${body}).join('')}`
       } else if (node.mapPreamble) {
-        mapExpr = `\${${wrappedArray}.${iterMethod}(${callbackParam} => { ${node.mapPreamble} return \`${childTemplate}\` }).join('')}`
+        // Stage 3 / D4 — substitute JSX leaves in an arbitrary array-builder
+        // preamble (the hydrate-template context uses the bare loop param).
+        const preamble = substituteJsxFragments(node.mapPreamble, node.preambleFragments, (ir) => irToHtmlTemplate(ir, restSpreadNames, loopDepth + 1, loopParams, branchSlotsVar, insideLoop))
+        mapExpr = `\${${wrappedArray}.${iterMethod}(${callbackParam} => { ${preamble} return \`${childTemplate}\` }).join('')}`
       } else {
         mapExpr = `\${${wrappedArray}.${iterMethod}(${callbackParam} => \`${childTemplate}\`).join('')}`
       }
@@ -1138,12 +1172,18 @@ export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<stri
       // as HTML (template.innerHTML), so re-escape for the HTML parser.
       return escapeHtml(node.value)
 
-    case 'expression':
+    case 'expression': {
       if (node.expr === 'null' || node.expr === 'undefined') return ''
+      const wrapped = wrapExpr(node.expr)
+      // Stage 3 / D4 — join an element-array child ({out}) built by the preamble.
+      const value = node.joinArrayChild
+        ? `Array.isArray(${wrapped}) ? ${wrapped}.join('') : (${wrapped} ?? '')`
+        : wrapped
       if (node.slotId) {
-        return `<!--bf:${node.slotId}-->\${${escapeTextSlotExpr(wrapExpr(node.expr))}}<!--/-->`
+        return `<!--bf:${node.slotId}-->\${${node.joinArrayChild ? value : escapeTextSlotExpr(wrapped)}}<!--/-->`
       }
-      return `\${${wrapExpr(node.expr)}}`
+      return `\${${value}}`
+    }
 
     case 'conditional': {
       const trueBranch = recurse(node.whenTrue)
@@ -1187,7 +1227,9 @@ export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<stri
         }
         mapExpr = `\${${wrappedArray}.flatMap(${node.flatMapCallback.params} => ${body}).join('')}`
       } else if (node.mapPreamble) {
-        mapExpr = `\${${wrappedArray}.${iterMethod}(${callbackParam} => { ${node.mapPreamble} return \`${childTemplate}\` }).join('')}`
+        // Stage 3 / D4 — substitute JSX leaves in an arbitrary array-builder preamble.
+        const preamble = substituteJsxFragments(node.mapPreamble, node.preambleFragments, (ir) => irToPlaceholderTemplate(ir, restSpreadNames, loopDepth + 1, loopParams))
+        mapExpr = `\${${wrappedArray}.${iterMethod}(${callbackParam} => { ${preamble} return \`${childTemplate}\` }).join('')}`
       } else {
         mapExpr = `\${${wrappedArray}.${iterMethod}(${callbackParam} => \`${childTemplate}\`).join('')}`
       }
@@ -1553,12 +1595,18 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
       // as HTML (template.innerHTML), so re-escape for the HTML parser.
       return escapeHtml(node.value)
 
-    case 'expression':
+    case 'expression': {
       if (node.expr === 'null' || node.expr === 'undefined') return ''
+      const wrapped = transformExpr(node.expr, node.templateExpr)
+      // Stage 3 / D4 — join an element-array child ({out}) built by the preamble.
+      const value = node.joinArrayChild
+        ? `Array.isArray(${wrapped}) ? ${wrapped}.join('') : (${wrapped} ?? '')`
+        : wrapped
       if (node.slotId) {
-        return `<!--bf:${node.slotId}-->\${${escapeTextSlotExpr(transformExpr(node.expr, node.templateExpr))}}<!--/-->`
+        return `<!--bf:${node.slotId}-->\${${node.joinArrayChild ? value : escapeTextSlotExpr(wrapped)}}<!--/-->`
       }
-      return `\${${transformExpr(node.expr, node.templateExpr)}}`
+      return `\${${value}}`
+    }
 
     case 'conditional': {
       // A client-only conditional (auto-deferred brand read or manual
@@ -2134,10 +2182,14 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
         // before init's createEffect overwrites the slot (#1128). Emit
         // an empty placeholder instead.
         const expr = transformed === UNSAFE_TEMPLATE_EXPR ? "''" : transformed
+        // Stage 3 / D4 — join an element-array child ({out}) built by the preamble.
+        const value = node.joinArrayChild
+          ? `Array.isArray(${expr}) ? ${expr}.join('') : (${expr} ?? '')`
+          : expr
         if (node.slotId) {
-          return `<!--bf:${node.slotId}-->\${${escapeTextSlotExpr(expr)}}<!--/-->`
+          return `<!--bf:${node.slotId}-->\${${node.joinArrayChild ? value : escapeTextSlotExpr(expr)}}<!--/-->`
         }
-        return `\${${expr}}`
+        return `\${${value}}`
       }
 
     case 'conditional': {
@@ -2296,7 +2348,9 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
         mapExpr = `\${${iterArrayExpr}.flatMap(${node.flatMapCallback.params} => ${body}).join('')}`
       } else if (node.mapPreamble) {
         const rawPreamble = node.templateMapPreamble ?? node.mapPreamble
-        const preamble = applyPropsRewrite(rawPreamble, propsObjectName ?? null)
+        // Stage 3 / D4 — substitute JSX leaves after the props rewrite
+        // (placeholders are inert identifiers it leaves untouched).
+        const preamble = substituteJsxFragments(applyPropsRewrite(rawPreamble, propsObjectName ?? null), node.preambleFragments, (ir) => recurseInLoopBody(ir))
         mapExpr = `\${${iterArrayExpr}.${iterMethod}(${callbackParam} => { ${preamble} return \`${childTemplate}\` }).join('')}`
       } else {
         mapExpr = `\${${iterArrayExpr}.${iterMethod}(${callbackParam} => \`${childTemplate}\`).join('')}`

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -22,6 +22,7 @@ import type {
   ImportInfo,
   TypeInfo,
   TypeDefinition,
+  FlatMapJsxFragment,
 } from '../types.ts'
 import type { CsrInlinabilityMap } from './csr-substitute.ts'
 import type { SkeletonSlotPaths } from './html-template.ts'
@@ -600,6 +601,8 @@ export interface TopLevelLoop extends LoopCore {
   }
   chainOrder?: 'filter-sort' | 'sort-filter'
   mapPreamble?: string
+  /** Stage 3 / D4 — compiled JSX leaves in an arbitrary array-builder preamble. */
+  preambleFragments?: FlatMapJsxFragment[]
 }
 
 /**

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -48,11 +48,13 @@ import {
 import { resolveFreeRefs, isNameBound as isNameBoundInEnv, type BindingEnvironment } from './free-refs.ts'
 import { computeFileScope } from './ir-to-client-js/component-scope.ts'
 import { createTemplateAwareStringProtector } from './ir-to-client-js/html-template.ts'
+import { extractFreeIdentifiersFromText } from './ir-to-client-js/csr-substitute.ts'
 import { datePlugin, DATE_METHODS } from './date-lowering.ts'
 import { toLocaleDatePlugin, foldedArgToClientJs } from './to-locale-date-lowering.ts'
 import type { LoweringMatcher } from './lowering-registry.ts'
 import { extractFreeIdentifiersFromNode, initializerShapeContainsJsx, extractMultiReturnJsxBranches, type MultiReturnJsxBranches } from './analyzer.ts'
 import { iterateJsTokens, replaceInExprContexts } from './scanner/js-scanner.ts'
+import { reconstructWithReplacements } from './strip-types.ts'
 import { toHTMLAttrName, decodeEntities } from '@barefootjs/shared'
 
 // =============================================================================
@@ -3740,6 +3742,11 @@ function transformMapCall(
   let mapPreamble: string | undefined
   let templateMapPreamble: string | undefined
   let typedMapPreamble: string | undefined
+  // Stage 3 / D4 (spec/callback-fidelity.md) — JSX leaves compiled from an
+  // arbitrary array-builder preamble, and the names that preamble declares (for
+  // the D5 key-derivability guard and the {out} array-child join).
+  let preambleFragments: FlatMapJsxFragment[] | undefined
+  let preambleDeclaredNames: ReadonlySet<string> | undefined
   let iterationShape: 'entries' | 'keys' | undefined
   let objectIteration: 'entries' | 'keys' | 'values' | undefined
 
@@ -4185,25 +4192,62 @@ function transformMapCall(
           }
         }
         if (jsxPreambleStmt) {
-          ctx.analyzer.errors.push(
-            createError(
-              ErrorCodes.UNSUPPORTED_JSX_PATTERN,
-              getSourceLocation(jsxPreambleStmt, ctx.sourceFile, ctx.filePath),
-              {
-                message:
-                  'A .map() callback that builds JSX in a statement before its ' +
-                  '`return` (for example pushing elements into an array in a loop) ' +
-                  'cannot be lowered to a template.',
-                suggestion: {
+          // Stage 3 / D4 (spec/callback-fidelity.md). A JS-runtime adapter runs
+          // the callback body verbatim — each JSX leaf lowers to a template-
+          // literal HTML string, the imperative control flow runs as-is, and the
+          // element-array child ({out}) is joined into the row. A DSL template
+          // runtime can't do this, so it refuses with the /* @client */ escape
+          // (which renders the loop client-only, where the browser — always JS —
+          // runs the same body). Mirrors the const-preamble gate above and the
+          // Stage-1 filter/sort sites (all consult `acceptsCallbackBody`).
+          const jsRuntime = isClientOnly || (ctx.analyzer.acceptsCallbackBody?.('map') ?? false)
+          if (!jsRuntime) {
+            ctx.analyzer.errors.push(
+              createError(
+                ErrorCodes.UNSUPPORTED_JSX_PATTERN,
+                getSourceLocation(jsxPreambleStmt, ctx.sourceFile, ctx.filePath),
+                {
                   message:
-                    'Return the JSX directly — e.g. project with a nested .map() ' +
-                    'inside the returned element — instead of constructing it in a ' +
-                    'preceding statement.',
-                },
-              }
+                    'A .map() callback that builds JSX in a statement before its ' +
+                    '`return` (for example pushing elements into an array in a loop) ' +
+                    'cannot be lowered to a template on this backend.',
+                  suggestion: {
+                    message: 'Add /* @client */ to render this loop on the client only',
+                  },
+                }
+              )
             )
-          )
-          // Do NOT collect the JSX-bearing preamble: that splice is the leak.
+          } else {
+            const collected = buildPreambleJsxFragments(body.statements, returnStmt, ctx)
+            if (collected.refusalNode) {
+              // A leaf carries wiring the verbatim path can't render (event
+              // handler, component, nested loop, reactive slot, spread). Refuse
+              // loudly (D-E) rather than emit a silently-degraded node.
+              ctx.analyzer.errors.push(
+                createError(
+                  ErrorCodes.UNSUPPORTED_JSX_PATTERN,
+                  getSourceLocation(collected.refusalNode, ctx.sourceFile, ctx.filePath),
+                  {
+                    message:
+                      'A JSX element built in a .map() callback preamble cannot carry ' +
+                      'event handlers, components, nested loops, or reactive expressions — ' +
+                      'the verbatim render path builds it once, with no reactive wiring.',
+                    suggestion: {
+                      message:
+                        'Return the element directly (not through a preamble variable), ' +
+                        'or add /* @client */ to render the loop on the client only.',
+                    },
+                  }
+                )
+              )
+            } else {
+              mapPreamble = collected.clientText
+              templateMapPreamble = collected.clientText
+              typedMapPreamble = collected.typedText
+              preambleFragments = collected.fragments
+              preambleDeclaredNames = collected.declaredNames
+            }
+          }
         } else {
           const preambleStmts: string[] = []
           const templatePreambleStmts: string[] = []
@@ -4280,6 +4324,35 @@ function transformMapCall(
   const key = bodyIsItemConditional
     ? extractItemConditionalKey(itemConditional!)
     : (children.length > 0 ? extractLoopKey(children[0]) : null)
+
+  // Stage 3 / D5 (spec/callback-fidelity.md) — the keyFn is hoisted: `mapArray`
+  // computes it from the raw item BEFORE the callback body runs, so the key must
+  // be derivable from the item (and index), never from a value the preamble
+  // computes. A key that reads a preamble-declared local would compile to an
+  // unbound keyFn; refuse instead.
+  if (key && preambleDeclaredNames && preambleDeclaredNames.size > 0) {
+    const keyRefs = extractFreeIdentifiersFromText(key)
+    const usesLocal = [...keyRefs].some((r) => preambleDeclaredNames!.has(r))
+    if (usesLocal) {
+      ctx.analyzer.errors.push(
+        createError(ErrorCodes.UNSUPPORTED_JSX_PATTERN, getSourceLocation(node, ctx.sourceFile, ctx.filePath), {
+          message:
+            'A .map() loop key must be derivable from the loop item — it is ' +
+            'evaluated before the callback body runs, so it cannot reference a ' +
+            'value computed in the callback preamble.',
+          suggestion: {
+            message: 'Derive the key directly from the loop item (e.g. key={item.id}).',
+          },
+        })
+      )
+    }
+  }
+
+  // Stage 3 / D4 — flag element-array children ({out}) built by the preamble so
+  // Phase-2 string emission joins them instead of `String([])`-collapsing them.
+  if (preambleDeclaredNames && preambleDeclaredNames.size > 0) {
+    flagArrayChildExpressions(children, preambleDeclaredNames)
+  }
 
   // Extract childComponent info if the loop body is a single component
   // This enables createComponent-based rendering with proper prop passing
@@ -4386,6 +4459,7 @@ function transformMapCall(
     paramType,
     indexType,
     typedMapPreamble,
+    preambleFragments,
     paramBindings,
     arrayFreeIdentifiers: extractFreeIdentifiersFromNode(arrayExpr),
     flatMapCallback,
@@ -4489,6 +4563,157 @@ function buildFlatMapCallback(
     templateBody: compiledBody,
     rawBody: bodyText,
     fragments,
+  }
+}
+
+/**
+ * Stage 3 / D4 (spec/callback-fidelity.md) — the collected JSX-bearing preamble
+ * of an arbitrary `.map()` callback (an imperative array-builder).
+ */
+interface PreambleCollection {
+  /** Pre-return statements, TS types stripped, each JSX leaf → `__BF_JSX_N__`. */
+  clientText: string
+  /** Same statements verbatim (types + raw JSX kept) for JS-runtime SSR adapters. */
+  typedText: string
+  /** Compiled IR per placeholder, in index order. */
+  fragments: FlatMapJsxFragment[]
+  /** const/let/function names the preamble declares (D5 key guard, {out} join). */
+  declaredNames: Set<string>
+  /** Set when a leaf carries wiring the verbatim path can't render (D-E). */
+  refusalNode?: ts.Node
+}
+
+/**
+ * Does a compiled preamble JSX leaf carry wiring the verbatim render path can't
+ * honour? The path builds each leaf once as an interpolated HTML string with no
+ * reactive effects, event listeners, or child reconciliation — so an event
+ * handler, a component, a nested loop, a reactive slot, or a spread would be
+ * silently dropped. Refuse instead (D-E), never diverge silently.
+ */
+function preambleFragmentNeedsWiring(ir: IRNode): boolean {
+  switch (ir.type) {
+    case 'component':
+    case 'loop':
+      return true
+    case 'element':
+      if (ir.events.length > 0) return true
+      // JSX spread (`<x {...rest} />`) keeps `name === '...'` as its marker.
+      if (ir.attrs.some((a) => a.name.startsWith('...'))) return true
+      return ir.children.some(preambleFragmentNeedsWiring)
+    case 'expression':
+      return ir.reactive === true
+    case 'conditional':
+      return (
+        preambleFragmentNeedsWiring(ir.whenTrue) ||
+        (ir.whenFalse ? preambleFragmentNeedsWiring(ir.whenFalse) : false)
+      )
+    case 'fragment':
+      return ir.children.some(preambleFragmentNeedsWiring)
+    default:
+      return false
+  }
+}
+
+/**
+ * Stage 3 / D4 — walk loop-body children and flag each `IRExpression` child
+ * whose free identifiers intersect the preamble-declared names (e.g. `{out}`).
+ * Phase-2 string emission then joins the array instead of `String([])`-collapsing
+ * it. JSX SSR adapters ignore the flag (their JSX runtime renders arrays).
+ */
+function flagArrayChildExpressions(nodes: IRNode[], declared: ReadonlySet<string>): void {
+  for (const node of nodes) {
+    switch (node.type) {
+      case 'expression': {
+        const refs = extractFreeIdentifiersFromText(node.expr)
+        if ([...refs].some((r) => declared.has(r))) node.joinArrayChild = true
+        break
+      }
+      case 'element':
+      case 'fragment':
+        flagArrayChildExpressions(node.children, declared)
+        break
+      case 'conditional':
+        flagArrayChildExpressions(
+          [node.whenTrue, ...(node.whenFalse ? [node.whenFalse] : [])],
+          declared,
+        )
+        break
+    }
+  }
+}
+
+/** Names a preamble statement declares (const/let/var/function). */
+function collectPreambleDeclaredNames(stmt: ts.Statement, out: Set<string>): void {
+  if (ts.isVariableStatement(stmt)) {
+    for (const decl of stmt.declarationList.declarations) {
+      if (ts.isIdentifier(decl.name)) out.add(decl.name.text)
+    }
+  } else if (ts.isFunctionDeclaration(stmt) && stmt.name) {
+    out.add(stmt.name.text)
+  }
+}
+
+/**
+ * Collect an arbitrary `.map()` callback's pre-return statements, replacing each
+ * top-level JSX leaf with a `__BF_JSX_N__` placeholder (mirrors
+ * {@link buildFlatMapCallback}). `clientText` is type-stripped for the plain-JS
+ * bundle; `typedText` keeps the raw JSX so a JS-runtime SSR adapter renders it
+ * natively. Each leaf is compiled to IR (and checked against
+ * {@link preambleFragmentNeedsWiring}). Never regex over JS — the placeholder
+ * swap is a single AST-span reconstruction ({@link reconstructWithReplacements}).
+ */
+function buildPreambleJsxFragments(
+  statements: ts.NodeArray<ts.Statement>,
+  returnStmt: ts.Statement | undefined,
+  ctx: TransformContext,
+): PreambleCollection {
+  const clientParts: string[] = []
+  const typedParts: string[] = []
+  const fragments: FlatMapJsxFragment[] = []
+  const declaredNames = new Set<string>()
+  let refusalNode: ts.Node | undefined
+  let fragIndex = 0
+
+  for (const stmt of statements) {
+    if (stmt === returnStmt) break
+    collectPreambleDeclaredNames(stmt, declaredNames)
+
+    // Top-level JSX leaves in this statement — don't descend into a JSX node
+    // (transformNode compiles its interior). Same walk as buildFlatMapCallback.
+    const jsxSpans: Array<{ start: number; end: number; text: string }> = []
+    const collect = (n: ts.Node): void => {
+      if (ts.isJsxElement(n) || ts.isJsxSelfClosingElement(n) || ts.isJsxFragment(n)) {
+        const placeholder = `__BF_JSX_${fragIndex++}__`
+        jsxSpans.push({ start: n.getStart(ctx.sourceFile), end: n.getEnd(), text: placeholder })
+        const ir = transformNode(n as ts.Expression, ctx)
+        if (ir && preambleFragmentNeedsWiring(ir)) refusalNode ??= n
+        fragments.push({
+          placeholder,
+          ir: ir ?? { type: 'text', value: '', loc: getSourceLocation(n, ctx.sourceFile, ctx.filePath) },
+        })
+        return
+      }
+      n.forEachChild(collect)
+    }
+    collect(stmt)
+
+    const clientText = reconstructWithReplacements(
+      stmt,
+      ctx.sourceFile,
+      ctx.analyzer.typeExcludeRanges,
+      jsxSpans,
+    )
+    const rawText = stmt.getText(ctx.sourceFile)
+    clientParts.push(clientText.endsWith(';') ? clientText : clientText + ';')
+    typedParts.push(rawText.endsWith(';') ? rawText : rawText + ';')
+  }
+
+  return {
+    clientText: clientParts.join(' '),
+    typedText: typedParts.join(' '),
+    fragments,
+    declaredNames,
+    refusalNode,
   }
 }
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -4624,8 +4624,16 @@ function flagArrayChildExpressions(nodes: IRNode[], declared: ReadonlySet<string
   for (const node of nodes) {
     switch (node.type) {
       case 'expression': {
+        // Only the bare `{out}` shape — the whole expression is a single
+        // identifier that is itself a preamble-declared array. A broader
+        // expression (`{out.length}`, `{f(out)}`) must NOT get the array-join
+        // coercion: it would change the value, and the join ternary reads the
+        // expression twice, so a call could double-fire its side effects.
+        const name = node.expr.trim()
         const refs = extractFreeIdentifiersFromText(node.expr)
-        if ([...refs].some((r) => declared.has(r))) node.joinArrayChild = true
+        if (refs.size === 1 && refs.has(name) && declared.has(name)) {
+          node.joinArrayChild = true
+        }
         break
       }
       case 'element':
@@ -4642,11 +4650,28 @@ function flagArrayChildExpressions(nodes: IRNode[], declared: ReadonlySet<string
   }
 }
 
+/**
+ * Collect the names a binding introduces, recursing through object/array
+ * destructuring patterns (`const { id: k } = r`, `const [k, ...rest] = xs`) so
+ * the D5 key-derivability guard sees every preamble-scoped local — mirrors
+ * `collectParamBindingNames`.
+ */
+function collectBindingNames(name: ts.BindingName, out: Set<string>): void {
+  if (ts.isIdentifier(name)) {
+    out.add(name.text)
+    return
+  }
+  // Object / array binding pattern; array holes are OmittedExpression, skipped.
+  for (const el of name.elements) {
+    if (ts.isBindingElement(el)) collectBindingNames(el.name, out)
+  }
+}
+
 /** Names a preamble statement declares (const/let/var/function). */
 function collectPreambleDeclaredNames(stmt: ts.Statement, out: Set<string>): void {
   if (ts.isVariableStatement(stmt)) {
     for (const decl of stmt.declarationList.declarations) {
-      if (ts.isIdentifier(decl.name)) out.add(decl.name.text)
+      collectBindingNames(decl.name, out)
     }
   } else if (ts.isFunctionDeclaration(stmt) && stmt.name) {
     out.add(stmt.name.text)

--- a/packages/jsx/src/strip-types.ts
+++ b/packages/jsx/src/strip-types.ts
@@ -71,6 +71,52 @@ export function reconstructWithoutTypes(
   return result
 }
 
+/**
+ * Reconstruct a node's text with types stripped (via `ranges`) AND selected
+ * sub-spans replaced by literal text. Used by Stage 3 / D4 preamble collection
+ * (spec/callback-fidelity.md) to strip TS types while swapping each JSX leaf for
+ * a `__BF_JSX_N__` placeholder in one span-walk — never regex, per the repo's
+ * "no string-matching JS syntax" rule.
+ *
+ * `replacements` are absolute-position sub-spans of `node`, non-overlapping, in
+ * any order. A type range that falls inside a replacement span is subsumed (the
+ * replacement text wins); type ranges outside are stripped as usual.
+ */
+export function reconstructWithReplacements(
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+  ranges: ExcludeRange[],
+  replacements: Array<{ start: number; end: number; text: string }>
+): string {
+  const nodeStart = node.getStart(sourceFile)
+  const nodeEnd = node.getEnd()
+  const fullText = sourceFile.text
+
+  // One merged, position-sorted edit list: type ranges emit nothing,
+  // replacements emit their text. Replacements sort first at a shared start so
+  // a subsumed type range (same start) is skipped by the `edit.start < pos` guard.
+  type Edit = { start: number; end: number; text: string }
+  const edits: Edit[] = []
+  for (const r of ranges) {
+    if (r.end <= nodeStart || r.start >= nodeEnd) continue
+    edits.push({ start: r.start, end: r.end, text: '' })
+  }
+  for (const rep of replacements) {
+    edits.push({ start: rep.start, end: rep.end, text: rep.text })
+  }
+  edits.sort((a, b) => a.start - b.start || b.end - a.end)
+
+  let result = ''
+  let pos = nodeStart
+  for (const edit of edits) {
+    if (edit.start < pos) continue // subsumed by an already-emitted span
+    result += fullText.slice(pos, edit.start) + edit.text
+    pos = edit.end
+  }
+  if (pos < nodeEnd) result += fullText.slice(pos, nodeEnd)
+  return result
+}
+
 function mergeRanges(ranges: ExcludeRange[]): ExcludeRange[] {
   if (ranges.length === 0) return []
   const merged: ExcludeRange[] = [ranges[0]]

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -371,6 +371,15 @@ export interface IRExpression {
   loc: SourceLocation
   /** When true, expression should be evaluated on client side only */
   clientOnly?: boolean
+  /**
+   * Stage 3 / D4 (spec/callback-fidelity.md) — this expression child references
+   * an array built by an arbitrary `.map()` preamble (`return <tr>{out}</tr>`
+   * where `out` is `push`-populated with element strings). Phase-2 string-
+   * template emission must join it (`Array.isArray(out) ? out.join('') : …`)
+   * rather than `String([])`-comma-collapse it. JSX SSR adapters ignore the
+   * flag (their JSX runtime renders an array child natively).
+   */
+  joinArrayChild?: boolean
   /** When true, expression calls signal getters or memos (has reactive `foo()` pattern). */
   callsReactiveGetters?: boolean
   /** When true, expression contains function call(s) — any `identifier()` pattern (computed from AST). */
@@ -693,6 +702,20 @@ export interface IRLoop {
   indexType?: string
   /** mapPreamble with TypeScript type annotations preserved, for .tsx output */
   typedMapPreamble?: string
+
+  /**
+   * Stage 3 / D4 (spec/callback-fidelity.md) — JSX leaves embedded in an
+   * arbitrary `.map()` callback preamble (an imperative array-builder:
+   * `const out = []; for (…) out.push(<td>{c}</td>); return <tr>{out}</tr>`).
+   * `mapPreamble` / `templateMapPreamble` carry the preamble text with each JSX
+   * span replaced by a `__BF_JSX_N__` placeholder; this holds the compiled IR
+   * per placeholder so Phase 2 substitutes a template-literal HTML string at
+   * each. `typedMapPreamble` keeps the raw JSX intact for JS-runtime SSR
+   * adapters (Hono's JSX runtime renders it natively). Mirrors
+   * {@link FlatMapCallback.fragments}. Only populated on a JS-runtime adapter
+   * (or a `/* @client *\/`-marked map); a DSL target refuses with BF021.
+   */
+  preambleFragments?: FlatMapJsxFragment[]
 
   /**
    * When `.map(callback)` destructures its item parameter (array or object

--- a/spec/callback-fidelity.md
+++ b/spec/callback-fidelity.md
@@ -10,7 +10,11 @@
 > (adapter-gate the Phase-1 `filter`/`sort` constraint), `#2374` (close the
 > `fill` gap + doc/comment cleanup), `#2375` (find/some/every off-subset
 > conformance), `#2376` (reduce/reduceRight/flatMap off-subset conformance).
-> Stage 2 is in progress.
+> Stage 2 has landed (if/else-if + `switch` fold, `const`-preamble fold
+> adapter-gated). Stage 3 is in progress — the imperative array-builder body
+> (`const out = []; for (…) out.push(<td/>); return <tr>{out}</tr>`) now renders
+> verbatim on JS-runtime adapters (D4 + D5(a), keyFn hoisted); DSL adapters
+> refuse with `BF021` + `/* @client */`.
 
 ## Vision
 
@@ -295,8 +299,16 @@ Each stage is independently shippable, tested, and PR-sized. Value/risk-ordered.
 
 ## Open decisions (resolve in Stage 0)
 
-1. **`keyFn` contract (D5):** hoist (a) vs report (b). *Leaning (b)* for
-   generality, accepting a scoped `mapArray` API change.
+1. **`keyFn` contract (D5):** hoist (a) vs report (b). **Resolved: (a) hoist.**
+   Though the RFC leaned (b) for generality, the `mapArray` runtime already
+   computes `getKey(rawItem, index)` from the raw item *before* `renderItem`
+   runs, and the compiler's `keyFn` is already a pure `(item, index) => …`
+   closure — so (a) needs zero runtime/call-site change and preserves SSR/CSR
+   hydration parity, whereas (b) is a real `mapArray` API change with a
+   key-ordering inversion across every call site. The array-builder PR
+   implements (a): the key must be derivable from the item; a key that reads a
+   preamble-computed local is refused. (b)'s extra generality — a key computed
+   inside the body — can be revisited if a real use case needs it.
 2. **Capability-predicate granularity (D1):** binary (`JsxAdapter` vs
    `BaseAdapter`) vs shape-granular `acceptsCallbackBody(parsed)`. *Leaning
    granular*, symmetric with `acceptsTemplateCall`, to let DSL adapters accept

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2279,6 +2279,56 @@
           ]
         }
       },
+      "map-array-builder-body": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        }
+      },
       "map-preamble-branch-body": {
         "blade": {
           "kind": "refusal",
@@ -2660,6 +2710,10 @@
       "flatmap-typeof-projection": {
         "description": "Off-subset `.flatMap()` projection (typeof) — JS-runtime faithful, DSL diagnostic",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/flatmap-typeof-projection.ts"
+      },
+      "map-array-builder-body": {
+        "description": "imperative array-builder .map() body — JS-runtime verbatim, DSL refuses (BF021)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/map-array-builder-body.ts"
       },
       "map-preamble-branch-body": {
         "description": "const preamble + if/else as a .map() body — JS-runtime folds, DSL refuses (BF021)",

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 275,
+    "totalFixtures": 276,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1886,11 +1886,11 @@
       }
     },
     "identifier": {
-      "total": 256,
+      "total": 257,
       "cells": {
         "hono": {
-          "pass": 255,
-          "total": 256,
+          "pass": 256,
+          "total": 257,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1901,8 +1901,8 @@
           ]
         },
         "blade": {
-          "pass": 242,
-          "total": 256,
+          "pass": 243,
+          "total": 257,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1973,8 +1973,8 @@
           ]
         },
         "erb": {
-          "pass": 243,
-          "total": 256,
+          "pass": 244,
+          "total": 257,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2039,8 +2039,8 @@
           ]
         },
         "go-template": {
-          "pass": 242,
-          "total": 256,
+          "pass": 243,
+          "total": 257,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2111,8 +2111,8 @@
           ]
         },
         "jinja": {
-          "pass": 242,
-          "total": 256,
+          "pass": 243,
+          "total": 257,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2183,8 +2183,8 @@
           ]
         },
         "minijinja": {
-          "pass": 242,
-          "total": 256,
+          "pass": 243,
+          "total": 257,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2255,8 +2255,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 243,
-          "total": 256,
+          "pass": 244,
+          "total": 257,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2321,8 +2321,8 @@
           ]
         },
         "twig": {
-          "pass": 242,
-          "total": 256,
+          "pass": 243,
+          "total": 257,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2393,8 +2393,8 @@
           ]
         },
         "xslate": {
-          "pass": 242,
-          "total": 256,
+          "pass": 243,
+          "total": 257,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3018,11 +3018,11 @@
       }
     },
     "member": {
-      "total": 135,
+      "total": 136,
       "cells": {
         "hono": {
-          "pass": 134,
-          "total": 135,
+          "pass": 135,
+          "total": 136,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3033,8 +3033,8 @@
           ]
         },
         "blade": {
-          "pass": 121,
-          "total": 135,
+          "pass": 122,
+          "total": 136,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3105,8 +3105,8 @@
           ]
         },
         "erb": {
-          "pass": 122,
-          "total": 135,
+          "pass": 123,
+          "total": 136,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3171,8 +3171,8 @@
           ]
         },
         "go-template": {
-          "pass": 121,
-          "total": 135,
+          "pass": 122,
+          "total": 136,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3243,8 +3243,8 @@
           ]
         },
         "jinja": {
-          "pass": 121,
-          "total": 135,
+          "pass": 122,
+          "total": 136,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3315,8 +3315,8 @@
           ]
         },
         "minijinja": {
-          "pass": 121,
-          "total": 135,
+          "pass": 122,
+          "total": 136,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3387,8 +3387,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 122,
-          "total": 135,
+          "pass": 123,
+          "total": 136,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3453,8 +3453,8 @@
           ]
         },
         "twig": {
-          "pass": 121,
-          "total": 135,
+          "pass": 122,
+          "total": 136,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3525,8 +3525,8 @@
           ]
         },
         "xslate": {
-          "pass": 121,
-          "total": 135,
+          "pass": 122,
+          "total": 136,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1901,7 +1901,7 @@
           ]
         },
         "blade": {
-          "pass": 243,
+          "pass": 242,
           "total": 257,
           "gaps": [
             {
@@ -1940,6 +1940,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -1973,7 +1977,7 @@
           ]
         },
         "erb": {
-          "pass": 244,
+          "pass": 243,
           "total": 257,
           "gaps": [
             {
@@ -2006,6 +2010,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -2039,7 +2047,7 @@
           ]
         },
         "go-template": {
-          "pass": 243,
+          "pass": 242,
           "total": 257,
           "gaps": [
             {
@@ -2078,6 +2086,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -2111,7 +2123,7 @@
           ]
         },
         "jinja": {
-          "pass": 243,
+          "pass": 242,
           "total": 257,
           "gaps": [
             {
@@ -2150,6 +2162,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -2183,7 +2199,7 @@
           ]
         },
         "minijinja": {
-          "pass": 243,
+          "pass": 242,
           "total": 257,
           "gaps": [
             {
@@ -2222,6 +2238,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -2255,7 +2275,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 244,
+          "pass": 243,
           "total": 257,
           "gaps": [
             {
@@ -2288,6 +2308,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -2321,7 +2345,7 @@
           ]
         },
         "twig": {
-          "pass": 243,
+          "pass": 242,
           "total": 257,
           "gaps": [
             {
@@ -2360,6 +2384,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -2393,7 +2421,7 @@
           ]
         },
         "xslate": {
-          "pass": 243,
+          "pass": 242,
           "total": 257,
           "gaps": [
             {
@@ -2432,6 +2460,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -3033,7 +3065,7 @@
           ]
         },
         "blade": {
-          "pass": 122,
+          "pass": 121,
           "total": 136,
           "gaps": [
             {
@@ -3072,6 +3104,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -3105,7 +3141,7 @@
           ]
         },
         "erb": {
-          "pass": 123,
+          "pass": 122,
           "total": 136,
           "gaps": [
             {
@@ -3138,6 +3174,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -3171,7 +3211,7 @@
           ]
         },
         "go-template": {
-          "pass": 122,
+          "pass": 121,
           "total": 136,
           "gaps": [
             {
@@ -3210,6 +3250,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -3243,7 +3287,7 @@
           ]
         },
         "jinja": {
-          "pass": 122,
+          "pass": 121,
           "total": 136,
           "gaps": [
             {
@@ -3282,6 +3326,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -3315,7 +3363,7 @@
           ]
         },
         "minijinja": {
-          "pass": 122,
+          "pass": 121,
           "total": 136,
           "gaps": [
             {
@@ -3354,6 +3402,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -3387,7 +3439,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 123,
+          "pass": 122,
           "total": 136,
           "gaps": [
             {
@@ -3420,6 +3472,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -3453,7 +3509,7 @@
           ]
         },
         "twig": {
-          "pass": 122,
+          "pass": 121,
           "total": 136,
           "gaps": [
             {
@@ -3492,6 +3548,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {
@@ -3525,7 +3585,7 @@
           ]
         },
         "xslate": {
-          "pass": 122,
+          "pass": 121,
           "total": 136,
           "gaps": [
             {
@@ -3564,6 +3624,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "map-array-builder-body",
               "issues": []
             },
             {


### PR DESCRIPTION
## Summary

Stage 3 / D4 + D5 of `spec/callback-fidelity.md`. A `.map()` callback that **constructs JSX in a statement before its `return`** — the imperative array-builder — previously refused on every backend (it would otherwise leak raw JSX into the plain-JS bundle). On a **JS-runtime adapter** it now renders verbatim, at full SSR/CSR/hydration parity.

```tsx
{rows.map((r) => {
  const out = []
  for (const c of r.cells) out.push(<td>{c}</td>)
  return <tr key={r.id}>{out}</tr>
})}
```

## What changed

- **JSX leaves → HTML strings.** Each JSX leaf in the preamble lowers to a template-literal HTML string, reusing the existing flatMap-callback fragment mechanism (`__BF_JSX_N__` placeholders + per-leaf IR). A new single-pass span-walk (`reconstructWithReplacements`) strips TS types **and** swaps each JSX span for a placeholder — never regex over JS syntax (per the repo convention).
- **`{out}` element-array join.** The element-array child is joined into the row (`Array.isArray(out) ? out.join('') : (out ?? '')`) across all four template emitters, so the renderItem, hydrate template, and SSR markup are byte-identical.
- **keyFn hoisted (D5 = (a)).** The key is derived from the raw item and evaluated *before* the body runs — zero `mapArray` runtime change. A key that reads a preamble-computed local is refused rather than compiled to an unbound `keyFn`. (Decision recorded in the spec: the RFC leaned (b)-report, but the runtime already implements the (a)-hoist contract, so (a) is smaller and parity-safe.)
- **Leaf-scope refusals (no silent divergence).** A leaf carrying an event handler, component, nested loop, reactive expression, or spread is refused loudly (BF021).
- **DSL escape.** A DSL adapter refuses the whole shape with `BF021` + the `/* @client */` suggestion, which renders the loop client-only (the browser — always JS — runs the same verbatim body).
- **Latent bug fix.** `TestAdapter.renderLoop` dropped the `.map()` preamble entirely, emitting unbound identifiers; it now splices the (typed, JSX-intact) preamble.

## Tests

- **Compiler-unit** (`map-arbitrary-body.test.ts`, rewritten): verbatim lowering, no raw-JSX leak, `{out}` join, keyFn hoist, key-derivability refusal, leaf-scope refusal, DSL BF021 + `@client`, and the `/* @client */`-escape path.
- **Adapter conformance**: new `map-array-builder-body` fixture — Hono/CSR render faithfully (reference `expectedHtml` generated from Hono), pinned `BF021` on all 8 DSL adapters.
- **CSR conformance**: the fixture round-trips (client-rendered DOM === reference).
- Full `@barefootjs/jsx` suite green (2664 pass); adapter-tests green after regenerating the coverage / compat / support-matrix ledgers.

## Notes

- Deferred (documented): same-key item-mutation staleness (an existing Stage-2 preamble semantic — rows update via key add/remove), and non-JSX-`push` escaping divergence.
- Changeset: `.changeset/map-array-builder-verbatim.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FG9KVo7k7nmVkvpuDXKCaC)_