### PR TITLE
fix(jsx): route JSX-returning flatMap expression bodies through the segments carrier

### DIFF
--- a/.changeset/flatmap-expression-body-segments.md
+++ b/.changeset/flatmap-expression-body-segments.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Route JSX-returning `.flatMap()` expression bodies through the structured-segments carrier. Previously `items.flatMap(t => t.tags.map(tag => <li key={...}>{tag}</li>))` (the unbraced twin of the supported block-body form) fell through to the scalar expression path and spliced raw JSX verbatim into the client bundle — invalid JS, so the whole component silently failed to hydrate. Also adds a structural net (any map-like callback with an inline JSX literal that produces no loop lowering now refuses loudly instead of leaking) and an adapter gate for segment-carried flatMap bodies on DSL backends (BF021 + `/* @client */` instead of an empty SSR loop body).

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -39,6 +39,12 @@ export const conformancePins: ConformancePins = {
   'reduce-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'reduce-right-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'flatmap-typeof-projection': [{ code: 'BF101', severity: 'error' }],
+  // JSX-returning `.flatMap()` body carried as structured segments
+  // (expression body / block body): a JS runtime executes it verbatim; a
+  // DSL template runtime can't, so it refuses with BF021 + `/* @client */`
+  // (pre-gate this emitted an empty loop body — silent divergence).
+  // See spec/callback-fidelity.md.
+  'flatmap-expression-body': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -40,6 +40,12 @@ export const conformancePins: ConformancePins = {
   'reduce-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'reduce-right-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'flatmap-typeof-projection': [{ code: 'BF101', severity: 'error' }],
+  // JSX-returning `.flatMap()` body carried as structured segments
+  // (expression body / block body): a JS runtime executes it verbatim; a
+  // DSL template runtime can't, so it refuses with BF021 + `/* @client */`
+  // (pre-gate this emitted an empty loop body — silent divergence).
+  // See spec/callback-fidelity.md.
+  'flatmap-expression-body': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -39,6 +39,12 @@ export const conformancePins: ConformancePins = {
   'reduce-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'reduce-right-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'flatmap-typeof-projection': [{ code: 'BF101', severity: 'error' }],
+  // JSX-returning `.flatMap()` body carried as structured segments
+  // (expression body / block body): a JS runtime executes it verbatim; a
+  // DSL template runtime can't, so it refuses with BF021 + `/* @client */`
+  // (pre-gate this emitted an empty loop body — silent divergence).
+  // See spec/callback-fidelity.md.
+  'flatmap-expression-body': [{ code: 'BF021', severity: 'error' }],
   // `style-object-dynamic` / `style-3-signals` no longer pinned — a
   // `style={{ … }}` object literal now lowers to a CSS string with dynamic
   // values interpolated (`background-color:{{.Color}};padding:8px`) via

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -39,6 +39,12 @@ export const conformancePins: ConformancePins = {
   'reduce-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'reduce-right-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'flatmap-typeof-projection': [{ code: 'BF101', severity: 'error' }],
+  // JSX-returning `.flatMap()` body carried as structured segments
+  // (expression body / block body): a JS runtime executes it verbatim; a
+  // DSL template runtime can't, so it refuses with BF021 + `/* @client */`
+  // (pre-gate this emitted an empty loop body — silent divergence).
+  // See spec/callback-fidelity.md.
+  'flatmap-expression-body': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -37,6 +37,12 @@ export const conformancePins: ConformancePins = {
   'reduce-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'reduce-right-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'flatmap-typeof-projection': [{ code: 'BF101', severity: 'error' }],
+  // JSX-returning `.flatMap()` body carried as structured segments
+  // (expression body / block body): a JS runtime executes it verbatim; a
+  // DSL template runtime can't, so it refuses with BF021 + `/* @client */`
+  // (pre-gate this emitted an empty loop body — silent divergence).
+  // See spec/callback-fidelity.md.
+  'flatmap-expression-body': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -40,6 +40,12 @@ export const conformancePins: ConformancePins = {
   'reduce-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'reduce-right-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'flatmap-typeof-projection': [{ code: 'BF101', severity: 'error' }],
+  // JSX-returning `.flatMap()` body carried as structured segments
+  // (expression body / block body): a JS runtime executes it verbatim; a
+  // DSL template runtime can't, so it refuses with BF021 + `/* @client */`
+  // (pre-gate this emitted an empty loop body — silent divergence).
+  // See spec/callback-fidelity.md.
+  'flatmap-expression-body': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2009,6 +2009,19 @@
         "text"
       ]
     },
+    "flatmap-expression-body": {
+      "kinds": [
+        "identifier",
+        "member",
+        "template-literal"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "flatmap-typeof-projection": {
       "kinds": [
         "array-literal",
@@ -4453,13 +4466,13 @@
     "binary": 75,
     "call": 173,
     "conditional": 20,
-    "identifier": 258,
+    "identifier": 259,
     "index-access": 12,
     "literal": 213,
     "logical": 42,
-    "member": 137,
+    "member": 138,
     "object-literal": 46,
-    "template-literal": 27,
+    "template-literal": 28,
     "unary": 22,
     "unsupported": 29
   },

--- a/packages/adapter-tests/fixtures/flatmap-expression-body.ts
+++ b/packages/adapter-tests/fixtures/flatmap-expression-body.ts
@@ -37,6 +37,10 @@ export { TagList }
     ],
   },
   expectedHtml: `
-    <ul bf-s="test" bf="s0"><li>&lt;b&gt;bold&lt;/b&gt;</li><li>x &amp; &quot;y&quot;</li><li>it&#39;s</li></ul>
+    <ul bf-s="test" bf="s0">
+      <li>&lt;b&gt;bold&lt;/b&gt;</li>
+      <li>x &amp; &quot;y&quot;</li>
+      <li>it&#39;s</li>
+    </ul>
   `,
 })

--- a/packages/adapter-tests/fixtures/flatmap-expression-body.ts
+++ b/packages/adapter-tests/fixtures/flatmap-expression-body.ts
@@ -1,0 +1,42 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `Array.prototype.flatMap` with a JSX-returning EXPRESSION body — the
+ * unbraced twin of the block-body form (`{ return it.tags.map(...) }`) that
+ * rides the structured-segments carrier (`FlatMapCallback`).
+ *
+ * Pre-fix, this shape fell through every `transformMapCall` dispatch arm to
+ * the IRExpression scalar path with ZERO diagnostics, splicing the raw
+ * callback — JSX included — verbatim into the client bundle: the module was
+ * invalid JS (`Unexpected token '<'`) and the whole component silently failed
+ * to hydrate while SSR looked correct.
+ *
+ * Per `spec/callback-fidelity.md` the shape is adapter-gated like the other
+ * segment-carried bodies:
+ *   - JS-runtime adapters (Hono / CSR) run the projection verbatim and render
+ *     the flattened leaves.
+ *   - DSL adapters can't execute the body at SSR and surface BF021 with a
+ *     `/* @client *\/` escape (declared via each adapter's `conformancePins`)
+ *     — pre-gate they emitted an EMPTY loop body (silent divergence).
+ *
+ * Leaf text carries `<`, `&`, `"`, `'` to pin escaping through the leaf door.
+ */
+export const fixture = createFixture({
+  id: 'flatmap-expression-body',
+  description: 'JSX-returning `.flatMap()` expression body — segments carrier, adapter-gated on DSL',
+  source: `
+function TagList({ items }: { items: { id: string; tags: string[] }[] }) {
+  return <ul>{items.flatMap((it) => it.tags.map((tag) => <li key={\`\${it.id}:\${tag}\`}>{tag}</li>))}</ul>
+}
+export { TagList }
+`,
+  props: {
+    items: [
+      { id: 'a', tags: ['<b>bold</b>', 'x & "y"'] },
+      { id: 'b', tags: ["it's"] },
+    ],
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s0"><li>&lt;b&gt;bold&lt;/b&gt;</li><li>x &amp; &quot;y&quot;</li><li>it&#39;s</li></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -127,6 +127,7 @@ import { fixture as everyTypeofPredicate } from './every-typeof-predicate'
 import { fixture as reduceTypeofBody } from './reduce-typeof-body'
 import { fixture as reduceRightTypeofBody } from './reduce-right-typeof-body'
 import { fixture as flatMapTypeofProjection } from './flatmap-typeof-projection'
+import { fixture as flatMapExpressionBody } from './flatmap-expression-body'
 import { fixture as mapIfChainBody } from './map-if-chain-body'
 import { fixture as mapSwitchFallthroughBody } from './map-switch-fallthrough-body'
 import { fixture as mapPreambleBranchBody } from './map-preamble-branch-body'
@@ -496,6 +497,7 @@ export const jsxFixtures: JSXFixture[] = [
   reduceTypeofBody,
   reduceRightTypeofBody,
   flatMapTypeofProjection,
+  flatMapExpressionBody,
   mapIfChainBody,
   mapSwitchFallthroughBody,
   mapPreambleBranchBody,

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -105,6 +105,15 @@ describe('CSR Conformance Tests', () => {
     'toggle-shared',
     'reactive-props',
     'props-reactivity-comparison',
+    // flatMap segment leaves: the CSR string template stamps the leaf's
+    // `key` as a `data-key` attribute (unescaped interpolation), while the
+    // Hono SSR rawBody path renders the raw JSX where `key` is a JSX prop
+    // and emits NO data-key — the pre-existing CSR/SSR leaf asymmetry
+    // documented in `flatmap-segments.test.ts`'s header. Removed by the
+    // flatMap client-loop rewiring PR stacked on this one (leaf keys move
+    // to mapArray's setAttribute path, off the string template), which
+    // deletes this skip.
+    'flatmap-expression-body',
     //   - `search-params-derived-memo`: the memo's template-eval reads the
     //     env-signal getter (`sp()`), a binding only init/hydration wires up
     //     (the per-request reader) — same init-wired-binding class as

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -39,6 +39,12 @@ export const conformancePins: ConformancePins = {
   'reduce-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'reduce-right-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'flatmap-typeof-projection': [{ code: 'BF101', severity: 'error' }],
+  // JSX-returning `.flatMap()` body carried as structured segments
+  // (expression body / block body): a JS runtime executes it verbatim; a
+  // DSL template runtime can't, so it refuses with BF021 + `/* @client */`
+  // (pre-gate this emitted an empty loop body — silent divergence).
+  // See spec/callback-fidelity.md.
+  'flatmap-expression-body': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -37,6 +37,12 @@ export const conformancePins: ConformancePins = {
   'reduce-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'reduce-right-typeof-body': [{ code: 'BF101', severity: 'error' }],
   'flatmap-typeof-projection': [{ code: 'BF101', severity: 'error' }],
+  // JSX-returning `.flatMap()` body carried as structured segments
+  // (expression body / block body): a JS runtime executes it verbatim; a
+  // DSL template runtime can't, so it refuses with BF021 + `/* @client */`
+  // (pre-gate this emitted an empty loop body — silent divergence).
+  // See spec/callback-fidelity.md.
+  'flatmap-expression-body': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/jsx/src/__tests__/flatmap-segments.test.ts
+++ b/packages/jsx/src/__tests__/flatmap-segments.test.ts
@@ -59,6 +59,42 @@ export { F }
     expect(tpl).not.toMatch(/[^.\w]limit\b/)
   })
 
+  test('expression bodies ride the same segments carrier as block bodies', () => {
+    // `t => t.tags.map(...)` (no braces) is the block form minus the braces.
+    // Pre-fix it fell through to the IRExpression scalar path and spliced the
+    // raw callback — JSX included — verbatim into the client bundle (invalid
+    // JS; the whole component failed to hydrate with `Unexpected token '<'`).
+    const src = `
+function F({ items }: { items: { id: string; tags: string[] }[] }) {
+  return <ul>{items.flatMap((it) => it.tags.map((t) => <li key={t}>{t}</li>))}</ul>
+}
+export { F }
+`
+    const r = compileJSX(src, 'F.tsx', { adapter: new TestAdapter() })
+    expect(r.errors).toHaveLength(0)
+    const cj = r.files.find(f => f.type === 'clientJs')!.content
+    // The hydrate template lowers the leaf to an escaped HTML template string…
+    expect(cj).toMatch(/escapeText\(\(t\)\)/)
+    // …and no raw JSX survives anywhere in the bundle.
+    expect(cj).not.toMatch(/<li key=\{t\}>/)
+    expect(cj).not.toMatch(/__BF_JSX_/)
+  })
+
+  test('destructured prop refs rewrite to _p.xxx in expression-body hydrate templates', () => {
+    const src = `
+function F({ owner, items }: { owner: string; items: { id: string; tags: string[] }[] }) {
+  return <ul>{items.flatMap((it) => it.tags.map((t) => <li key={t}>{t} ({owner})</li>))}</ul>
+}
+export { F }
+`
+    const r = compileJSX(src, 'F.tsx', { adapter: new TestAdapter() })
+    expect(r.errors).toHaveLength(0)
+    const cj = r.files.find(f => f.type === 'clientJs')!.content
+    const tpl = cj.match(/template: \(_p\) => `[\s\S]*?` \}\)/)?.[0] ?? ''
+    expect(tpl).toMatch(/_p\.owner/)
+    expect(tpl).not.toMatch(/[^.\w]owner\b/)
+  })
+
   test('TS type annotations in the block body are stripped from the client bundle', () => {
     const src = `
 function F({ items }: { items: { id: string; labels: string[] }[] }) {

--- a/packages/jsx/src/__tests__/map-body-no-silent-divergence.test.ts
+++ b/packages/jsx/src/__tests__/map-body-no-silent-divergence.test.ts
@@ -261,6 +261,51 @@ function T({ groups }: { groups: { id: string; items: { id: string; tags: string
 export { T }`,
   },
   {
+    id: 'flatmap-expression-body',
+    // The unbraced twin of flatmap-block-body: `t => t.tags.map(...)` with no
+    // block. Pre-fix this fell through every dispatch arm to the IRExpression
+    // scalar path and spliced the raw callback — JSX included — verbatim into
+    // the client bundle (a silent SyntaxError caught only by parseErrors).
+    dslTier: true,
+    source: `
+function T({ items }: { items: { id: string; tags: string[] }[] }) {
+  return <ul>{items.flatMap((it) => it.tags.map((t) => <li key={t}>{t}</li>))}</ul>
+}
+export { T }`,
+  },
+  {
+    id: 'flatmap-expression-body-parenthesized',
+    source: `
+function T({ items }: { items: { id: string; tags: string[] }[] }) {
+  return <ul>{items.flatMap((it) => (it.tags.map((t) => <li key={t}>{t}</li>)))}</ul>
+}
+export { T }`,
+  },
+  {
+    id: 'flatmap-expression-body-signal-array',
+    source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+function T() {
+  const [items] = createSignal([{ id: '1', tags: ['a'] }])
+  return <ul>{items().flatMap((it) => it.tags.map((t) => <li key={t}>{t}</li>))}</ul>
+}
+export { T }`,
+  },
+  {
+    id: 'map-jsx-inside-unrecognized-call',
+    // An inline JSX literal in a body shape no dispatch arm recognizes (a call
+    // wrapping JSX). The structural net refuses loudly instead of letting the
+    // scalar fallback splice the raw JSX into the bundle.
+    dslTier: true,
+    source: `
+declare function wrap(x: unknown): unknown
+function T({ items }: { items: { id: string }[] }) {
+  return <ul>{items.map((it) => wrap(<li key={it.id}>{it.id}</li>))}</ul>
+}
+export { T }`,
+  },
+  {
     id: 'flatmap-leaf-in-template-literal',
     // A leaf inside a template literal is refused (segment boundary would
     // split the literal's lexical state) — same rule as map preambles.

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -4279,6 +4279,43 @@ function transformMapCall(
       tryTransformRenderableBody(body)
     }
 
+    // flatMap EXPRESSION body containing JSX — e.g.
+    // `todos().flatMap(t => t.tags.map(tag => <li key={...}>{tag}</li>))`,
+    // parenthesized or not. The block-body form (`{ return t.tags.map(...) }`)
+    // already rides the structured-segments carrier in the isBlock branch
+    // above; an unbraced body is the same shape minus the braces, so route it
+    // through the same door. Without this the dispatch falls to the
+    // IRExpression scalar path, which splices the raw callback — JSX included
+    // — verbatim into the client bundle: a silent SyntaxError that kills the
+    // whole component's hydration.
+    if (method === 'flatMap' && children.length === 0 && !flatMapCallback && !ts.isBlock(body)) {
+      flatMapCallback = buildFlatMapCallback(callback, body, ctx)
+    }
+
+    // Adapter gate (spec/callback-fidelity.md fidelity model): a flatMap body
+    // carried as structured segments runs verbatim on a JS runtime; a DSL
+    // template runtime cannot execute it at SSR — pre-gate, e.g. the Go
+    // adapter emitted `{{range …}}{{end}}` with an EMPTY body (silent
+    // divergence, the exact failure class the sound-or-loud invariant
+    // forbids). Refuse loudly with the /* @client */ escape, mirroring the
+    // const-preamble and array-builder gates above.
+    if (flatMapCallback && !isClientOnly && !(ctx.analyzer.acceptsCallbackBody?.('flatMap') ?? false)) {
+      ctx.analyzer.errors.push(
+        createError(
+          ErrorCodes.UNSUPPORTED_JSX_PATTERN,
+          getSourceLocation(body, ctx.sourceFile, ctx.filePath),
+          {
+            message:
+              'A .flatMap() callback body with statements or a nested projection ' +
+              'cannot be lowered to a template on this backend.',
+            suggestion: {
+              message: 'Add /* @client */ to render this loop on the client only',
+            },
+          }
+        )
+      )
+    }
+
     // Unregister loop params
     if (paramBindings) {
       for (const b of paramBindings) ctx.loopParams.delete(b.name)
@@ -4293,6 +4330,37 @@ function transformMapCall(
   // fall back to treating the entire expression as an IRExpression — unless
   // flatMap already built a compiled callback (flatMapCallback).
   if (children.length === 0 && !flatMapCallback) {
+    // Structural net (sound-or-loud, spec/callback-fidelity.md): a callback
+    // body that carries an INLINE JSX literal but produced no loop lowering
+    // must never fall through to the IRExpression scalar path — `ctx.getJS`
+    // strips types, not JSX, so the raw `<li …>` would splice verbatim into
+    // the emitted client bundle as a silent SyntaxError. Any recognizer gap
+    // for a JSX-bearing shape becomes a loud diagnostic here instead of a
+    // leak. (A JSX-helper CALL — `map(t => renderItem(t))` — carries no
+    // inline JSX literal and legitimately stays on the reactive-text path.)
+    const cb = node.arguments[0]
+    const cbBody = cb && (ts.isArrowFunction(cb) || ts.isFunctionExpression(cb)) ? cb.body : undefined
+    if (cbBody && containsJsxInExpression(cbBody)) {
+      ctx.analyzer.errors.push(
+        createError(
+          ErrorCodes.UNSUPPORTED_JSX_PATTERN,
+          getSourceLocation(cbBody, ctx.sourceFile, ctx.filePath),
+          {
+            message:
+              `A .${method}() callback that builds JSX in this shape cannot be ` +
+              'compiled — the JSX would leak verbatim into the client bundle. ' +
+              'Recognized bodies: a JSX element/fragment, a ternary or ' +
+              '&& / || / ?? expression, an array literal (flatMap), or a block ' +
+              'body whose return the compiler can lower.',
+            suggestion: {
+              message:
+                'Restructure the callback to return the JSX element directly ' +
+                '(or via a block body with a plain `return`).',
+            },
+          }
+        )
+      )
+    }
     return null
   }
 
@@ -4527,15 +4595,19 @@ function containsJsx(node: ts.Node): boolean {
 }
 
 /**
- * Build a FlatMapCallback for complex flatMap block bodies (conditional
- * returns, variable-assigned JSX, etc.). Walks the callback body AST and
- * carries it as structured segments — JS text (types stripped) interleaved
- * with compiled JSX-leaf IR — never as a sentinel-bearing string (the
- * write-side rule in CLAUDE.md; same shape as the map-preamble carrier).
+ * Build a FlatMapCallback for complex flatMap bodies (conditional returns,
+ * variable-assigned JSX, etc.). Accepts a block body OR an expression body
+ * (`t => t.tags.map(tag => <li/>)`) — segment reconstruction and the SSR
+ * rawBody are position-based, so both shapes flow through identically (a
+ * block's text keeps its braces; an expression's text is a valid arrow body
+ * as-is). Walks the callback body AST and carries it as structured segments
+ * — JS text (types stripped) interleaved with compiled JSX-leaf IR — never
+ * as a sentinel-bearing string (the write-side rule in CLAUDE.md; same shape
+ * as the map-preamble carrier).
  */
 function buildFlatMapCallback(
   callback: ts.ArrowFunction | ts.FunctionExpression,
-  body: ts.Block,
+  body: ts.Block | ts.Expression,
   ctx: TransformContext,
 ): FlatMapCallback | undefined {
   if (!containsJsx(body)) return undefined

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 277,
+    "totalFixtures": 278,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -2226,6 +2226,56 @@
           "kind": "refusal",
           "codes": [
             "BF101"
+          ]
+        }
+      },
+      "flatmap-expression-body": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
           ]
         }
       },
@@ -2756,6 +2806,10 @@
       "find-typeof-predicate": {
         "description": "Off-subset `.find()` predicate (typeof) — JS-runtime faithful, DSL diagnostic",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/find-typeof-predicate.ts"
+      },
+      "flatmap-expression-body": {
+        "description": "JSX-returning `.flatMap()` expression body — segments carrier, adapter-gated on DSL",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/flatmap-expression-body.ts"
       },
       "flatmap-typeof-projection": {
         "description": "Off-subset `.flatMap()` projection (typeof) — JS-runtime faithful, DSL diagnostic",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1886,11 +1886,11 @@
       }
     },
     "identifier": {
-      "total": 258,
+      "total": 259,
       "cells": {
         "hono": {
-          "pass": 257,
-          "total": 258,
+          "pass": 258,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1902,7 +1902,7 @@
         },
         "blade": {
           "pass": 242,
-          "total": 258,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1936,6 +1936,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -1982,7 +1986,7 @@
         },
         "erb": {
           "pass": 243,
-          "total": 258,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2010,6 +2014,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -2056,7 +2064,7 @@
         },
         "go-template": {
           "pass": 242,
-          "total": 258,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2090,6 +2098,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -2136,7 +2148,7 @@
         },
         "jinja": {
           "pass": 242,
-          "total": 258,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2170,6 +2182,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -2216,7 +2232,7 @@
         },
         "minijinja": {
           "pass": 242,
-          "total": 258,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2250,6 +2266,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -2296,7 +2316,7 @@
         },
         "mojolicious": {
           "pass": 243,
-          "total": 258,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2324,6 +2344,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -2370,7 +2394,7 @@
         },
         "twig": {
           "pass": 242,
-          "total": 258,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2404,6 +2428,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -2450,7 +2478,7 @@
         },
         "xslate": {
           "pass": 242,
-          "total": 258,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2484,6 +2512,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -3082,11 +3114,11 @@
       }
     },
     "member": {
-      "total": 137,
+      "total": 138,
       "cells": {
         "hono": {
-          "pass": 136,
-          "total": 137,
+          "pass": 137,
+          "total": 138,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3098,7 +3130,7 @@
         },
         "blade": {
           "pass": 121,
-          "total": 137,
+          "total": 138,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3132,6 +3164,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -3178,7 +3214,7 @@
         },
         "erb": {
           "pass": 122,
-          "total": 137,
+          "total": 138,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3206,6 +3242,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -3252,7 +3292,7 @@
         },
         "go-template": {
           "pass": 121,
-          "total": 137,
+          "total": 138,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3286,6 +3326,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -3332,7 +3376,7 @@
         },
         "jinja": {
           "pass": 121,
-          "total": 137,
+          "total": 138,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3366,6 +3410,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -3412,7 +3460,7 @@
         },
         "minijinja": {
           "pass": 121,
-          "total": 137,
+          "total": 138,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3446,6 +3494,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -3492,7 +3544,7 @@
         },
         "mojolicious": {
           "pass": 122,
-          "total": 137,
+          "total": 138,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3520,6 +3572,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -3566,7 +3622,7 @@
         },
         "twig": {
           "pass": 121,
-          "total": 137,
+          "total": 138,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3600,6 +3656,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -3646,7 +3706,7 @@
         },
         "xslate": {
           "pass": 121,
-          "total": 137,
+          "total": 138,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3680,6 +3740,10 @@
             },
             {
               "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-expression-body",
               "issues": []
             },
             {
@@ -3900,43 +3964,91 @@
       }
     },
     "template-literal": {
-      "total": 27,
+      "total": 28,
       "cells": {
         "hono": {
-          "pass": 27,
-          "total": 27
+          "pass": 28,
+          "total": 28
         },
         "blade": {
           "pass": 27,
-          "total": 27
+          "total": 28,
+          "gaps": [
+            {
+              "fixture": "flatmap-expression-body",
+              "issues": []
+            }
+          ]
         },
         "erb": {
           "pass": 27,
-          "total": 27
+          "total": 28,
+          "gaps": [
+            {
+              "fixture": "flatmap-expression-body",
+              "issues": []
+            }
+          ]
         },
         "go-template": {
           "pass": 27,
-          "total": 27
+          "total": 28,
+          "gaps": [
+            {
+              "fixture": "flatmap-expression-body",
+              "issues": []
+            }
+          ]
         },
         "jinja": {
           "pass": 27,
-          "total": 27
+          "total": 28,
+          "gaps": [
+            {
+              "fixture": "flatmap-expression-body",
+              "issues": []
+            }
+          ]
         },
         "minijinja": {
           "pass": 27,
-          "total": 27
+          "total": 28,
+          "gaps": [
+            {
+              "fixture": "flatmap-expression-body",
+              "issues": []
+            }
+          ]
         },
         "mojolicious": {
           "pass": 27,
-          "total": 27
+          "total": 28,
+          "gaps": [
+            {
+              "fixture": "flatmap-expression-body",
+              "issues": []
+            }
+          ]
         },
         "twig": {
           "pass": 27,
-          "total": 27
+          "total": 28,
+          "gaps": [
+            {
+              "fixture": "flatmap-expression-body",
+              "issues": []
+            }
+          ]
         },
         "xslate": {
           "pass": 27,
-          "total": 27
+          "total": 28,
+          "gaps": [
+            {
+              "fixture": "flatmap-expression-body",
+              "issues": []
+            }
+          ]
         }
       },
       "source": {
@@ -3945,9 +4057,10 @@
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L173"
       },
       "example": {
-        "fixture": "input",
-        "description": "site/ui Input — native text field survives hydration + accepts typing",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/input.ts"
+        "fixture": "flatmap-expression-body",
+        "description": "JSX-returning `.flatMap()` expression body — segments carrier, adapter-gated on DSL",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/flatmap-expression-body.ts",
+        "code": "`${it.id}:${tag}`"
       }
     },
     "unary": {


### PR DESCRIPTION
Fixes **BUG-1** from the tagged-todo SSR/hydration audit (#2385) — first PR in a stack of three (BUG-1 → BUG-2 → BUG-3/4).

## Problem

A `.flatMap()` arrow with an **expression** body returning JSX:

```tsx
<ul>{todos().flatMap(t => t.tags.map(tag => <li key={`${t.id}:${tag}`}>{tag}</li>))}</ul>
```

fell through every `transformMapCall` dispatch arm to the `IRExpression` scalar path with **zero diagnostics**. `ctx.getJS` strips types, not JSX, so the raw callback — JSX included — spliced verbatim into the client bundle. The module is invalid JS (`Unexpected token '<'`), so **the whole component silently fails to hydrate** while SSR looks correct. The braced twin (`{ return t.tags.map(...) }`) already rode the `FlatMapCallback` structured-segments carrier; the unbraced form is the same shape minus the braces.

This is exactly the "raw JSX in the client bundle" leak class the Stage-3 root cure (`spec/callback-fidelity.md`) exists to prevent — it survived because the expression-body shape was outside both the dispatch and the `map-body-no-silent-divergence` sweep.

## Fix (three structural changes, sound-or-loud)

1. **Route the shape through the existing carrier.** `buildFlatMapCallback` now accepts a block *or* expression body (segment reconstruction and the SSR `rawBody` are position-based, so both flow through identically), and `transformMapCall` routes any JSX-bearing non-block flatMap body through it, parenthesized or not. SSR (Hono) and the hydrate template render it correctly.
2. **Structural net at the scalar fallthrough.** A map-like callback whose body carries an **inline JSX literal** but produced no loop lowering now refuses loudly (BF021) instead of leaking — any future recognizer gap in this class becomes a diagnostic, not a silent SyntaxError. (A JSX-helper *call* — `map(t => renderItem(t))` — carries no inline JSX literal and legitimately stays on the reactive-text path.)
3. **Adapter gate for segment-carried flatMap bodies.** A DSL template runtime can't execute the body at SSR — pre-gate, the Go adapter emitted `{{range …}}{{end}}` with an **empty body** (silent divergence, block bodies included). DSL targets now refuse with BF021 + the `/* @client */` escape, mirroring the const-preamble and array-builder gates. JS runtimes are unaffected.

## Tests / fixtures (change-time coupling)

- `map-body-no-silent-divergence.test.ts`: four new shapes (expression body, parenthesized, signal-array, JSX-inside-unrecognized-call) across JS + DSL tiers.
- `flatmap-segments.test.ts`: expression-body pins (segments carrier, `escapeText`, `_p.` rewrite in hydrate templates).
- New conformance fixture `flatmap-expression-body` (leaf data carries `<`, `&`, `"`, `'`) + BF021 `conformancePins` entries on all eight DSL adapters + regenerated `coverage-map.json`.
- The fixture is CSR-skip-listed with a pointer to the pre-existing CSR/SSR flatMap-leaf `data-key` asymmetry; the stacked client-loop rewiring PR removes the skip.

## Scope boundary

The client-side `mapArray` wiring for flatMap loops (un-flattened source, `null` keyFn, empty item template → item loss at hydration, `cloneNode(null)` crash on add) is a separate pre-existing defect shared by block and expression bodies alike — **fixed by the next PR in this stack** (BUG-2).

## Verification

- `bun test packages/jsx` — 2694 pass / 0 fail
- `bun test packages/adapter-tests` — 1425 pass / 0 fail
- `bun test packages/adapter-hono` — 972 pass / 0 fail
- `bun test packages/adapter-go-template` — 1177 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_