### PR TITLE
benchmarks(ssr): Stage 0 measurement spike for slot unification (claim-once prototype)

### DIFF
--- a/benchmarks/ssr/apps/barefoot-claim/build.ts
+++ b/benchmarks/ssr/apps/barefoot-claim/build.ts
@@ -1,0 +1,94 @@
+/**
+ * Production build for the barefoot-claim Stage 0 spike app
+ * (spec/slot-unification.md). Derives its SSR HTML from the real barefoot
+ * SSR pipeline via ./lib/render-server.ts (which calls barefoot's real
+ * renderPage then strips markers per ./lib/strip-markers.ts — see that
+ * module's docstring for exactly what's elided and what's kept), and
+ * bundles the hand-written claim-once client (./client/hydrate.js) as the
+ * "shipped hydration JS" — no @barefootjs/client runtime included, since
+ * this prototype doesn't use it (see hydrate.js's docstring for the list
+ * of things a real implementation would still need that this skips).
+ *
+ * lib/render-server.ts transitively imports barefoot's real
+ * lib/render-server.ts, which needs the @barefootjs/* + hono symlinks
+ * barefoot/build.ts's ensureWorkspaceLinks() creates under
+ * apps/barefoot/node_modules (gitignored, so absent on a fresh clone).
+ * Build that sibling app first if those links aren't there yet — cheap to
+ * skip once present, and bench-ssr.ts builds barefoot as its own framework
+ * anyway so this is rarely the first thing to create them.
+ */
+import { mkdir, cp, rm } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { build as buildBarefoot } from '../barefoot/build.ts'
+import rows from '../../data.json'
+
+const appDir = dirname(fileURLToPath(import.meta.url))
+const barefootAppDir = join(appDir, '..', 'barefoot')
+const distDir = join(appDir, 'dist')
+const sharedStylesPath = join(appDir, '..', '..', '..', 'apps', 'shared', 'styles.css')
+const clientEntry = join(appDir, 'client', 'hydrate.js')
+
+export async function build(): Promise<void> {
+  if (!existsSync(join(barefootAppDir, 'node_modules', '@barefootjs'))) {
+    await buildBarefoot()
+  }
+
+  // Dynamic import, not a top-level one: this module (and everything it
+  // statically imports, transitively including barefoot's real
+  // lib/render-server.ts) must not be evaluated until the symlink check
+  // above has run — a top-level import would resolve @barefootjs/* before
+  // ensureWorkspaceLinks() had a chance to create them on a fresh clone.
+  const { renderPage } = await import('./lib/render-server.ts')
+
+  if (existsSync(distDir)) await rm(distDir, { recursive: true, force: true })
+  await mkdir(distDir, { recursive: true })
+
+  const ssrHtml = await renderPage(rows)
+
+  const result = await Bun.build({
+    entrypoints: [clientEntry],
+    target: 'browser',
+    format: 'esm',
+    minify: true,
+    naming: 'app.client.js',
+    define: {
+      'process.env.NODE_ENV': '"production"',
+    },
+  })
+
+  if (!result.success) {
+    for (const message of result.logs) console.error(message)
+    throw new Error('barefoot-claim SSR bench app build failed')
+  }
+
+  for (const output of result.outputs) {
+    const bytes = await output.arrayBuffer()
+    await Bun.write(join(distDir, output.path.split('/').pop()!), bytes)
+  }
+
+  await cp(sharedStylesPath, join(distDir, 'styles.css'))
+
+  await Bun.write(
+    join(distDir, 'index.html'),
+    `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>BarefootJS SSR Bench — BarefootJS (claim-once spike)</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div id="app">${ssrHtml}</div>
+    <script type="module" src="./app.client.js"></script>
+  </body>
+</html>
+`,
+  )
+}
+
+if (import.meta.main) {
+  await build()
+  console.log('barefoot-claim: built SSR bench to benchmarks/ssr/apps/barefoot-claim/dist')
+}

--- a/benchmarks/ssr/apps/barefoot-claim/client/hydrate.js
+++ b/benchmarks/ssr/apps/barefoot-claim/client/hydrate.js
@@ -1,0 +1,93 @@
+/**
+ * barefoot-claim — claim-once hydration prototype.
+ * spec/slot-unification.md Stage 0 spike for hypotheses (a)/(b)/(c).
+ *
+ * Hand-written, plain JS, NO framework — this is a throwaway prototype of
+ * what a claim-plan-based hydrator's *shape of work* would look like for
+ * this one benchmark row, not a general-purpose runtime. It hardcodes the
+ * one row template this bench uses instead of deriving child paths from a
+ * compiled claim plan (spec section 4's "one claim mechanism"). See the
+ * spike report for the list of things a real implementation would still
+ * need that this prototype skips (signals, effect scheduling, multi-shape
+ * templates, nested components, nested loops, nested conditionals, nested
+ * `bf-s` scoping, nested marker fallback for adjacent-text/empty-region
+ * cases, etc.) — this prototype's number is a CEILING, not a design.
+ *
+ * Row shape, after marker elision (see ../lib/strip-markers.ts) — the
+ * bf-loop boundary comments and `data-key` anchor survive elision, this
+ * row's own text-slot pairs and `bf="sN"` scope attrs do not:
+ *
+ *   <tr class="" data-key="N">                                   tr
+ *     <td class="col-md-1">ID_TEXT</td>                          [0].firstChild
+ *     <td class="col-md-4"><a class="lbl">LABEL_TEXT</a></td>    [1].firstChild.firstChild
+ *     <td class="col-md-1"><a class="remove">x</a></td>
+ *     <td class="col-md-6"></td>
+ *   </tr>
+ *
+ * Hydration itself (main(), below) does ZERO per-row work: one delegated
+ * click listener on #tbody, nothing else — no loop over the 1,000 rows,
+ * no per-row effect, no per-row marker scan. A row's dynamic positions
+ * (its id/label text nodes — the class attribute lives on the tr itself,
+ * no child path needed for that one) are claimed lazily, on the row's
+ * FIRST write, and the refs are held in `claims` (one shared WeakMap) for
+ * every later write to that row. A row that is never clicked is never
+ * claimed and never walked.
+ */
+
+performance.mark('hydrate-start')
+
+// One shared claim table (spec section 3(a)/4): WeakMap<tr, RowClaim>.
+// RowClaim = { tr, idText, labelText }.
+const claims = new WeakMap()
+
+/** Claim a row's dynamic positions via hardcoded child paths — once. */
+function claimRow(tr) {
+  let claim = claims.get(tr)
+  if (claim) return claim
+  claim = {
+    tr,
+    idText: tr.children[0].firstChild,
+    labelText: tr.children[1].firstChild.firstChild,
+  }
+  claims.set(tr, claim)
+  return claim
+}
+
+let selectedTr = null
+
+/** Row selection: write-through on held refs, claiming lazily as needed. */
+function selectRow(tr) {
+  if (selectedTr === tr) return
+  if (selectedTr) claimRow(selectedTr).tr.setAttribute('class', '')
+  claimRow(tr).tr.setAttribute('class', 'danger')
+  selectedTr = tr
+}
+
+function main() {
+  const tbody = document.getElementById('tbody')
+  if (tbody) {
+    // The one delegated listener — attached once, at hydration, and never
+    // again touched per-row. Resolves the clicked row by `data-key`
+    // (spec section 3(a): "resolve rows by data-key").
+    tbody.addEventListener('click', (event) => {
+      const target = event.target
+      const anchor = target && target.closest ? target.closest('a.lbl') : null
+      if (!anchor || !tbody.contains(anchor)) return
+      const tr = anchor.closest('tr[data-key]')
+      if (!tr) return
+      selectRow(tr)
+    })
+  }
+
+  // Same double-rAF fence + hydrated flag every app in this bench uses
+  // (see benchmarks/ssr/apps/barefoot/build-impl.ts's CLIENT_ENTRY_WRAPPER).
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      performance.mark('hydrate-end')
+      performance.measure('hydrate', 'hydrate-start', 'hydrate-end')
+      document.body.dataset.hydrated = '1'
+    })
+  })
+}
+
+main()

--- a/benchmarks/ssr/apps/barefoot-claim/lib/render-server.ts
+++ b/benchmarks/ssr/apps/barefoot-claim/lib/render-server.ts
@@ -1,0 +1,21 @@
+/**
+ * Server render entry for the barefoot-claim Stage 0 spike.
+ *
+ * Reuses the REAL barefoot SSR pipeline (../../barefoot/lib/render-server.ts
+ * — compileJSX + HonoAdapter + renderToHtml, see that file's docstring) to
+ * produce byte-identical row HTML for the given rows, then applies the
+ * marker-elision transform (./strip-markers.ts) that a claim-once hydrator
+ * would let the compiler skip emitting in the first place. This is an
+ * honest per-call render + strip, not a cached/static read, so the n=20
+ * server-render timing bench-ssr.ts runs is a real (if slightly inflated
+ * by the extra regex pass) measurement — see the spike report's caveats.
+ */
+import { renderPage as renderBarefootPage, type RowData } from '../../barefoot/lib/render-server.ts'
+import { stripMarkers } from './strip-markers.ts'
+
+export type { RowData }
+
+export async function renderPage(rows: RowData[]): Promise<string> {
+  const html = await renderBarefootPage(rows)
+  return stripMarkers(html)
+}

--- a/benchmarks/ssr/apps/barefoot-claim/lib/strip-markers.ts
+++ b/benchmarks/ssr/apps/barefoot-claim/lib/strip-markers.ts
@@ -1,0 +1,41 @@
+/**
+ * Marker-elision transform for the claim-once Stage 0 spike
+ * (spec/slot-unification.md section 3(b)). Strips the two marker
+ * categories that a claim-plan-based hydrator (spec section 4) would no
+ * longer need at all, given a fixed row template shape and hardcoded
+ * child paths (see ../client/hydrate.js):
+ *
+ *  1. Text-slot comment pairs `<!--bf:sN-->…<!--/-->` — the compiler
+ *     currently wraps every text interpolation this way so the runtime
+ *     can re-find the text node at hydration/update time by scanning.
+ *     A claim-once hydrator resolves the text node once via a
+ *     compile-time child path and never scans again, so the pair is
+ *     redundant once the row shape is trusted (byte parity — the whole
+ *     premise of BarefootJS hydration already trusts SSR shape).
+ *  2. Per-element ` bf="sN"` scope attributes — used by the current
+ *     runtime's marker-based DOM query helpers (`G0`/`U0` in the compiled
+ *     client, see benchmarks/ssr/apps/barefoot/dist/app.client.js) to
+ *     re-find an element by scope id. A claim-once hydrator never queries
+ *     by these ids; it walks `tr.children[…]` directly.
+ *
+ * Deliberately NOT stripped (kept byte-for-byte from the real barefoot
+ * SSR output): `<!--bf-loop:l0-->`/`<!--bf-/loop:l0-->` boundaries (loop
+ * range boundaries — spec section 3(b)(iii), structurally required even
+ * under the target design), the root `bf-s="…"` component-scope attr, and
+ * `data-key` (keyed reconciliation anchor). `bf-r`/`bf-p` (the real
+ * hydration prop-JSON channel) are also left untouched — this spike's
+ * hand-written client doesn't read them, but stripping them isn't part of
+ * the (b) marker-elision hypothesis being measured here, so they're out of
+ * scope for this transform.
+ *
+ * Regex-on-HTML-text is fine here per CLAUDE.md's "don't regex-parse
+ * JS/TS" rule — that rule targets parsing *source code* (imports, JS/TS
+ * syntax) where string matching false-matches inside literals/comments.
+ * This is a plain-text strip of a small, closed, self-authored comment/
+ * attribute grammar in already-compiled HTML output, not code parsing.
+ */
+export function stripMarkers(html: string): string {
+  return html
+    .replace(/<!--bf:s\d+-->(.*?)<!--\/-->/g, '$1')
+    .replace(/ bf="s\d+"/g, '')
+}

--- a/benchmarks/ssr/bench-ssr-memory.ts
+++ b/benchmarks/ssr/bench-ssr-memory.ts
@@ -1,0 +1,90 @@
+/**
+ * Stage 0 spike addendum (spec/slot-unification.md) — post-hydration JS
+ * heap size for the SSR bench's four apps, n=3, forced GC, borrowing
+ * benchmarks/runner/bench-dom.ts's memory methodology (CDP
+ * `HeapProfiler.collectGarbage` + `Performance.getMetrics` /
+ * `JSHeapUsedSize`).
+ *
+ * NOT the same measurement as the "1755KB / 1480KB" figures quoted in
+ * spec/slot-unification.md — those come from bench-dom.ts's DOM-update
+ * suite (benchmarks/apps/, a different app harness), which measures the
+ * heap DELTA of a `#run` button click that CREATES 1,000 rows client-side.
+ * This script's apps are SSR'd (rows already exist as parsed HTML before
+ * any JS runs) and there's no equivalent "create" action to delta against
+ * — so this instead reports the ABSOLUTE post-hydration JS heap per app,
+ * which isolates each framework's/prototype's JS-side hydration bookkeeping
+ * (signals, effects, closures, listener maps) for the same 1,000-row DOM,
+ * not the DOM node memory itself (that part should be near-identical
+ * across apps modulo marker byte/node-count differences). Treat this as a
+ * DIRECTIONAL number for this spike, not as comparable to the DOM-suite
+ * figures — see the spike report's caveats.
+ *
+ * Usage:
+ *   PLAYWRIGHT_CHROMIUM_EXECUTABLE=/opt/pw-browsers/chromium \
+ *     bun benchmarks/ssr/bench-ssr-memory.ts
+ */
+import { join } from 'node:path'
+import { chromium, type Browser, type CDPSession, type Page } from '@playwright/test'
+import { chromiumLaunchOptions } from '../runner/chromium.ts'
+import { median, computeStats } from '../runner/stats.ts'
+import { startServer } from './serve.ts'
+
+const FRAMEWORKS = ['react', 'solid', 'barefoot', 'barefoot-claim'] as const
+const ITERS = 3
+
+async function waitHydrated(page: Page): Promise<void> {
+  await page.waitForFunction(() => document.body.dataset.hydrated === '1', undefined, { timeout: 10_000 })
+}
+
+async function forceGC(session: CDPSession): Promise<void> {
+  await session.send('HeapProfiler.collectGarbage')
+}
+
+async function getJsHeapUsed(session: CDPSession): Promise<number> {
+  const { metrics } = await session.send('Performance.getMetrics')
+  const m = metrics.find((x) => x.name === 'JSHeapUsedSize')
+  return m ? m.value : Number.NaN
+}
+
+async function measureHeapOnce(browser: Browser, appUrl: string): Promise<number> {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await page.goto(appUrl)
+  await waitHydrated(page)
+
+  const session = await context.newCDPSession(page)
+  await session.send('Performance.enable')
+  await forceGC(session)
+  const heap = await getJsHeapUsed(session)
+
+  await context.close()
+  return heap
+}
+
+function fmtBytes(n: number): string {
+  return `${(n / 1024).toFixed(1)}KB`
+}
+
+async function main() {
+  const server = startServer(0)
+  const browser = await chromium.launch(chromiumLaunchOptions())
+  try {
+    console.log(`Post-hydration JS heap (forced GC), n=${ITERS}, 1000 rows\n`)
+    for (const framework of FRAMEWORKS) {
+      const appUrl = `http://localhost:${server.port}/${framework}/index.html`
+      const iterations: number[] = []
+      for (let i = 0; i < ITERS; i++) iterations.push(await measureHeapOnce(browser, appUrl))
+      const stats = computeStats(iterations)
+      console.log(
+        `${framework.padEnd(16)} median ${fmtBytes(median(iterations)).padStart(10)}  (n=${ITERS}: ${iterations
+          .map(fmtBytes)
+          .join(', ')})  stdev ${fmtBytes(stats.stddev)}`,
+      )
+    }
+  } finally {
+    await browser.close()
+    server.stop()
+  }
+}
+
+await main()

--- a/benchmarks/ssr/bench-ssr.ts
+++ b/benchmarks/ssr/bench-ssr.ts
@@ -48,7 +48,11 @@ const appsRoot = join(ssrDir, 'apps')
 const repoRoot = join(ssrDir, '..', '..')
 const resultsDir = join(ssrDir, '..', 'results')
 
-const ALL_FRAMEWORKS = ['react', 'solid', 'barefoot'] as const
+// 'barefoot-claim' is the spec/slot-unification.md Stage 0 measurement
+// spike (claim-once hydration prototype) — see
+// benchmarks/ssr/apps/barefoot-claim/build.ts. Same methodology, extra
+// column; not a real framework, throwaway per that spec's Stage 0.
+const ALL_FRAMEWORKS = ['react', 'solid', 'barefoot', 'barefoot-claim'] as const
 type Framework = (typeof ALL_FRAMEWORKS)[number]
 
 // ---------------------------------------------------------------------------
@@ -73,6 +77,7 @@ const RENDER_SERVER_MODULE: Record<Framework, string> = {
   react: join(appsRoot, 'react', 'src', 'render-server.tsx'),
   solid: join(appsRoot, 'solid', 'src', 'render-server.ts'),
   barefoot: join(appsRoot, 'barefoot', 'lib', 'render-server.ts'),
+  'barefoot-claim': join(appsRoot, 'barefoot-claim', 'lib', 'render-server.ts'),
 }
 
 async function measureServerRender(framework: Framework): Promise<{ iterations: number[]; stats: Stats; html: string }> {


### PR DESCRIPTION
Executes `spec/slot-unification.md` §5 **Stage 0** (merged in #2394): measure the claim-once hypotheses before committing to Stages 1–5. Adds a fourth SSR-bench app `barefoot-claim` — real barefoot SSR output with text-slot pairs and `bf="sN"` attrs stripped (loop boundaries / `bf-s` / `data-key` kept), plus a hand-written claim-once client: **one** delegated listener at hydration, zero per-row work, row-level lazy claim on first write via hardcoded child paths. Same interactivity gate, same double-rAF fencing. Also adds `bench-ssr-memory.ts` (post-hydration heap, forced GC).

## Results (agent runs ×2, independently re-verified ×1 — all consistent)

| Metric | react | solid | barefoot | **barefoot-claim** |
|---|---|---|---|---|
| Hydration (median, n=10) | 42–46ms | 23–26ms | 28–32ms | **24–30ms** |
| Interactivity gate | PASS | PASS | PASS | **PASS** |
| HTML (raw / gzip) | 220.0 / 14.9KB | 235.9 / 18.6KB | 318.6 / 19.5KB | **263.9 / 18.9KB** |
| Client JS (raw / gzip) | 182.3 / 58.1KB | 17.0 / 6.6KB | 19.6 / 7.3KB | 0.7 / 0.4KB (no runtime — ceiling) |
| Post-hydration heap (n=3, stdev ≤4KB) | 3477KB | 2586KB | 2729KB | **1169KB** |

## Reading (what gates Stages 1–5)

- **Memory is the headline** (hypothesis (c)): −57% vs current, well under solid, perfectly reproducible. Even discounting the no-runtime ceiling heavily, row-level lazy claim + fewer live closures/DOM nodes has real headroom.
- **Hydration** (hypothesis (a)): consistent but modest ~2–4ms (~10%) — page-nav/script-parse dominates this methodology at 1k rows; the mechanism works (zero per-row hydration cost proven) but is not the big prize at this scale.
- **HTML size** (hypothesis (b), corrected): raw −54.7KB (exact byte-math match with the marker census: 39.1KB pairs + 15.6KB `bf` attrs) but **gzip only −0.6KB** — markers compress too well for a transfer-size win. (b)'s real value routes through DOM node count (4,000 comments + 2,001 attrs per 1k rows) into memory/parse, not the wire. The spec should reframe (b) accordingly.
- barefoot-claim's server-render column is barefoot + a strip-regex pass (prototype artifact, noisy under load); the real design elides at template emission with zero server cost.

Full ceiling caveats are in the spike client's header and the run journal: hardcoded row shape, no signals/effects/mapArray shipped, no prop-hydration channel — a real implementation lands between `barefoot` and `barefoot-claim`.

**Recommendation**: proceed to Stages 1–2 (claim infrastructure, client-only, no SSR byte change); keep Stage 4 (marker elision) but justified by node-count/memory rather than transfer size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_