### PR TITLE
feat(client): claim-plan interpreter and claimed-slot primitives (slot unification A2)

### DIFF
--- a/packages/client/__tests__/runtime/claim-slots.test.ts
+++ b/packages/client/__tests__/runtime/claim-slots.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit tests for `claimSlots` / `lazySlots` — the claim-plan interpreter
+ * and claimed-slot primitives (slot unification A2,
+ * `spec/slot-unification.md` §4/§5-A2). Anchors are the existing
+ * `<!--bf:sN-->…<!--/-->` marker pairs (SSR bytes unchanged in Step A), but
+ * once claimed, writes go through held references and never re-scan.
+ */
+
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+const { claimSlots, lazySlots } = await import('../../src/runtime/claim-slots.ts')
+type SlotSpec = import('../../src/runtime/claim-slots.ts').SlotSpec
+
+function mount(html: string): HTMLElement {
+  const host = document.createElement('div')
+  host.innerHTML = html
+  return host
+}
+
+function withWarnings(fn: () => void): string[] {
+  const warnings: string[] = []
+  const orig = console.warn
+  console.warn = (msg: string) => {
+    warnings.push(String(msg))
+  }
+  try {
+    fn()
+  } finally {
+    console.warn = orig
+  }
+  return warnings
+}
+
+describe('claimSlots — text kind', () => {
+  test('adopts an existing Text node after the marker', () => {
+    const root = mount('<div><!--bf:s0-->hello<!--/--></div>')
+    const row = root.firstElementChild as HTMLElement
+    const plan: SlotSpec[] = [{ id: 's0', kind: 'text', path: [0] }]
+    const before = row.childNodes[1]
+    expect(before.nodeType).toBe(Node.TEXT_NODE)
+
+    const claimed = claimSlots(row, plan)
+    claimed.write('s0', 'updated')
+
+    expect(row.childNodes[1]).toBe(before) // adopted, not replaced
+    expect(row.innerHTML).toBe('<!--bf:s0-->updated<!--/-->')
+  })
+
+  test('creates a Text node when SSR emitted an empty value', () => {
+    const root = mount('<div><!--bf:s1--><!--/--></div>')
+    const row = root.firstElementChild as HTMLElement
+    const plan: SlotSpec[] = [{ id: 's1', kind: 'text', path: [0] }]
+
+    // Claiming (not just writing) creates the missing Text node immediately.
+    claimSlots(row, plan)
+    expect(row.childNodes[1]?.nodeType).toBe(Node.TEXT_NODE)
+    expect(row.innerHTML).toBe('<!--bf:s1--><!--/-->')
+  })
+
+  test('writes preserve Text node identity across repeated writes', () => {
+    const root = mount('<div><!--bf:s2-->x<!--/--></div>')
+    const row = root.firstElementChild as HTMLElement
+    const plan: SlotSpec[] = [{ id: 's2', kind: 'text', path: [0] }]
+
+    const claimed = claimSlots(row, plan)
+    const ref = row.childNodes[1]
+    claimed.write('s2', 'one')
+    expect(row.childNodes[1]).toBe(ref)
+    claimed.write('s2', 'two')
+    expect(row.childNodes[1]).toBe(ref)
+    expect(row.innerHTML).toBe('<!--bf:s2-->two<!--/-->')
+  })
+})
+
+describe('claimSlots — markup kind', () => {
+  test('holds boundaries and patches string content', () => {
+    const root = mount('<div><!--bf:s3-->old<!--/--></div>')
+    const row = root.firstElementChild as HTMLElement
+    const plan: SlotSpec[] = [{ id: 's3', kind: 'markup', path: [0] }]
+
+    const claimed = claimSlots(row, plan)
+    claimed.write('s3', '<b>new</b>')
+    expect(row.innerHTML).toBe('<!--bf:s3--><b>new</b><!--/-->')
+  })
+
+  test('nested bf: comment pairs inside the range do not break matching', () => {
+    const root = mount(
+      '<div><!--bf:s4-->outer<!--bf:s9-->inner<!--/-->tail<!--/--><p>after</p></div>',
+    )
+    const row = root.firstElementChild as HTMLElement
+    const plan: SlotSpec[] = [{ id: 's4', kind: 'markup', path: [0] }]
+
+    const claimed = claimSlots(row, plan)
+    claimed.write('s4', '<span>replaced</span>')
+    expect(row.innerHTML).toBe('<!--bf:s4--><span>replaced</span><!--/--><p>after</p>')
+  })
+
+  test('empty -> content -> empty roundtrip; boundaries never removed', () => {
+    const root = mount('<div><!--bf:s5--><!--/--></div>')
+    const row = root.firstElementChild as HTMLElement
+    const plan: SlotSpec[] = [{ id: 's5', kind: 'markup', path: [0] }]
+
+    const claimed = claimSlots(row, plan)
+    const start = row.childNodes[0]
+    const end = row.childNodes[1]
+
+    claimed.write('s5', 'hello')
+    expect(row.innerHTML).toBe('<!--bf:s5-->hello<!--/-->')
+    claimed.write('s5', '')
+    expect(row.innerHTML).toBe('<!--bf:s5--><!--/-->')
+
+    const comments = Array.from(row.childNodes).filter(n => n.nodeType === Node.COMMENT_NODE)
+    expect(comments).toEqual([start, end])
+  })
+
+  test('splices a Node value in by identity', () => {
+    const root = mount('<div><!--bf:s6-->old<!--/--></div>')
+    const row = root.firstElementChild as HTMLElement
+    const plan: SlotSpec[] = [{ id: 's6', kind: 'markup', path: [0] }]
+
+    const el = document.createElement('b')
+    el.textContent = 'X'
+    const claimed = claimSlots(row, plan)
+    claimed.write('s6', el)
+
+    expect(row.innerHTML).toBe('<!--bf:s6--><b>X</b><!--/-->')
+    expect(row.childNodes[1]).toBe(el)
+  })
+})
+
+describe('lazySlots', () => {
+  test('does nothing to the DOM before the first write', () => {
+    const root = mount('<div><!--bf:s7--><!--/--><!--bf:s8-->x<!--/--></div>')
+    const row = root.firstElementChild as HTMLElement
+    const plan: SlotSpec[] = [
+      { id: 's7', kind: 'text', path: [0] },
+      { id: 's8', kind: 'markup', path: [2] },
+    ]
+    const before = Array.from(row.childNodes)
+
+    lazySlots(row, plan) // constructing the writer must not touch the DOM
+
+    expect(Array.from(row.childNodes)).toEqual(before)
+    // s7 is an empty text slot — claiming it would have created a Text node.
+    expect(row.childNodes[1]?.nodeType).toBe(Node.COMMENT_NODE)
+  })
+
+  test('first write claims the WHOLE plan at once (batch-claim)', () => {
+    const root = mount('<div><!--bf:sA-->A0<!--/--><!--bf:sB-->B0<!--/--></div>')
+    const row = root.firstElementChild as HTMLElement
+    const plan: SlotSpec[] = [
+      { id: 'sA', kind: 'text', path: [0] },
+      { id: 'sB', kind: 'markup', path: [3] },
+    ]
+
+    const write = lazySlots(row, plan)
+    write('sA', 'A1') // claims sA AND sB now, holding sB's TRUE end ref
+
+    // External mutation: inject a spurious `/`-comment inside sB's range,
+    // strictly before the TRUE end comment already held.
+    const trueEnd = row.childNodes[5]
+    expect((trueEnd as Comment).nodeValue).toBe('/')
+    row.insertBefore(document.createComment('/'), trueEnd)
+
+    write('sB', 'B1')
+
+    // If sB's boundaries had been (re-)resolved by a fresh scan at this
+    // point instead of during the batch claim, the scan would stop at the
+    // injected `/` and leave the true end (plus the injected one) behind —
+    // producing a trailing double `<!--/--><!--/-->`. Hitting the
+    // pre-mutation ref instead clears through the injected node and leaves
+    // exactly one `/`.
+    expect(row.innerHTML).toBe('<!--bf:sA-->A1<!--/--><!--bf:sB-->B1<!--/-->')
+  })
+})
+
+describe('path-miss fallback', () => {
+  test('falls back to a marker scan and warns when the path misses', () => {
+    const root = mount('<div><!--bf:s10-->hello<!--/--></div>')
+    const row = root.firstElementChild as HTMLElement
+    // Deliberately wrong path (out of range) so the claim must fall back.
+    const plan: SlotSpec[] = [{ id: 's10', kind: 'text', path: [99] }]
+
+    let claimed: ReturnType<typeof claimSlots>
+    const warnings = withWarnings(() => {
+      claimed = claimSlots(row, plan)
+    })
+    claimed.write('s10', 'updated')
+
+    expect(row.innerHTML).toBe('<!--bf:s10-->updated<!--/-->')
+    expect(warnings.some(w => w.includes('s10') && w.includes('falling back'))).toBe(true)
+  })
+
+  test('fallback scan skips a same-id marker owned by a nested bf-s scope', () => {
+    const root = mount(
+      '<div><section bf-s="Badge_x1"><!--bf:s0-->child<!--/--></section><!--bf:s0-->own<!--/--></div>',
+    )
+    const row = root.firstElementChild as HTMLElement
+    // Wrong path forces the fallback scan; the scan must land on the row's
+    // OWN marker, never the nested child's same-numbered one.
+    const plan: SlotSpec[] = [{ id: 's0', kind: 'text', path: [99] }]
+
+    const claimed = claimSlots(row, plan)
+    claimed.write('s0', 'patched')
+
+    expect(row.innerHTML).toBe(
+      '<section bf-s="Badge_x1"><!--bf:s0-->child<!--/--></section><!--bf:s0-->patched<!--/-->',
+    )
+  })
+
+  test('totally missing slot warns and no-ops without breaking other slots', () => {
+    const root = mount('<div><!--bf:s11-->kept<!--/--></div>')
+    const row = root.firstElementChild as HTMLElement
+    const plan: SlotSpec[] = [
+      { id: 's11', kind: 'text', path: [0] },
+      { id: 's12', kind: 'text', path: [99] }, // no bf:s12 marker anywhere
+    ]
+
+    const warnings = withWarnings(() => {
+      const claimed = claimSlots(row, plan)
+      claimed.write('s11', 'updated')
+      claimed.write('s12', 'never applied')
+    })
+
+    expect(row.innerHTML).toBe('<!--bf:s11-->updated<!--/-->')
+    expect(warnings.some(w => w.includes('s12'))).toBe(true)
+  })
+})

--- a/packages/client/src/runtime/claim-slots.ts
+++ b/packages/client/src/runtime/claim-slots.ts
@@ -1,0 +1,298 @@
+/**
+ * Claim-plan interpreter and claimed-slot primitives (slot unification
+ * Step A2, `spec/slot-unification.md` §4/§5-A2).
+ *
+ * This module is the ONE claim mechanism the spec's §4 target architecture
+ * describes: a compile-time `ClaimPlan` (per-slot child-index paths from a
+ * claim root down to the slot's anchor comment) is resolved ONCE — either
+ * eagerly (`claimSlots`) or lazily on first write (`lazySlots`) — and every
+ * later write goes through the held reference, never re-scanning the DOM.
+ * It supersedes (but, per A2's scope, does not yet replace — that's A3) the
+ * four mechanisms inventoried in §1: `$t`/text-effect writes, `__bfText`,
+ * `patchSlotRange`, and `updateClientMarker`.
+ *
+ * Anchors are still the existing `<!--bf:sN-->…<!--/-->` marker pairs — SSR
+ * bytes are unchanged in Step A (§5, §6) so the new client claims against
+ * known-good SSR output. A path is only required to be valid AT THE MOMENT
+ * OF CLAIM (§2): once a 'text' Text node or a 'markup' boundary pair is
+ * held, subsequent writes never consult the path or the marker again, so a
+ * sibling slot's later variable-length change cannot invalidate anything
+ * already claimed.
+ *
+ * Kind contracts (mirroring the mechanisms being superseded — this is the
+ * "one slot concept with an identity contract" of §4):
+ *   - 'text': held ref is the Text node immediately after the anchor
+ *     comment, CREATED if SSR emitted an empty value (`textNodeAfterComment`,
+ *     exactly `$t`'s `tAfter` behavior). Writes are a `nodeValue` assignment
+ *     — the Text node's identity never changes, which is the guarantee
+ *     effect closures and `mapArray`'s same-key path rely on.
+ *   - 'markup': held ref is BOTH boundary comments (start = anchor, end =
+ *     the matching `<!--/-->` found by the same nesting-depth rule as
+ *     `patchSlotRange`). A string write clears everything strictly between
+ *     the boundaries and inserts freshly `<template>`-parsed HTML before
+ *     the end comment; a `Node` write clears the range and splices the node
+ *     in by identity (the `__bfText` live-Node case). The boundaries
+ *     themselves are never removed — same "permanent range" contract as
+ *     `patchSlotRange`. Because the end ref is already held, a write never
+ *     needs to re-walk for nesting depth — only the CLAIM does.
+ *
+ * Warn-don't-guess (§4, "one ownership rule"): a path that fails to resolve
+ * to its slot's own `bf:sN` comment — out of range, or shape drift where
+ * the path now lands on some other node — falls back to a marker scan
+ * within the claim root, using the same ownership rule as
+ * `patchSlotRange`/`query.ts`'s `$t`: a `bf:sN` comment owned by a nested
+ * `bf-s` scope (a child component's own same-numbered slot — ids are
+ * assigned per component, so collisions are expected) is never a candidate.
+ * If neither the path nor the fallback scan finds an owned marker, that one
+ * slot is dropped with a `console.warn` and the rest of the plan still
+ * claims — never guess a boundary, and never let one bad slot sink its
+ * siblings.
+ *
+ * Row-pristine lazy claim (§3(a)): `lazySlots` touches NOTHING until the
+ * first write, and that first write claims the WHOLE plan at once (not just
+ * the slot being written) — so no earlier write into one slot can shift a
+ * sibling slot's still-unclaimed path out from under it. A row that never
+ * updates never pays for a claim at all. `claimSlots` is the eager escape
+ * hatch for callers that cannot honor that invariant (streaming/portal
+ * paths that mutate row content before any write would occur, per §6's
+ * risk note) — it claims every slot in the plan immediately.
+ */
+
+import { BF_SCOPE } from '@barefootjs/shared'
+import { textNodeAfterComment } from './query.ts'
+
+/**
+ * A slot's compile-time descriptor. `path` is the list of child indices
+ * from the claim root to the slot's ANCHOR NODE — in Step A that anchor is
+ * always the existing `<!--bf:sN-->` start comment (markers are still
+ * emitted; Step B may point paths at other node kinds), so resolution
+ * walks `childNodes` by index with no assumption about the target's
+ * `nodeType` until the kind-specific claim inspects it. `id` is kept for
+ * diagnostics and as the marker-scan fallback's search key.
+ */
+export interface SlotSpec {
+  id: string
+  kind: 'text' | 'markup'
+  path: readonly number[]
+}
+
+export type ClaimPlan = readonly SlotSpec[]
+
+/** A claimed 'text' slot: the live Text node, held by identity forever. */
+interface ClaimedTextSlot {
+  readonly kind: 'text'
+  readonly node: Text
+}
+
+/**
+ * A claimed 'markup' slot: both boundary comments, held by identity.
+ * Content lives strictly between `start` and `end`; both survive every
+ * write.
+ */
+interface ClaimedMarkupSlot {
+  readonly kind: 'markup'
+  readonly start: Comment
+  readonly end: Comment
+}
+
+type ClaimedSlotRef = ClaimedTextSlot | ClaimedMarkupSlot
+
+/**
+ * The result of claiming a plan: a write door keyed by slot id. Writing an
+ * id that failed to claim (or was never in the plan) warns and no-ops —
+ * one bad/missing slot never breaks any other slot's writes.
+ */
+export interface ClaimedSlots {
+  write(id: string, value: unknown): void
+}
+
+/** `lazySlots`'s per-write function — the same shape `ClaimedSlots.write` has. */
+export type SlotWriter = (id: string, value: unknown) => void
+
+// --- path resolution ---
+
+/** Walk `childNodes` by index from `root`. No node-kind assumption — the
+ *  caller checks whether the result is actually the expected comment. */
+function resolvePath(root: Node, path: readonly number[]): Node | null {
+  let node: Node = root
+  for (const index of path) {
+    const child: Node | undefined = node.childNodes[index]
+    if (!child) return null
+    node = child
+  }
+  return node
+}
+
+function isSlotComment(node: Node | null, id: string): node is Comment {
+  return node != null && node.nodeType === Node.COMMENT_NODE && (node as Comment).nodeValue === `bf:${id}`
+}
+
+/**
+ * Fallback marker scan, used only when a slot's compile-time path fails to
+ * resolve to its own `bf:sN` comment (shape drift, or a plan built against
+ * a differently-shaped claim root). Mirrors `patchSlotRange`'s ownership
+ * loop: a same-id marker owned by a nested `bf-s` scope (a child
+ * component's own slot — ids collide across components by design) is
+ * skipped so the fallback can never claim into a child's content.
+ */
+function findOwnedMarker(root: Element, id: string): Comment | null {
+  const marker = `bf:${id}`
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_COMMENT)
+  while (walker.nextNode()) {
+    const comment = walker.currentNode as Comment
+    if (comment.nodeValue !== marker) continue
+    let owned = true
+    for (let el = comment.parentElement; el && el !== root; el = el.parentElement) {
+      if (el.hasAttribute(BF_SCOPE)) {
+        owned = false
+        break
+      }
+    }
+    if (owned) return comment
+  }
+  return null
+}
+
+/**
+ * Find the matching `<!--/-->` end comment for a 'markup' slot's start
+ * comment, using the same nesting-depth rule as `patchSlotRange`: any
+ * further `bf:`-prefixed comment along the way opens a nested region (a
+ * leaf rendered inside this one can carry its own ordinary slot markers)
+ * and increments a depth counter so that region's own `/` doesn't
+ * prematurely close this outer range. Runs once, at claim time — writes
+ * never need this since the end ref is held afterward.
+ */
+function findMarkupEnd(start: Comment): Comment | null {
+  let depth = 0
+  let node: Node | null = start.nextSibling
+  while (node) {
+    if (node.nodeType === Node.COMMENT_NODE) {
+      const value = (node as Comment).nodeValue ?? ''
+      if (value.startsWith('bf:')) {
+        depth++
+      } else if (value === '/') {
+        if (depth === 0) return node as Comment
+        depth--
+      }
+    }
+    node = node.nextSibling
+  }
+  return null
+}
+
+/**
+ * Resolve one slot's anchor comment: try the compile-time path first, fall
+ * back to an owned marker scan on any miss (path resolves to nothing, or to
+ * a node that isn't this slot's own comment — shape drift), and warn on
+ * either the fallback-needed or the total-miss case. Never throws — a bad
+ * slot returns `null` and the caller drops it from the claimed set.
+ */
+function resolveAnchor(root: Element, spec: SlotSpec): Comment | null {
+  const resolved = resolvePath(root, spec.path)
+  if (isSlotComment(resolved, spec.id)) return resolved
+
+  console.warn(
+    `[barefootjs] claim path for slot ${spec.id} did not resolve to its bf:${spec.id} marker; falling back to a scan`,
+  )
+  const found = findOwnedMarker(root, spec.id)
+  if (!found) {
+    console.warn(`[barefootjs] slot ${spec.id} marker not found; skipping`)
+  }
+  return found
+}
+
+/** Claim one slot per its kind's contract. `null` on any failure (already warned). */
+function claimOne(root: Element, spec: SlotSpec): ClaimedSlotRef | null {
+  const anchor = resolveAnchor(root, spec)
+  if (!anchor) return null
+
+  if (spec.kind === 'text') {
+    return { kind: 'text', node: textNodeAfterComment(anchor) }
+  }
+
+  const end = findMarkupEnd(anchor)
+  if (!end) {
+    console.warn(`[barefootjs] slot ${spec.id} has no end marker; skipping`)
+    return null
+  }
+  return { kind: 'markup', start: anchor, end }
+}
+
+// --- writes ---
+
+function writeText(ref: ClaimedTextSlot, value: unknown): void {
+  ref.node.nodeValue = String(value ?? '')
+}
+
+/** Remove every node strictly between `start` and `end` (both survive). */
+function clearMarkupRange(start: Comment, end: Comment): void {
+  const parent = end.parentNode
+  if (!parent) return
+  let node: Node | null = start.nextSibling
+  while (node && node !== end) {
+    const next = node.nextSibling
+    parent.removeChild(node)
+    node = next
+  }
+}
+
+function writeMarkup(ref: ClaimedMarkupSlot, value: unknown): void {
+  const { start, end } = ref
+  const parent = end.parentNode
+  if (!parent) return
+  clearMarkupRange(start, end)
+
+  if (typeof Node !== 'undefined' && value instanceof Node) {
+    parent.insertBefore(value, end)
+    return
+  }
+
+  const tpl = document.createElement('template')
+  tpl.innerHTML = String(value ?? '')
+  parent.insertBefore(tpl.content, end)
+}
+
+function writeSlot(refs: ReadonlyMap<string, ClaimedSlotRef>, id: string, value: unknown): void {
+  const ref = refs.get(id)
+  if (!ref) {
+    console.warn(`[barefootjs] no claimed slot for id ${id}; write ignored`)
+    return
+  }
+  if (ref.kind === 'text') {
+    writeText(ref, value)
+  } else {
+    writeMarkup(ref, value)
+  }
+}
+
+// --- public API ---
+
+/**
+ * Claim every slot in `plan` against `root` NOW. Escape hatch for callers
+ * that cannot honor the row-pristine invariant `lazySlots` relies on
+ * (streaming/portal paths that may mutate row content before any write
+ * would naturally occur, per §6) — claim eagerly there instead.
+ */
+export function claimSlots(root: Element, plan: ClaimPlan): ClaimedSlots {
+  const refs = new Map<string, ClaimedSlotRef>()
+  for (const spec of plan) {
+    const ref = claimOne(root, spec)
+    if (ref) refs.set(spec.id, ref)
+  }
+  return { write: (id, value) => writeSlot(refs, id, value) }
+}
+
+/**
+ * Lazy wrapper honoring the row-pristine invariant (§3(a)): nothing touches
+ * `root`'s DOM until the first write, and that first write claims the
+ * WHOLE plan at once — so no earlier write into a sibling slot can shift
+ * this row's still-unclaimed paths first. A row that never updates never
+ * pays for a claim at all.
+ */
+export function lazySlots(root: Element, plan: ClaimPlan): SlotWriter {
+  let claimed: ClaimedSlots | null = null
+  return (id: string, value: unknown) => {
+    if (!claimed) claimed = claimSlots(root, plan)
+    claimed.write(id, value)
+  }
+}

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -85,6 +85,10 @@ export { mapArray, mapArrayAnchored } from './map-array.ts'
 export { patchLeaf } from './patch-leaf.ts'
 export { patchSlotRange } from './patch-slot-range.ts'
 
+// Claim-plan interpreter (slot unification A2, spec/slot-unification.md).
+// Standalone for now — no compiler emission site yet (that's A3).
+export { claimSlots, lazySlots, type SlotSpec, type ClaimPlan, type ClaimedSlots, type SlotWriter } from './claim-slots.ts'
+
 // Template registry
 export { registerTemplate, getTemplate, hasTemplate, type TemplateFn } from './template.ts'
 


### PR DESCRIPTION
Second PR (A2) of the slot-unification series (**#2396 → this → A3 → A4**; merge #2396 first — this diff shows only the runtime addition).

## What this adds

`packages/client/src/runtime/claim-slots.ts` — the ONE claim mechanism from `spec/slot-unification.md` §4, runtime-side only:

- **`SlotSpec { id, kind: 'text' | 'markup', path }` / `ClaimPlan`** — compile-time child-index paths from a claim root to each slot's anchor (in Step A: the existing `&lt;!--bf:sN--&gt;` comment; SSR bytes unchanged, so claims validate against known-good SSR output).
- **`claimSlots(root, plan)`** — eager claim (the escape hatch for streaming/portal paths that mutate rows before any write).
- **`lazySlots(root, plan) → SlotWriter`** — the pay-per-use core: touches NOTHING until the first write, which claims the WHOLE plan at once (row-pristine invariant — no earlier write can shift a sibling's unclaimed path). A row that never updates never pays.
- **Kind contracts mirror the mechanisms being superseded**: `'text'` holds the Text node after the anchor (created if SSR emitted empty — exactly `tAfter`'s behavior; identity stable forever), `'markup'` holds BOTH boundary comments at claim (nesting-depth scan happens once) and writes replace the range (string → template-parsed, `Node` → identity splice; boundaries never removed).
- **Warn-don't-guess**: a path miss falls back to an ownership-guarded marker scan (nested `bf-s` scopes opaque); a total miss warns and drops that slot without sinking its siblings.

**No compiler changes, no deletions** — the four old mechanisms keep working untouched; A3 switches emission and deletes them, A4 cleans up and re-benchmarks.

## Tests

New `claim-slots.test.ts` (12 tests): text adopt/create/identity-stability; markup boundary-holding, nested-`bf:` depth, empty↔content roundtrips, Node splice; `lazySlots` zero-touch-before-write (childNodes snapshot unchanged, no Text materialized) and batch-claim proof (external mutation between writes hits the pre-claimed ref); path-miss fallback warning, nested-scope skip, total-miss no-op. `bun test packages/client`: **558 pass / 0 fail** (independently re-verified).

## Flagged for A3 (from implementation)

- The claim root decides what paths mean — A3 picks it per emission site (row element vs component scope).
- `SlotWriter` has no "did slot X claim?" query — add only if row-granularity effects actually need to short-circuit.
- `'markup'` end-marker scan cost at claim time is O(region); a compiled end-path is a possible later optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_