### PR TITLE
chore: post-migration cleanup for slot unification — retire stale references, simplify contracts

### DIFF
--- a/.changeset/slot-unification-cleanup.md
+++ b/.changeset/slot-unification-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/client": patch
+"@barefootjs/jsx": patch
+---
+
+Remove dead runtime surface left by the slot unification: `getComponentProps`, `getPropsUpdateFn`, and `registerPropsUpdate` (consumer-less since `reconcileList`'s removal) are deleted from `@barefootjs/client/runtime`, and `tAfter` is dropped from the compiler's runtime-import candidates (no emission site remains). Documentation for the `/* @client */` directive is rewritten to describe the claimed-slot behavior that actually ships.

--- a/docs/core/rendering/client-directive.md
+++ b/docs/core/rendering/client-directive.md
@@ -32,22 +32,39 @@ See [JSX Compatibility — Limitations](./jsx-compatibility.md#limitations) for 
 
 ## How It Works
 
-The compiler skips template generation for the expression. The server outputs a comment marker; the client JS evaluates it:
+The compiler skips template generation for the expression: the server can never evaluate it, so the SSR-rendered width is always zero. The client claims a slot for it and writes the real value once the browser evaluates the expression — the general case behind both compiled shapes below (`spec/slot-unification.md` §4).
 
-**Server output:**
+**Claimed slot (the common case):** a marker pair is still emitted so the client has an anchor comment to claim against.
 
 ```html
-<!--bf-client:s2--><!--/-->
+<!-- server output -->
+<!--bf:s0--><!--/--> items left
 ```
-
-**Client JS:**
 
 ```js
-// @client: s2
+// client JS
+{ const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'text', path: [] }])
 createEffect(() => {
-  updateClientMarker(__scope, 's2', todos().filter(t => !t.done).length)
-})
+  __bfw_s0('s0', todos().filter(t => !t.done).length)
+}) }
 ```
+
+**Markerless elision (Step B):** when the expression is the ONLY content of its own element — not adjacent to other text/expressions, and not inside a loop or conditional branch — the compiler proves a static child-index path to the slot's position and drops the marker pair entirely from both SSR and CSR output. `<strong>{/* @client */ todos().filter(t => !t.done).length}</strong>` from the [TodoApp example](https://github.com/piconic-ai/barefootjs/blob/main/integrations/shared/components/TodoApp.tsx) qualifies:
+
+```html
+<!-- server output -->
+<strong bf="s1"></strong>
+```
+
+```js
+// client JS
+{ const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'text', path: [0, 0], markerless: true }])
+createEffect(() => {
+  __bfw_s0('s0', todos().filter(t => !t.done).length)
+}) }
+```
+
+Either way, the claim happens lazily on the first write — nothing is touched until the effect actually runs — and every later write goes through the held reference, never re-scanning the DOM (`packages/client/src/runtime/claim-slots.ts`).
 
 
 ## Examples

--- a/packages/client/src/runtime/claim-slots.ts
+++ b/packages/client/src/runtime/claim-slots.ts
@@ -30,21 +30,22 @@
  *     — the Text node's identity never changes, which is the guarantee
  *     effect closures and `mapArray`'s same-key path rely on.
  *   - 'markup': held ref is BOTH boundary comments (start = anchor, end =
- *     the matching `<!--/-->` found by the same nesting-depth rule as
- *     `patchSlotRange`). A string write clears everything strictly between
- *     the boundaries and inserts freshly `<template>`-parsed HTML before
- *     the end comment; a `Node` write clears the range and splices the node
- *     in by identity (the `__bfText` live-Node case). The boundaries
- *     themselves are never removed — same "permanent range" contract as
- *     `patchSlotRange`. Because the end ref is already held, a write never
- *     needs to re-walk for nesting depth — only the CLAIM does.
+ *     the matching `<!--/-->` found by a nesting-depth walk (any further
+ *     `bf:`-prefixed comment along the way opens a nested region). A string
+ *     write clears everything strictly between the boundaries and inserts
+ *     freshly `<template>`-parsed HTML before the end comment; a `Node`
+ *     write clears the range and splices the node in by identity (the
+ *     `__bfText` live-Node case). The boundaries themselves are never
+ *     removed, so the range stays writeable on every later write. Because
+ *     the end ref is already held, a write never needs to re-walk for
+ *     nesting depth — only the CLAIM does.
  *
  * Warn-don't-guess (§4, "one ownership rule"): a path that fails to resolve
  * to its slot's own `bf:sN` comment — out of range, or shape drift where
  * the path now lands on some other node — falls back to a marker scan
- * within the claim root, using the same ownership rule as
- * `patchSlotRange`/`query.ts`'s `$t`: a `bf:sN` comment owned by a nested
- * `bf-s` scope (a child component's own same-numbered slot — ids are
+ * within the claim root, using the same ownership rule as `query.ts`'s `$t`:
+ * a `bf:sN` comment owned by a nested `bf-s` scope (a child component's own
+ * same-numbered slot — ids are
  * assigned per component, so collisions are expected) is never a candidate
  * — UNLESS the id is `^`-prefixed (`BF_PARENT_OWNED_PREFIX`), meaning the
  * marker is content the claiming component itself authored and merely
@@ -82,25 +83,22 @@
  * `nodeValue` assignment (already idempotent, per §5's design note) — no
  * dedup state needed.
  *
- * An EARLIER revision of this module skipped the first write entirely
- * ("trust-first-run": assume the claimed range already holds matching
- * SSR/CSR content, so recording `last` without touching the DOM is safe).
- * That assumption is true ONLY for the narrow case it was lifted from —
- * `patchSlotRange`'s preamble-region reuse, where the row's SSR content and
+ * The first write is never skipped on the assumption that the claimed
+ * range already matches SSR/CSR content ("trust-first-run") — that
+ * assumption only holds for a preamble-region row whose SSR content and
  * the effect's mount-time recomputation are both derived from the exact
  * same source data, so they cannot disagree. It is false in general: any
  * markup slot whose value comes from client-only state that the server
  * cannot see — `createSignal(readFromLocalStorage())`, a client-side region
  * swap adopting HTML the server rendered from a different default — can
  * genuinely differ from the SSR/CSR content on the very first write, and
- * trust-first-run silently discarded that first real value, leaving the
- * stale SSR default on screen until the NEXT change (site/ui's
- * `admin-gallery.spec.ts` cross-page time-range persistence regression).
- * The old `__bfText`/`$t` mechanism this module superseded never had this
- * skip — every write, first or not, unconditionally applied — so removing
- * it here restores that guarantee for every 'markup' caller, including the
- * preamble-region case (which merely loses a same-value redundant-patch
- * skip on mount, not correctness).
+ * skipping that first write would silently leave the stale SSR default on
+ * screen until the NEXT change (regression pin: site/ui's
+ * `admin-gallery.spec.ts` cross-page time-range persistence test). So every
+ * write unconditionally applies unless deduped by value/identity — never
+ * because it happens to be the first one — for every 'markup' caller,
+ * including the preamble-region case (which only loses a same-value
+ * redundant-patch skip on mount, not correctness).
  */
 
 import { BF_SCOPE, BF_PARENT_OWNED_PREFIX } from '@barefootjs/shared'
@@ -193,10 +191,10 @@ function isSlotComment(node: Node | null, id: string): node is Comment {
 /**
  * Fallback marker scan, used only when a slot's compile-time path fails to
  * resolve to its own `bf:sN` comment (shape drift, or a plan built against
- * a differently-shaped claim root). Mirrors `patchSlotRange`'s ownership
- * loop: a same-id marker owned by a nested `bf-s` scope (a child
- * component's own slot — ids collide across components by design) is
- * skipped so the fallback can never claim into a child's content.
+ * a differently-shaped claim root). The ownership rule: a same-id marker
+ * owned by a nested `bf-s` scope (a child component's own slot — ids
+ * collide across components by design) is skipped so the fallback can
+ * never claim into a child's content.
  *
  * `commentsInScope` (not a bare `document.createTreeWalker(root, …)`) so a
  * whole-item loop conditional's claim root (`insert.ts`'s detached
@@ -244,10 +242,9 @@ function findOwnedMarker(root: Element, id: string): Comment | null {
 
 /**
  * Find the matching `<!--/-->` end comment for a 'markup' slot's start
- * comment, using the same nesting-depth rule as `patchSlotRange`: any
- * further `bf:`-prefixed comment along the way opens a nested region (a
- * leaf rendered inside this one can carry its own ordinary slot markers)
- * and increments a depth counter so that region's own `/` doesn't
+ * comment: any further `bf:`-prefixed comment along the way opens a nested
+ * region (a leaf rendered inside this one can carry its own ordinary slot
+ * markers) and increments a depth counter so that region's own `/` doesn't
  * prematurely close this outer range. Runs once, at claim time — writes
  * never need this since the end ref is held afterward.
  */

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -25,20 +25,6 @@ export function setParentScopeId(id: string | null): void {
   _parentScopeId = id
 }
 
-// WeakMap to store props update functions for each component element.
-// Originally read by the (removed, slot unification A4) `reconcileList`
-// element-reconciler to update props when an element was reused; mapArray's
-// reuse path goes through `initChild` instead (`./map-array.ts`), so
-// `getPropsUpdateFn` currently has no caller. Left in place — it's cheap
-// bookkeeping populated on every component creation, not a live bug.
-const propsUpdateMap = new WeakMap<HTMLElement, (props: Record<string, unknown>) => void>()
-
-// WeakMap to store the current props for each component element.
-// Same history as `propsUpdateMap` above — `getComponentProps` currently
-// has no caller now that `reconcileList` is gone.
-const propsMap = new WeakMap<HTMLElement, Record<string, unknown>>()
-
-
 /**
  * Create a component instance with DOM element and initialized state.
  *
@@ -219,14 +205,12 @@ export function createComponent(
     if (materialised && !materialised.hasAttribute(BF_PLACEHOLDER)) {
       // The deferred child was created in place of the placeholder.
       // `materialised` is the child's OWN element, created via
-      // upsertChild -> createComponent, which already registered itself
-      // (hydratedScopes / propsMap / registerPropsUpdate) keyed to the
-      // child with the child's own props. We must NOT re-register it here:
-      // overwriting propsMap/registerPropsUpdate with the *parent's* props
-      // would mis-key the child (e.g. a later getComponentProps would read
-      // the parent's props), and re-running the parent's init on an element
-      // whose placeholder is already gone could not re-materialise. So just
-      // restore the scope and return the already-registered child.
+      // upsertChild -> createComponent, which already marked itself
+      // hydrated with its own props. We must NOT re-run this function's
+      // own registration steps on it here — that would re-run the
+      // *parent's* init on an element whose placeholder is already gone
+      // and could not re-materialise. So just restore the scope and
+      // return the already-registered child.
       // (Parent-scope effects are unaffected: createEffect ownership lives
       // in the EffectContext tree, not the discarded placeholder element.)
       setCurrentScope(prevScope)
@@ -253,53 +237,8 @@ export function createComponent(
   // 12. Mark element as initialized
   hydratedScopes.add(element)
 
-  // 13. Store props and register update function for element reuse (see
-  //     propsUpdateMap/propsMap docstrings above)
-  propsMap.set(element, props)
-  registerPropsUpdate(element, name, props)
-
   return element
 }
-
-/**
- * Get the props stored for a component element.
- * See `propsMap`'s docstring — currently unused now that `reconcileList` is
- * gone, kept for the WeakMap it reads.
- */
-export function getComponentProps(element: HTMLElement): Record<string, unknown> | undefined {
-  return propsMap.get(element)
-}
-
-/**
- * Register a props update function for a component element.
- * When called, this function re-initializes the component with new props.
- */
-function registerPropsUpdate(
-  element: HTMLElement,
-  name: string,
-  _initialProps: Record<string, unknown>
-): void {
-  // Register update function (see `propsUpdateMap`'s docstring above)
-  propsUpdateMap.set(element, (newProps: Record<string, unknown>) => {
-    // Re-initialize the component with new props
-    // This allows the component to capture new values (e.g., todo with editing: true)
-    // and set up new effects that reference the new values
-    const init = getComponentInit(name)
-    if (init) {
-      init(element, newProps)
-    }
-  })
-}
-
-/**
- * Get the props update function for an element.
- * See `propsUpdateMap`'s docstring — currently unused now that
- * `reconcileList` is gone, kept for the WeakMap it reads.
- */
-export function getPropsUpdateFn(element: HTMLElement): ((props: Record<string, unknown>) => void) | undefined {
-  return propsUpdateMap.get(element)
-}
-
 
 /**
  * Render a child component's template to an HTML string.
@@ -479,12 +418,13 @@ export function escapeAttr(value: unknown): string {
  *
  * A nullish value renders as empty text — the JSX/Solid semantics the Hono
  * SSR reference follows (`{undefined}` / `{null}` produce no text), and
- * what the reactive text-update path already does (`dynamic-text.ts` and
- * `client-marker.ts` both `String(value ?? '')`). Only this initial-render
- * escape site used to stringify `undefined` / `null` into literal
- * "undefined" / "null" text, so a bare `{props.x}` on an absent prop
- * diverged from SSR at first paint (#2137). Non-nullish values (including
- * `0` and `false`) keep their `String()` form, matching the reactive path.
+ * what the reactive text-update path already does (`claim-slots.ts`'s
+ * `writeText`/`writeMarkup` and `dynamic-text.ts` all `String(value ?? '')`).
+ * Only this initial-render escape site used to stringify `undefined` /
+ * `null` into literal "undefined" / "null" text, so a bare `{props.x}` on
+ * an absent prop diverged from SSR at first paint (#2137). Non-nullish
+ * values (including `0` and `false`) keep their `String()` form, matching
+ * the reactive path.
  */
 export function escapeText(value: unknown): string {
   if (value == null) return ''
@@ -625,9 +565,6 @@ function createComponentFromDef(
 
   // Mark as initialized
   hydratedScopes.add(element)
-
-  // Store props for element reuse
-  propsMap.set(element, props)
 
   return element
 }

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -96,8 +96,6 @@ export { registerTemplate, getTemplate, hasTemplate, type TemplateFn } from './t
 export {
   createComponent,
   renderChild,
-  getPropsUpdateFn,
-  getComponentProps,
   parseHTML,
   escapeAttr,
   escapeText,

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -1473,7 +1473,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/client-directive.md doc-examples L59 — Nested higher-order methods 1`] = `
+exports[`docs/core/rendering/client-directive.md doc-examples L76 — Nested higher-order methods 1`] = `
 "import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -1533,7 +1533,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/client-directive.md doc-examples L62 — Unsupported array methods 1`] = `
+exports[`docs/core/rendering/client-directive.md doc-examples L79 — Unsupported array methods 1`] = `
 "import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -1593,7 +1593,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/client-directive.md doc-examples L74 — (no label) 1`] = `
+exports[`docs/core/rendering/client-directive.md doc-examples L91 — (no label) 1`] = `
 "import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {

--- a/packages/jsx/src/__tests__/early-return-scope-var-ref.test.ts
+++ b/packages/jsx/src/__tests__/early-return-scope-var-ref.test.ts
@@ -65,12 +65,10 @@ describe('JSX expression referencing a local declared inside an early-return if-
 
     const content = clientJsContent(result)
 
-    // Pre-fix: emitted `updateClientMarker(__scope, 's4', aLocal)` at
-    // outer init scope — `aLocal` undefined. Post-fix: the JSX is
-    // inlined directly into the template, so the createEffect /
-    // updateClientMarker block is not needed at all for this static
-    // shape.
-    expect(content).not.toContain('updateClientMarker')
+    // Pre-fix, `aLocal` leaked into a reactive-update block at outer init
+    // scope where it doesn't exist (see file docstring). Post-fix: the JSX
+    // is inlined directly into the template, so no reactive-update block is
+    // needed at all for this static shape.
     expect(content).not.toMatch(/\baLocal\b/)
 
     const hydrate = hydrateLine(result)
@@ -97,8 +95,8 @@ describe('JSX expression referencing a local declared inside an early-return if-
     const content = clientJsContent(result)
     // The bare `label` identifier must not appear in the emitted init
     // function — it's resolved to its initializer value at IR-build
-    // time. Slot unification A3: `@client` writes through a claimed
-    // 'text' slot writer instead of `updateClientMarker`.
+    // time. `@client` writes through a claimed 'text' slot writer
+    // (`claim-slots.ts`).
     expect(content).not.toMatch(/__bfw_\w+\([^)]*\blabel\b[^)]*\)/)
     expect(content).toContain("__bfw_s4('s4', 'hello')")
   })
@@ -125,8 +123,8 @@ describe('JSX expression referencing a local declared inside an early-return if-
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
     const content = clientJsContent(result)
-    // Pre-fix: `updateClientMarker(__scope, 's*', compactResize)`
-    // referenced an undeclared name. Post-fix: the ternary becomes an
+    // Pre-fix, `compactResize` leaked into the emitted reactive-update
+    // block as an undeclared name. Post-fix: the ternary becomes an
     // IRConditional with `clientOnly: true`, routed through `insert()`
     // — and `props.readOnly` is rewritten to `_p.readOnly`.
     expect(content).not.toMatch(/\bcompactResize\b/)

--- a/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
@@ -89,8 +89,8 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
 
   test('inline literal array stays static (optimisation preserved)', () => {
     // `[1, 2, 3]` is an ArrayLiteralExpression with no calls — the
-    // existing static-render path is the right call. No reconcileList /
-    // mapArray should appear.
+    // existing static-render path is the right call. No `mapArray` call
+    // should appear.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -107,7 +107,6 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
 
     const clientJs = getClientJs(source, 'List.tsx')
     expect(clientJs).not.toMatch(/\bmapArray\s*\(/)
-    expect(clientJs).not.toMatch(/\breconcileList\s*\(/)
   })
 
   test('prop array compiles to mapArray (#1586)', () => {

--- a/packages/jsx/src/__tests__/preamble-region-patch.test.ts
+++ b/packages/jsx/src/__tests__/preamble-region-patch.test.ts
@@ -12,11 +12,12 @@
  * region — slot-marked like an ordinary reactive text (so SSR/CSR row
  * templates render `<!--bf:sN-->...<!--/-->` / `{bfText("sN")}` the same
  * door a reactive text uses), but wired on the client via a claimed
- * 'markup' slot writer (slot unification A3, `@barefootjs/client/runtime/
- * claim-slots.ts`) rather than a `reactiveTexts` `.textContent` assignment
- * (which would corrupt the array-joined markup). Trust-first-run and
- * dedup — previously a per-region `__last` local next to a `patchSlotRange`
- * call — now live inside the writer itself.
+ * 'markup' slot writer (`@barefootjs/client/runtime/claim-slots.ts`) rather
+ * than a `reactiveTexts` `.textContent` assignment (which would corrupt the
+ * array-joined markup). Dedup — skip the DOM write when the new value
+ * matches the writer's own held `last` value — lives inside that writer;
+ * every write, including the first, applies unless deduped (see
+ * `claim-slots.ts`'s module docstring).
  */
 
 import { describe, test, expect } from 'bun:test'

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -14,7 +14,6 @@ export const RUNTIME_IMPORT_CANDIDATES = [
   'provideContext', 'createContext', 'useContext',
   'forwardProps', 'applyRestAttrs', 'splitProps', 'spreadAttrs', 'styleToCss', 'escapeAttr', 'escapeText', 'escapeTextOrNode',
   'qsa', 'qsaItem', 'qsaChildScope', 'qsaChildScopes', 'upsertChildItem', '__slot', '__bfSlot', '__bfText',
-  'tAfter',
   // Claim-plan interpreter (slot unification A2/A3, spec/slot-unification.md)
   // — the "one claim mechanism" that replaced `patchSlotRange` and
   // `updateClientMarker` (both deleted) as the content-slot update door.

--- a/spec/callback-fidelity.md
+++ b/spec/callback-fidelity.md
@@ -45,9 +45,11 @@
 > node on a same-key `setItem` update and re-runs only wired slots — without
 > the region, a preamble-derived child froze at its mount-time value forever
 > while sibling wired slots (`{t.name}`) updated normally. The effect re-runs
-> the preamble (accessor-wrapped) and patches the marker-delimited DOM range
-> via `patchSlotRange` (`@barefootjs/client`) only when the recomputed value
-> changed — the first run always just records, trusting the SSR/CSR mount.
+> the preamble (accessor-wrapped) and writes the recomputed value through a
+> claimed 'markup' slot (`@barefootjs/client/runtime/claim-slots.ts`,
+> `spec/slot-unification.md`), which patches the marker-delimited DOM range
+> only when the value actually changed — every write, including the first,
+> goes through that dedup, never skipped just for being first.
 > #2389, `preamble-region-patch.test.ts` + the `preamble-cells` fixture.
 
 ## Vision

--- a/spec/slot-unification.md
+++ b/spec/slot-unification.md
@@ -1,15 +1,20 @@
-# Slot unification (proposal — not yet implemented)
+# Slot unification
 
-Status: **draft for review, revision 2**. Root-cure design prompted by the
-#2389/#2393 review. Revision 2 replaces the scan-based `updateSlot` door
-from revision 1 with a claim-once model, informed by how SolidJS resolves
-dynamic positions — and identifies where BarefootJS's own constraints
-(multi-backend SSR, byte parity) suggest different choices than Solid's.
-No code change ships with this document.
+Status: **implemented (Steps A+B, PRs #2396–#2400; revision history in
+git)**. Root-cure design prompted by the #2389/#2393 review. Revision 2
+replaced the scan-based `updateSlot` door from revision 1 with a
+claim-once model, informed by how SolidJS resolves dynamic positions — and
+identified where BarefootJS's own constraints (multi-backend SSR, byte
+parity) suggested different choices than Solid's. Deferred follow-up work
+is tracked in §8.
 
-## 1. Current state — the inventory
+## 1. Pre-unification inventory
 
-Reactive content-update mechanisms, by addressing scheme:
+The mechanisms below are what existed before Steps A+B. Rows #1–#4 and #9
+were replaced by the claim-plan model (§4) and no longer exist in the
+codebase; rows #5–#8 were kept as-is (§7 non-goals) and remain current.
+Reactive content-update mechanisms, by addressing scheme, as they stood at
+the time this design was proposed:
 
 | # | Mechanism | Marker / anchor | Value | Update discipline |
 |---|-----------|-----------------|-------|-------------------|
@@ -23,7 +28,7 @@ Reactive content-update mechanisms, by addressing scheme:
 | 8 | attr effects | `bf="sN"` attr | string/bool | setAttribute/property |
 | 9 | `reconcileElements` / `reconcileList` | loop pair + `data-key` | elements | **dead — no compiler emission site** |
 
-Facts that shape the design:
+Facts that shaped the design:
 
 - Rows #1–#3 share one marker format with three different lookups and
   three ownership rules.
@@ -47,8 +52,9 @@ on update — is the core of this proposal. A path is only required to be
 valid at the moment of claim, and at mount the row DOM is always in its
 pristine template shape on both SSR and CSR, so later variable-length
 changes cannot invalidate anything: the claim captures boundary/text
-references and paths are never consulted again. BarefootJS already has
-this shape in embryo: the hoisted `tAfter(__p[i])` path (#2143).
+references and paths are never consulted again. BarefootJS already had
+this shape in embryo: the hoisted `tAfter(__p[i])` path (#2143), later
+generalized by the claim-plan mechanism (§4) that superseded it.
 
 ## 3. Where BarefootJS's constraints suggest different choices
 
@@ -254,41 +260,47 @@ are the load-bearing claim here and they're deterministic build outputs,
 not timing-sensitive; hydration/server-render numbers above are
 consistent with A4's jitter range and are not this note's point.)
 
-## 5. Migration — two steps, stacked semantic PRs
+## 5. Migration — what shipped, two steps of stacked semantic PRs
 
-Compatibility with the current emitted grammar is explicitly NOT a goal
-(pre-1.0; fixtures and snapshots regenerate wholesale). What survives is
-not compatibility but **verifiability**: Step A keeps SSR bytes unchanged
-so the new client is validated against known-good SSR output — the
-existing byte-parity corpus is the debugging baseline. The old five-stage
-coexistence plan (mechanisms folded one at a time) is retired.
+Compatibility with the pre-unification emitted grammar was explicitly NOT
+a goal (pre-1.0; fixtures and snapshots regenerated wholesale). What
+survived was not compatibility but **verifiability**: Step A kept SSR
+bytes unchanged so the new client was validated against known-good SSR
+output — the existing byte-parity corpus was the debugging baseline. The
+old five-stage coexistence plan (mechanisms folded one at a time) was
+retired in favor of this two-step plan.
 
 **Step A — claim infrastructure, wholesale (SSR bytes unchanged).**
-Replace all four content mechanisms (`$t`-effect text slots, `__bfText`,
+Replaced all four content mechanisms (`$t`-effect text slots, `__bfText`,
 `patchSlotRange`, `updateClientMarker`) in one series of stacked PRs; old
-mechanisms are deleted, not shimmed:
+mechanisms were deleted, not shimmed:
 
-- **A1 (this revision)**: spec.
-- **A2 — runtime**: claim-plan interpreter + claimed-slot primitives in
-  `@barefootjs/client/runtime` (claim a row/scope from a compile-time
-  plan; held-ref writes for `'text'`/`'markup'`/`Node`; row-level lazy
-  claim with the row-pristine invariant; eager-claim escape for the
-  streaming/portal paths enumerated below). Unit-tested standalone; no
-  compiler change yet.
-- **A3 — compiler switch**: emit claim plans (data) for every content
-  slot; all four old emission forms and their runtime exports removed;
-  snapshots and CSR/fixture goldens regenerate once. `bf-client:` markers
-  stop being emitted (its SSR comment was claim-input only; removing it
-  is the one SSR byte change allowed in Step A, since nothing adopts it).
-- **A4 — cleanup**: remove dead exports (`reconcileElements`,
-  `reconcileList`); re-run the SSR bench and record real (non-ceiling)
-  numbers here.
+- **A1** (#2396): spec (this document, revision 3).
+- **A2 — runtime** (#2397): claim-plan interpreter + claimed-slot
+  primitives in `@barefootjs/client/runtime` (claim a row/scope from a
+  compile-time plan; held-ref writes for `'text'`/`'markup'`/`Node`;
+  row-level lazy claim with the row-pristine invariant; eager-claim escape
+  for the streaming/portal paths enumerated in §6). Unit-tested
+  standalone; no compiler change yet.
+- **A3 — compiler switch** (#2398): emit claim plans (data) for every
+  content slot; all four old emission forms and their runtime exports
+  removed; snapshots and CSR/fixture goldens regenerated once. `bf-client:`
+  markers stopped being emitted (its SSR comment was claim-input only;
+  removing it was the one SSR byte change Step A allowed, since nothing
+  adopted it). A follow-up fix (§6) removed trust-first-run for 'markup'
+  slots.
+- **A4 — cleanup** (#2399): removed dead exports (`reconcileElements`,
+  `reconcileList`); re-ran the SSR bench and recorded real (non-ceiling)
+  numbers in §5a.
 
-**Step B — marker elision.** Drop markers outside (i)–(iii) from both SSR
-and CSR templates through the single doors (nine adapters + goldens in
-one PR), and land claim-plan verification (d) with it: conformance
-mechanically checks every adapter's output against the plans. Justified
-by node count/memory (§5a), not transfer size.
+**Step B — marker elision** (#2400): dropped markers outside (i)–(iii)
+from both SSR and CSR templates through the single doors, for the
+narrow slice described in §5a's "Step B measured" section (`/* @client */`
+text slots outside any loop/conditional, one elided slot per static
+subtree), and landed claim-plan verification (d) alongside it:
+conformance mechanically checks every adapter's output against the plans.
+Justified by node count/memory (§5a), not transfer size. The general case
+(ordinary reactive text in loop rows) was deferred — see §8.
 
 ## 6. Constraints and risks
 
@@ -327,3 +339,38 @@ by node count/memory (§5a), not transfer size.
   door.
 - Matching SolidJS feature-for-feature; it is a reference point, not a
   target.
+
+## 8. Follow-ups
+
+Work this proposal identified but did not ship, tracked here so it isn't
+re-discovered from scratch:
+
+- **Row-granularity / lazy effects (§3(c)).** The compiler still builds one
+  effect closure per binding rather than one effect per row driving a
+  compiled slot table. Row-level lazy CLAIM shipped (`lazySlots`, A2); the
+  row-level lazy EFFECT-GRAPH construction that §5a's −57% memory ceiling
+  assumes did not — every row's reactive graph (signals, subscriptions,
+  effect closures) is still built eagerly at hydration regardless of
+  whether that row is ever written to. Needs its own measured PR against
+  the real (non-prototype) pipeline, the way A4 and Step B measured their
+  own slices.
+- **General-case marker elision (element-path vocabulary beyond `'text'`
+  slots).** Step B's `client-only-elision.ts` only elides `/* @client */`
+  text slots outside any loop/conditional (§5a "Step B measured" explains
+  why: their SSR-rendered width is the one case that's deterministically
+  zero on every request). Ordinary reactive text in loop rows — the actual
+  1k-row benchmark hot path — stays marker-owned because a later sibling's
+  absolute child-index path is only valid for the specific width THIS
+  request produced. The identified path forward (freeze-after-first,
+  minus the `clientOnly` restriction, decided where loop-row `'text'`-kind
+  classification already happens in `collect-elements.ts` /
+  `ir-to-client-js/control-flow/plan/loop.ts`) needs the elision decision
+  moved inside `generateClientJs` instead of running as a pre-pass before
+  `adapter.generate` — re-verifying that reordering against the loop-row
+  planner's own invariants is real, unstarted work.
+- **`getComponentProps`/`getPropsUpdateFn` dead-export removal.** Flagged
+  consumer-less in A4's report after `reconcileList` (their only reader)
+  was deleted. Removed in the post-migration cleanup that added this
+  section, along with the now-dead `propsMap`/`propsUpdateMap` bookkeeping
+  those two functions existed to expose (`packages/client/src/runtime/
+  component.ts`).


### PR DESCRIPTION
Post-merge inspection pass over the slot-unification series (#2396–#2400): leftovers and comment/code simplification. 11 files, +180/−185.

## Leftovers fixed

- **spec/slot-unification.md**: header no longer claims "proposal — not yet implemented" — now "implemented (Steps A+B, PRs #2396–#2400)"; §1 retitled as the *pre-unification* inventory; §5 rewritten past-tense with PR numbers; new **§8 Follow-ups** consolidates row-granularity/lazy effects and general-case marker elision.
- **`docs/core/rendering/client-directive.md` was fully stale** (documented the deleted `bf-client:` comment + `updateClientMarker`): rewritten from a real compiled sample — documents the claimed-slot shape and the Step B markerless-elision case.
- **`spec/callback-fidelity.md`**: preamble-region paragraph described the deleted `patchSlotRange` + the removed trust-first-run behavior — corrected to the claimed 'markup' writer contract.
- **Dead runtime deleted**: `getComponentProps`/`getPropsUpdateFn` (consumer-less since `reconcileList`'s removal, verified repo-wide) plus the now-dead `propsMap`/`propsUpdateMap`/`registerPropsUpdate`.
- **`RUNTIME_IMPORT_CANDIDATES` audited against real emission sites**: `tAfter` removed (zero emitters); `__bfText`/`$t`/`__bfSlot`/`insert`/`getLoopChildren`/`getLoopNodes` kept (verified emitters).
- Two vacuously-true assertions removed (`not.toContain('updateClientMarker')` etc. — those strings can never appear anymore); a `component.ts` docstring pointing at a deleted file corrected.

## Simplifications

- `claim-slots.ts`: 6+ cross-references to the deleted mechanism and an "an earlier revision…" narrative reduced to one canonical historical mention; every docstring now states its own present-tense contract.
- Migration-narrating comments in three test files rewritten to describe the pinned regressions directly.
- `patchLeaf`/`writeMarkup` template-parse dedup **deliberately skipped**: shared code is ~2 lines and the two contracts differ (single-root + attr diff vs multi-node fragment at a boundary) — a helper would cost more than it saves.

CHANGELOGs and spec history untouched (history is history).

## Verification

`packages/jsx` 2718/0 · `packages/client` 561/0 (independently re-verified) · `adapter-tests` 1436/0 · `adapter-hono` 1257/0 · fixture-hydrate **34/34** · site/ui e2e 1124 passed with only the 3 known pre-existing failures (form-builder ×2, studio ×1) · biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_