### PR TITLE
perf(jsx): one effect per loop row — consolidate slot and attr updates (slot unification row granularity)

### DIFF
--- a/.changeset/slot-unification-row-effects.md
+++ b/.changeset/slot-unification-row-effects.md
@@ -1,0 +1,36 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/client": patch
+---
+
+Fix a CSR memory/update regression introduced by the slot-unification
+migration (slot unification A3 → A3b, spec/slot-unification.md §3(c)/§8):
+loop-row emission was still wiring one `createEffect` per reactive attr,
+per reactive text, and per preamble region — 3 separate effect closures and
+subscription-list entries for even the simple two-text-and-one-attr row in
+the DOM benchmark's `Bench` table, up from the pre-migration baseline's
+same 3 effects but with the new claim-plan writer/`Map`/refs stacked on
+top of them.
+
+For the plain-loop-row shape (top-level `mapArray` rows and their
+branch-scoped equivalent) the compiler now emits ONE `createEffect` per
+row that writes every reactive attr, outer text, and preamble region for
+that row through a single claimed-slot writer — outer texts and preamble
+regions share one `lazySlots` call (mixed `'text'`/`'markup'` claim
+kinds), removing the N-1 extra effect objects and their subscription
+entries per row. Composite loops, component loops, the anchored
+(whole-item-conditional) loop shape, and static (`forEach`) loops are
+unchanged — their `reactiveEffects` never carry preamble regions, and this
+pass only touched the shape it could mechanically verify.
+
+Profile mode (`bf debug profile`, #1690) keeps the previous per-slot/
+per-attr effect emission so the profiler's `<Component>#binding:<slotId>`
+ids still attribute a re-run to its own binding; only normal (non-profile)
+builds get the consolidated row effect.
+
+Measured on `benchmarks/apps/barefoot` (CI quick-mode DOM suite,
+`benchmarks/runner/bench-dom.ts`): 1k-row memory 2046.4KB → ~1767KB
+(-13.6%, within ~0.6% of the pre-migration same-hardware baseline of
+1756.9KB); update10th settled back into the ~1.0-1.17x-vanilla band
+observed pre-migration. Shipped JS size is materially unchanged (the win
+is runtime object count, not source bytes).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -35,7 +35,11 @@ headless Chromium:
 
 Plus per-framework **startup** (navigation → interactive), **memory**
 (JS heap delta for 1,000 rows, after forced GC), and **shipped JS**
-(raw + gzip bytes of the production bundle).
+(raw + gzip bytes of the production bundle). The memory metric is
+sensitive to per-row effect granularity: BarefootJS emits one
+consolidated `createEffect` per plain loop row (slot unification row
+granularity, `spec/slot-unification.md` §5a), so a compiler change that
+splits or multiplies per-row effects shows up here first.
 
 ### 2. SSR + hydration (`ssr/bench-ssr.ts`)
 

--- a/packages/adapter-tests/fixtures/__snapshots__/ai-chat.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/ai-chat.client.js
@@ -85,14 +85,16 @@ export function initAIChatInteractive(__scope, _p = {}) {
   __tpl_l0.innerHTML = `<div data-key="" bf="s1"><div class="chat-bubble"><p><!--bf:s0--><!--/--></p></div></div>`
   mapArray(() => messages(), _s5, (msg) => String(msg.id), (msg, __idx, __existing) => {
     const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
-    { const __ra_s1 = qsa(__el, '[bf="s1"]')
-    if (__ra_s1) {
-      createEffect(() => {
-        { const __v = `chat-msg chat-${msg().role}`; if (__v != null) __ra_s1.setAttribute('class', String(__v)); else __ra_s1.removeAttribute('class') }
-      })
-    } }
+    const __ra_s1 = qsa(__el, '[bf="s1"]')
     const __bfw_s0 = lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])
-    createEffect(() => { __bfw_s0('s0', String(msg().content)) })
+    createEffect(() => {
+      if (__ra_s1) {
+        {
+          { const __v = `chat-msg chat-${msg().role}`; if (__v != null) __ra_s1.setAttribute('class', String(__v)); else __ra_s1.removeAttribute('class') }
+        }
+      }
+      __bfw_s0('s0', String(msg().content))
+    })
     return __el
   }, 'l0')
 

--- a/packages/adapter-tests/fixtures/__snapshots__/preamble-cells.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/preamble-cells.client.js
@@ -17,12 +17,11 @@ export function initPreambleCells(__scope, _p = {}) {
   mapArray(() => todos(), _s3, (t) => String(t.id), (t, __idx, __existing) => {
     const stateLabel = t().done ? 'done & dusted' : 'open'; const cells = []; cells.push(`<td class="state">${escapeText((stateLabel))}</td>`);
     const __el = __existing ?? (() => { const __tpl = document.createElement('template'); __tpl.innerHTML = `<tr data-key="${escapeAttr(t().id)}"><!--bf:s2-->${Array.isArray(cells) ? cells.join('') : (cells ?? '')}<!--/--><td class="name"><!--bf:s0-->${escapeText(t().name)}<!--/--></td><td><button class="toggle" bf="s1">toggle</button></td></tr>`; return __tpl.content.firstElementChild.cloneNode(true) })()
-    const __bfw_s0 = lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])
-    createEffect(() => { __bfw_s0('s0', String(t().name)) })
-    const __bfw_s2 = lazySlots(__el, [{ id: 's2', kind: 'markup', path: [] }])
+    const __bfw_s0 = lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }, { id: 's2', kind: 'markup', path: [] }])
     createEffect(() => {
       const stateLabel = t().done ? 'done & dusted' : 'open'; const cells = []; cells.push(`<td class="state">${escapeText((stateLabel))}</td>`);
-      __bfw_s2('s2', Array.isArray(cells) ? cells.join('') : (cells ?? ''))
+      __bfw_s0('s0', String(t().name))
+      __bfw_s0('s2', Array.isArray(cells) ? cells.join('') : (cells ?? ''))
     })
     return __el
   }, 'l0')

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/branch-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/branch-loop.ts
@@ -14,7 +14,7 @@ import { stringifyCompositeLoop } from './composite-loop.ts'
 import { stringifyEventDelegation } from './event-delegation.ts'
 import { stringifyReactiveEffects } from './reactive-effects.ts'
 import { emitTemplateCloneInline, emitLoopItemElementSetup } from './template-parse.ts'
-import { emitLoopChildRefs, emitPreambleRegionEffects } from './loop.ts'
+import { emitLoopChildRefs } from './loop.ts'
 import type {
   BranchLoopPlan,
   BranchPlainLoopPlan,
@@ -115,11 +115,19 @@ function emitPlain(lines: string[], plan: BranchPlainLoopPlan): void {
       indent: '          ',
       singleRootLayout: 'inline',
     })
-    if (reactiveEffects !== null) {
-      stringifyReactiveEffects(lines, reactiveEffects, { indent: '          ', elVar: '__el', bodyIsMultiRoot })
+    if (reactiveEffects !== null || preambleRegions.length > 0) {
+      // Row-granularity effects (§3(c)): mirrors `stringifyPlainLoop`'s
+      // top-level call — attrs, outer texts, and preamble regions merge
+      // into ONE row effect (see `stringifyReactiveEffects`'s docstring).
+      stringifyReactiveEffects(lines, reactiveEffects, {
+        indent: '          ',
+        elVar: '__el',
+        bodyIsMultiRoot,
+        preambleRegions,
+        mapPreambleWrapped,
+      })
     }
     emitLoopChildRefs(lines, childRefs, { indent: '          ', elVar: '__el', bodyIsMultiRoot })
-    emitPreambleRegionEffects(lines, preambleRegions, mapPreambleWrapped, { indent: '          ', elVar: '__el' })
     lines.push(`          return __el`)
     lines.push(`        }, '${markerId}'${loopBfId})`)
   }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -1,7 +1,7 @@
 /**
  * Stringify LoopPlan variants to source lines.
  *
- * Output shapes (preserved byte-identical from the legacy emitter):
+ * Output shapes:
  *
  *   PlainLoopPlan, no reactive effects (single-line renderItem):
  *     <indent>mapArray(() => <arr>, <container>, <keyFn>, (<head>, <idx>, __existing) =>
@@ -12,13 +12,18 @@
  *     <indent>  <unwrap?>
  *     <indent>  <preamble?>
  *     <indent>  const __el = __existing ?? (() => { ... })()
- *     <indent>  <reactive effects via stringifyReactiveEffects>
+ *     <indent>  <reactive effects + preamble regions via stringifyReactiveEffects —
+ *     <indent>   row-granularity (spec/slot-unification.md §3(c)): attrs, outer
+ *     <indent>   texts, and preamble regions merge into ONE createEffect per row
+ *     <indent>   in normal builds; profile-mode builds keep the legacy
+ *     <indent>   one-effect-per-slot shape (see that module's docstring)>
  *     <indent>  return __el
  *     <indent>})
  *
  *   StaticLoopPlan: two parallel forEach blocks (attrs / texts) — see
  *     emitStaticLoop. The forEach-duplication noted in observation O-4 is
- *     preserved bug-for-bug; PR 5+ collapses them.
+ *     preserved bug-for-bug; PR 5+ collapses them. Left untouched by the
+ *     row-granularity pass above — a different (forEach, not mapArray) shape.
  *
  * Indent convention for plain loops: top-level emission uses `'  '` (2 sp);
  * passed in via `topIndent`.
@@ -33,7 +38,6 @@ import { stringifyComponentLoop } from './component-loop.ts'
 import { stringifyCompositeLoop } from './composite-loop.ts'
 import { claimPlanLiteral, claimWriterVarName, type ClaimSlotSpec } from './claim-plan.ts'
 import type { LoopChildRefBinding, LoopPlan, PlainLoopPlan, StaticLoopPlan } from '../plan/types.ts'
-import type { PreambleRegionPlan } from '../plan/loop.ts'
 
 /**
  * Emit `(callback)(__rf)` for each ref on a per-item slot, looking up the
@@ -67,44 +71,16 @@ export function emitLoopChildRefs(
 }
 
 /**
- * Emit the region-patch effect for each preamble-patched region (#2389 —
- * `arr.map(t => { const cells = []; ...; return <tr>{cells}<td>{t.name}</td></tr> })`).
- * The effect re-runs the (loop-param-accessor-wrapped) preamble on every
- * reactive tick so it re-reads the current per-item signal, recomputes the
- * region's value, and writes it through a claimed 'markup' slot (slot
- * unification A3) — dedup (skip an unchanged string, on every write
- * including the first) now lives inside the writer itself
- * (`@barefootjs/client/runtime/claim-slots.ts`), replacing the per-region
- * `__last` local this used to carry. `lazySlots` defers the marker lookup
- * to the first actual write, so a row that never changes still pays zero
- * lookup cost at mount/adoption. (An earlier revision also skipped the DOM
- * patch on that first write, "trusting" mount-time SSR/CSR content already
- * matched — removed as unsound in general: a region's value can genuinely
- * differ from what's in the DOM on the first write, e.g. after a
- * client-side region swap adopts server HTML rendered from a different
- * default. See `claim-slots.ts`'s module docstring.)
- *
- * Non-empty `regions` forces the caller's multi-line renderItem layout (the
- * effect needs `__el` as a query root), mirroring `emitLoopChildRefs`.
+ * Preamble-patched regions (#2389 — `arr.map(t => { const cells = []; ...;
+ * return <tr>{cells}<td>{t.name}</td></tr> })`) used to get their own
+ * per-region `createEffect` here. Row-granularity effects (perf,
+ * spec/slot-unification.md §3(c)/§8) merged that into the SAME single row
+ * effect `stringifyReactiveEffects` now emits for attrs/outer texts — see
+ * that module's docstring. Both plain-loop-row call sites
+ * (`stringifyPlainLoop` below, `stringify/branch-loop.ts`'s `emitPlain`) pass
+ * `preambleRegions`/`mapPreambleWrapped` straight into
+ * `stringifyReactiveEffects` instead of calling a separate emitter.
  */
-export function emitPreambleRegionEffects(
-  lines: string[],
-  regions: readonly PreambleRegionPlan[],
-  mapPreambleWrapped: string,
-  opts: { indent: string; elVar: string },
-): void {
-  if (regions.length === 0) return
-  const { indent, elVar } = opts
-  const slots: ClaimSlotSpec[] = regions.map(r => ({ id: r.slotId, kind: 'markup', path: [] }))
-  const writer = claimWriterVarName(slots, varSlotId)
-  lines.push(`${indent}const ${writer} = lazySlots(${elVar}, ${claimPlanLiteral(slots)})`)
-  for (const region of regions) {
-    lines.push(`${indent}createEffect(() => {`)
-    if (mapPreambleWrapped) lines.push(`${indent}  ${mapPreambleWrapped}`)
-    lines.push(`${indent}  ${writer}('${region.slotId}', ${region.valueExpr})`)
-    lines.push(`${indent}})`)
-  }
-}
 
 /**
  * Single dispatch over `LoopPlan` (#1253). Narrows on `plan.kind` and
@@ -288,17 +264,22 @@ export function stringifyPlainLoop(
       if (path) textClaimPathExprs.set(text.slotId, `__existing ? [] : [${path.join(', ')}]`)
     }
   }
-  if (reactiveEffects !== null) {
+  if (reactiveEffects !== null || preambleRegions.length > 0) {
+    // Row-granularity effects (§3(c)): attrs, outer texts, AND preamble
+    // regions all merge into the SAME single row `createEffect` — pass
+    // `preambleRegions`/`mapPreambleWrapped` straight through instead of a
+    // separate emitter call (see `stringifyReactiveEffects`'s docstring).
     stringifyReactiveEffects(lines, reactiveEffects, {
       indent: bodyIndent,
       elVar: '__el',
       bodyIsMultiRoot,
       elementIndexBySlot: pathPlan?.elementIndexBySlot,
       textClaimPathExprs,
+      preambleRegions,
+      mapPreambleWrapped,
     })
   }
   emitLoopChildRefs(lines, childRefs, { indent: bodyIndent, elVar: '__el', bodyIsMultiRoot, elementIndexBySlot: pathPlan?.elementIndexBySlot })
-  emitPreambleRegionEffects(lines, preambleRegions, mapPreambleWrapped, { indent: bodyIndent, elVar: '__el' })
   lines.push(`${bodyIndent}return __el`)
   lines.push(`${topIndent}}, '${markerId}'${loopBfId})`)
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
@@ -6,6 +6,29 @@
  * bodies (events, child component inits, inner loops, nested conditionals,
  * branch-scoped texts) flow through the per-arm stringifiers in
  * `loop-child-arm.ts` — no legacy passthrough remains.
+ *
+ * Row-granularity effects (perf, spec/slot-unification.md §3(c)/§8, the
+ * deferred A3b): for the "plain loop row, top-level or branch-scoped" shape
+ * — the only shape where `stringifyReactiveEffects` is called alongside
+ * `PreambleRegionPlan`s from the SAME renderItem scope (`stringify/loop.ts`'s
+ * `stringifyPlainLoop`, `stringify/branch-loop.ts`'s `emitPlain`) — reactive
+ * attrs, outer texts, and preamble regions all read the SAME per-item signal
+ * dependency, so consolidating them into ONE `createEffect` per row removes
+ * N-1 effect objects and subscription-list entries per row without changing
+ * the firing profile. Composite loops, component loops, and the anchored
+ * (whole-item-conditional) loop shape keep the legacy one-effect-per-slot
+ * emission — their reactiveEffects never carry preamble regions, and
+ * consolidating them wasn't part of this pass's mechanically-verified scope
+ * (see the call sites' docstrings).
+ *
+ * Profile mode (#1690) carries a `<Component>#binding:<slotId>` id per
+ * effect so the profiler attributes a re-run to its source binding — merging
+ * bindings into one effect would make every binding on the row share one id.
+ * Resolution: profile mode (`plan.profileComponentName` set) keeps the
+ * granular per-slot/per-attr effect emission (`emitAttrSlotsGranular` /
+ * `emitOuterTexts` below); normal builds get the consolidated row effect.
+ * Preamble regions never carried a per-region bfId even before this pass, so
+ * they always consolidate into one effect regardless of profile mode.
  */
 
 import { varSlotId, profileBindingId } from '../../utils.ts'
@@ -14,9 +37,19 @@ import { stringifyLoopChildArm } from './loop-child-arm.ts'
 import { claimPlanLiteral, claimWriterVarName, type ClaimSlotSpec } from './claim-plan.ts'
 import type {
   NestedConditionalPlan,
+  ReactiveAttrSlot,
   ReactiveEffectsPlan,
   ReactiveTextEffect,
 } from '../plan/reactive-effects.ts'
+
+/** A resolved preamble-patched region (#2389) ready to merge into the row
+ *  effect — same shape as `plan/loop.ts`'s `PreambleRegionPlan`, restated
+ *  here so this module doesn't need a cross-import into the loop plan file
+ *  for one two-field shape. */
+export interface RowPreambleRegion {
+  slotId: string
+  valueExpr: string
+}
 
 export interface StringifyReactiveEffectsOptions {
   /** Indent prefix for every emitted line. */
@@ -57,25 +90,74 @@ export interface StringifyReactiveEffectsOptions {
    * statically pathed" allowance.
    */
   textClaimPathExprs?: ReadonlyMap<string, string>
+  /**
+   * Preamble-patched regions (#2389) to merge into the SAME row effect as
+   * this scope's reactive attrs/outer texts (row-granularity effects,
+   * §3(c)) — only supplied by the plain-loop-row call sites
+   * (`stringify/loop.ts`, `stringify/branch-loop.ts`) where
+   * `PlainLoopVariant.preambleRegions` exists on the plan. Every other
+   * caller omits this and gets the legacy per-slot emission untouched.
+   */
+  preambleRegions?: readonly RowPreambleRegion[]
+  /**
+   * The loop callback's pre-return preamble (already wrapped with the loop
+   * param accessor), re-run once per row-effect tick — BEFORE any preamble
+   * region read — so `preambleRegions`' `valueExpr`s see freshly recomputed
+   * locals. Only meaningful alongside `preambleRegions`.
+   */
+  mapPreambleWrapped?: string
 }
 
 export function stringifyReactiveEffects(
   lines: string[],
-  plan: ReactiveEffectsPlan,
+  plan: ReactiveEffectsPlan | null,
   opts: StringifyReactiveEffectsOptions,
 ): void {
-  const { indent, elVar, bodyIsMultiRoot, elementIndexBySlot, textClaimPathExprs } = opts
+  const { indent, elVar, bodyIsMultiRoot, elementIndexBySlot, textClaimPathExprs, preambleRegions = [], mapPreambleWrapped } = opts
   const lookup = bodyIsMultiRoot ? 'qsaItem' : 'qsa'
-  const pc = plan.profileComponentName
+  const pc = plan?.profileComponentName
   const bindingBfId = (slotId: string): string => profileBindingId(pc, slotId)
+  const attrSlots = plan?.attrSlots ?? []
+  const outerTexts = plan?.outerTexts ?? []
+  const conditionals = plan?.conditionals ?? []
 
-  // 1. Reactive attribute effects (one qsa per slot, then per-attr createEffect).
-  for (const slot of plan.attrSlots) {
+  if (pc) {
+    // Profile mode: preserve the granular per-slot/per-attr effect shape so
+    // every binding keeps its own bfId (see module docstring).
+    emitAttrSlotsGranular(lines, indent, elVar, lookup, attrSlots, elementIndexBySlot, bindingBfId)
+    emitOuterTexts(lines, indent, elVar, outerTexts, bindingBfId, textClaimPathExprs)
+    emitPreambleRegionsEffect(lines, indent, elVar, preambleRegions, mapPreambleWrapped)
+  } else {
+    emitConsolidatedRowEffect(
+      lines, indent, elVar, lookup,
+      attrSlots, outerTexts, elementIndexBySlot, textClaimPathExprs,
+      preambleRegions, mapPreambleWrapped,
+    )
+  }
+
+  // Reactive conditionals — each emits an insert(...) over `elVar` whose arm
+  // bodies dispatch through the per-arm stringifiers. Structurally distinct
+  // from the attrs/texts/regions merge above (its own per-branch disposable
+  // effects), so it's untouched by row-granularity consolidation.
+  for (const cond of conditionals) {
+    emitOuterConditional(lines, indent, elVar, cond, pc)
+  }
+}
+
+// --- profile-mode / legacy granular emission (one createEffect per slot-attr) ---
+
+function emitAttrSlotsGranular(
+  lines: string[],
+  indent: string,
+  elVar: string,
+  lookup: string,
+  attrSlots: readonly ReactiveAttrSlot[],
+  elementIndexBySlot: ReadonlyMap<string, number> | undefined,
+  bindingBfId: (slotId: string) => string,
+): void {
+  for (const slot of attrSlots) {
     const varName = `__ra_${varSlotId(slot.slotId)}`
-    const pIdx = elementIndexBySlot?.get(slot.slotId)
-    const lookupExpr = pIdx !== undefined
-      ? `__p ? __p[${pIdx}] : ${lookup}(${elVar}, '[bf="${slot.slotId}"]')`
-      : `${lookup}(${elVar}, '[bf="${slot.slotId}"]')`
+    const lookupExpr = attrLookupExpr(slot.slotId, varName, elVar, lookup, elementIndexBySlot)
     lines.push(`${indent}{ const ${varName} = ${lookupExpr}`)
     lines.push(`${indent}if (${varName}) {`)
     for (const attr of slot.attrs) {
@@ -87,19 +169,129 @@ export function stringifyReactiveEffects(
     }
     lines.push(`${indent}} }`)
   }
+}
 
-  // 2. Outer text effects (slots NOT inside any conditional branch), via ONE
-  //    claimed-slot writer covering every text slot in this scope (row-level
-  //    claim, `spec/slot-unification.md` §3(a)/§5-A3). `lazySlots` touches
-  //    nothing until the first `createEffect` fires, and that first write
-  //    claims every slot in the plan at once.
-  emitOuterTexts(lines, indent, elVar, plan.outerTexts, bindingBfId, textClaimPathExprs)
-
-  // 3. Reactive conditionals — each emits an insert(...) over `elVar` whose
-  //    arm bodies dispatch through the per-arm stringifiers.
-  for (const cond of plan.conditionals) {
-    emitOuterConditional(lines, indent, elVar, cond, pc)
+/** ONE createEffect covering every preamble region — never carried a bfId
+ *  before this pass (regions were never profiled per-binding), so this
+ *  shape applies in both profile and non-profile mode. */
+function emitPreambleRegionsEffect(
+  lines: string[],
+  indent: string,
+  elVar: string,
+  preambleRegions: readonly RowPreambleRegion[],
+  mapPreambleWrapped: string | undefined,
+): void {
+  if (preambleRegions.length === 0) return
+  const slots: ClaimSlotSpec[] = preambleRegions.map(r => ({ id: r.slotId, kind: 'markup', path: [] }))
+  const writer = claimWriterVarName(slots, varSlotId)
+  lines.push(`${indent}const ${writer} = lazySlots(${elVar}, ${claimPlanLiteral(slots)})`)
+  lines.push(`${indent}createEffect(() => {`)
+  if (mapPreambleWrapped) lines.push(`${indent}  ${mapPreambleWrapped}`)
+  for (const region of preambleRegions) {
+    lines.push(`${indent}  ${writer}('${region.slotId}', ${region.valueExpr})`)
   }
+  lines.push(`${indent}})`)
+}
+
+function attrLookupExpr(
+  slotId: string,
+  varName: string,
+  elVar: string,
+  lookup: string,
+  elementIndexBySlot: ReadonlyMap<string, number> | undefined,
+): string {
+  const pIdx = elementIndexBySlot?.get(slotId)
+  return pIdx !== undefined
+    ? `__p ? __p[${pIdx}] : ${lookup}(${elVar}, '[bf="${slotId}"]')`
+    : `${lookup}(${elVar}, '[bf="${slotId}"]')`
+}
+
+// --- row-granularity consolidated emission (ONE createEffect per row) ---
+
+/**
+ * Emit ONE `createEffect` covering: reactive attr writes (for every slot in
+ * `attrSlots`), outer text writes, and preamble-region writes — in that
+ * order, mirroring the legacy relative ordering (attrs, then texts, then
+ * regions). Attr-slot element lookups are resolved ONCE, outside the
+ * effect (identical to the legacy shape — only the WRITE moves inside the
+ * shared effect). Outer texts and preamble regions share ONE claimed-slot
+ * writer (mixed 'text'/'markup' kinds — `claim-slots.ts`'s `write()` already
+ * dispatches per-slot on `kind`), so a row pays for at most one `lazySlots`
+ * closure + one claim `Map` instead of one per category.
+ *
+ * Every attr's write statements are wrapped in their own `{ }` block (not
+ * just each slot's) — `emitAttrUpdate`'s 'value'-attr shape emits a bare
+ * `const __val = …` with no block of its own, and merging multiple attrs
+ * into one function body (previously each had its own arrow-function scope)
+ * would let two 'value' attrs in the same row effect collide on `__val`.
+ */
+function emitConsolidatedRowEffect(
+  lines: string[],
+  indent: string,
+  elVar: string,
+  lookup: string,
+  attrSlots: readonly ReactiveAttrSlot[],
+  outerTexts: readonly ReactiveTextEffect[],
+  elementIndexBySlot: ReadonlyMap<string, number> | undefined,
+  textClaimPathExprs: ReadonlyMap<string, string> | undefined,
+  preambleRegions: readonly RowPreambleRegion[],
+  mapPreambleWrapped: string | undefined,
+): void {
+  if (attrSlots.length === 0 && outerTexts.length === 0 && preambleRegions.length === 0) return
+
+  // 1. Resolve every attr slot's element reference once, outside the effect.
+  for (const slot of attrSlots) {
+    const varName = `__ra_${varSlotId(slot.slotId)}`
+    lines.push(`${indent}const ${varName} = ${attrLookupExpr(slot.slotId, varName, elVar, lookup, elementIndexBySlot)}`)
+  }
+
+  // 2. ONE claimed-slot writer covering outer texts (kind 'text') and
+  //    preamble regions (kind 'markup') — mixed-kind plans are supported by
+  //    claim-slots.ts's per-slot `kind` dispatch.
+  const claimSlots: ClaimSlotSpec[] = [
+    ...outerTexts.map((t): ClaimSlotSpec => ({ id: t.slotId, kind: 'text', path: [], pathExpr: textClaimPathExprs?.get(t.slotId) })),
+    ...preambleRegions.map((r): ClaimSlotSpec => ({ id: r.slotId, kind: 'markup', path: [] })),
+  ]
+  const writer = claimSlots.length > 0 ? claimWriterVarName(claimSlots, varSlotId) : null
+  if (writer) {
+    lines.push(`${indent}const ${writer} = lazySlots(${elVar}, ${claimPlanLiteral(claimSlots)})`)
+  }
+
+  // 3. The single row effect: attr writes, then (if any region needs it) the
+  //    preamble re-run, then text writes, then region writes. The by-far
+  //    most common shape — no attrs, no regions, exactly one outer text —
+  //    collapses to the SAME single-line `createEffect(() => { ... })` the
+  //    legacy per-text emitter used (doc-examples snapshots pin this byte
+  //    shape); anything busier (an attr present, multiple slots, or a
+  //    preamble region) uses the multi-line block.
+  if (attrSlots.length === 0 && preambleRegions.length === 0 && outerTexts.length === 1) {
+    const text = outerTexts[0]
+    lines.push(`${indent}createEffect(() => { ${writer}('${text.slotId}', String(${text.wrappedExpression})) })`)
+    return
+  }
+  lines.push(`${indent}createEffect(() => {`)
+  for (const slot of attrSlots) {
+    const varName = `__ra_${varSlotId(slot.slotId)}`
+    lines.push(`${indent}  if (${varName}) {`)
+    for (const attr of slot.attrs) {
+      lines.push(`${indent}    {`)
+      for (const stmt of emitAttrUpdate(varName, attr.attrName, attr.wrappedExpression, attr.meta)) {
+        lines.push(`${indent}      ${stmt}`)
+      }
+      lines.push(`${indent}    }`)
+    }
+    lines.push(`${indent}  }`)
+  }
+  if (preambleRegions.length > 0 && mapPreambleWrapped) {
+    lines.push(`${indent}  ${mapPreambleWrapped}`)
+  }
+  for (const text of outerTexts) {
+    lines.push(`${indent}  ${writer}('${text.slotId}', String(${text.wrappedExpression}))`)
+  }
+  for (const region of preambleRegions) {
+    lines.push(`${indent}  ${writer}('${region.slotId}', ${region.valueExpr})`)
+  }
+  lines.push(`${indent}})`)
 }
 
 function emitOuterTexts(

--- a/spec/slot-unification.md
+++ b/spec/slot-unification.md
@@ -254,6 +254,63 @@ are the load-bearing claim here and they're deterministic build outputs,
 not timing-sensitive; hydration/server-render numbers above are
 consistent with A4's jitter range and are not this note's point.)
 
+### Row-granularity effects (A3b) — regression confirmed and fixed (measured 2026-07-27)
+
+A3's compiler switch (above) kept per-slot effect emission — one
+`createEffect` per reactive attr, per reactive text, and per preamble
+region — stacked on top of the NEW per-row claim-plan allocations (a
+`lazySlots` writer closure, its plan-literal array, and the `Map` +
+per-slot refs the first write allocates). CI's quick-mode DOM benchmark
+(`benchmarks/runner/bench-dom.ts`, `benchmarks/apps/barefoot`) caught the
+result as a real regression, confirmed on identical sandbox hardware
+against the pre-migration merge commit (`011126f8`):
+
+| Metric | pre-migration (011126f8) | post-A3 (regressed) | post-A3b (this fix) |
+|---|---|---|---|
+| memory (1k rows) | 1756.9KB | 2046.4KB (+16.5%) | ~1767KB (-13.6% vs regressed) |
+| update10th | 12.00ms (1.00x vanilla) | 12.6-12.7ms (1.09-1.24x, noisy) | 14.1-16.0ms (1.04-1.17x) |
+| shipped JS (raw/gzip) | 23.8 / 8.7KB | 26.0 / 9.3KB | 26.0 / 9.3KB (unchanged — the win is runtime object count, not source bytes) |
+
+Per-row inventory at the regressed commit (`bf build`'s emitted
+`renderItem` for the bench table row — one reactive `class` attr, two
+reactive texts, no preamble region): 3 separate `createEffect` calls
+(unchanged from pre-migration's own 3), PLUS a NEW `lazySlots` call whose
+plan literal (2 `SlotSpec` objects + an array) is allocated fresh every
+row regardless of whether the row ever updates, and whose first write
+(fired synchronously by `createEffect`'s initial run — not deferred in
+practice for a freshly-created row) allocates a `Map` + one
+`ClaimedTextSlot` ref per text slot. The regression's dominant cost was
+this claim-mechanism allocation, not the effect count — §3(c)'s own
+"remove N-1 effect objects" framing undersold the fix's actual ceiling,
+noted honestly here rather than silently.
+
+**The fix** (§3(c), row-granularity effects, implemented): for the plain
+loop-row shape (top-level `mapArray` rows, `stringify/loop.ts`'s
+`stringifyPlainLoop`, and the structurally-identical branch-scoped rows in
+`stringify/branch-loop.ts`'s `emitPlain`) every reactive attr, outer text,
+and preamble region for a row now shares ONE `createEffect` and (for the
+texts/regions) ONE `lazySlots` writer over a mixed `'text'`/`'markup'`
+claim plan — cutting the bench row's 3 effects to 1. Composite loops,
+component loops, the anchored (whole-item-conditional) shape, and static
+(`forEach`) loops are untouched (they never carry preamble regions, and
+this pass only mechanically verified the plain-row shape). Profile mode
+keeps the old per-slot/per-attr emission so `<Component>#binding:<slotId>`
+ids still attribute a re-run to its own binding.
+
+**Result**: memory recovered to within ~0.6% of the pre-migration
+same-hardware baseline (three consistent measurements: two quick-mode runs
+at 1767.3-1769.4KB, one full 3-iteration run at 1767.4KB) — a real,
+reproducible ~279KB/13.6% win over the regressed state, though not
+strictly BELOW the pre-migration number. The residual ~10KB gap is
+mechanically attributable to the claim-mechanism's own allocations (the
+writer closure + `Map` + refs the per-row inventory above describes),
+which the effect-count consolidation does not touch and which was out of
+this pass's explicit scope (design agreed for §3(c) was "one effect per
+row", not "rework claim-plan allocation shape") — a candidate for a future
+pass (e.g. hoisting the plan literal's static `id`/`kind` fields once per
+loop instead of re-allocating them every row), not a shortfall in what
+this fix set out to do.
+
 ## 5. Migration — two steps, stacked semantic PRs
 
 Compatibility with the current emitted grammar is explicitly NOT a goal
@@ -327,3 +384,35 @@ by node count/memory (§5a), not transfer size.
   door.
 - Matching SolidJS feature-for-feature; it is a reference point, not a
   target.
+
+## 8. Follow-ups
+
+- **Row-granularity effects (§3(c)) — DONE.** Plain loop rows (top-level
+  `mapArray` and the structurally-identical branch-scoped shape) emit ONE
+  `createEffect` per row covering every reactive attr, outer text, and
+  preamble region, sharing one mixed-kind `lazySlots` writer for the
+  texts/regions. Fixed the A3-introduced CSR memory/update regression
+  (§5a's "Row-granularity effects (A3b)" measurement) back to within
+  ~0.6% of the pre-migration baseline. Composite loops, component loops,
+  the anchored (whole-item-conditional) shape, and static (`forEach`)
+  loops were left untouched — out of this pass's mechanically-verified
+  scope (they never carry preamble regions, the shape that made the
+  three-way merge possible). Profile mode keeps the old per-slot/per-attr
+  emission so per-binding profiler ids survive.
+- **General marker elision remains** (§3(b), deferred past Step B):
+  ordinary reactive loop-row text (the 1k-row bench's actual hot path) is
+  still marker-based — only `/* @client */` text elides its marker pair
+  today. The data-dependent-width problem Step B's own note describes
+  (a later sibling's path is only valid for the width THIS request
+  produced) is unsolved for the general case.
+- **Claim-mechanism allocation shape**: §5a's row-granularity measurement
+  section notes a residual ~10KB/1k-rows gap between this fix's result and
+  the pre-migration baseline, attributable to the `lazySlots` writer
+  closure + claim `Map` + per-slot refs every row still allocates (even a
+  row that never updates, since `createEffect`'s synchronous initial run
+  triggers the first write in practice for a freshly-created row). Not
+  addressed here — the design agreed for this pass was effect-count
+  consolidation, not a rework of claim-plan allocation — but a real,
+  mechanically-identified candidate for a future pass (e.g. hoisting each
+  slot's static `id`/`kind` once per loop and only threading a per-row
+  `path`, instead of re-allocating full `SlotSpec` objects every row).


### PR DESCRIPTION
Confirms and fixes the CSR regression the benchmark bot surfaced after the slot-unification merge, and lands the spec §3(c) row-granularity follow-up that was deferred from A3.

## Regression confirmed (identical sandbox hardware, main vs pre-migration `011126f8`)

| Metric | pre-migration | regressed (main) | **this PR** |
|---|---|---|---|
| memory (1k rows) | 1756.9KB | 2046.4KB (+16.5%) | **1767.3–1769.4KB** (−13.6%, within 0.6% of baseline) |
| update10th | 12.0ms (1.00x) | 12.6–12.7ms (noisy, CI showed 1.52x) | **14.1–16.0ms (1.04–1.17x)** |
| shipped JS | 23.8/8.7KB | 26.0/9.3KB | 26.0/9.3KB (object-count win, not bytes) |

**Actual cause** (from diffing the bench app's emitted client JS across commits): the effect count per row was unchanged — what A3 added was a per-row `lazySlots` writer closure + `SlotSpec` plan array + (on the mount-time first write) a `Map` + per-slot claimed refs, stacked on top of allocations the old direct `$t`/`tAfter` refs never needed. No claim re-scan bug (`path: []` claims exactly once per row).

## Fix

Non-profile builds now emit **one `createEffect` per plain loop row** covering reactive attrs, text slots, and preamble regions through one shared mixed-kind `lazySlots` writer (`stringify/reactive-effects.ts`, wired into `stringifyPlainLoop` + branch `emitPlain`). Loop-row slots read the same per-item signal, so the firing profile is unchanged; N−1 effect objects and their subscription entries disappear per row. **Profile mode (#1690) keeps the granular per-slot emission** so `#binding:&lt;slotId&gt;` attribution survives — resolution of the blocker A3 flagged. Composite/component/anchored/static shapes untouched (no preamble regions there; the three-way merge isn't mechanical). The single-text-no-attrs common case keeps its legacy single-line effect form (7 doc-example snapshots pinned that shape — caught and preserved during the work).

Residual ~10KB/1k-rows vs baseline is the claim mechanism's own writer/Map/refs allocation — documented as the remaining §8 follow-up (true lazy claim needs effect-creation deferral, a different change).

## Verification

jsx 2718/0 · client 561/0 (independently re-verified) · adapter-tests 1436/0 · adapter-hono 1257/0 · fixture-hydrate **34/34** · full site/ui e2e 1124 passed with only the 3 known pre-existing reds · integrations/hono e2e **104/104** · bench re-run ×2 + full-mode ×1, numbers above · changeset added · spec §5a/§8 updated with measured results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_