### PR TITLE
docs: update hydration examples to the claim-plan model

### DIFF
--- a/docs/core/advanced/compiler-internals.md
+++ b/docs/core/advanced/compiler-internals.md
@@ -195,7 +195,7 @@ createEffect(() => {
 ### 4. Code Generation Order
 
 ```javascript
-import { $, $t, createEffect, createMemo, createSignal, hydrate, onMount } from '@barefootjs/client'
+import { $, createEffect, createMemo, createSignal, escapeTextOrNode, hydrate, lazySlots, onMount } from '@barefootjs/client/runtime'
 
 export function initCounter(__scope, _p = {}) {
   if (!__scope) return
@@ -216,15 +216,16 @@ export function initCounter(__scope, _p = {}) {
   const doubled = createMemo(() => count() * 2)
 
   // 4. Element references (always destructured, always returns array)
-  //    $()  — regular elements:  querySelector('[bf="id"]') within scope
-  //    $t() — text nodes:        find comment marker <!--bf:id-->
+  //    $() — regular elements: querySelector('[bf="id"]') within scope
   const [_s3] = $(__scope, 's3')
-  const [_s0, _s2] = $t(__scope, 's0', 's2')
 
-  // 5. Dynamic text updates
+  // 5. Dynamic content updates — the compiler emits a claim plan (data)
+  //    per slot; lazySlots() claims the <!--bf:id-->…<!--/--> marker
+  //    range once on first write, then writes through the held reference
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
   createEffect(() => {
     const __val = count()
-    if (_s0 && !__val?.__isSlot) _s0.nodeValue = String(__val ?? '')
+    __bfw_s0('s0', escapeTextOrNode(__val))
   })
 
   // 6. Reactive attribute updates
@@ -266,7 +267,7 @@ hydrate('Counter', {
 Only used imports are included:
 
 ```javascript
-import { $, $t, createEffect, createMemo, createSignal, hydrate, onMount } from '@barefootjs/client'
+import { $, createEffect, createMemo, createSignal, escapeTextOrNode, hydrate, lazySlots, onMount } from '@barefootjs/client/runtime'
 ```
 
 ### 6. Template Registration

--- a/docs/core/core-concepts/how-it-works.mdx
+++ b/docs/core/core-concepts/how-it-works.mdx
@@ -82,7 +82,7 @@ export function Counter({ __instanceId, ... }) {
 Client JS (Phase 2b):
 
 ```js
-import { $, $t, createEffect, createSignal, hydrate } from '@barefootjs/client'
+import { $, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
 
 export function initCounter(__scope, _p = {}) {
   if (!__scope) return
@@ -90,11 +90,13 @@ export function initCounter(__scope, _p = {}) {
   const [count, setCount] = createSignal(0)
 
   const [_s1] = $(__scope, 's1')       // element lookup
-  const [_s0] = $t(__scope, 's0')      // text node lookup
 
+  // Content slot: claimed lazily from the <!--bf:s0-->…<!--/--> marker
+  // pair on first write, then updated through the held reference
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
   createEffect(() => {
     const __val = count()
-    if (_s0) _s0.nodeValue = String(__val ?? '')
+    __bfw_s0('s0', escapeTextOrNode(__val))
   })
 
   if (_s1) _s1.addEventListener('click', () => { setCount(n => n + 1) })
@@ -102,7 +104,7 @@ export function initCounter(__scope, _p = {}) {
 
 hydrate('Counter', {
   init: initCounter,
-  template: (_p) => `<button bf="s1"> Count: <!--bf:s0-->${(0)}<!--/--></button>`
+  template: (_p) => `<button bf="s1"> Count: <!--bf:s0-->${escapeText((0))}<!--/--></button>`
 })
 ```
 
@@ -135,9 +137,11 @@ Marker-driven hydration attaches behavior to server-rendered HTML.
 4. Init function runs per scope — signals, effects, handlers
 5. Runtime tracks scopes to prevent double initialization
 
-### Scoped Queries
+### Scoped Queries and Slot Claiming
 
-`$()` and `$t()` search within a scope, excluding child component scopes:
+Element lookups (`$()`) and content-slot claims (`claimSlots()` /
+`lazySlots()`) both operate within a scope, excluding child component
+scopes:
 
 ```html
 <div bf-s="TodoApp_x1">
@@ -148,4 +152,16 @@ Marker-driven hydration attaches behavior to server-rendered HTML.
 </div>
 ```
 
-`$(__scope, 's0')` in TodoApp finds `<h1>`, not the `<span>` inside TodoItem. The `~` prefix marks a child scope excluded from parent queries.
+`$(__scope, 's0')` in TodoApp finds `<h1>`, not the `<span>` inside
+TodoItem. The `~` prefix marks a child scope excluded from parent
+queries.
+
+Dynamic *content* (reactive text and markup regions) is not looked up
+per update. Instead the compiler emits a **claim plan** — a data
+description of each slot (`{ id, kind, path }`) — and the runtime claims
+the slot's DOM position **once**: `lazySlots()` scans for the slot's
+`<!--bf:id-->…<!--/-->` marker pair on the first write (skipping child
+scopes, same as `$()`), holds the reference, and every later write goes
+through that held reference with no re-scanning. `claimSlots()` is the
+eager variant used where content may be mutated before the first write
+(streaming, portals).

--- a/docs/core/introduction.mdx
+++ b/docs/core/introduction.mdx
@@ -63,7 +63,7 @@ export function Counter({ __instanceId, ... }) {
 **Client script** — Wires up only the interactive parts:
 
 ```js
-import { $, $t, createEffect, createSignal, hydrate } from '@barefootjs/client'
+import { $, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
 
 export function initCounter(__scope, _p = {}) {
   if (!__scope) return
@@ -71,11 +71,13 @@ export function initCounter(__scope, _p = {}) {
   const [count, setCount] = createSignal(0)
 
   const [_s1] = $(__scope, 's1')       // find element with bf="s1"
-  const [_s0] = $t(__scope, 's0')      // find text node at <!--bf:s0-->
 
+  // Claim the content slot between <!--bf:s0--> and <!--/--> on first
+  // write; later writes reuse the claimed reference (no re-scanning)
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
   createEffect(() => {
     const __val = count()
-    if (_s0) _s0.nodeValue = String(__val ?? '')
+    __bfw_s0('s0', escapeTextOrNode(__val))
   })
 
   if (_s1) _s1.addEventListener('click', () => { setCount(n => n + 1) })
@@ -83,6 +85,6 @@ export function initCounter(__scope, _p = {}) {
 
 hydrate('Counter', {
   init: initCounter,
-  template: (_p) => `<button bf="s1"> Count: <!--bf:s0-->${(0)}<!--/--></button>`
+  template: (_p) => `<button bf="s1"> Count: <!--bf:s0-->${escapeText((0))}<!--/--></button>`
 })
 ```


### PR DESCRIPTION
Follow-up to the slot unification series (#2396–#2400, #2402, #2403): the documentation site still described the pre-unification hydration mechanism.

## What was stale

Three pages showed compiled client JS with `$t()` text-node lookups and per-slot effects writing `_s0.nodeValue` directly — a form the compiler has not emitted since the A3 compiler switch (#2398):

- `docs/core/introduction.mdx` — the Counter "client script" output
- `docs/core/core-concepts/how-it-works.mdx` — the same Counter example, plus a "Scoped Queries" section documenting `$t()`
- `docs/core/advanced/compiler-internals.md` — the annotated codegen-order walkthrough (steps 4–5) and the import-detection example

## What changed

Rewritten from real compiled output of the current compiler (cross-checked against the doc-examples snapshot corpus, where the intro Counter is pinned):

- `$t()` lookups → `lazySlots()` claim plans: the compiler emits slot descriptions as data (`{ id, kind, path }`), and the runtime claims the `&lt;!--bf:id--&gt;…&lt;!--/--&gt;` marker range once on first write, writing through the held reference afterwards.
- Import lines corrected to `@barefootjs/client/runtime` with the actually-emitted names (`escapeText`, `escapeTextOrNode`, `lazySlots`, …).
- how-it-works' "Scoped Queries" section renamed to "Scoped Queries and Slot Claiming" and extended: `$()` scope semantics unchanged, plus an explanation of claim-once semantics and `claimSlots()` as the eager variant for content mutated before first write (streaming, portals).

The SSR-side story (marked templates, `bf-*` attributes, `&lt;!--bf:id--&gt;` comment pairs) is unchanged and those descriptions were left as-is.

## Verification

`bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 219 pass / 0 fail (the edited fences are output examples, not compiled tsx fences; the tsx contracts still compile and their snapshots are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_