### PR TITLE
docs(lp): update hydration runtime size claim to measured ~16 kB

### DIFF
--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -68,8 +68,9 @@ if (!await Bun.file(domDistFile).exists()) {
 // Fully minify the runtime at copy time (identifier mangling included —
 // unlike component client JS, only the runtime's ESM export names must
 // survive, and Bun.build preserves those). The runtime is the largest
-// single script the site serves, and the LP's "~14 kB gzipped" claim is
-// measured on this minified build.
+// single script the site serves, and the LP's runtime-size claim
+// (hero.tsx, "min+gzip") is measured on this minified build — re-measure
+// and update hero.tsx when runtime changes move it.
 const runtimeBuild = await Bun.build({
   entrypoints: [domDistFile],
   target: 'browser',

--- a/site/core/landing/components/hero.tsx
+++ b/site/core/landing/components/hero.tsx
@@ -44,7 +44,7 @@ export function Hero({ uiHref = 'https://ui.barefootjs.dev' }: { uiHref?: string
         <p className="lp-hero-sub">
           BarefootJS compiles TSX components into your backend's own templates —{' '}
           <strong>Go, Rails, Django, Perl, PHP, Rust</strong>. Your server renders them.
-          A small hydration runtime (~14&nbsp;kB min+gzip) makes them interactive. Node never ships.
+          A small hydration runtime (~16&nbsp;kB min+gzip) makes them interactive. Node never ships.
         </p>
         <div className="lp-cta-row">
           <a className="lp-btn lp-btn-primary" href="/docs/quick-start">Get started</a>
@@ -106,7 +106,7 @@ export async function DemoSection() {
         <p className="demo-note">
           It's a compiler, not a framework. TSX and type-checking exist at build time,
           like a Sass compiler. At runtime there is only your template engine and one
-          small <code>~14&nbsp;kB min+gzip</code> hydration script.
+          small <code>~16&nbsp;kB min+gzip</code> hydration script.
         </p>
       </div>
       <script dangerouslySetInnerHTML={{ __html: DEMO_TABS_SCRIPT }} />


### PR DESCRIPTION
The landing page hero claimed the hydration runtime is "~14 kB min+gzip" (two spots in `hero.tsx`). Re-measured with the exact method `site/core/build.ts` documents for this claim — minify `packages/client/dist/runtime/standalone.js` with `Bun.build({ minify: true })`, then gzip:

| | measured |
|---|---|
| minified | 49.7 kB |
| min+gzip | 16.7 kB (level 9: 16.3 kB) |

## Changes

- `site/core/landing/components/hero.tsx` — both "~14&amp;nbsp;kB min+gzip" mentions updated to "~16&amp;nbsp;kB min+gzip".
- `site/core/build.ts` — the comment that anchored the claim to this minified build no longer hard-codes the number (it had drifted); it now points at `hero.tsx` and says to re-measure when runtime changes move the size.

No behavior change; copy and comment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_