### PR TITLE
feat(client): mapArrayLazy — lazy row graph runtime (slot unification §9, L2)

### DIFF
--- a/.changeset/lazy-rows-runtime.md
+++ b/.changeset/lazy-rows-runtime.md
@@ -1,0 +1,17 @@
+---
+"@barefootjs/client": patch
+---
+
+Add `mapArrayLazy` (plus its `LazyRowPlan`/`LazyRowEntry` contract types) to
+`@barefootjs/client/runtime` — the lazy row graph runtime for keyed loops
+(spec/slot-unification.md §9, L2 of the stacked series). Rows carry NO
+per-row reactive resources: hydration adopts SSR rows with zero DOM
+mutations (key read from `data-key`, never written on adopted rows),
+item-driven updates are direct reconciler calls into the plan's `applyItem`
+with lazy per-row ref claiming, and outer-involving bindings run through ONE
+loop-level effect (`applyOuter`) with read-compare-write seeding on its
+first run. Keyed diff, duplicate-key warning, clear-all fast path, and LIS
+minimal-move reorder mirror `mapArray`'s; `createRow`/`applyItem` run
+untracked so the reconciler subscribes only to the loop accessor. No
+compiler change yet — the L3 compiler switch targets this entry point for
+eligible plain loops.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -60,6 +60,7 @@
         "packages/client/src/runtime/insert.ts",
         "packages/client/src/runtime/hydrate.ts",
         "packages/client/src/runtime/map-array.ts",
+        "packages/client/src/runtime/map-array-lazy.ts",
         "packages/client/src/runtime/component.ts",
         "packages/client/src/runtime/apply-rest-attrs.ts",
         "packages/client/src/runtime/dynamic-text.ts"

--- a/packages/client/__tests__/env-signal.test.ts
+++ b/packages/client/__tests__/env-signal.test.ts
@@ -14,6 +14,16 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator'
 beforeAll(() => {
   if (typeof window === 'undefined') {
     GlobalRegistrator.register({ url: 'https://example.test/list?sort=price' })
+  } else {
+    // Test-file execution order is filesystem-dependent: another DOM suite
+    // may have registered happy-dom first (default URL, no query). This
+    // suite's client-branch assertions depend on the URL below, and
+    // `searchParams()` reads the URL lazily on first access (which happens
+    // in the tests, after this hook) — so forcing the URL here makes the
+    // suite order-independent instead of first-registrar-wins.
+    ;(window as unknown as { happyDOM: { setURL(url: string): void } }).happyDOM.setURL(
+      'https://example.test/list?sort=price',
+    )
   }
 })
 

--- a/packages/client/__tests__/map-array-lazy.test.ts
+++ b/packages/client/__tests__/map-array-lazy.test.ts
@@ -1,0 +1,510 @@
+/**
+ * Unit tests for `mapArrayLazy` — the lazy row graph runtime
+ * (spec/slot-unification.md §9, L2 of the stacked series).
+ *
+ * The row plans built here stand in for what the L3 compiler will emit:
+ * `createRow` fully writes a row and records refs/dedup with no scan,
+ * `applyItem` claims refs lazily on the first item-driven write, and
+ * `applyOuter` applies outer-involving bindings to every entry with
+ * read-compare-write seeding on its first run (§9.3(1)).
+ */
+
+import { describe, test, expect, beforeAll, beforeEach, spyOn } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+const { createSignal } = await import('../src/reactive')
+const { mapArrayLazy } = await import('../src/runtime/map-array-lazy')
+type LazyRowEntry<T> = import('../src/runtime/map-array-lazy').LazyRowEntry<T>
+type LazyRowPlan<T> = import('../src/runtime/map-array-lazy').LazyRowPlan<T>
+
+type Item = { id: string; label: string }
+
+const item = (id: string, label: string): Item => ({ id, label })
+const keyOf = (it: Item) => it.id
+
+/** SSR-shaped row markup: `<li data-key=K class=C><span>LABEL</span></li>`. */
+const rowHtml = (key: string | null, label: string, cls?: string) =>
+  `<li${key !== null ? ` data-key="${key}"` : ''}${cls !== undefined ? ` class="${cls}"` : ''}><span>${label}</span></li>`
+
+/** Container with scoped loop markers wrapping SSR-rendered rows. */
+function ssrContainer(rowsHtml: string): HTMLElement {
+  document.body.innerHTML = ''
+  const parent = document.createElement('ul')
+  parent.innerHTML = `<!--bf-loop:l0-->${rowsHtml}<!--bf-/loop:l0-->`
+  document.body.appendChild(parent)
+  return parent
+}
+
+type Refs = { label: Text }
+type Last = { label?: string; cls?: string }
+
+/**
+ * Build a spy-instrumented row plan of the shape the compiler will emit.
+ *
+ * - `selected` (optional): an outer signal accessor. When given, rows carry
+ *   a mixed item+outer `class` binding (`selected() === item.id`) that
+ *   `createRow` writes eagerly and `applyItem` re-applies non-reactively.
+ * - `withOuter`: also emit `applyOuter` for the class binding (the
+ *   loop-level reactive side).
+ * - `setKeyInCreate: false`: createRow skips `data-key` so the runtime's
+ *   stamping path is observable.
+ */
+function makePlan(opts: {
+  selected?: () => string
+  withOuter?: boolean
+  setKeyInCreate?: boolean
+} = {}) {
+  const createRowCalls: string[] = []
+  const applyItemCalls: Array<{ key: string; prev: Item; next: Item }> = []
+  const applyOuterCalls: Array<{ seed: boolean; keys: string[] }> = []
+  let claimCount = 0
+
+  // Lazy claim: scan within this one row, cached on entry.refs by applyItem.
+  const claim = (entry: LazyRowEntry<Item>): Refs => {
+    claimCount++
+    const span = entry.primaryEl.querySelector('span')!
+    if (!span.firstChild) span.appendChild(document.createTextNode(''))
+    return { label: span.firstChild as Text }
+  }
+
+  const plan: LazyRowPlan<Item> = {
+    createRow(entry, _index) {
+      createRowCalls.push(entry.key)
+      const li = document.createElement('li')
+      if (opts.setKeyInCreate !== false) li.setAttribute('data-key', entry.key)
+      const span = document.createElement('span')
+      const text = document.createTextNode(entry.item.label)
+      span.appendChild(text)
+      li.appendChild(span)
+      const last: Last = { label: entry.item.label }
+      if (opts.selected) {
+        // Contract: createRow writes ALL bindings, outer-involving included,
+        // with current values — this outer-signal read must NOT subscribe
+        // the reconciler (the runtime untracks createRow).
+        const cls = opts.selected() === entry.item.id ? 'sel' : ''
+        li.setAttribute('class', cls)
+        last.cls = cls
+      }
+      entry.refs = { label: text }
+      entry.last = last
+      return li
+    },
+    applyItem(entry, prevItem) {
+      applyItemCalls.push({ key: entry.key, prev: prevItem, next: entry.item })
+      const refs = (entry.refs ?? (entry.refs = claim(entry))) as Refs
+      const last = (entry.last ?? (entry.last = {})) as Last
+      // Adopted rows seed their item-driven dedup from the previous item
+      // (trusted hydration-consistent per §9.3(2)).
+      if (last.label === undefined) last.label = prevItem.label
+      if (last.label !== entry.item.label) {
+        refs.label.nodeValue = entry.item.label
+        last.label = entry.item.label
+      }
+      if (opts.selected) {
+        // Mixed binding: non-reactive outer read (runtime untracks applyItem).
+        const cls = opts.selected() === entry.item.id ? 'sel' : ''
+        if (last.cls !== cls) {
+          entry.primaryEl.setAttribute('class', cls)
+          last.cls = cls
+        }
+      }
+    },
+  }
+
+  if (opts.withOuter) {
+    plan.applyOuter = (list, seed) => {
+      const sel = opts.selected!() // the outer-signal read the effect subscribes to
+      applyOuterCalls.push({ seed, keys: list.map((e) => e.key) })
+      for (const en of list) {
+        const cls = sel === en.item.id ? 'sel' : ''
+        const last = (en.last ?? (en.last = {})) as Last
+        if (seed) {
+          // Read-compare-write seeding (§9.3(1)): read current DOM state,
+          // write only where the computed value differs.
+          const dom = en.primaryEl.getAttribute('class') ?? ''
+          last.cls = dom
+          if (dom !== cls) {
+            en.primaryEl.setAttribute('class', cls)
+            last.cls = cls
+          }
+        } else if (last.cls !== cls) {
+          en.primaryEl.setAttribute('class', cls)
+          last.cls = cls
+        }
+      }
+    }
+  }
+
+  return { plan, createRowCalls, applyItemCalls, applyOuterCalls, claims: () => claimCount }
+}
+
+describe('mapArrayLazy — hydration adoption', () => {
+  test('adoption performs zero DOM mutations', () => {
+    const a = item('1', 'A')
+    const b = item('2', 'B')
+    const [items] = createSignal([a, b])
+    const container = ssrContainer(rowHtml('1', 'A') + rowHtml('2', 'B'))
+    const before = container.innerHTML
+
+    const { plan, createRowCalls, applyItemCalls } = makePlan()
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+
+    expect(container.innerHTML).toBe(before)
+    expect(createRowCalls.length).toBe(0)
+    expect(applyItemCalls.length).toBe(0)
+  })
+
+  test('adopted rows without data-key fall back to getKey and are NOT stamped', () => {
+    const a = item('1', 'A')
+    const [items, setItems] = createSignal([a])
+    const container = ssrContainer(rowHtml(null, 'A'))
+    const before = container.innerHTML
+
+    const { plan } = makePlan()
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+
+    // No data-key write on the adopted row — byte-identical adoption.
+    expect(container.innerHTML).toBe(before)
+    expect(container.querySelector('li')!.hasAttribute('data-key')).toBe(false)
+
+    // The getKey fallback keyed the entry correctly: a same-key item change
+    // updates the adopted row in place.
+    setItems([item('1', 'A2')])
+    expect(container.querySelector('span')!.textContent).toBe('A2')
+  })
+
+  test('SSR-fewer-than-items: missing rows are created via plan.createRow', () => {
+    const [items] = createSignal([item('1', 'A'), item('2', 'B'), item('3', 'C')])
+    const container = ssrContainer(rowHtml('1', 'A'))
+    const adopted = container.querySelector('li')!
+
+    const { plan, createRowCalls } = makePlan()
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+
+    expect(createRowCalls).toEqual(['2', '3'])
+    const lis = container.querySelectorAll('li')
+    expect(lis.length).toBe(3)
+    expect(lis[0]).toBe(adopted)
+    expect(lis[1].getAttribute('data-key')).toBe('2')
+    expect(lis[2].getAttribute('data-key')).toBe('3')
+    expect(lis[2].textContent).toBe('C')
+    // Created rows land inside the loop range (before the end marker).
+    expect(lis[2].nextSibling!.nodeValue).toBe('bf-/loop:l0')
+  })
+
+  test('SSR-more-than-items: orphaned rows are removed, adopted rows untouched', () => {
+    const [items] = createSignal([item('1', 'A'), item('2', 'B')])
+    const container = ssrContainer(rowHtml('1', 'A') + rowHtml('2', 'B') + rowHtml('3', 'C'))
+
+    const { plan, createRowCalls, applyItemCalls } = makePlan()
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+
+    const lis = container.querySelectorAll('li')
+    expect(lis.length).toBe(2)
+    expect(lis[0].outerHTML).toBe(rowHtml('1', 'A'))
+    expect(lis[1].outerHTML).toBe(rowHtml('2', 'B'))
+    expect(createRowCalls.length).toBe(0)
+    expect(applyItemCalls.length).toBe(0)
+  })
+})
+
+describe('mapArrayLazy — item-driven updates', () => {
+  test('item change calls applyItem with prev item, updates DOM, claims refs once', () => {
+    const b = item('2', 'B')
+    const [items, setItems] = createSignal([item('1', 'A'), b])
+    const container = ssrContainer(rowHtml('1', 'A') + rowHtml('2', 'B'))
+
+    const { plan, applyItemCalls, claims } = makePlan()
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+    expect(claims()).toBe(0) // adoption never claims
+
+    setItems([item('1', 'A2'), b])
+    expect(applyItemCalls.length).toBe(1)
+    expect(applyItemCalls[0].key).toBe('1')
+    expect(applyItemCalls[0].prev.label).toBe('A')
+    expect(applyItemCalls[0].next.label).toBe('A2')
+    expect(container.querySelectorAll('span')[0].textContent).toBe('A2')
+    expect(claims()).toBe(1)
+
+    // Second update to the same row: refs are cached, no re-claim.
+    setItems([item('1', 'A3'), b])
+    expect(container.querySelectorAll('span')[0].textContent).toBe('A3')
+    expect(claims()).toBe(1)
+  })
+
+  test('unchanged items (same identity) do not call applyItem', () => {
+    const a = item('1', 'A')
+    const b = item('2', 'B')
+    const [items, setItems] = createSignal([a, b])
+    const container = ssrContainer(rowHtml('1', 'A') + rowHtml('2', 'B'))
+
+    const { plan, applyItemCalls, claims } = makePlan()
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+
+    // New array, same item identities — reconcile runs, no row work.
+    setItems([a, b])
+    expect(applyItemCalls.length).toBe(0)
+    expect(claims()).toBe(0)
+
+    // Only the changed row is applied.
+    setItems([a, item('2', 'B2')])
+    expect(applyItemCalls.length).toBe(1)
+    expect(applyItemCalls[0].key).toBe('2')
+  })
+})
+
+describe('mapArrayLazy — CSR create / remove / reorder / clear', () => {
+  test('CSR append creates via plan.createRow with data-key stamped by the runtime', () => {
+    const a = item('1', 'A')
+    const [items, setItems] = createSignal([a])
+    const container = ssrContainer(rowHtml('1', 'A'))
+
+    // createRow does NOT set data-key — the runtime must stamp it.
+    const { plan, createRowCalls } = makePlan({ setKeyInCreate: false })
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+
+    setItems([a, item('2', 'B')])
+    expect(createRowCalls).toEqual(['2'])
+    const lis = container.querySelectorAll('li')
+    expect(lis.length).toBe(2)
+    expect(lis[1].getAttribute('data-key')).toBe('2')
+    expect(lis[1].textContent).toBe('B')
+  })
+
+  test('CSR mount (no SSR rows) creates every row', () => {
+    const [items] = createSignal([item('1', 'A'), item('2', 'B')])
+    const container = ssrContainer('')
+
+    const { plan, createRowCalls } = makePlan()
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+
+    expect(createRowCalls).toEqual(['1', '2'])
+    const lis = container.querySelectorAll('li')
+    expect(lis.length).toBe(2)
+    expect(lis[0].getAttribute('data-key')).toBe('1')
+    expect(lis[1].getAttribute('data-key')).toBe('2')
+  })
+
+  test('removal detaches the row', () => {
+    const a = item('1', 'A')
+    const c = item('3', 'C')
+    const [items, setItems] = createSignal([a, item('2', 'B'), c])
+    const container = ssrContainer(rowHtml('1', 'A') + rowHtml('2', 'B') + rowHtml('3', 'C'))
+
+    const { plan } = makePlan()
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+    const removed = container.querySelectorAll('li')[1]
+
+    setItems([a, c])
+    const lis = container.querySelectorAll('li')
+    expect(lis.length).toBe(2)
+    expect(removed.isConnected).toBe(false)
+    expect(lis[0].getAttribute('data-key')).toBe('1')
+    expect(lis[1].getAttribute('data-key')).toBe('3')
+  })
+
+  test('swap reorder preserves element identity (LIS path)', () => {
+    const a = item('1', 'A')
+    const b = item('2', 'B')
+    const c = item('3', 'C')
+    const [items, setItems] = createSignal([a, b, c])
+    const container = ssrContainer(rowHtml('1', 'A') + rowHtml('2', 'B') + rowHtml('3', 'C'))
+
+    const { plan, applyItemCalls, createRowCalls } = makePlan()
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+
+    const [elA, elB, elC] = Array.from(container.querySelectorAll('li'))
+
+    // Swap first and last — same item identities, pure reorder.
+    setItems([c, b, a])
+    const lis = container.querySelectorAll('li')
+    expect(lis[0]).toBe(elC)
+    expect(lis[1]).toBe(elB)
+    expect(lis[2]).toBe(elA)
+    expect(applyItemCalls.length).toBe(0)
+    expect(createRowCalls.length).toBe(0)
+  })
+
+  test('clear-all fast path empties the range and preserves markers', () => {
+    const [items, setItems] = createSignal([item('1', 'A'), item('2', 'B')])
+    const container = ssrContainer(rowHtml('1', 'A') + rowHtml('2', 'B'))
+
+    const { plan, createRowCalls } = makePlan()
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+
+    setItems([])
+    expect(container.querySelectorAll('li').length).toBe(0)
+    expect(container.innerHTML).toBe('<!--bf-loop:l0--><!--bf-/loop:l0-->')
+
+    // The list is fully forgotten: repopulating creates fresh rows in range.
+    setItems([item('1', 'A')])
+    expect(createRowCalls).toEqual(['1'])
+    expect(container.querySelectorAll('li').length).toBe(1)
+    expect(container.innerHTML).toBe(
+      `<!--bf-loop:l0-->${rowHtml('1', 'A')}<!--bf-/loop:l0-->`,
+    )
+  })
+
+  test('clear-all without markers bulk-clears the container', () => {
+    document.body.innerHTML = ''
+    const container = document.createElement('ul')
+    document.body.appendChild(container)
+    const [items, setItems] = createSignal([item('1', 'A'), item('2', 'B')])
+
+    const { plan } = makePlan()
+    mapArrayLazy(items, container, keyOf, plan)
+
+    expect(container.children.length).toBe(2)
+    setItems([])
+    expect(container.children.length).toBe(0)
+  })
+})
+
+describe('mapArrayLazy — duplicate-key warning', () => {
+  test('warns once per unique duplicate key per reconcile', () => {
+    const warnSpy = spyOn(console, 'warn')
+    warnSpy.mockClear()
+    const filterDupWarns = () =>
+      warnSpy.mock.calls.filter(
+        (args) => typeof args[0] === 'string' && args[0].includes('duplicate key'),
+      )
+
+    const [items] = createSignal([item('x', 'A'), item('x', 'B'), item('x', 'C')])
+    const container = ssrContainer('')
+    const { plan } = makePlan()
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+
+    expect(filterDupWarns().length).toBe(1)
+    expect(filterDupWarns()[0][0]).toContain('"x"')
+  })
+})
+
+describe('mapArrayLazy — applyOuter loop-level effect', () => {
+  test('seed=true exactly once; consistent SSR state produces zero writes', () => {
+    const [selected] = createSignal('1')
+    const a = item('1', 'A')
+    const b = item('2', 'B')
+    const [items] = createSignal([a, b])
+    // SSR classes already agree with selected() === '1'.
+    const container = ssrContainer(rowHtml('1', 'A', 'sel') + rowHtml('2', 'B', ''))
+    const before = container.innerHTML
+
+    const { plan, applyOuterCalls } = makePlan({ selected, withOuter: true })
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+
+    expect(applyOuterCalls.length).toBe(1)
+    expect(applyOuterCalls[0].seed).toBe(true)
+    expect(applyOuterCalls[0].keys).toEqual(['1', '2'])
+    // Read-compare-write: no divergence, no mutation.
+    expect(container.innerHTML).toBe(before)
+  })
+
+  test('seed run patches only where computed value differs from DOM', () => {
+    // Client-only outer state diverges from what SSR rendered (§9.3(1)):
+    // SSR marked row 1 selected, but the client signal starts at '2'.
+    const [selected] = createSignal('2')
+    const [items] = createSignal([item('1', 'A'), item('2', 'B')])
+    const container = ssrContainer(rowHtml('1', 'A', 'sel') + rowHtml('2', 'B', ''))
+
+    const { plan, applyOuterCalls } = makePlan({ selected, withOuter: true })
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+
+    expect(applyOuterCalls.length).toBe(1)
+    expect(applyOuterCalls[0].seed).toBe(true)
+    const lis = container.querySelectorAll('li')
+    expect(lis[0].getAttribute('class')).toBe('')
+    expect(lis[1].getAttribute('class')).toBe('sel')
+  })
+
+  test('re-runs on outer-signal change with seed=false; reconciles do not re-run it', () => {
+    const [selected, setSelected] = createSignal('1')
+    const a = item('1', 'A')
+    const b = item('2', 'B')
+    const [items, setItems] = createSignal([a, b])
+    const container = ssrContainer(rowHtml('1', 'A', 'sel') + rowHtml('2', 'B', ''))
+
+    const { plan, applyOuterCalls } = makePlan({ selected, withOuter: true })
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+    expect(applyOuterCalls.length).toBe(1)
+
+    // Outer-signal change → effect re-runs, seed=false, writes with dedup.
+    setSelected('2')
+    expect(applyOuterCalls.length).toBe(2)
+    expect(applyOuterCalls[1].seed).toBe(false)
+    const lis = container.querySelectorAll('li')
+    expect(lis[0].getAttribute('class')).toBe('')
+    expect(lis[1].getAttribute('class')).toBe('sel')
+
+    // Reconcile (append + reorder) must NOT re-run the outer effect...
+    setItems([item('3', 'C'), a, b])
+    expect(applyOuterCalls.length).toBe(2)
+    // ...the created row is already consistent (createRow wrote the class).
+    expect(container.querySelector('[data-key="3"]')!.getAttribute('class')).toBe('')
+
+    // ...but the NEXT outer run sees the post-reconcile entry list in order.
+    setSelected('3')
+    expect(applyOuterCalls.length).toBe(3)
+    expect(applyOuterCalls[2].keys).toEqual(['3', '1', '2'])
+    expect(container.querySelector('[data-key="3"]')!.getAttribute('class')).toBe('sel')
+    expect(container.querySelector('[data-key="2"]')!.getAttribute('class')).toBe('')
+  })
+
+  test('no applyOuter → outer-signal changes trigger no plan calls at all', () => {
+    const [selected, setSelected] = createSignal('1')
+    const a = item('1', 'A')
+    const [items] = createSignal([a])
+    const container = ssrContainer(rowHtml('1', 'A', 'sel'))
+
+    // Plan reads `selected` in createRow/applyItem but declares no applyOuter.
+    const { plan, createRowCalls, applyItemCalls, applyOuterCalls } = makePlan({ selected })
+    mapArrayLazy(items, container, keyOf, plan, 'l0')
+
+    setSelected('2')
+    setSelected('3')
+    expect(applyOuterCalls.length).toBe(0)
+    expect(createRowCalls.length).toBe(0)
+    expect(applyItemCalls.length).toBe(0)
+  })
+})
+
+describe('mapArrayLazy — reconciler tracking isolation', () => {
+  test('outer-signal reads inside createRow/applyItem do not subscribe the reconciler', () => {
+    const [selected, setSelected] = createSignal('1')
+    const a = item('1', 'A')
+    const [items, setItems] = createSignal([a])
+    const container = ssrContainer('')
+
+    let accessorRuns = 0
+    const countingAccessor = () => {
+      accessorRuns++
+      return items()
+    }
+
+    // createRow and applyItem both read selected() (mixed class binding);
+    // no applyOuter, so ONLY the reconciler effect exists.
+    const { plan, createRowCalls, applyItemCalls } = makePlan({ selected })
+    mapArrayLazy(countingAccessor, container, keyOf, plan, 'l0')
+    expect(accessorRuns).toBe(1)
+    expect(createRowCalls).toEqual(['1']) // createRow ran, read selected()
+
+    // Changing the outer signal must NOT re-run the reconciler effect.
+    setSelected('2')
+    expect(accessorRuns).toBe(1)
+    expect(createRowCalls.length).toBe(1)
+    expect(applyItemCalls.length).toBe(0)
+
+    // Same after an item-driven update (applyItem also reads selected()).
+    setItems([item('1', 'A2')])
+    expect(accessorRuns).toBe(2)
+    expect(applyItemCalls.length).toBe(1)
+    setSelected('3')
+    expect(accessorRuns).toBe(2)
+    expect(applyItemCalls.length).toBe(1)
+  })
+})

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -82,6 +82,10 @@ export {
 export { getLoopChildren, getLoopNodes } from './loop-markers.ts'
 export { qsaItem, upsertChildItem } from './qsa-item.ts'
 export { mapArray, mapArrayAnchored } from './map-array.ts'
+// Lazy row graph (slot unification §9, L2) — keyed list rendering with no
+// per-row reactive resources; compiler targets it for eligible plain loops
+// (L3). See ./map-array-lazy.ts for the pinned row-plan contract.
+export { mapArrayLazy, type LazyRowEntry, type LazyRowPlan } from './map-array-lazy.ts'
 export { patchLeaf } from './patch-leaf.ts'
 
 // Claim-plan interpreter (slot unification A2/A3, spec/slot-unification.md)

--- a/packages/client/src/runtime/map-array-lazy.ts
+++ b/packages/client/src/runtime/map-array-lazy.ts
@@ -1,0 +1,398 @@
+/**
+ * BarefootJS - Lazy Row Graph List Rendering (slot unification §9, L2)
+ *
+ * `mapArrayLazy` renders a keyed reactive array WITHOUT any per-row reactive
+ * resources: no `createRoot`, no per-item signal, no per-row effect, no
+ * hydration-time query/claim/DOM-write per row. See
+ * `spec/slot-unification.md` §9 for the design and the measurement spike
+ * that motivated it (branch `claude/lazy-effect-spike`).
+ *
+ * A plain loop row has exactly two update paths, both already known without
+ * per-row reactivity (§9.1):
+ *
+ *  1. **Item-driven changes** — the keyed reconciler detects them itself
+ *     (`!Object.is(oldItem, newItem)` per key) and calls the row plan's
+ *     `applyItem` directly. The row's DOM refs are claimed lazily on that
+ *     row's FIRST item-driven write (a scan inside that one row, cached on
+ *     `entry.refs`); a row that never updates never pays.
+ *  2. **Outer-signal reads** — applied by ONE loop-level `createEffect`
+ *     (`applyOuter`) iterating all entries with per-entry dedup, created
+ *     only when the loop has such bindings.
+ *
+ * ## Row-plan contract (PINNED — L3's compiler emission targets exactly this)
+ *
+ * The compiler emits a {@link LazyRowPlan} per eligible loop
+ * (§9.4 eligibility: plain single-root keyed rows whose data source is
+ * hydration-consistent; everything else keeps the eager `mapArray`
+ * emission). Obligations, split by side:
+ *
+ * **Runtime (this module) guarantees:**
+ * - Hydration first run adopts SSR rows with ZERO per-row DOM mutations:
+ *   `entry.key` is READ from the SSR-rendered `data-key` attribute (never
+ *   written on adopted rows; `getKey(items[i], i)` is the fallback when the
+ *   attribute is absent), `entry.item = items[i]` positionally (sound by
+ *   the §9.3(2) compile-time eligibility gate), `refs`/`last` start `null`.
+ * - `plan.createRow` / `plan.applyItem` are invoked inside the reconciler
+ *   effect but wrapped in `untrack()`, so outer-signal reads during row
+ *   creation or item application never subscribe the reconciler — it re-runs
+ *   only when `accessor()`'s dependencies change. (`applyItem` is untracked
+ *   for the same reason `createRow` is: mixed item+outer bindings read outer
+ *   signals non-reactively there; the `applyOuter` effect owns the reactive
+ *   side.)
+ * - The runtime assigns `createRow`'s returned element to `entry.primaryEl`
+ *   and stamps `data-key` on CSR-created rows if `createRow` didn't (same
+ *   semantics as `mapArray`'s create path).
+ * - When `plan.applyOuter` exists, ONE loop-level effect is created (after
+ *   the reconciler effect, so its first run happens after adoption) whose
+ *   body calls `applyOuter(entryList, seed)` with `seed === true` exactly
+ *   once, on the very first run. `entryList` is a closure variable holding
+ *   the entries in current order, REBUILT (reassigned) by the reconciler
+ *   after every reconcile — chosen over a live/mutable view so a run of the
+ *   effect can never observe a half-reconciled list, and read
+ *   non-reactively so the effect re-runs ONLY on the outer signals
+ *   `applyOuter` itself reads, never because the list was reconciled.
+ *
+ * **Plan (compiler-emitted) obligations:**
+ * - `createRow` MUST write ALL bindings — item-driven AND outer-involving —
+ *   with current values (it is CSR creation; it computes everything anyway)
+ *   and MUST seed `entry.refs`/`entry.last` from known clone paths (no
+ *   scan). Freshly-created rows are therefore consistent immediately; the
+ *   `applyOuter` effect's per-entry dedup (seeded via `entry.last`) keeps
+ *   them consistent on later outer-signal changes.
+ * - `applyOuter`'s FIRST run (`seed === true`) must READ current DOM state
+ *   (`getAttribute` / `nodeValue`) to initialize each entry's dedup value
+ *   and write only where the computed value differs — read-compare-write
+ *   seeding (§9.3(1)), sound even when outer state is client-only and
+ *   diverges from SSR. No trust-first-run regression (§6).
+ * - `applyItem` claims refs lazily (scan within `entry.primaryEl`) when
+ *   `entry.refs` is null, and writes through per-binding dedup held on
+ *   `entry.last` / `entry.refs`.
+ *
+ * ## Reconciliation
+ *
+ * The keyed diff, duplicate-key once-per-reconcile warning, clear-all fast
+ * path, and LIS minimal-move reorder mirror `mapArray`'s exactly — minus
+ * every per-row reactive resource. Removal is plain DOM detach: entries
+ * hold no reactive resources (CSR rows created by `plan.createRow` hold
+ * none either), so there is nothing to dispose.
+ *
+ * Single-root rows only (v1): the §9.4 eligibility gate guarantees the
+ * compiler never targets this entry point for multi-root (Fragment) rows,
+ * so there is no `startMarker`/`extras`/`bf-loop-i` bookkeeping here.
+ *
+ * Rows are NOT added to `hydratedScopes`: that mark exists for element
+ * scopes the hydration walker must skip, and lazy-eligible rows are plain
+ * markup (no nested component/host scopes — the eligibility gate excludes
+ * them), so the mark would only spend per-row memory this design exists to
+ * eliminate.
+ *
+ * Shared helpers: `findLoopMarkers` and `longestIncreasingSubsequenceIndices`
+ * are imported from `./map-array.ts` (now exported for internal reuse)
+ * rather than duplicated or extracted into a third module — they are pure,
+ * behavior-identical for both reconcilers, and importing keeps exactly one
+ * copy without churning `map-array.ts`'s structure. The loop-shaped logic
+ * around them (partition, diff, clear fast path) is intentionally
+ * re-written here rather than shared: it differs in what it carries per row
+ * (plain entries vs reactive scopes) and forcing one parameterized body
+ * would obscure both.
+ *
+ * `bfId` is forwarded to the reconciler effect only (same attribution point
+ * as `mapArray`); profile mode never emits lazy loops (§9.4), so the outer
+ * effect carries no id.
+ */
+
+import { createEffect, untrack } from '@barefootjs/client/reactive'
+import { BF_KEY } from '@barefootjs/shared'
+import { findLoopMarkers, longestIncreasingSubsequenceIndices } from './map-array.ts'
+
+/**
+ * One row of a lazy loop: plain data, no reactive resources.
+ * Built at adoption (hydration) or by the reconciler via `plan.createRow`.
+ */
+export interface LazyRowEntry<T> {
+  key: string
+  primaryEl: HTMLElement
+  item: T
+  /** plan-owned: claimed DOM refs, null until the row's first item-driven write */
+  refs: unknown | null
+  /** plan-owned: per-binding last-value dedup state */
+  last: unknown | null
+}
+
+/**
+ * The compiler-emitted row plan for a lazy-eligible loop.
+ * See the module docstring for the pinned contract and each side's
+ * obligations.
+ */
+export interface LazyRowPlan<T> {
+  /** CSR create: clone/build a fully-written row element for item; record refs
+   *  and dedup state directly on the entry (no scan). Returns the element. */
+  createRow(entry: LazyRowEntry<T>, index: number): HTMLElement
+  /** Item-driven (and mixed) bindings: called by the reconciler AFTER
+   *  entry.item has been updated to the new item; prevItem is the old value.
+   *  Claims refs lazily (scan within entry.primaryEl) when entry.refs is null.
+   *  Writes through per-binding dedup held on entry.last / entry.refs. */
+  applyItem(entry: LazyRowEntry<T>, prevItem: T): void
+  /** Outer-involving bindings (present only when the loop has bindings that
+   *  read signals from outside the row). Runtime wraps this in ONE
+   *  createEffect for the whole loop. Reads its outer signals inside the
+   *  callback (so the effect subscribes), then applies those bindings to
+   *  every entry with per-entry dedup. `seed` is true on the effect's FIRST
+   *  run only: the binding must READ current DOM state (getAttribute /
+   *  nodeValue) to initialize its dedup value and write only where the
+   *  computed value differs (read-compare-write, spec §9.3(1)). */
+  applyOuter?(entries: ReadonlyArray<LazyRowEntry<T>>, seed: boolean): void
+}
+
+/**
+ * Lazy-row-graph keyed list rendering (spec/slot-unification.md §9).
+ *
+ * @param accessor - Function returning the reactive array (signal/memo read)
+ * @param container - DOM container element
+ * @param getKey - Key extractor (null = use index). Receives plain item value.
+ * @param plan - Compiler-emitted row plan (see {@link LazyRowPlan})
+ * @param markerId - Scoped loop marker id (`<!--bf-loop:<id>-->`), see #1087
+ * @param bfId - Profiler attribution id for the reconciler effect
+ */
+export function mapArrayLazy<T>(
+  accessor: () => T[],
+  container: HTMLElement | null,
+  getKey: ((item: T, index: number) => string) | null,
+  plan: LazyRowPlan<T>,
+  markerId?: string,
+  bfId?: string,
+): void {
+  if (!container) return
+
+  const entries = new Map<string, LazyRowEntry<T>>()
+  /**
+   * Entries in current item order — the closure variable the reconciler
+   * reassigns after every reconcile and the `applyOuter` effect reads
+   * non-reactively (so reconciles never re-run that effect).
+   */
+  let entryList: LazyRowEntry<T>[] = []
+  let hydrated = false
+
+  // Loop boundary markers are structural — never removed or re-inserted by
+  // this module — so cache them across effect runs, same as `mapArray`.
+  let cachedStart: Comment | null = null
+  let cachedEnd: Comment | null = null
+  const resolveMarkers = (): { start: Comment | null; end: Comment | null } => {
+    if (cachedStart && cachedEnd && cachedStart.isConnected && cachedEnd.isConnected) {
+      return { start: cachedStart, end: cachedEnd }
+    }
+    const found = findLoopMarkers(container, markerId)
+    cachedStart = found.start
+    cachedEnd = found.end
+    return found
+  }
+
+  /**
+   * CSR row creation. `plan.createRow` runs inside the reconciler effect,
+   * so it is wrapped in `untrack()`: it writes outer-involving bindings
+   * with current values (contract), and those signal reads must not
+   * subscribe the reconciler. The returned element is assigned to
+   * `entry.primaryEl`; `data-key` is stamped if `createRow` didn't
+   * (mirrors `mapArray`'s create path).
+   */
+  const createEntry = (item: T, index: number, key: string): LazyRowEntry<T> => {
+    const entry: LazyRowEntry<T> = {
+      key,
+      // Assigned from createRow's return value below; createRow builds the
+      // element and must not read primaryEl.
+      primaryEl: undefined as unknown as HTMLElement,
+      item,
+      refs: null,
+      last: null,
+    }
+    entry.primaryEl = untrack(() => plan.createRow(entry, index))
+    if (!entry.primaryEl.dataset.key) entry.primaryEl.setAttribute(BF_KEY, key)
+    return entry
+  }
+
+  createEffect(() => {
+    const items = accessor()
+    if (!items) return
+
+    const { start: startMarker, end: endMarker } = resolveMarkers()
+    const anchor: Node | null = endMarker ?? null
+
+    // --- First run: adopt SSR-rendered rows (zero per-row DOM mutations) ---
+    if (!hydrated) {
+      hydrated = true
+      // Single-root rows: each ELEMENT_NODE child in the loop range is one row.
+      const doms: HTMLElement[] = []
+      for (
+        let node: Node | null = startMarker ? startMarker.nextSibling : container.firstChild;
+        node && node !== anchor;
+        node = node.nextSibling
+      ) {
+        if (node.nodeType === Node.ELEMENT_NODE) doms.push(node as HTMLElement)
+      }
+      if (doms.length > 0 && entries.size === 0) {
+        const list: LazyRowEntry<T>[] = []
+        const shared = Math.min(doms.length, items.length)
+        for (let i = 0; i < shared; i++) {
+          const el = doms[i]
+          // READ the SSR-rendered key (never write it on adopted rows);
+          // positional item pairing is sound by the §9.3(2) eligibility gate.
+          const ssrKey = el.getAttribute(BF_KEY)
+          const key = ssrKey !== null ? ssrKey : getKey ? getKey(items[i], i) : String(i)
+          const entry: LazyRowEntry<T> = { key, primaryEl: el, item: items[i], refs: null, last: null }
+          entries.set(key, entry)
+          list.push(entry)
+        }
+        // SSR rendered fewer rows than the current array — create the rest (CSR).
+        for (let i = doms.length; i < items.length; i++) {
+          const item = items[i]
+          const key = getKey ? getKey(item, i) : String(i)
+          const entry = createEntry(item, i, key)
+          entries.set(key, entry)
+          list.push(entry)
+          container.insertBefore(entry.primaryEl, anchor)
+        }
+        // SSR rendered more rows than the current array — drop the orphans.
+        for (let i = items.length; i < doms.length; i++) doms[i].remove()
+        entryList = list
+        return // Adoption complete — later accessor changes reconcile below.
+      }
+      // No SSR rows (CSR mount): fall through to the keyed path.
+    }
+
+    // --- Fast path: clearing the whole list ---
+    // Mirrors `mapArray`: one ranged delete between markers, or a bulk
+    // `textContent = ''` when the list owns the container's children
+    // outright (verified by a node count so foreign siblings survive).
+    if (items.length === 0) {
+      if (entries.size > 0) {
+        if (startMarker && endMarker) {
+          const range = document.createRange()
+          range.setStartAfter(startMarker)
+          range.setEndBefore(endMarker)
+          range.deleteContents()
+        } else {
+          let actualNodeCount = 0
+          for (let node = container.firstChild; node; node = node.nextSibling) actualNodeCount++
+          if (actualNodeCount === entries.size) {
+            container.textContent = ''
+          } else {
+            for (const entry of entries.values()) entry.primaryEl.remove()
+          }
+        }
+        entries.clear()
+        entryList = []
+      }
+      return
+    }
+
+    // --- Key-based diff ---
+    const newKeys = new Set<string>()
+    // Distinct from `newKeys`: tracks which keys have ALREADY emitted a
+    // duplicate warning in this reconcile, so a 1000-item list where every
+    // item shares one key emits ONE warning, not 999 (same as `mapArray`).
+    const warnedKeys = new Set<string>()
+    const desiredOrder: LazyRowEntry<T>[] = []
+
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]
+      const key = getKey ? getKey(item, i) : String(i)
+      if (newKeys.has(key) && !warnedKeys.has(key)) {
+        warnedKeys.add(key)
+        console.warn(
+          `[BarefootJS] mapArrayLazy: duplicate key "${key}" — items with this key collapse to a single DOM row, ` +
+            `so only the last one renders. Use a per-item identifier (e.g. \`key={item.id}\`) for correct reconciliation.`,
+        )
+      }
+      newKeys.add(key)
+
+      const existing = entries.get(key)
+      if (existing) {
+        // Same key: item-driven update is a DIRECT call — no signal, no
+        // setItem. `applyItem` runs after `entry.item` is updated, receives
+        // the previous item, and is untracked (mixed bindings may read
+        // outer signals; the applyOuter effect owns the reactive side).
+        if (!Object.is(existing.item, item)) {
+          const prevItem = existing.item
+          existing.item = item
+          untrack(() => plan.applyItem(existing, prevItem))
+        }
+        desiredOrder.push(existing)
+      } else {
+        const entry = createEntry(item, i, key)
+        entries.set(key, entry)
+        desiredOrder.push(entry)
+      }
+    }
+
+    // Remove rows no longer in the array. Plain DOM detach — entries hold
+    // no reactive resources (adopted and CSR-created alike), nothing to
+    // dispose.
+    for (const [key, entry] of entries) {
+      if (!newKeys.has(key)) {
+        if (entry.primaryEl.parentNode) entry.primaryEl.remove()
+        entries.delete(key)
+      }
+    }
+
+    // --- Reconcile DOM order: minimal-move, LIS-based (same as mapArray) ---
+    // Rows kept stationary by the LIS are provably never detached; every
+    // other row (moves + brand-new rows) is grouped into contiguous runs
+    // inserted with ONE insertBefore per run.
+    const primaryElToDesiredIndex = new Map<HTMLElement, number>()
+    for (let i = 0; i < desiredOrder.length; i++) {
+      primaryElToDesiredIndex.set(desiredOrder[i].primaryEl, i)
+    }
+
+    const domOrderIndices: number[] = []
+    for (
+      let node: Node | null = startMarker ? startMarker.nextSibling : container.firstChild;
+      node && node !== anchor;
+      node = node.nextSibling
+    ) {
+      if (node.nodeType !== Node.ELEMENT_NODE) continue
+      const idx = primaryElToDesiredIndex.get(node as HTMLElement)
+      if (idx !== undefined) domOrderIndices.push(idx)
+    }
+
+    const stationary = new Array<boolean>(desiredOrder.length).fill(false)
+    for (const pos of longestIncreasingSubsequenceIndices(domOrderIndices)) {
+      stationary[domOrderIndices[pos]] = true
+    }
+
+    let i = 0
+    while (i < desiredOrder.length) {
+      if (stationary[i]) { i++; continue }
+      let j = i
+      while (j < desiredOrder.length && !stationary[j]) j++
+      const before = j < desiredOrder.length ? desiredOrder[j].primaryEl : anchor
+      if (j - i === 1) {
+        container.insertBefore(desiredOrder[i].primaryEl, before)
+      } else {
+        const runFragment = document.createDocumentFragment()
+        for (let k = i; k < j; k++) runFragment.appendChild(desiredOrder[k].primaryEl)
+        container.insertBefore(runFragment, before)
+      }
+      i = j
+    }
+
+    entryList = desiredOrder
+  }, bfId)
+
+  // --- ONE loop-level effect for outer-involving bindings ---
+  // Created AFTER the reconciler effect (createEffect runs its body
+  // synchronously, so adoption has already happened when this first runs).
+  // `seed` is true exactly once, on the very first run — set false before
+  // calling so a throwing applyOuter can never seed twice. The effect reads
+  // `entryList` from the closure (non-reactive), so it re-runs only when
+  // the outer signals `applyOuter` reads inside its body change — never
+  // because the list was reconciled.
+  if (plan.applyOuter) {
+    const applyOuter = plan.applyOuter.bind(plan)
+    let seed = true
+    createEffect(() => {
+      const isSeed = seed
+      seed = false
+      applyOuter(entryList, isSeed)
+    })
+  }
+}

--- a/packages/client/src/runtime/map-array.ts
+++ b/packages/client/src/runtime/map-array.ts
@@ -62,8 +62,11 @@ type ItemScope<T> = {
  * When omitted (e.g. hand-written tests that drop in unscoped markers),
  * falls back to the first start / first end found, matching either the
  * scoped or legacy unscoped form.
+ *
+ * Exported for `./map-array-lazy.ts` (internal reuse only — not re-exported
+ * from the runtime index).
  */
-function findLoopMarkers(
+export function findLoopMarkers(
   container: HTMLElement,
   markerId?: string,
 ): { start: Comment | null; end: Comment | null } {
@@ -171,8 +174,11 @@ function insertScope<T>(scope: ItemScope<T>, target: Node, anchor: Node | null):
  * (plus any brand-new one) needs to move. This is the same strategy
  * keyed-diff reconcilers in the udomdiff/Solid family use to turn an
  * arbitrary reorder into a minimal set of DOM moves.
+ *
+ * Exported for `./map-array-lazy.ts` (internal reuse only — not re-exported
+ * from the runtime index).
  */
-function longestIncreasingSubsequenceIndices(arr: number[]): number[] {
+export function longestIncreasingSubsequenceIndices(arr: number[]): number[] {
   const n = arr.length
   if (n === 0) return []
   // tails[k] = index into `arr` of the smallest possible tail value for an


### PR DESCRIPTION
**L2 of the lazy-row-graph stack** (base: #2406 L1 spec). Runtime only — no compiler change yet; nothing emits `mapArrayLazy` until L3.

Implements spec §9.2's runtime half: `mapArrayLazy` renders a keyed reactive array with **zero per-row reactive resources** — no `createRoot`, no per-item signal, no per-row effect, and hydration adoption performs zero per-row DOM mutations, queries, or claims.

## Contract (pinned for L3)

`LazyRowPlan&lt;T&gt;` = `createRow` (CSR create, writes all bindings, records refs from clone paths) / `applyItem` (called directly by the reconciler on `!Object.is` item change; claims refs lazily on the row's first write) / optional `applyOuter(entries, seed)` (wrapped in ONE loop-level effect; `seed === true` exactly once — read-compare-write seeding per §9.3(1), so client-divergent outer state is patched, no trust-first-run regression).

Key isolation property: `createRow`/`applyItem` run inside the reconciler effect but under `untrack()`, so outer-signal reads there never subscribe the reconciler; the `applyOuter` effect owns the reactive side. The entry list handed to `applyOuter` is rebuilt after each reconcile and read non-reactively — the effect re-runs only on the outer signals it reads, never because the list was reconciled.

Keyed diff, duplicate-key warning, clear-all fast path, and LIS minimal-move reorder mirror `mapArray` exactly (two pure helpers exported from `map-array.ts` for reuse; zero behavior change there).

## Tests

18 new tests (`packages/client/__tests__/map-array-lazy.test.ts`): zero-mutation adoption (innerHTML snapshot), claim-once ref caching, unchanged-identity no-op, CSR create + data-key stamping, removal, LIS swap identity preservation, clear-all (both marker variants), applyOuter seed/dedup/divergent-SSR patch/re-run semantics, SSR-fewer/more edges, duplicate-key warn-once, and reconciler tracking isolation.

Full `packages/client` suite: **579 pass / 0 fail** (independently re-run). `bun run build` clean; changeset added (patch, @barefootjs/client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_