### PR TITLE
feat(jsx): emit lazy row plans for eligible plain loops (slot unification §9, L3)

### DIFF
--- a/.changeset/lazy-rows-compiler.md
+++ b/.changeset/lazy-rows-compiler.md
@@ -1,0 +1,23 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Emit lazy row plans for eligible plain loops (slot unification §9, L3)
+
+A plain loop row whose shape passes the §9.4 eligibility gate now compiles to
+`mapArrayLazy(...)` with a compiler-built row plan instead of `mapArray(...)`
+plus a renderItem: no `createRoot`, no per-item signal, no per-row effect, and
+no hydration-time query/claim/DOM write per row. Item-driven bindings are
+applied by the reconciler through `applyItem` (refs claimed lazily on a row's
+first update, per-binding dedup on `entry.last`); outer-involving bindings are
+applied by ONE loop-level effect (`applyOuter`) with read-compare-write seeding
+on its first run, so there is no trust-first-run regression.
+
+Eligibility is an explicit, unit-tested decision function
+(`lazyRowEligibility`): keyed single-root conditional-free plain rows, no refs
+/ nested components / inner loops / map-callback preamble, every reactive outer
+dependency a primable signal or memo getter, a loop source provably derived
+from props and literals, and never in profile mode. Every other loop keeps
+today's eager emission byte-for-byte — sound-or-loud, no silent third path.
+
+SSR templates are unchanged; this is a client-JS-only change.

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2323,6 +2323,46 @@
         "text"
       ]
     },
+    "lazy-row-ineligible-fallback": {
+      "kinds": [
+        "array-literal",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:boolean",
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "condition",
+        "loop",
+        "text"
+      ]
+    },
+    "lazy-row-outer-class": {
+      "kinds": [
+        "array-literal",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "local-record-union-index": {
       "kinds": [
         "literal",
@@ -4509,18 +4549,18 @@
     }
   },
   "kindCounts": {
-    "array-literal": 65,
+    "array-literal": 67,
     "array-method": 65,
     "arrow": 63,
     "binary": 76,
-    "call": 175,
+    "call": 177,
     "conditional": 21,
-    "identifier": 261,
+    "identifier": 263,
     "index-access": 12,
-    "literal": 215,
+    "literal": 217,
     "logical": 43,
-    "member": 140,
-    "object-literal": 47,
+    "member": 142,
+    "object-literal": 49,
     "template-literal": 29,
     "unary": 22,
     "unsupported": 31
@@ -4560,10 +4600,10 @@
     "binary:===": 39,
     "binary:>": 11,
     "binary:>=": 1,
-    "literal:boolean": 39,
+    "literal:boolean": 40,
     "literal:null": 22,
-    "literal:number": 91,
-    "literal:string": 155,
+    "literal:number": 93,
+    "literal:string": 157,
     "logical:&&": 7,
     "logical:??": 38,
     "logical:||": 13,

--- a/packages/adapter-tests/fixtures/__snapshots__/ai-chat.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/ai-chat.client.js
@@ -1,4 +1,4 @@
-import { $, __bfSlot, createComponent, createDisposableEffect, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, insert, lazySlots, mapArray, qsa } from '@barefootjs/client/runtime'
+import { $, __bfSlot, createComponent, createDisposableEffect, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, insert, lazySlots, mapArrayLazy, qsa } from '@barefootjs/client/runtime'
 
 
 export function initAIChatInteractive(__scope, _p = {}) {
@@ -83,19 +83,43 @@ export function initAIChatInteractive(__scope, _p = {}) {
   })
   const __tpl_l0 = document.createElement('template')
   __tpl_l0.innerHTML = `<div data-key="" bf="s1"><div class="chat-bubble"><p><!--bf:s0--><!--/--></p></div></div>`
-  mapArray(() => messages(), _s5, (msg) => String(msg.id), (msg, __idx, __existing) => {
-    const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
-    const __ra_s1 = qsa(__el, '[bf="s1"]')
-    const __bfw_s0 = lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])
-    createEffect(() => {
-      if (__ra_s1) {
-        {
-          { const __v = `chat-msg chat-${msg().role}`; if (__v != null) __ra_s1.setAttribute('class', String(__v)); else __ra_s1.removeAttribute('class') }
+  const __lzc_l0 = (__e) => {
+    const __el = __e.primaryEl
+    return [qsa(__el, '[bf="s1"]'), lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+  }
+  mapArrayLazy(() => messages(), _s5, (msg) => String(msg.id), {
+    createRow: (__e, __idx) => {
+      const msg = () => __e.item
+      const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
+      const __r = __e.refs = [qsa(__el, '[bf="s1"]'), lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+      const __l = __e.last = []
+      { const __t = __r[0]
+      if (__t) {
+        const __x = `chat-msg chat-${msg().role}`
+        { const __v = __x; if (__v != null) __t.setAttribute('class', String(__v)); else __t.removeAttribute('class') }
+        __l[0] = __x
+      } }
+      { const __x = msg().content
+      __r[1]('s0', String(__x))
+      __l[1] = __x }
+      return __el
+    },
+    applyItem: (__e) => {
+      const msg = () => __e.item
+      const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
+      const __l = __e.last ?? (__e.last = [])
+      { const __t = __r[0]
+      if (__t) {
+        const __x = `chat-msg chat-${msg().role}`
+        if (!(0 in __l) || !Object.is(__l[0], __x)) {
+          { const __v = __x; if (__v != null) __t.setAttribute('class', String(__v)); else __t.removeAttribute('class') }
         }
-      }
-      __bfw_s0('s0', String(msg().content))
-    })
-    return __el
+        __l[0] = __x
+      } }
+      { const __x = msg().content
+      if (!(1 in __l) || !Object.is(__l[1], __x)) __r[1]('s0', String(__x))
+      __l[1] = __x }
+    },
   }, 'l0')
 
 }

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -143,6 +143,9 @@ import { fixture as sortSimple } from './sort-simple'
 import { fixture as filterSortChain } from './filter-sort-chain'
 import { fixture as mapNested } from './map-nested'
 import { fixture as mapDynamicClass } from './map-dynamic-class'
+// Lazy row graph (spec/slot-unification.md §9) — eligible + refused pair
+import { fixture as lazyRowOuterClass } from './lazy-row-outer-class'
+import { fixture as lazyRowIneligibleFallback } from './lazy-row-ineligible-fallback'
 import { fixture as siblingMaps } from './sibling-maps'
 import { fixture as fragmentLoopChildren } from './fragment-loop-children'
 // Priority 5: Elements and attributes
@@ -515,6 +518,8 @@ export const jsxFixtures: JSXFixture[] = [
   filterSortChain,
   mapNested,
   mapDynamicClass,
+  lazyRowOuterClass,
+  lazyRowIneligibleFallback,
   siblingMaps,
   fragmentLoopChildren,
   // Priority 5: Elements and attributes

--- a/packages/adapter-tests/fixtures/lazy-row-ineligible-fallback.ts
+++ b/packages/adapter-tests/fixtures/lazy-row-ineligible-fallback.ts
@@ -1,0 +1,46 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Lazy row graph (`spec/slot-unification.md` §9) — the INELIGIBLE twin of
+ * `lazy-row-outer-class`, pinning the fallback half of the sound-or-loud
+ * contract (§9.3): a loop the §9.4 gate refuses keeps today's eager
+ * `mapArray` + renderItem emission, unchanged.
+ *
+ * The refusal here is §9.4's "no conditionals in the row": the row body is a
+ * reactive conditional (`row.done ? <b/> : <i/>`), which needs `insert()` and
+ * its own per-branch disposable effects — exactly the per-row reactive
+ * machinery the lazy row graph deletes. The loop is otherwise a textbook
+ * eligible shape (keyed, single-root, no preamble, literal-seeded signal
+ * source), so this fixture isolates that one gate.
+ *
+ * Same SSR-bytes obligation as the eligible fixture: this golden must not
+ * move — L3 touches client JS only.
+ */
+export const fixture = createFixture({
+  id: 'lazy-row-ineligible-fallback',
+  description: 'Keyed loop whose row is a reactive conditional — refused by the §9.4 gate, keeps eager emission',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string; done: boolean }
+export function LazyRowIneligibleFallback() {
+  const [rows, setRows] = createSignal<Row[]>([
+    { id: 1, label: 'alpha', done: true },
+    { id: 2, label: 'beta', done: false },
+  ])
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>{row.done ? <b>{row.label}</b> : <i>{row.label}</i>}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s3">
+      <li data-key="1"><b bf-c="s0"><!--bf:s1-->alpha<!--/--></b></li>
+      <li data-key="2"><i bf-c="s0"><!--bf:s2-->beta<!--/--></i></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/lazy-row-outer-class.ts
+++ b/packages/adapter-tests/fixtures/lazy-row-outer-class.ts
@@ -1,0 +1,56 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Lazy row graph (`spec/slot-unification.md` §9) — the ELIGIBLE shape.
+ *
+ * A keyed, single-root, conditional-free plain loop whose row carries both
+ * item-driven texts (`{row.id}` / `{row.label}`) and one outer-involving
+ * attribute (`className` reading the component-scope `selected()` signal).
+ * That combination is exactly what `mapArrayLazy` splits across `applyItem`
+ * (item texts) and the ONE loop-level `applyOuter` effect (the class), so it
+ * is the fixture that would break first if the eligibility gate or the
+ * emitted plan shape regressed.
+ *
+ * The SSR bytes below are the point of the fixture as much as the client JS:
+ * L3 changes client emission ONLY, so this golden must stay byte-identical
+ * to what the eager emission produced. `data-key` on each row is what the
+ * runtime READS at adoption (never writes), per §9.2.
+ */
+export const fixture = createFixture({
+  id: 'lazy-row-outer-class',
+  description: 'Keyed plain loop with item texts plus an outer-signal class (lazy row graph, §9)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string }
+export function LazyRowOuterClass() {
+  const [rows, setRows] = createSignal<Row[]>([
+    { id: 1, label: 'alpha' },
+    { id: 2, label: 'beta' },
+  ])
+  const [selected, setSelected] = createSignal(0)
+  return (
+    <tbody>
+      {rows().map(row => (
+        <tr key={row.id} className={selected() === row.id ? 'danger' : 'plain'}>
+          <td>{row.id}</td>
+          <td onClick={() => setSelected(row.id)}>{row.label}</td>
+        </tr>
+      ))}
+    </tbody>
+  )
+}
+`,
+  expectedHtml: `
+    <tbody bf-s="test" bf="s4">
+      <tr bf="s3" class="plain" data-key="1">
+        <td><!--bf:s0-->1<!--/--></td>
+        <td bf="s2"><!--bf:s1-->alpha<!--/--></td>
+      </tr>
+      <tr bf="s3" class="plain" data-key="2">
+        <td><!--bf:s0-->2<!--/--></td>
+        <td bf="s2"><!--bf:s1-->beta<!--/--></td>
+      </tr>
+    </tbody>
+  `,
+})

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -4380,7 +4380,7 @@ export function Example(_p, __bfKey) { return createComponent('Example', _p, __b
 `;
 
 exports[`docs/core/adapters/hono-adapter.md doc-examples L190 — (no label) 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArray } from '@barefootjs/client/runtime'
+"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
   if (!__scope) return
@@ -4431,11 +4431,30 @@ export function initExample(__scope, _p = {}) {
 
   const __tpl_l0 = document.createElement('template')
   __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
-  mapArray(() => items(), _s1, (item) => String(item), (item, __idx, __existing) => {
-    const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
-    const __bfw_s0 = lazySlots(__el, [{ id: 's0', kind: 'text', path: __existing ? [] : [0] }])
-    createEffect(() => { __bfw_s0('s0', String(item())) })
-    return __el
+  const __lzp_l0 = [[0]]
+  const __lzc_l0 = (__e) => {
+    const __el = __e.primaryEl
+    return [lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+  }
+  mapArrayLazy(() => items(), _s1, (item) => String(item), {
+    createRow: (__e, __idx) => {
+      const item = () => __e.item
+      const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
+      const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
+      const __l = __e.last = []
+      { const __x = item()
+      __r[0]('s0', String(__x))
+      __l[0] = __x }
+      return __el
+    },
+    applyItem: (__e) => {
+      const item = () => __e.item
+      const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
+      const __l = __e.last ?? (__e.last = [])
+      { const __x = item()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', String(__x))
+      __l[0] = __x }
+    },
   }, 'l0')
 
 }
@@ -4494,7 +4513,7 @@ export function Counter(_p, __bfKey) { return createComponent('Counter', _p, __b
 `;
 
 exports[`docs/core/adapters/go-template-adapter.md doc-examples L168 — (no label) 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArray } from '@barefootjs/client/runtime'
+"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
   if (!__scope) return
@@ -4545,11 +4564,30 @@ export function initExample(__scope, _p = {}) {
 
   const __tpl_l0 = document.createElement('template')
   __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
-  mapArray(() => items(), _s1, (item) => String(item), (item, __idx, __existing) => {
-    const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
-    const __bfw_s0 = lazySlots(__el, [{ id: 's0', kind: 'text', path: __existing ? [] : [0] }])
-    createEffect(() => { __bfw_s0('s0', String(item())) })
-    return __el
+  const __lzp_l0 = [[0]]
+  const __lzc_l0 = (__e) => {
+    const __el = __e.primaryEl
+    return [lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+  }
+  mapArrayLazy(() => items(), _s1, (item) => String(item), {
+    createRow: (__e, __idx) => {
+      const item = () => __e.item
+      const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
+      const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
+      const __l = __e.last = []
+      { const __x = item()
+      __r[0]('s0', String(__x))
+      __l[0] = __x }
+      return __el
+    },
+    applyItem: (__e) => {
+      const item = () => __e.item
+      const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
+      const __l = __e.last ?? (__e.last = [])
+      { const __x = item()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', String(__x))
+      __l[0] = __x }
+    },
   }, 'l0')
 
 }
@@ -4559,7 +4597,7 @@ export function Example(_p, __bfKey) { return createComponent('Example', _p, __b
 `;
 
 exports[`docs/core/adapters/go-template-adapter.md doc-examples L180 — (no label) 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArray } from '@barefootjs/client/runtime'
+"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
   if (!__scope) return
@@ -4610,11 +4648,30 @@ export function initExample(__scope, _p = {}) {
 
   const __tpl_l0 = document.createElement('template')
   __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
-  mapArray(() => items().filter(item => item.active), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
-    const __bfw_s0 = lazySlots(__el, [{ id: 's0', kind: 'text', path: __existing ? [] : [0] }])
-    createEffect(() => { __bfw_s0('s0', String(item().name)) })
-    return __el
+  const __lzp_l0 = [[0]]
+  const __lzc_l0 = (__e) => {
+    const __el = __e.primaryEl
+    return [lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+  }
+  mapArrayLazy(() => items().filter(item => item.active), _s1, (item) => String(item.id), {
+    createRow: (__e, __idx) => {
+      const item = () => __e.item
+      const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
+      const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
+      const __l = __e.last = []
+      { const __x = item().name
+      __r[0]('s0', String(__x))
+      __l[0] = __x }
+      return __el
+    },
+    applyItem: (__e) => {
+      const item = () => __e.item
+      const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
+      const __l = __e.last ?? (__e.last = [])
+      { const __x = item().name
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', String(__x))
+      __l[0] = __x }
+    },
   }, 'l0')
 
 }
@@ -5032,7 +5089,7 @@ export function StatementExample(_p, __bfKey) { return createComponent('Statemen
 `;
 
 exports[`docs/core/advanced/compiler-internals.md doc-examples L126 — (no label) 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArray } from '@barefootjs/client/runtime'
+"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
   if (!__scope) return
@@ -5083,11 +5140,30 @@ export function initExample(__scope, _p = {}) {
 
   const __tpl_l0 = document.createElement('template')
   __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
-  mapArray(() => todos().filter(t => !t.done).toSorted((a, b) => a.date - b.date), _s1, (t) => String(t.id), (t, __idx, __existing) => {
-    const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
-    const __bfw_s0 = lazySlots(__el, [{ id: 's0', kind: 'text', path: __existing ? [] : [0] }])
-    createEffect(() => { __bfw_s0('s0', String(t().name)) })
-    return __el
+  const __lzp_l0 = [[0]]
+  const __lzc_l0 = (__e) => {
+    const __el = __e.primaryEl
+    return [lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+  }
+  mapArrayLazy(() => todos().filter(t => !t.done).toSorted((a, b) => a.date - b.date), _s1, (t) => String(t.id), {
+    createRow: (__e, __idx) => {
+      const t = () => __e.item
+      const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
+      const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
+      const __l = __e.last = []
+      { const __x = t().name
+      __r[0]('s0', String(__x))
+      __l[0] = __x }
+      return __el
+    },
+    applyItem: (__e) => {
+      const t = () => __e.item
+      const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
+      const __l = __e.last ?? (__e.last = [])
+      { const __x = t().name
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', String(__x))
+      __l[0] = __x }
+    },
   }, 'l0')
 
 }
@@ -5159,7 +5235,7 @@ export function StatementExample(_p, __bfKey) { return createComponent('Statemen
 `;
 
 exports[`docs/core/advanced/performance.md doc-examples L67 — ✅ Stable key — DOM nodes reused when list changes 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArray } from '@barefootjs/client/runtime'
+"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
   if (!__scope) return
@@ -5210,11 +5286,30 @@ export function initExample(__scope, _p = {}) {
 
   const __tpl_l0 = document.createElement('template')
   __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
-  mapArray(() => items(), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
-    const __bfw_s0 = lazySlots(__el, [{ id: 's0', kind: 'text', path: __existing ? [] : [0] }])
-    createEffect(() => { __bfw_s0('s0', String(item().name)) })
-    return __el
+  const __lzp_l0 = [[0]]
+  const __lzc_l0 = (__e) => {
+    const __el = __e.primaryEl
+    return [lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+  }
+  mapArrayLazy(() => items(), _s1, (item) => String(item.id), {
+    createRow: (__e, __idx) => {
+      const item = () => __e.item
+      const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
+      const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
+      const __l = __e.last = []
+      { const __x = item().name
+      __r[0]('s0', String(__x))
+      __l[0] = __x }
+      return __el
+    },
+    applyItem: (__e) => {
+      const item = () => __e.item
+      const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
+      const __l = __e.last ?? (__e.last = [])
+      { const __x = item().name
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', String(__x))
+      __l[0] = __x }
+    },
   }, 'l0')
 
 }
@@ -5224,7 +5319,7 @@ export function Example(_p, __bfKey) { return createComponent('Example', _p, __b
 `;
 
 exports[`docs/core/advanced/performance.md doc-examples L70 — ❌ Index key — DOM nodes recreated on reorder 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArray } from '@barefootjs/client/runtime'
+"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
   if (!__scope) return
@@ -5275,11 +5370,30 @@ export function initExample(__scope, _p = {}) {
 
   const __tpl_l0 = document.createElement('template')
   __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
-  mapArray(() => items(), _s1, (item, i) => String(i), (item, i, __existing) => {
-    const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
-    const __bfw_s0 = lazySlots(__el, [{ id: 's0', kind: 'text', path: __existing ? [] : [0] }])
-    createEffect(() => { __bfw_s0('s0', String(item().name)) })
-    return __el
+  const __lzp_l0 = [[0]]
+  const __lzc_l0 = (__e) => {
+    const __el = __e.primaryEl
+    return [lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+  }
+  mapArrayLazy(() => items(), _s1, (item, i) => String(i), {
+    createRow: (__e, i) => {
+      const item = () => __e.item
+      const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
+      const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
+      const __l = __e.last = []
+      { const __x = item().name
+      __r[0]('s0', String(__x))
+      __l[0] = __x }
+      return __el
+    },
+    applyItem: (__e) => {
+      const item = () => __e.item
+      const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
+      const __l = __e.last ?? (__e.last = [])
+      { const __x = item().name
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', String(__x))
+      __l[0] = __x }
+    },
   }, 'l0')
 
 }

--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -2638,7 +2638,10 @@ describe('Client JS generation', () => {
       const js = result.files.find(f => f.type === 'clientJs')!.content
       // The branch arm's mapArray call must live inside a
       // createDisposableEffect that is pushed into __disposers.
-      expect(js).toMatch(/__disposers\.push\(createDisposableEffect\(\(\)\s*=>\s*\{[\s\S]*?mapArray\(/)
+      // `mapArray(` or `mapArrayLazy(` — a lazy-row-eligible branch loop
+      // (spec/slot-unification.md §9.4) uses the latter and has exactly the
+      // same disposal obligation.
+      expect(js).toMatch(/__disposers\.push\(createDisposableEffect\(\(\)\s*=>\s*\{[\s\S]*?mapArray(Lazy)?\(/)
     })
 
     test('nested conditional inside a conditional branch is wrapped in createDisposableEffect', () => {

--- a/packages/jsx/src/__tests__/composite-branch-loop.test.ts
+++ b/packages/jsx/src/__tests__/composite-branch-loop.test.ts
@@ -53,7 +53,10 @@ describe('composite loops inside conditional branches (#724)', () => {
     const js = clientJs!.content
 
     // Should use mapArray inside the branch's bindEvents
-    expect(js).toContain('mapArray(')
+    // `mapArray(` or `mapArrayLazy(` — a lazy-row-eligible branch loop
+    // (spec/slot-unification.md §9.4) uses the latter; either satisfies
+    // "keyed reconciliation, not a composite/component shape".
+    expect(js).toMatch(/\bmapArray(Lazy)?\(/)
 
     // After O-1's mode-collapse PR, child component init goes through the
     // runtime `upsertChild` helper instead of an emit-side
@@ -96,7 +99,10 @@ describe('composite loops inside conditional branches (#724)', () => {
     const js = clientJs!.content
 
     // Should use mapArray for per-item reactivity
-    expect(js).toContain('mapArray(')
+    // `mapArray(` or `mapArrayLazy(` — a lazy-row-eligible branch loop
+    // (spec/slot-unification.md §9.4) uses the latter; either satisfies
+    // "keyed reconciliation, not a composite/component shape".
+    expect(js).toMatch(/\bmapArray(Lazy)?\(/)
 
     // Should NOT use createComponent inside the init body (no child
     // components in this fixture). The CLI also emits a callable shim
@@ -147,7 +153,10 @@ describe('composite loops inside conditional branches (#724)', () => {
     const js = clientJs!.content
 
     // Should use mapArray for the loop
-    expect(js).toContain('mapArray(')
+    // `mapArray(` or `mapArrayLazy(` — a lazy-row-eligible branch loop
+    // (spec/slot-unification.md §9.4) uses the latter; either satisfies
+    // "keyed reconciliation, not a composite/component shape".
+    expect(js).toMatch(/\bmapArray(Lazy)?\(/)
 
     // Should have event delegation (addEventListener + closest pattern)
     expect(js).toContain(".addEventListener('click', (__bfEvt) => {")

--- a/packages/jsx/src/__tests__/conditional-mapArray-key.test.ts
+++ b/packages/jsx/src/__tests__/conditional-mapArray-key.test.ts
@@ -29,11 +29,17 @@ function clientJs(source: string, file = 'CondKey.tsx'): string {
   return cjs!.content
 }
 
+/**
+ * Reconciler call sites, whichever family they use. A lazy-row-eligible loop
+ * (spec/slot-unification.md §9.4) emits `mapArrayLazy(`; everything else keeps
+ * `mapArray(`. The key expression this suite asserts on is the same third
+ * argument in both shapes, so match the family, not one member of it.
+ */
 function mapArrayCalls(content: string): string[] {
   return content
     .split('\n')
     .map((ln) => ln.trim())
-    .filter((ln) => ln.startsWith('mapArray('))
+    .filter((ln) => ln.startsWith('mapArray(') || ln.startsWith('mapArrayLazy('))
 }
 
 describe('mapArray key extraction across conditional branches (#1098)', () => {

--- a/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
+++ b/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
@@ -452,3 +452,45 @@ export function CondRows() {
     expect(js).toMatch(/\bmapArray\(/)
   })
 })
+
+/**
+ * Presence-or-undefined attributes are the one kind where SSR and the
+ * client writer legitimately disagree on the VALUE while agreeing on
+ * presence: SSR renders a bare attribute name (`templateAttrExpr`), which
+ * parses to `""`, while `emitAttrUpdate` writes `'true'` for `aria-*`. A
+ * presence-only seed comparison therefore skips a write it must perform.
+ */
+const ELIGIBLE_ARIA = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string }
+export function LazyAriaRows() {
+  const [rows, setRows] = createSignal<Row[]>([])
+  const [selected, setSelected] = createSignal(0)
+  return (
+    <tbody>
+      {rows().map(row => (
+        <tr key={row.id} aria-selected={(selected() === row.id) || undefined}>
+          <td>{row.label}</td>
+        </tr>
+      ))}
+    </tbody>
+  )
+}
+`
+
+describe('lazy row emission — presence-or-undefined seed comparison', () => {
+  const js = clientJs(ELIGIBLE_ARIA, 'LazyAriaRows.tsx')
+
+  test('the loop is eligible (guards the rest of this describe)', () => {
+    expect(js).toContain('mapArrayLazy(')
+  })
+
+  test('seeds an aria-* presence attr by VALUE, not by presence', () => {
+    // SSR renders `aria-selected` bare (value ""), the writer writes
+    // "true" — comparing `hasAttribute` would call those equal and leave
+    // the row at `aria-selected=""` forever.
+    expect(js).toContain(`getAttribute('aria-selected') !== (__x ? 'true' : null)`)
+    expect(js).not.toContain(`hasAttribute('aria-selected')`)
+  })
+})

--- a/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
+++ b/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
@@ -1,0 +1,454 @@
+/**
+ * BarefootJS Compiler — lazy row graph eligibility + emission
+ * (`spec/slot-unification.md` §9, L3).
+ *
+ * Two layers:
+ *
+ *  1. `lazyRowEligibility` unit tests — the explicit decision function. One
+ *     test per ineligibility reason so a future gate change surfaces as a
+ *     single named failure instead of a generated-JS diff. The eligible case
+ *     is pinned too, so a gate that accidentally refuses EVERYTHING (the
+ *     silent way this feature dies) fails loudly.
+ *  2. Emitted-shape assertions — an eligible loop must emit `mapArrayLazy`
+ *     with the pinned plan shape, and an ineligible loop must keep the eager
+ *     `mapArray` + renderItem emission. Sound-or-loud: exactly two outcomes.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import {
+  classifyLazyBinding,
+  lazyRowEligibility,
+  type LazyRowEligibilityArgs,
+  type LazyRowScopeInfo,
+  type LazyRowShapeFacts,
+} from '../ir-to-client-js/control-flow/plan/lazy-row-eligibility'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+// --- fixtures ---------------------------------------------------------------
+
+function makeScope(overrides: Partial<LazyRowScopeInfo> = {}): LazyRowScopeInfo {
+  return {
+    // `rows` is a signal whose initializer is a literal (`[]`) — the
+    // canonical §9.3(2)-passing source.
+    signals: new Map([['rows', { initializerFreeIdentifiers: new Set<string>() }]]),
+    memos: new Set<string>(),
+    props: new Set<string>(['_p', 'items']),
+    constants: new Map<string, ReadonlySet<string> | null>(),
+    inert: new Set<string>(['clsx']),
+    profile: false,
+    ...overrides,
+  }
+}
+
+function makeShape(overrides: Partial<LazyRowShapeFacts> = {}): LazyRowShapeFacts {
+  return {
+    callSite: 'plain',
+    flatMapLeafItem: false,
+    anchored: false,
+    bodyIsMultiRoot: false,
+    hasExplicitKey: true,
+    conditionalCount: 0,
+    childRefCount: 0,
+    nestedComponentCount: 0,
+    innerLoopCount: 0,
+    hasChildComponent: false,
+    hasMapPreamble: false,
+    preambleRegionCount: 0,
+    hasParamUnwrap: false,
+    ...overrides,
+  }
+}
+
+function args(overrides: Partial<LazyRowEligibilityArgs> = {}): LazyRowEligibilityArgs {
+  return {
+    shape: makeShape(),
+    bindings: [],
+    arraySourceIdentifiers: new Set(['rows']),
+    scope: makeScope(),
+    ...overrides,
+  }
+}
+
+const itemBinding = (kind: 'attr' | 'text' = 'text') => ({
+  kind,
+  slotId: 's1',
+  readsItem: true,
+  readsOuter: false,
+  reactiveOuterNames: [] as string[],
+  opaqueOuterNames: [] as string[],
+  referencesIndex: false,
+})
+
+// --- eligibility ------------------------------------------------------------
+
+describe('lazyRowEligibility — eligible', () => {
+  test('a keyed, single-root, conditional-free plain row over a literal-seeded signal is eligible', () => {
+    expect(lazyRowEligibility(args())).toEqual({ eligible: true })
+  })
+
+  test('a mixed item+outer attr binding on a primable signal stays eligible', () => {
+    const decision = lazyRowEligibility(args({
+      bindings: [{
+        kind: 'attr',
+        slotId: 's3',
+        readsItem: true,
+        readsOuter: true,
+        reactiveOuterNames: ['selected'],
+        opaqueOuterNames: [],
+        referencesIndex: false,
+      }],
+      scope: makeScope({
+        signals: new Map([
+          ['rows', { initializerFreeIdentifiers: new Set<string>() }],
+          ['selected', { initializerFreeIdentifiers: new Set<string>() }],
+        ]),
+      }),
+    }))
+    expect(decision).toEqual({ eligible: true })
+  })
+
+  test('branch-scoped plain rows are in scope too', () => {
+    expect(lazyRowEligibility(args({ shape: makeShape({ callSite: 'branch-plain' }) })))
+      .toEqual({ eligible: true })
+  })
+})
+
+describe('lazyRowEligibility — shape refusals', () => {
+  const cases: Array<[string, Partial<LazyRowShapeFacts>, RegExp]> = [
+    ['flatMap descriptor loop', { flatMapLeafItem: true }, /flatMap/],
+    ['anchored whole-item conditional', { anchored: true }, /anchored/],
+    ['multi-root row', { bodyIsMultiRoot: true }, /multi-root/],
+    ['index-keyed loop', { hasExplicitKey: false }, /index-keyed/],
+    ['reactive conditional in the row', { conditionalCount: 1 }, /reactive conditional/],
+    ['imperative child ref', { childRefCount: 1 }, /child refs/],
+    ['child-component body', { hasChildComponent: true }, /child component/],
+    ['nested child components', { nestedComponentCount: 1 }, /nested child components/],
+    ['inner loop', { innerLoopCount: 1 }, /inner loop/],
+    ['map-callback preamble', { hasMapPreamble: true }, /preamble/],
+    ['preamble-patched regions', { preambleRegionCount: 1 }, /preamble-patched regions/],
+    ['destructured param without bindings', { hasParamUnwrap: true }, /destructured loop param/],
+  ]
+  for (const [name, shapeOverride, reason] of cases) {
+    test(name, () => {
+      const decision = lazyRowEligibility(args({ shape: makeShape(shapeOverride) }))
+      expect(decision.eligible).toBe(false)
+      expect((decision as { reason: string }).reason).toMatch(reason)
+    })
+  }
+})
+
+describe('lazyRowEligibility — profile mode', () => {
+  test('profile mode is never lazy, even for an otherwise perfect row', () => {
+    const decision = lazyRowEligibility(args({ scope: makeScope({ profile: true }) }))
+    expect(decision.eligible).toBe(false)
+    expect((decision as { reason: string }).reason).toMatch(/profile mode/)
+  })
+})
+
+describe('lazyRowEligibility — binding refusals', () => {
+  test('a binding referencing the loop index parameter is refused', () => {
+    const decision = lazyRowEligibility(args({
+      bindings: [{ ...itemBinding(), referencesIndex: true }],
+    }))
+    expect(decision.eligible).toBe(false)
+    expect((decision as { reason: string }).reason).toMatch(/index parameter/)
+  })
+
+  test('an unprimable outer dependency (a prop accessor) is refused', () => {
+    const decision = lazyRowEligibility(args({
+      bindings: [{
+        kind: 'attr',
+        slotId: 's3',
+        readsItem: false,
+        readsOuter: true,
+        reactiveOuterNames: [],
+        opaqueOuterNames: ['_p'],
+        referencesIndex: false,
+      }],
+    }))
+    expect(decision.eligible).toBe(false)
+    expect((decision as { reason: string }).reason).toMatch(/cannot be primed: _p/)
+  })
+
+  test('an outer-involving TEXT binding is refused (no DOM read-back for content slots)', () => {
+    const decision = lazyRowEligibility(args({
+      bindings: [{
+        kind: 'text',
+        slotId: 's1',
+        readsItem: true,
+        readsOuter: true,
+        reactiveOuterNames: ['selected'],
+        opaqueOuterNames: [],
+        referencesIndex: false,
+      }],
+      scope: makeScope({
+        signals: new Map([
+          ['rows', { initializerFreeIdentifiers: new Set<string>() }],
+          ['selected', { initializerFreeIdentifiers: new Set<string>() }],
+        ]),
+      }),
+    }))
+    expect(decision.eligible).toBe(false)
+    expect((decision as { reason: string }).reason).toMatch(/outer-involving text binding/)
+  })
+})
+
+describe('lazyRowEligibility — §9.3(2) loop-source consistency gate', () => {
+  test('absent arrayFreeIdentifiers is refused, never assumed empty', () => {
+    const decision = lazyRowEligibility(args({ arraySourceIdentifiers: null }))
+    expect(decision.eligible).toBe(false)
+    expect((decision as { reason: string }).reason).toMatch(/free identifiers unavailable/)
+  })
+
+  test('a prop-derived source passes', () => {
+    expect(lazyRowEligibility(args({ arraySourceIdentifiers: new Set(['items']) })))
+      .toEqual({ eligible: true })
+  })
+
+  test('a signal with NO structured initializer is unprovable → refused', () => {
+    const decision = lazyRowEligibility(args({
+      scope: makeScope({ signals: new Map([['rows', { initializerFreeIdentifiers: null }]]) }),
+    }))
+    expect(decision.eligible).toBe(false)
+    expect((decision as { reason: string }).reason).toMatch(/no structured initializer/)
+  })
+
+  test('a signal seeded from a props/literal chain passes transitively', () => {
+    const decision = lazyRowEligibility(args({
+      scope: makeScope({
+        signals: new Map([['rows', { initializerFreeIdentifiers: new Set(['seed']) }]]),
+        constants: new Map<string, ReadonlySet<string> | null>([['seed', new Set(['items'])]]),
+      }),
+    }))
+    expect(decision).toEqual({ eligible: true })
+  })
+
+  test('a signal seeded from an ENVIRONMENT read is refused', () => {
+    const decision = lazyRowEligibility(args({
+      scope: makeScope({
+        signals: new Map([['rows', { initializerFreeIdentifiers: new Set(['localStorage']) }]]),
+      }),
+    }))
+    expect(decision.eligible).toBe(false)
+    expect((decision as { reason: string }).reason).toMatch(/localStorage/)
+  })
+
+  test('an imported name in the source is refused', () => {
+    const decision = lazyRowEligibility(args({ arraySourceIdentifiers: new Set(['clsx']) }))
+    expect(decision.eligible).toBe(false)
+    expect((decision as { reason: string }).reason).toMatch(/import or local function/)
+  })
+
+  test('a memo source is refused by the v1 gate', () => {
+    const decision = lazyRowEligibility(args({
+      arraySourceIdentifiers: new Set(['sorted']),
+      scope: makeScope({ memos: new Set(['sorted']) }),
+    }))
+    expect(decision.eligible).toBe(false)
+    expect((decision as { reason: string }).reason).toMatch(/memo 'sorted'/)
+  })
+
+  test('a constant with no analyzable value is refused', () => {
+    const decision = lazyRowEligibility(args({
+      arraySourceIdentifiers: new Set(['table']),
+      scope: makeScope({ constants: new Map([['table', null]]) }),
+    }))
+    expect(decision.eligible).toBe(false)
+    expect((decision as { reason: string }).reason).toMatch(/no analyzable value/)
+  })
+})
+
+describe('classifyLazyBinding — fail-safe', () => {
+  const scope = makeScope({
+    signals: new Map([
+      ['rows', { initializerFreeIdentifiers: new Set<string>() }],
+      ['selected', { initializerFreeIdentifiers: new Set<string>() }],
+    ]),
+  })
+  const base = { slotId: 's1', rowLocalNames: new Set(['row']), indexParam: '__idx', scope }
+
+  test('unavailable free identifiers force BOTH readsItem and readsOuter, and mark the binding opaque', () => {
+    const c = classifyLazyBinding({ kind: 'attr', free: null, ...base })
+    expect(c.readsItem).toBe(true)
+    expect(c.readsOuter).toBe(true)
+    expect(c.opaqueOuterNames).toEqual(['<unknown>'])
+    // …and the gate therefore refuses, rather than shipping an effect that
+    // could never subscribe.
+    const decision = lazyRowEligibility(args({ bindings: [c], scope }))
+    expect(decision.eligible).toBe(false)
+  })
+
+  test('a pure item read is item-only', () => {
+    const c = classifyLazyBinding({ kind: 'text', free: new Set(['row']), ...base })
+    expect(c).toMatchObject({ readsItem: true, readsOuter: false, reactiveOuterNames: [], opaqueOuterNames: [] })
+  })
+
+  test('a signal read is a primable reactive-outer dependency', () => {
+    const c = classifyLazyBinding({ kind: 'attr', free: new Set(['row', 'selected']), ...base })
+    expect(c).toMatchObject({ readsItem: true, readsOuter: true, reactiveOuterNames: ['selected'], opaqueOuterNames: [] })
+  })
+
+  test('pure globals and literal-derived consts need no subscription and are not outer', () => {
+    const litScope = makeScope({
+      signals: scope.signals,
+      constants: new Map<string, ReadonlySet<string> | null>([['SIZES', new Set<string>()]]),
+    })
+    const c = classifyLazyBinding({
+      kind: 'attr', free: new Set(['row', 'Math', 'SIZES']), ...base, scope: litScope,
+    })
+    expect(c).toMatchObject({ readsItem: true, readsOuter: false, opaqueOuterNames: [] })
+  })
+
+  test('an import, a local function, and a non-literal const are all OPAQUE, not inert', () => {
+    // A reactive accessor hides behind ordinary-looking names — the
+    // `createSelector` const is the canonical case. Guessing "inert" here
+    // would emit an applyOuter effect that never subscribes.
+    const selScope = makeScope({
+      signals: scope.signals,
+      constants: new Map<string, ReadonlySet<string> | null>([['isSelected', new Set(['createSelector', 'selected'])]]),
+      inert: new Set(['clsx']),
+    })
+    const c = classifyLazyBinding({
+      kind: 'attr', free: new Set(['row', 'isSelected', 'clsx']), ...base, scope: selScope,
+    })
+    expect(c.readsOuter).toBe(true)
+    expect(c.opaqueOuterNames.sort()).toEqual(['clsx', 'isSelected'])
+    expect(lazyRowEligibility(args({ bindings: [c], scope: selScope })).eligible).toBe(false)
+  })
+
+  test('the index parameter is flagged, not silently treated as outer', () => {
+    const c = classifyLazyBinding({ kind: 'text', free: new Set(['__idx']), ...base })
+    expect(c.referencesIndex).toBe(true)
+  })
+})
+
+// --- emitted shape ----------------------------------------------------------
+
+function clientJs(source: string, file: string): string {
+  const result = compileJSX(source, file, { adapter: new TestAdapter() })
+  const js = result.files.find(f => f.path.endsWith('.client.js'))
+  if (!js) throw new Error(`no client JS emitted for ${file}`)
+  return js.content
+}
+
+const ELIGIBLE = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string }
+export function LazyRows() {
+  const [rows, setRows] = createSignal<Row[]>([])
+  const [selected, setSelected] = createSignal(0)
+  return (
+    <tbody>
+      {rows().map(row => (
+        <tr key={row.id} className={selected() === row.id ? 'danger' : ''}>
+          <td>{row.id}</td>
+          <td>{row.label}</td>
+        </tr>
+      ))}
+    </tbody>
+  )
+}
+`
+
+describe('lazy row emission — eligible loop', () => {
+  const js = clientJs(ELIGIBLE, 'LazyRows.tsx')
+
+  test('emits mapArrayLazy, not mapArray', () => {
+    expect(js).toContain('mapArrayLazy(')
+    expect(js).not.toMatch(/\bmapArray\(/)
+  })
+
+  test('imports mapArrayLazy from the runtime', () => {
+    expect(js).toMatch(/import \{[^}]*\bmapArrayLazy\b[^}]*\} from '@barefootjs\/client\/runtime'/)
+  })
+
+  test('emits all three plan members with the pinned signatures', () => {
+    expect(js).toContain('createRow: (__e, __idx) => {')
+    expect(js).toContain('applyItem: (__e) => {')
+    expect(js).toContain('applyOuter: (__es, __seed) => {')
+  })
+
+  test('rows carry no per-row reactive resources', () => {
+    const planBody = js.slice(js.indexOf('mapArrayLazy('), js.indexOf("}, 'l0')"))
+    expect(planBody).not.toContain('createEffect')
+    expect(planBody).not.toContain('createRoot')
+    expect(planBody).not.toContain('createSignal')
+  })
+
+  test('createRow writes every binding — item-driven AND outer-involving — and seeds refs/last', () => {
+    const createRow = js.slice(js.indexOf('createRow:'), js.indexOf('applyItem:'))
+    expect(createRow).toContain('__e.refs = [')
+    expect(createRow).toContain('__e.last = []')
+    expect(createRow).toContain("setAttribute('class'")   // outer-involving
+    expect(createRow).toContain("('s0', String(__x))")     // item text
+    expect(createRow).toContain("('s1', String(__x))")     // item text
+  })
+
+  test('applyItem claims refs lazily and dedups against entry.last', () => {
+    const applyItem = js.slice(js.indexOf('applyItem:'), js.indexOf('applyOuter:'))
+    expect(applyItem).toContain('__e.refs ?? (__e.refs = __lzc_l0(__e))')
+    expect(applyItem).toContain('!Object.is(__l[1], __x)')
+  })
+
+  test('applyOuter primes its outer signal read before the row loop (§9 empty-list subscription)', () => {
+    const applyOuter = js.slice(js.indexOf('applyOuter:'))
+    const primeIdx = applyOuter.indexOf('\n      selected()\n')
+    const loopIdx = applyOuter.indexOf('for (const __e of __es)')
+    expect(primeIdx).toBeGreaterThan(-1)
+    expect(loopIdx).toBeGreaterThan(primeIdx)
+  })
+
+  test('applyOuter seeds by read-compare-write (§9.3(1)), never a blind first write', () => {
+    const applyOuter = js.slice(js.indexOf('applyOuter:'))
+    expect(applyOuter).toContain("__seed ? (__t.getAttribute('class') !== (__x != null ? String(__x) : null))")
+  })
+
+  test('the lazy claim helper scans inside ONE row and is shared by both apply paths', () => {
+    expect(js).toContain('const __lzc_l0 = (__e) => {')
+    expect(js).toContain('const __el = __e.primaryEl')
+  })
+})
+
+describe('lazy row emission — ineligible loops fall back', () => {
+  test('an index-keyed loop keeps the eager mapArray emission', () => {
+    const js = clientJs(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function UnkeyedRows() {
+  const [rows, setRows] = createSignal<string[]>([])
+  return <ul>{rows().map(row => <li>{row}</li>)}</ul>
+}
+`, 'UnkeyedRows.tsx')
+    expect(js).toContain('mapArray(')
+    expect(js).not.toContain('mapArrayLazy(')
+  })
+
+  test('a row with a reactive conditional keeps the eager mapArray emission', () => {
+    const js = clientJs(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string; done: boolean }
+export function CondRows() {
+  const [rows, setRows] = createSignal<Row[]>([])
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>{row.done ? <b>{row.label}</b> : <i>{row.label}</i>}</li>
+      ))}
+    </ul>
+  )
+}
+`, 'CondRows.tsx')
+    expect(js).toMatch(/\bmapArray\(/)
+    expect(js).not.toContain('mapArrayLazy(')
+  })
+
+  test('profile mode keeps the eager, per-binding-attributed emission', () => {
+    const result = compileJSX(ELIGIBLE, 'LazyRowsProfiled.tsx', { adapter: new TestAdapter(), profile: true })
+    const js = result.files.find(f => f.path.endsWith('.client.js'))!.content
+    expect(js).not.toContain('mapArrayLazy(')
+    expect(js).toMatch(/\bmapArray\(/)
+  })
+})

--- a/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
@@ -58,7 +58,7 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     const clientJs = getClientJs(source, 'List.tsx')
     // Dynamic loops emit a `mapArray(` call site. Tighter than
     // `/mapArray|reconcile/` which would fire on any stray mention.
-    expect(clientJs).toContain('mapArray(')
+    expect(clientJs).toMatch(/\bmapArray(Lazy)?\(/)
     expect(clientJs).toContain('items()')
   })
 
@@ -83,7 +83,7 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     `
 
     const clientJs = getClientJs(source, 'List.tsx')
-    expect(clientJs).toContain('mapArray(')
+    expect(clientJs).toMatch(/\bmapArray(Lazy)?\(/)
     expect(clientJs).toContain('getItems()')
   })
 
@@ -124,7 +124,11 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     `
 
     const clientJs = getClientJs(source, 'List.tsx')
-    expect(clientJs).toMatch(/\bmapArray\s*\(/)
+    // `mapArrayLazy` counts: a keyed, single-root, conditional-free row over a
+    // PROP array is lazy-row-eligible (spec/slot-unification.md §9.4 — props
+    // are the canonical hydration-consistent source), so it takes the lazy
+    // reconciler. What #1586 pins is "reconciles at all", not which family.
+    expect(clientJs).toMatch(/\bmapArray(Lazy)?\s*\(/)
   })
 
   test('unrecognised-call chain with filter now reconciles', () => {
@@ -149,7 +153,7 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     `
 
     const clientJs = getClientJs(source, 'DoneList.tsx')
-    expect(clientJs).toContain('mapArray(')
+    expect(clientJs).toMatch(/\bmapArray(Lazy)?\(/)
     expect(clientJs).toContain('computeItems()')
   })
 
@@ -181,7 +185,7 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     // Outer reconciles via mapArray. Also assert the inner loop's array
     // expression (`o.children`) appears in the emitted template — without
     // this, the test would pass even if the inner loop were dropped.
-    expect(clientJs).toContain('mapArray(')
+    expect(clientJs).toMatch(/\bmapArray(Lazy)?\(/)
     expect(clientJs).toContain('outer()')
     expect(clientJs).toContain('o.children')
   })
@@ -219,8 +223,13 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     // mapArray is emitted (widening now applies). renderItem uses the
     // synthetic `__bfItem` param; references to `cfg` are rewritten
     // inline and no unwrap statement is emitted.
-    expect(clientJs).toContain('mapArray(')
-    expect(clientJs).toContain('(__bfItem, ')
+    expect(clientJs).toMatch(/\bmapArray(Lazy)?\(/)
+    // The synthetic accessor param, in whichever reconciler shape applies:
+    // `mapArray`'s renderItem head `(__bfItem, __idx, __existing) =>`, or a
+    // lazy row plan's `const __bfItem = () => __e.item` binding
+    // (spec/slot-unification.md §9). Either way the destructured references
+    // below must read through the accessor, which is what this pins.
+    expect(clientJs).toMatch(/\(__bfItem, |const __bfItem = \(\) => __e\.item/)
     expect(clientJs).not.toContain('const [, cfg] = __bfItem();')
     expect(clientJs).toContain('__bfItem()[1].color')
   })
@@ -247,7 +256,7 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     `
 
     const clientJs = getClientJs(source, 'Shelf.tsx')
-    expect(clientJs).toContain('mapArray(')
+    expect(clientJs).toMatch(/\bmapArray(Lazy)?\(/)
     expect(clientJs).toContain('listOf()')
   })
 
@@ -278,8 +287,13 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     `
 
     const clientJs = getClientJs(source, 'TypedLegend.tsx')
-    expect(clientJs).toContain('mapArray(')
-    expect(clientJs).toContain('(__bfItem, ')
+    expect(clientJs).toMatch(/\bmapArray(Lazy)?\(/)
+    // The synthetic accessor param, in whichever reconciler shape applies:
+    // `mapArray`'s renderItem head `(__bfItem, __idx, __existing) =>`, or a
+    // lazy row plan's `const __bfItem = () => __e.item` binding
+    // (spec/slot-unification.md §9). Either way the destructured references
+    // below must read through the accessor, which is what this pins.
+    expect(clientJs).toMatch(/\(__bfItem, |const __bfItem = \(\) => __e\.item/)
     expect(clientJs).not.toContain('const [, cfg] = __bfItem();')
     expect(clientJs).toContain('__bfItem()[1].color')
   })
@@ -309,8 +323,13 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     `
 
     const clientJs = getClientJs(source, 'Fields.tsx')
-    expect(clientJs).toContain('mapArray(')
-    expect(clientJs).toContain('(__bfItem, ')
+    expect(clientJs).toMatch(/\bmapArray(Lazy)?\(/)
+    // The synthetic accessor param, in whichever reconciler shape applies:
+    // `mapArray`'s renderItem head `(__bfItem, __idx, __existing) =>`, or a
+    // lazy row plan's `const __bfItem = () => __e.item` binding
+    // (spec/slot-unification.md §9). Either way the destructured references
+    // below must read through the accessor, which is what this pins.
+    expect(clientJs).toMatch(/\(__bfItem, |const __bfItem = \(\) => __e\.item/)
     expect(clientJs).not.toContain('const { label, value } = __bfItem();')
     expect(clientJs).toContain('__bfItem().label')
     expect(clientJs).toContain('__bfItem().value')

--- a/packages/jsx/src/__tests__/loop-hoisted-template.test.ts
+++ b/packages/jsx/src/__tests__/loop-hoisted-template.test.ts
@@ -72,16 +72,20 @@ describe('hoisted loop-body skeleton template (perf)', () => {
     `
     const { clientJs, template } = compile(source, 'Bench.tsx')
 
-    // Hoisted declaration present, before the mapArray call.
+    // Hoisted declaration present, before the reconciler call. This row shape
+    // is also lazy-row-eligible (spec/slot-unification.md §9.4), so the
+    // reconciler is `mapArrayLazy` and the clone happens in the row plan's
+    // `createRow` rather than in a `mapArray` renderItem — the hoisting
+    // question this suite pins is orthogonal to which reconciler consumes it.
     const declIdx = clientJs.indexOf('.innerHTML = `<tr')
-    const mapArrayIdx = clientJs.indexOf('mapArray(')
+    const mapArrayIdx = clientJs.search(/\bmapArray(Lazy)?\(/)
     expect(declIdx).toBeGreaterThan(-1)
     expect(mapArrayIdx).toBeGreaterThan(-1)
     expect(declIdx).toBeLessThan(mapArrayIdx)
 
-    // renderItem clones from the hoisted template instead of re-parsing
+    // The row is built by cloning the hoisted template instead of re-parsing
     // innerHTML per row.
-    expect(clientJs).toMatch(/const __el = __existing \?\? __tpl_\w+\.content\.firstElementChild\.cloneNode\(true\)/)
+    expect(clientJs).toMatch(/const __el = __tpl_\w+\.content\.firstElementChild\.cloneNode\(true\)/)
 
     // The hoisted template itself carries no interpolations and no dynamic
     // `class` attribute (that's covered by the reactive-attr createEffect).
@@ -172,7 +176,7 @@ describe('hoisted loop-body skeleton template (perf)', () => {
       }
     `
     const { clientJs } = compile(source, 'SpreadList.tsx')
-    expect(clientJs).toContain('mapArray(')
+    expect(clientJs).toMatch(/\bmapArray(Lazy)?\(/)
     expect(clientJs).not.toMatch(/__tpl_\w+ = document\.createElement\('template'\)/)
   })
 
@@ -195,7 +199,7 @@ describe('hoisted loop-body skeleton template (perf)', () => {
       }
     `
     const { clientJs } = compile(source, 'Dots.tsx')
-    expect(clientJs).toContain('mapArray(')
+    expect(clientJs).toMatch(/\bmapArray(Lazy)?\(/)
     // A `<circle>` root with only dynamic attrs (all covered by reactive-attr
     // createEffects) and a literal `r="4"` is exactly the shape the fast path
     // proves safe — this DOES hoist, and it must wrap in a synthetic `<svg>`

--- a/packages/jsx/src/__tests__/static-loop-csr-materialize.test.ts
+++ b/packages/jsx/src/__tests__/static-loop-csr-materialize.test.ts
@@ -95,7 +95,12 @@ describe('#1247 — static-loop CSR self-heal', () => {
       }
     `
     const clientJs = getClientJs(source, 'PropList.tsx')
-    expect(clientJs).toMatch(/\bmapArray\s*\(/)
+    // Either reconciler shape satisfies the point of this test — the loop must
+    // go through the keyed `mapArray` family, not the static `forEach` path.
+    // A keyed, single-root, conditional-free row over a prop array is
+    // lazy-row-eligible (spec/slot-unification.md §9.4), so it emits
+    // `mapArrayLazy`; widen (don't narrow) the assertion.
+    expect(clientJs).toMatch(/\bmapArray(Lazy)?\s*\(/)
     expect(clientJs).not.toMatch(/\.forEach\s*\(/)
   })
 

--- a/packages/jsx/src/ir-to-client-js/control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow.ts
@@ -25,6 +25,7 @@ import { internalInvariant } from '../errors.ts'
 import { buildInsertPlan } from './control-flow/plan/build-insert.ts'
 import { stringifyInsert } from './control-flow/stringify/insert.ts'
 import { buildLoopPlan } from './control-flow/plan/build-loop.ts'
+import { buildLazyRowScopeInfo } from './control-flow/plan/build-lazy-row.ts'
 import { stringifyLoop } from './control-flow/stringify/loop.ts'
 import {
   buildDynamicLoopDelegationPlan,
@@ -36,7 +37,7 @@ import { stringifyEventDelegation } from './control-flow/stringify/event-delegat
 export function emitConditionalUpdates(lines: string[], ctx: ClientJsContext): void {
   const profileComponentName = ctx.profile ? ctx.componentName : undefined
   for (const elem of ctx.conditionalElements) {
-    const plan = buildInsertPlan(elem, { scope: { kind: 'top' }, eventNameMode: 'dom', profileComponentName })
+    const plan = buildInsertPlan(elem, { scope: { kind: 'top' }, eventNameMode: 'dom', profileComponentName, lazyScope: buildLazyRowScopeInfo(ctx) })
     stringifyInsert(lines, plan, { leadingIndent: '  ', bodyIndent: '      ' })
     lines.push('')
   }
@@ -46,7 +47,7 @@ export function emitConditionalUpdates(lines: string[], ctx: ClientJsContext): v
 export function emitClientOnlyConditionals(lines: string[], ctx: ClientJsContext): void {
   const profileComponentName = ctx.profile ? ctx.componentName : undefined
   for (const elem of ctx.clientOnlyConditionals) {
-    const plan = buildInsertPlan(elem, { scope: { kind: 'top' }, eventNameMode: 'raw', profileComponentName })
+    const plan = buildInsertPlan(elem, { scope: { kind: 'top' }, eventNameMode: 'raw', profileComponentName, lazyScope: buildLazyRowScopeInfo(ctx) })
     lines.push(`  // @client conditional: ${elem.slotId}`)
     stringifyInsert(lines, plan, { leadingIndent: '  ', bodyIndent: '      ' })
     lines.push('')
@@ -66,10 +67,14 @@ export function emitClientOnlyConditionals(lines: string[], ctx: ClientJsContext
  *     event surface, no delegation pass needed
  */
 export function emitLoopUpdates(lines: string[], ctx: ClientJsContext, unsafeLocalNames: Set<string>): void {
+  // Lazy row graph (§9.4) name facts — built once per component, consulted
+  // by every plain loop's eligibility gate.
+  const lazyScope = buildLazyRowScopeInfo(ctx)
   for (const elem of ctx.loopElements) {
     const plan = buildLoopPlan(elem, {
       unsafeLocalNames,
       profileComponentName: ctx.profile ? ctx.componentName : undefined,
+      lazyScope,
     })
     // Stage 3 root cure — a JSX-bearing preamble can only be spliced into a
     // string-templated row (renderPreamble). Every shape that reaches a

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/branch-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/branch-loop.ts
@@ -18,6 +18,7 @@
 import type { CompositeLoopPlan, LoopChildRefBinding, PreambleRegionPlan } from './loop.ts'
 import type { EventDelegationPlan } from './event-delegation.ts'
 import type { ReactiveEffectsPlan } from './reactive-effects.ts'
+import type { LazyRowPlanData } from './build-lazy-row.ts'
 
 export interface BranchPlainLoopPlan {
   /**
@@ -89,6 +90,11 @@ export interface BranchPlainLoopPlan {
    * renderItem layout, mirroring the top-level plain plan.
    */
   preambleRegions: readonly PreambleRegionPlan[]
+  /**
+   * Lazy row graph plan (`spec/slot-unification.md` §9, L3) — see
+   * `PlainLoopVariant.lazyRow`. Undefined ⇒ today's eager emission.
+   */
+  lazyRow?: LazyRowPlanData
 }
 
 export interface BranchCompositeLoopPlan {

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-branch-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-branch-loop.ts
@@ -15,6 +15,8 @@ import { buildChainedArrayExpr, varSlotId, wrapLoopParamAsAccessor } from '../..
 import { buildBranchCompositePlan } from './build-composite-loop.ts'
 import { buildBranchLoopDelegationPlan } from './build-event-delegation.ts'
 import { buildReactiveEffectsPlan } from './build-reactive-effects.ts'
+import { buildLazyRowPlan } from './build-lazy-row.ts'
+import type { LazyRowScopeInfo } from './lazy-row-eligibility.ts'
 import { destructureLoopParam, loopKeyFn, buildChildRefBindings, buildPreambleRegionPlans } from '../shared.ts'
 import { renderPreamble, irToHtmlTemplate } from '../../html-template.ts'
 import type {
@@ -23,7 +25,11 @@ import type {
   BranchPlainLoopPlan,
 } from './branch-loop.ts'
 
-export function buildBranchLoopPlan(loop: BranchLoop, profileComponentName?: string): BranchLoopPlan {
+export function buildBranchLoopPlan(
+  loop: BranchLoop,
+  profileComponentName?: string,
+  lazyScope?: LazyRowScopeInfo,
+): BranchLoopPlan {
   const containerSlotId = loop.containerSlotId
   const cv = varSlotId(containerSlotId)
   const containerVar = `__loop_${cv}`
@@ -45,6 +51,17 @@ export function buildBranchLoopPlan(loop: BranchLoop, profileComponentName?: str
 
   // flatMap descriptor mode — see buildPlainLoopPlan (build-loop.ts).
   const fm = loop.flatMapClient
+  const arrayExpr = fm
+    ? `(${buildChainedArrayExpr(loop)}).flatMap(${fm.params} => ${fm.body})`
+    : buildChainedArrayExpr(loop)
+  const indexParam = loop.index || '__idx'
+  const mapPreambleWrapped = loop.preamble
+    ? renderPreamble(loop.preamble, {
+        transformJs: (t) => wrapLoopParamAsAccessor(t, loop.param, loop.paramBindings),
+        renderLeaf: (ir) => irToHtmlTemplate(ir, undefined, 1, [{ param: loop.param, bindings: loop.paramBindings }], undefined, true),
+      })
+    : ''
+  const preambleRegions = buildPreambleRegionPlans(loop.preambleRegions, loop.param, loop.paramBindings)
   const plan: BranchPlainLoopPlan = {
     kind: 'plain',
     rowConstruction: 'string-template',
@@ -52,23 +69,29 @@ export function buildBranchLoopPlan(loop: BranchLoop, profileComponentName?: str
     containerVar,
     markerId: loop.markerId,
     flatMapLeafItem: fm ? true : undefined,
-    arrayExpr: fm
-      ? `(${buildChainedArrayExpr(loop)}).flatMap(${fm.params} => ${fm.body})`
-      : buildChainedArrayExpr(loop),
+    arrayExpr,
     keyFn: fm
       ? (fm.keyed ? '(__bfD, __bfI) => String(__bfD.k ?? __bfI)' : 'null')
       : loopKeyFn(loop),
     paramHead,
     paramUnwrap,
-    indexParam: loop.index || '__idx',
+    indexParam,
     // Wrap loop-param references to signal-accessor form so the preamble
     // matches the template literal's already-wrapped reads (#1065).
-    mapPreambleWrapped: loop.preamble
-      ? renderPreamble(loop.preamble, {
-          transformJs: (t) => wrapLoopParamAsAccessor(t, loop.param, loop.paramBindings),
-          renderLeaf: (ir) => irToHtmlTemplate(ir, undefined, 1, [{ param: loop.param, bindings: loop.paramBindings }], undefined, true),
-        })
-      : '',
+    mapPreambleWrapped,
+    // Lazy row graph (§9, L3) — undefined for every ineligible loop.
+    lazyRow: buildLazyRowPlan({
+      loop,
+      arrayExpr,
+      indexParam,
+      paramUnwrap,
+      mapPreambleWrapped,
+      preambleRegionCount: preambleRegions.length,
+      callSite: 'branch-plain',
+      flatMapLeafItem: Boolean(fm),
+      anchored: false,
+      scope: lazyScope,
+    }) ?? undefined,
     template: loop.template,
     reactiveEffects: hasReactiveEffects
       ? buildReactiveEffectsPlan({
@@ -82,7 +105,7 @@ export function buildBranchLoopPlan(loop: BranchLoop, profileComponentName?: str
       : null,
     eventDelegation: buildBranchLoopDelegationPlan(loop, cv, profileComponentName),
     childRefs: buildChildRefBindings(loop.bindings.refs, loop.param, loop.paramBindings),
-    preambleRegions: buildPreambleRegionPlans(loop.preambleRegions, loop.param, loop.paramBindings),
+    preambleRegions,
     bodyIsMultiRoot: loop.bodyIsMultiRoot ?? false,
     profileLoopId: profileComponentName ? `${profileComponentName}#binding:${containerSlotId}` : undefined,
   }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-insert.ts
@@ -14,6 +14,7 @@ import type {
 } from '../../types.ts'
 import { addCondAttrToTemplate } from '../../html-template.ts'
 import { buildBranchLoopPlan } from './build-branch-loop.ts'
+import type { LazyRowScopeInfo } from './lazy-row-eligibility.ts'
 import type {
   InsertPlan,
   InsertArm,
@@ -26,6 +27,12 @@ export interface BuildInsertOptions {
   eventNameMode: 'dom' | 'raw'
   /** Owning component name in profile mode (#1690, SR3) — else undefined. */
   profileComponentName?: string
+  /**
+   * Component-scope name facts for the lazy row graph gate
+   * (`spec/slot-unification.md` §9.4). Threaded down to branch-scoped plain
+   * loops; omitted → those loops keep today's eager emission.
+   */
+  lazyScope?: LazyRowScopeInfo
 }
 
 export function buildInsertPlan(
@@ -88,13 +95,13 @@ function buildArmBody(branch: BranchSummary, options: BuildInsertOptions): ArmBo
       expression: t.expression,
     })),
     // Branch-scoped loops, fully Plan-built (Item 2 final migration).
-    loops: branch.loops.map(l => buildBranchLoopPlan(l, pc)),
+    loops: branch.loops.map(l => buildBranchLoopPlan(l, pc, options.lazyScope)),
     // Nested conditionals are themselves InsertPlans — built recursively so
     // the same stringifier handles arbitrary depth. Their scope is always
     // `__branchScope` (the parent arm's bindEvents argument), regardless of
     // the outer scope; only the eventNameMode is inherited.
     conditionals: branch.conditionals.map(c =>
-      buildInsertPlan(c, { scope: { kind: 'branchScope' }, eventNameMode: options.eventNameMode, profileComponentName: pc }),
+      buildInsertPlan(c, { scope: { kind: 'branchScope' }, eventNameMode: options.eventNameMode, profileComponentName: pc, lazyScope: options.lazyScope }),
     ),
   }
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-lazy-row.ts
@@ -1,0 +1,286 @@
+/**
+ * Build the compiler-side `LazyRowPlan` payload (`spec/slot-unification.md`
+ * §9, L3) for one plain loop row — or `null` when the row is ineligible and
+ * must keep today's eager `mapArray` emission.
+ *
+ * Everything decided here is BUILD-TIME data: per-binding item/outer
+ * classification (`classifyLazyBinding`), ref-array and dedup-slot layout,
+ * and the outer-signal prime list. The stringifier
+ * (`stringify/lazy-row.ts`) is a deterministic walk over this plan — it
+ * makes no classification decision of its own.
+ *
+ * Free identifiers are never obtained by regex (repo rule). Texts carry
+ * `LoopChildReactiveText.freeIdentifiers` from the analyzer; attrs have no
+ * such field, so their expression is run through `parseExpression` +
+ * `freeIdentifiers` (`expression-parser.ts`) — both of which fail SAFE, the
+ * latter returning `null` on an `unsupported` node, which
+ * `classifyLazyBinding` turns into "reads both, and opaque".
+ */
+
+import { freeIdentifiers, parseExpression } from '../../../expression-parser.ts'
+import { pickAttrMeta, type AttrMeta } from '../../../types.ts'
+import { extractFreeIdentifiersFromText } from '../../csr-substitute.ts'
+import { wrapLoopParamAsAccessor, PROPS_PARAM } from '../../utils.ts'
+import type { BranchLoop, ClientJsContext, TopLevelLoop } from '../../types.ts'
+import {
+  classifyLazyBinding,
+  lazyRowEligibility,
+  type ClassifiedLazyBinding,
+  type LazyRowEligibility,
+  type LazyRowScopeInfo,
+  type LazyRowShapeFacts,
+} from './lazy-row-eligibility.ts'
+
+/** One reactive attribute of a lazy row. */
+export interface LazyRowAttrBinding {
+  slotId: string
+  attrName: string
+  /** Already wrapped via `wrapLoopParamAsAccessor` — reads `<param>()`. */
+  wrappedExpression: string
+  meta: AttrMeta
+  /** Index into `entry.refs` holding this slot's element. */
+  refIndex: number
+  /** Index into `entry.last` holding this binding's dedup value. */
+  ordinal: number
+  readsItem: boolean
+  readsOuter: boolean
+}
+
+/** One reactive outer text of a lazy row. Item-driven only (see §9.4 gate). */
+export interface LazyRowTextBinding {
+  slotId: string
+  wrappedExpression: string
+  ordinal: number
+  readsItem: boolean
+}
+
+export interface LazyRowPlanData {
+  /** Distinct attr slot ids, in declaration order — `entry.refs[0..n-1]`. */
+  attrSlotIds: readonly string[]
+  attrs: readonly LazyRowAttrBinding[]
+  texts: readonly LazyRowTextBinding[]
+  /** Index into `entry.refs` holding the claimed-slot writer; -1 when no texts. */
+  writerIndex: number
+  /** Total `entry.last` slots. */
+  lastCount: number
+  /**
+   * Signal / memo getters read at the top of `applyOuter` so the ONE
+   * loop-level effect subscribes even while the entry list is empty. Empty
+   * ⇒ no `applyOuter` is emitted at all (and hydration does literally
+   * nothing per row).
+   */
+  outerPrimeGetters: readonly string[]
+  /** True when at least one binding is outer-involving. */
+  hasOuter: boolean
+}
+
+export interface BuildLazyRowArgs {
+  loop: TopLevelLoop | BranchLoop
+  /** Fully-chained array expression as emitted (`buildChainedArrayExpr`). */
+  arrayExpr: string
+  indexParam: string
+  /** `destructureLoopParam(...).unwrap` — non-empty ⇒ ineligible. */
+  paramUnwrap: string
+  mapPreambleWrapped: string
+  preambleRegionCount: number
+  callSite: 'plain' | 'branch-plain'
+  flatMapLeafItem: boolean
+  anchored: boolean
+  scope: LazyRowScopeInfo | undefined
+}
+
+/**
+ * Returns the lazy row plan when eligible, otherwise `null` plus the
+ * decision (exposed for tests / diagnostics via {@link decideLazyRow}).
+ */
+export function buildLazyRowPlan(args: BuildLazyRowArgs): LazyRowPlanData | null {
+  return decideLazyRow(args).plan
+}
+
+export function decideLazyRow(args: BuildLazyRowArgs): {
+  plan: LazyRowPlanData | null
+  decision: LazyRowEligibility
+} {
+  const { loop, scope } = args
+  if (!scope) {
+    return { plan: null, decision: { eligible: false, reason: 'no component scope info supplied' } }
+  }
+
+  const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, loop.param, loop.paramBindings)
+  const rowLocalNames = new Set<string>([loop.param])
+  for (const b of loop.paramBindings ?? []) rowLocalNames.add(b.name)
+
+  // --- classify every binding -------------------------------------------
+  const classified: ClassifiedLazyBinding[] = []
+  const attrClass = new Map<number, ClassifiedLazyBinding>()
+  loop.bindings.reactiveAttrs.forEach((attr, i) => {
+    const c = classifyLazyBinding({
+      kind: 'attr',
+      slotId: attr.childSlotId,
+      free: attrFreeIdentifiers(attr.expression),
+      rowLocalNames,
+      indexParam: args.indexParam,
+      scope,
+    })
+    attrClass.set(i, c)
+    classified.push(c)
+  })
+  const textClass = new Map<number, ClassifiedLazyBinding>()
+  loop.bindings.reactiveTexts.forEach((text, i) => {
+    const c = classifyLazyBinding({
+      kind: 'text',
+      slotId: text.slotId,
+      free: text.freeIdentifiers ?? null,
+      rowLocalNames,
+      indexParam: args.indexParam,
+      scope,
+    })
+    textClass.set(i, c)
+    classified.push(c)
+  })
+
+  // --- §9.4 gate ---------------------------------------------------------
+  const shape: LazyRowShapeFacts = {
+    callSite: args.callSite,
+    flatMapLeafItem: args.flatMapLeafItem,
+    anchored: args.anchored,
+    bodyIsMultiRoot: loop.bodyIsMultiRoot ?? false,
+    hasExplicitKey: loop.key != null,
+    conditionalCount: loop.bindings.conditionals?.length ?? 0,
+    childRefCount: loop.bindings.refs?.length ?? 0,
+    nestedComponentCount: loop.nestedComponents?.length ?? 0,
+    innerLoopCount: loop.innerLoops?.length ?? 0,
+    hasChildComponent: 'childComponent' in loop && loop.childComponent != null,
+    hasMapPreamble: args.mapPreambleWrapped.length > 0,
+    preambleRegionCount: args.preambleRegionCount,
+    hasParamUnwrap: args.paramUnwrap.length > 0,
+  }
+
+  const decision = lazyRowEligibility({
+    shape,
+    bindings: classified,
+    arraySourceIdentifiers: loopSourceIdentifiers(loop, args.arrayExpr),
+    scope,
+  })
+  if (!decision.eligible) return { plan: null, decision }
+
+  // --- layout ------------------------------------------------------------
+  const attrSlotIds: string[] = []
+  for (const attr of loop.bindings.reactiveAttrs) {
+    if (!attrSlotIds.includes(attr.childSlotId)) attrSlotIds.push(attr.childSlotId)
+  }
+
+  let ordinal = 0
+  const attrs: LazyRowAttrBinding[] = loop.bindings.reactiveAttrs.map((attr, i) => {
+    const c = attrClass.get(i)!
+    return {
+      slotId: attr.childSlotId,
+      attrName: attr.attrName,
+      wrappedExpression: wrap(attr.expression),
+      meta: pickAttrMeta(attr),
+      refIndex: attrSlotIds.indexOf(attr.childSlotId),
+      ordinal: ordinal++,
+      readsItem: c.readsItem,
+      readsOuter: c.readsOuter,
+    }
+  })
+  const texts: LazyRowTextBinding[] = loop.bindings.reactiveTexts.map((text, i) => {
+    const c = textClass.get(i)!
+    return {
+      slotId: text.slotId,
+      wrappedExpression: wrap(text.expression),
+      ordinal: ordinal++,
+      // Outer-involving texts are refused by the gate, so an item-only text
+      // that somehow classified as neither still gets applied on item change
+      // (harmless, dedup-guarded) rather than silently never being written.
+      readsItem: true,
+    }
+  })
+
+  const outerPrimeGetters: string[] = []
+  for (const c of classified) {
+    for (const name of c.reactiveOuterNames) {
+      if (!outerPrimeGetters.includes(name)) outerPrimeGetters.push(name)
+    }
+  }
+
+  return {
+    plan: {
+      attrSlotIds,
+      attrs,
+      texts,
+      writerIndex: texts.length > 0 ? attrSlotIds.length : -1,
+      lastCount: ordinal,
+      outerPrimeGetters,
+      hasOuter: attrs.some(a => a.readsOuter),
+    },
+    decision,
+  }
+}
+
+/**
+ * Project a `ClientJsContext` down to the name facts the §9.4 gate resolves
+ * against. Built once per component and threaded into every loop plan
+ * builder, so the gate never reaches back into the whole context.
+ */
+export function buildLazyRowScopeInfo(ctx: ClientJsContext): LazyRowScopeInfo {
+  const signals = new Map<string, { initializerFreeIdentifiers: ReadonlySet<string> | null }>()
+  for (const s of ctx.signals) {
+    signals.set(s.getter, {
+      // `parsed` is the analyzer's structured initializer. Absent (or
+      // refused by `freeIdentifiers`) ⇒ unprovable, which the source gate
+      // treats as a hard stop rather than an assumption.
+      initializerFreeIdentifiers: s.parsed ? freeIdentifiers(s.parsed) : null,
+    })
+  }
+  const memos = new Set(ctx.memos.map(m => m.name))
+  const props = new Set<string>([PROPS_PARAM])
+  if (ctx.propsObjectName) props.add(ctx.propsObjectName)
+  for (const p of ctx.propsParams) props.add(p.name)
+  const constants = new Map<string, ReadonlySet<string> | null>()
+  for (const c of ctx.localConstants) {
+    constants.set(c.name, c.freeIdentifiers ?? null)
+  }
+  const inert = new Set<string>()
+  for (const f of ctx.localFunctions) inert.add(f.name)
+  for (const imp of ctx.imports) {
+    if (imp.isTypeOnly) continue
+    for (const spec of imp.specifiers) inert.add(spec.alias || spec.name)
+  }
+  return { signals, memos, props, constants, inert, profile: ctx.profile }
+}
+
+/**
+ * Free identifiers of a reactive-attr expression. `LoopChildReactiveAttr`
+ * carries none (unlike `LoopChildReactiveText`), so parse it structurally —
+ * `freeIdentifiers` returns `null` on an `unsupported` node, which is the
+ * fail-safe signal `classifyLazyBinding` expects.
+ */
+function attrFreeIdentifiers(expression: string): ReadonlySet<string> | null {
+  if (!expression || expression.trim().length === 0) return new Set()
+  try {
+    return freeIdentifiers(parseExpression(expression))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * §9.3(2) source names: the IR's pre-computed `arrayFreeIdentifiers` UNIONED
+ * with the free identifiers of the fully-chained expression actually emitted
+ * — `arrayFreeIdentifiers` describes `loop.array` alone, so a
+ * `.filter(t => t.done === showDone())` / `.sort(...)` chain would otherwise
+ * smuggle an unvetted dependency past the gate. `extractFreeIdentifiersFromNode`
+ * (via `...FromText`) scopes arrow parameters, so the predicate's own param
+ * never shows up as a free name. Returns `null` when the IR carried no
+ * pre-computed set — the gate refuses rather than assuming empty.
+ */
+function loopSourceIdentifiers(
+  loop: TopLevelLoop | BranchLoop,
+  arrayExpr: string,
+): ReadonlySet<string> | null {
+  if (!loop.arrayFreeIdentifiers) return null
+  const names = new Set<string>(loop.arrayFreeIdentifiers)
+  for (const name of extractFreeIdentifiersFromText(arrayExpr)) names.add(name)
+  return names
+}

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
@@ -38,6 +38,8 @@ import {
   buildPreambleRegionPlans,
 } from '../shared.ts'
 import { buildLoopReactiveEffectsPlan } from './build-reactive-effects.ts'
+import { buildLazyRowPlan } from './build-lazy-row.ts'
+import type { LazyRowScopeInfo } from './lazy-row-eligibility.ts'
 import { buildComponentLoopPlan } from './build-component-loop.ts'
 import { buildTopLevelCompositePlan } from './build-composite-loop.ts'
 import { renderPreamble, irToHtmlTemplate } from '../../html-template.ts'
@@ -54,6 +56,13 @@ export interface BuildLoopPlanOptions {
   unsafeLocalNames: Set<string>
   /** Owning component name when compiling in profile mode (#1690) — else undefined. */
   profileComponentName?: string
+  /**
+   * Component-scope name facts for the lazy row graph gate
+   * (`spec/slot-unification.md` §9.4, `buildLazyRowScopeInfo`). Omitted →
+   * no loop is lazy-eligible, i.e. today's emission everywhere. Optional so
+   * hand-built plan fixtures keep type-checking.
+   */
+  lazyScope?: LazyRowScopeInfo
 }
 
 /**
@@ -68,7 +77,7 @@ export function buildLoopPlan(elem: TopLevelLoop, opts: BuildLoopPlanOptions): L
   // array's per-item conditional still toggles reactively instead of freezing
   // in the SSR-time `forEach` (which has no conditional handling at all).
   if (elem.bodyIsItemConditional) {
-    return buildPlainLoopPlan(elem, opts.profileComponentName)
+    return buildPlainLoopPlan(elem, opts.profileComponentName, opts.lazyScope)
   }
   if (elem.isStaticArray) {
     return buildStaticLoopPlan(elem, opts.unsafeLocalNames, opts.profileComponentName)
@@ -81,11 +90,15 @@ export function buildLoopPlan(elem: TopLevelLoop, opts: BuildLoopPlanOptions): L
   if (elem.childComponent) {
     return buildComponentLoopPlan(elem, opts.profileComponentName)
   }
-  return buildPlainLoopPlan(elem, opts.profileComponentName)
+  return buildPlainLoopPlan(elem, opts.profileComponentName, opts.lazyScope)
 }
 
 /** @internal — prefer `buildLoopPlan`. Exported for the branch-loop wrapper only. */
-export function buildPlainLoopPlan(elem: TopLevelLoop, profileComponentName?: string): PlainLoopPlan {
+export function buildPlainLoopPlan(
+  elem: TopLevelLoop,
+  profileComponentName?: string,
+  lazyScope?: LazyRowScopeInfo,
+): PlainLoopPlan {
   const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, elem.param, elem.paramBindings)
   const { head: paramHead, unwrap: paramUnwrap } = destructureLoopParam(elem.param, elem.paramBindings)
   const hasReactive = elem.bindings.reactiveAttrs.length > 0
@@ -126,32 +139,51 @@ export function buildPlainLoopPlan(elem: TopLevelLoop, profileComponentName?: st
     }
   }
 
+  const arrayExpr = buildChainedArrayExpr(elem)
+  const indexParam = elem.index || '__idx'
+  const mapPreambleWrapped = elem.preamble
+    ? renderPreamble(elem.preamble, {
+        transformJs: wrap,
+        renderLeaf: (ir) => irToHtmlTemplate(ir, undefined, 1, [{ param: elem.param, bindings: elem.paramBindings }], undefined, true),
+      })
+    : ''
+  const preambleRegions = buildPreambleRegionPlans(elem.preambleRegions, elem.param, elem.paramBindings)
+
   return {
     kind: 'plain',
     rowConstruction: 'string-template',
     containerVar: `_${varSlotId(elem.slotId)}`,
     markerId: elem.markerId,
     profileLoopId: profileComponentName ? `${profileComponentName}#binding:${elem.slotId}` : undefined,
-    arrayExpr: buildChainedArrayExpr(elem),
+    arrayExpr,
     keyFn: loopKeyFn(elem),
     paramHead,
     paramUnwrap,
-    indexParam: elem.index || '__idx',
+    indexParam,
+    // Lazy row graph (§9, L3). `null` for every ineligible loop, which then
+    // keeps the eager emission below byte-for-byte.
+    lazyRow: buildLazyRowPlan({
+      loop: elem,
+      arrayExpr,
+      indexParam,
+      paramUnwrap,
+      mapPreambleWrapped,
+      preambleRegionCount: preambleRegions.length,
+      callSite: 'plain',
+      flatMapLeafItem: false,
+      anchored: elem.bodyIsItemConditional ?? false,
+      scope: lazyScope,
+    }) ?? undefined,
     // Stage 3 / D4 — js segments get the loop-param accessor wrap; jsx leaves
     // render as HTML-string templates under this loop's param context so a
     // leaf that reads the item (`r`) becomes `r()`.
-    mapPreambleWrapped: elem.preamble
-      ? renderPreamble(elem.preamble, {
-          transformJs: wrap,
-          renderLeaf: (ir) => irToHtmlTemplate(ir, undefined, 1, [{ param: elem.param, bindings: elem.paramBindings }], undefined, true),
-        })
-      : '',
+    mapPreambleWrapped,
     template: elem.template,
     skeletonTemplate: elem.skeletonTemplate,
     skeletonPaths: elem.skeletonPaths,
     reactiveEffects: hasReactive ? buildLoopReactiveEffectsPlan(elem, profileComponentName) : null,
     childRefs: buildChildRefBindings(elem.bindings.refs, elem.param, elem.paramBindings),
-    preambleRegions: buildPreambleRegionPlans(elem.preambleRegions, elem.param, elem.paramBindings),
+    preambleRegions,
     bodyIsMultiRoot: elem.bodyIsMultiRoot ?? false,
     anchored: elem.bodyIsItemConditional ?? false,
     // Fall back to the iteration index when the loop has no key. A whole-item

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-row-eligibility.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-row-eligibility.ts
@@ -1,0 +1,401 @@
+/**
+ * Lazy row graph eligibility — `spec/slot-unification.md` §9.4 (L3).
+ *
+ * ONE explicit decision function (`lazyRowEligibility`) answering a single
+ * question: may this plain loop row be emitted through `mapArrayLazy`
+ * (a compiler-emitted `LazyRowPlan`, no per-row reactive resources) instead
+ * of today's A3b-consolidated eager `mapArray` emission?
+ *
+ * Sound-or-loud (§9.3): the answer is always either `{ eligible: true }` or
+ * `{ eligible: false, reason }`. There is no silent third path — an
+ * ineligible loop keeps byte-for-byte today's emission, and `reason` is a
+ * human-readable string so a regression is diagnosable from a unit test
+ * rather than by diffing generated JS.
+ *
+ * The gate is deliberately conservative. Every restriction below is a
+ * "widen later" decision, never a correctness compromise:
+ *
+ *  1. **Shape** (§9.4 "plain loop-row shape"): non-anchored, non-flatMap,
+ *     single-root, keyed, conditional-free, ref-free, no nested components
+ *     or inner loops.
+ *  2. **No preamble.** A `.map()` callback preamble declares row-local
+ *     bindings (and can declare row-local signals/memos, which need per-row
+ *     reactivity by definition). Proving "declares no signal/memo" is not
+ *     cheap here, and every preamble-declared local would land in a
+ *     binding's free-identifier set as an unresolvable name anyway — so the
+ *     rule is the cheap conservative one: **any** `mapPreambleWrapped` or
+ *     any `preambleRegions` entry makes the loop ineligible.
+ *  3. **Every reactive outer dependency must be primable.** `mapArrayLazy`
+ *     creates ONE loop-level effect for `applyOuter`; that effect subscribes
+ *     only to what its body reads, and its body must read the outer signals
+ *     even when the entry list is momentarily EMPTY (otherwise the effect
+ *     never subscribes and the loop goes permanently dead). The emitter
+ *     primes those reads with `getter()` statements, which is only possible
+ *     for names it can prove are zero-arg component signal / memo getters.
+ *     Any other name that could change reactively — a prop accessor (props
+ *     may be defined as getters over the parent's signals), or a name the
+ *     compiler cannot classify at all — is `opaque` and makes the loop
+ *     ineligible. Names proven inert (imports, local functions, local /
+ *     module constants, pure globals) need no subscription and are ignored.
+ *  4. **No outer-involving TEXT binding.** §9.3(1) requires read-compare-
+ *     write seeding on `applyOuter`'s first run: compute the value, READ the
+ *     current DOM, write only on difference. For an attribute that read is
+ *     `getAttribute` / a DOM property on the held element ref. For a content
+ *     slot there is no read-back door — `lazySlots`' writer is write-only
+ *     (`claim-slots.ts`), and the runtime contract is PINNED for L3. Rather
+ *     than write unconditionally at hydration (sound, but it reintroduces
+ *     exactly the per-row hydration DOM write §9 exists to remove), an
+ *     outer-involving text binding makes the whole loop ineligible. Widening
+ *     this needs a runtime read door, i.e. an L5 change to the pinned
+ *     contract.
+ *  5. **Loop-source hydration consistency** (§9.3(2)): item-driven bindings
+ *     are never evaluated at hydration, so the SSR rows and the first client
+ *     `items()` read are TRUSTED to agree. That trust is only sound when
+ *     both derive from the same data — props (identical by construction via
+ *     the `bf-p` protocol), literals, and derivations thereof. Any name in
+ *     the loop source that reaches an import, an environment read, or
+ *     anything the compiler cannot resolve → ineligible.
+ *  6. **Profile mode is never lazy** (§9.4, same policy as A3b): a merged
+ *     loop-level effect would make every binding on every row share one
+ *     `#binding:<slotId>` id.
+ */
+
+/** Facts about one component signal needed by the §9.3(2) source gate. */
+export interface LazyRowSignalFacts {
+  /**
+   * Free identifiers of the signal's initializer, derived from its
+   * structured `SignalInfo.parsed` tree. `null` when `parsed` was absent or
+   * the tree contained an `unsupported` node — "unprovable", which the gate
+   * treats as a hard stop rather than an assumption.
+   */
+  initializerFreeIdentifiers: ReadonlySet<string> | null
+}
+
+/** Component-scope facts the gate resolves names against. */
+export interface LazyRowScopeInfo {
+  /** Signal getter name → initializer facts. */
+  signals: ReadonlyMap<string, LazyRowSignalFacts>
+  /** Memo getter names — reactive and primable via `name()`. */
+  memos: ReadonlySet<string>
+  /** Props emit name (`_p`), the source props object name, and every destructured prop param. */
+  props: ReadonlySet<string>
+  /**
+   * Constant name → free identifiers of its value (`ConstantInfo.freeIdentifiers`).
+   * An entry with an EMPTY set is literal-derived. Absent free-id data is
+   * modelled as `null` → unprovable for the source gate (but still inert for
+   * the binding gate — a `const` never changes reactively).
+   */
+  constants: ReadonlyMap<string, ReadonlySet<string> | null>
+  /**
+   * Import local names and component-local function names. Used ONLY by the
+   * §9.3(2) source gate (to name the failure precisely); binding
+   * classification treats them as OPAQUE, not inert — see
+   * {@link classifyLazyBinding}.
+   */
+  inert: ReadonlySet<string>
+  /** Profile mode (#1690) — never lazy. */
+  profile: boolean
+}
+
+/**
+ * Globals a loop source may legitimately reach without breaking
+ * hydration consistency: pure, deterministic, environment-free. Anything
+ * NOT in this list (`Date`, `window`, `document`, `localStorage`,
+ * `navigator`, `performance`, `Math.random` via `Math`… ) is rejected by
+ * the source gate. `Math` is deliberately absent: `Math.random()` is an
+ * environment read in every way that matters here.
+ */
+const PURE_SOURCE_GLOBALS: ReadonlySet<string> = new Set([
+  'Object', 'Array', 'JSON', 'Number', 'String', 'Boolean',
+])
+
+/**
+ * Globals that are inert for BINDING classification (they cannot change
+ * reactively, so a binding reading one needs no subscription). Broader than
+ * {@link PURE_SOURCE_GLOBALS} — a binding may read `Date`/`Intl` and still be
+ * lazy, because the binding is re-evaluated on every apply; only the LOOP
+ * SOURCE has a hydration-trust obligation.
+ */
+const INERT_BINDING_GLOBALS: ReadonlySet<string> = new Set([
+  'Object', 'Array', 'JSON', 'Number', 'String', 'Boolean', 'Math', 'Date',
+  'Intl', 'Symbol', 'Map', 'Set', 'WeakMap', 'WeakSet', 'Promise', 'RegExp',
+  'Error', 'BigInt', 'console', 'undefined', 'NaN', 'Infinity', 'globalThis',
+  'parseInt', 'parseFloat', 'isNaN', 'isFinite',
+  'encodeURIComponent', 'decodeURIComponent', 'encodeURI', 'decodeURI',
+])
+
+/** One reactive binding of the row, already classified at build time. */
+export interface ClassifiedLazyBinding {
+  kind: 'attr' | 'text'
+  slotId: string
+  /** Reads the loop param / a destructured param binding. */
+  readsItem: boolean
+  /** Reads at least one reactive outer name (or is `opaque`). */
+  readsOuter: boolean
+  /**
+   * Reactive outer names this binding depends on — signal / memo getters the
+   * emitter primes at the top of `applyOuter` so the loop-level effect
+   * subscribes even with zero rows.
+   */
+  reactiveOuterNames: readonly string[]
+  /**
+   * Outer names that are neither primable (signal/memo) nor provably inert
+   * — including the FAIL-SAFE case where free identifiers were unavailable
+   * (then `readsItem`/`readsOuter` are both forced true and this carries the
+   * `'<unknown>'` sentinel). Non-empty ⇒ ineligible.
+   */
+  opaqueOuterNames: readonly string[]
+  /** References the loop's index parameter — `applyItem`/`applyOuter` have no index. */
+  referencesIndex: boolean
+}
+
+/** §9.4 shape facts, read off the loop plan / IR by the caller. */
+export interface LazyRowShapeFacts {
+  /** Which emission site is asking. Both plain-loop-row sites are in scope. */
+  callSite: 'plain' | 'branch-plain'
+  flatMapLeafItem: boolean
+  anchored: boolean
+  bodyIsMultiRoot: boolean
+  /** `LoopCore.key != null` — index-keyed loops are ineligible in v1 (§9.4). */
+  hasExplicitKey: boolean
+  conditionalCount: number
+  childRefCount: number
+  nestedComponentCount: number
+  innerLoopCount: number
+  hasChildComponent: boolean
+  hasMapPreamble: boolean
+  preambleRegionCount: number
+  /** A destructured loop param with no `paramBindings` (snapshot unwrap). */
+  hasParamUnwrap: boolean
+}
+
+export interface LazyRowEligibilityArgs {
+  shape: LazyRowShapeFacts
+  bindings: readonly ClassifiedLazyBinding[]
+  /**
+   * Free identifiers of the loop's SOURCE (`LoopCore.arrayFreeIdentifiers`
+   * unioned with the free identifiers of the fully-chained array expression,
+   * so `.filter(...)`/`.sort(...)` dependencies are covered). `null` when the
+   * IR carried none — ineligible, never assumed empty.
+   */
+  arraySourceIdentifiers: ReadonlySet<string> | null
+  scope: LazyRowScopeInfo
+}
+
+export type LazyRowEligibility =
+  | { eligible: true }
+  | { eligible: false; reason: string }
+
+const NO: (reason: string) => LazyRowEligibility = (reason) => ({ eligible: false, reason })
+
+/**
+ * Decide whether one plain loop row may use the lazy row graph (§9.4).
+ * Pure — every input is pre-resolved data, so this is directly unit-testable
+ * without building a component.
+ */
+export function lazyRowEligibility(args: LazyRowEligibilityArgs): LazyRowEligibility {
+  const { shape, bindings, arraySourceIdentifiers, scope } = args
+
+  // (8) Profile mode keeps the granular eager emission so `#binding:<slotId>`
+  //     attribution stays truthful — same policy as A3b.
+  if (scope.profile) return NO('profile mode keeps the granular eager emission')
+
+  // (1) Plain loop-row shape.
+  if (shape.callSite !== 'plain' && shape.callSite !== 'branch-plain') {
+    return NO(`call site '${shape.callSite}' is not a plain loop row`)
+  }
+  if (shape.flatMapLeafItem) return NO('flatMap descriptor loop (build-or-patch renderItem)')
+  if (shape.anchored) return NO('anchored whole-item-conditional loop')
+
+  // (2) Single-root rows — multi-root needs startMarker/extras bookkeeping
+  //     `mapArrayLazy` deliberately does not carry.
+  if (shape.bodyIsMultiRoot) return NO('multi-root (Fragment) row')
+
+  // (3) Keyed via an explicit `key` — adoption pairs SSR rows to items by
+  //     the SSR-rendered `data-key`, which index-keyed loops do not render.
+  if (!shape.hasExplicitKey) return NO('index-keyed loop (no explicit key)')
+
+  // (4) No conditionals in the row.
+  if (shape.conditionalCount > 0) return NO('row contains a reactive conditional')
+
+  // (5) No refs / child components / inner loops.
+  if (shape.childRefCount > 0) return NO('row has imperative child refs')
+  if (shape.hasChildComponent) return NO('row body is a child component')
+  if (shape.nestedComponentCount > 0) return NO('row contains nested child components')
+  if (shape.innerLoopCount > 0) return NO('row contains an inner loop')
+
+  // (6) No row-local declarations — see the module docstring for why the
+  //     rule is "any preamble at all", not "a preamble declaring signals".
+  if (shape.hasMapPreamble) return NO('row has a map-callback preamble (may declare row-local reactivity)')
+  if (shape.preambleRegionCount > 0) return NO('row has preamble-patched regions')
+  if (shape.hasParamUnwrap) return NO('destructured loop param without param bindings')
+
+  // Per-binding gates.
+  for (const b of bindings) {
+    if (b.referencesIndex) {
+      return NO(`binding on slot ${b.slotId} references the loop index parameter`)
+    }
+    if (b.opaqueOuterNames.length > 0) {
+      return NO(
+        `binding on slot ${b.slotId} depends on an outer name that cannot be primed: ${b.opaqueOuterNames.join(', ')}`,
+      )
+    }
+    if (b.kind === 'text' && b.readsOuter) {
+      return NO(`outer-involving text binding on slot ${b.slotId} (content slots have no DOM read-back for §9.3(1) seeding)`)
+    }
+  }
+
+  // (7) Hydration-consistency gate on the loop source (§9.3(2)).
+  if (!arraySourceIdentifiers) return NO('loop source free identifiers unavailable')
+  const sourceGate = checkSourceConsistency(arraySourceIdentifiers, scope)
+  if (sourceGate) return NO(`loop source is not provably hydration-consistent: ${sourceGate}`)
+
+  return { eligible: true }
+}
+
+/**
+ * §9.3(2): walk each name in the loop source down to props / literals.
+ * Returns `null` when every name resolves, otherwise the first failure
+ * reason. Cycle-safe via `seen`.
+ */
+function checkSourceConsistency(
+  names: ReadonlySet<string>,
+  scope: LazyRowScopeInfo,
+): string | null {
+  const seen = new Set<string>()
+
+  const resolve = (name: string): string | null => {
+    if (seen.has(name)) return null // already proven (or in-progress) — cycles cannot add a new source
+    seen.add(name)
+
+    if (scope.props.has(name)) return null // prop accessor — identical to SSR by the bf-p protocol
+    if (PURE_SOURCE_GLOBALS.has(name)) return null
+
+    const constFree = scope.constants.get(name)
+    if (constFree !== undefined) {
+      if (constFree === null) return `constant '${name}' has no analyzable value`
+      for (const inner of constFree) {
+        const failure = resolve(inner)
+        if (failure) return failure
+      }
+      return null
+    }
+
+    const signal = scope.signals.get(name)
+    if (signal !== undefined) {
+      if (signal.initializerFreeIdentifiers === null) {
+        return `signal '${name}' has no structured initializer to prove props/literal derivation`
+      }
+      for (const inner of signal.initializerFreeIdentifiers) {
+        const failure = resolve(inner)
+        if (failure) return failure
+      }
+      return null
+    }
+
+    if (scope.memos.has(name)) return `memo '${name}' initializer is not analyzed by the v1 gate`
+    if (scope.inert.has(name)) return `'${name}' is an import or local function`
+    return `'${name}' does not resolve to a prop, literal-derived const, or props/literal-derived signal`
+  }
+
+  for (const name of names) {
+    const failure = resolve(name)
+    if (failure) return failure
+  }
+  return null
+}
+
+/**
+ * Classify one binding's free identifiers into the row-local / reactive-outer
+ * / opaque-outer partition {@link lazyRowEligibility} consumes.
+ *
+ * **FAIL-SAFE (mandatory, §9.2):** when `free` is `null` — the IR carried no
+ * pre-computed free identifiers, or `freeIdentifiers()` refused the parsed
+ * tree (an `unsupported` node) — BOTH `readsItem` and `readsOuter` are forced
+ * true. A binding with `readsItem` is emitted into `applyItem`; a binding with
+ * `readsOuter` into `applyOuter`; a binding in both is emitted in BOTH. Double
+ * application is idempotent because every emitted write is dedup-guarded
+ * against `entry.last`, so "both" is always the safe answer and never a
+ * correctness risk.
+ *
+ * The unknown case ALSO records an `'<unknown>'` opaque name, which makes the
+ * loop ineligible: an outer dependency the compiler cannot name is an outer
+ * dependency it cannot PRIME, and an unprimed `applyOuter` effect would never
+ * subscribe (see module docstring, restriction 3). So the fail-safe direction
+ * is preserved (maximally conservative classification) while the emission
+ * refuses loudly instead of shipping a dead effect.
+ */
+export function classifyLazyBinding(args: {
+  kind: 'attr' | 'text'
+  slotId: string
+  free: ReadonlySet<string> | null
+  /** Loop param name plus every destructured `paramBindings` name. */
+  rowLocalNames: ReadonlySet<string>
+  indexParam: string
+  scope: LazyRowScopeInfo
+}): ClassifiedLazyBinding {
+  const { kind, slotId, free, rowLocalNames, indexParam, scope } = args
+
+  if (free === null) {
+    return {
+      kind,
+      slotId,
+      readsItem: true,
+      readsOuter: true,
+      reactiveOuterNames: [],
+      opaqueOuterNames: ['<unknown>'],
+      referencesIndex: false,
+    }
+  }
+
+  let readsItem = false
+  let referencesIndex = false
+  const reactiveOuterNames: string[] = []
+  const opaqueOuterNames: string[] = []
+
+  for (const name of free) {
+    if (rowLocalNames.has(name)) {
+      readsItem = true
+      continue
+    }
+    if (name === indexParam) {
+      referencesIndex = true
+      continue
+    }
+    if (INERT_BINDING_GLOBALS.has(name)) continue
+    if (scope.signals.has(name) || scope.memos.has(name)) {
+      if (!reactiveOuterNames.includes(name)) reactiveOuterNames.push(name)
+      continue
+    }
+    // A LITERAL-DERIVED constant (empty free-identifier set) is the only
+    // non-signal local name provably incapable of reactivity: with nothing
+    // free in its initializer, it cannot close over a signal, a selector, or
+    // any other reactive accessor.
+    //
+    // Everything else is OPAQUE, and deliberately so — this is where the
+    // conservative line has to sit, because a reactive accessor can hide
+    // behind an ordinary-looking name:
+    //   - `const isSelected = createSelector(selected)` is a local `const`
+    //     whose CALL is reactive (`create-selector.test.ts`),
+    //   - a local function's body can read a signal,
+    //   - a prop may be defined as a getter over the parent's signals,
+    //   - an imported name may be another module's `@client` module signal.
+    // None of those can be primed by this emitter, and an unprimed
+    // `applyOuter` effect would never subscribe. Refusing the loop (eager
+    // fallback) is the sound answer; guessing "inert" would be a silent
+    // never-updates bug.
+    const constFree = scope.constants.get(name)
+    if (constFree !== undefined && constFree !== null && constFree.size === 0) continue
+    opaqueOuterNames.push(name)
+  }
+
+  return {
+    kind,
+    slotId,
+    readsItem,
+    readsOuter: reactiveOuterNames.length > 0 || opaqueOuterNames.length > 0,
+    reactiveOuterNames,
+    opaqueOuterNames,
+    referencesIndex,
+  }
+}

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-row-eligibility.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-row-eligibility.ts
@@ -35,8 +35,12 @@
  *     Any other name that could change reactively — a prop accessor (props
  *     may be defined as getters over the parent's signals), or a name the
  *     compiler cannot classify at all — is `opaque` and makes the loop
- *     ineligible. Names proven inert (imports, local functions, local /
- *     module constants, pure globals) need no subscription and are ignored.
+ *     ineligible. Imports and component-local functions are opaque TOO
+ *     (`const isSelected = createSelector(selected)` is an ordinary local
+ *     whose CALL is the reactive read), so they refuse the loop as well —
+ *     the `inert` set names them only so the refusal can say which one.
+ *     Genuinely ignorable are the names that cannot carry a reactive read
+ *     at all: literal-derived local / module constants and pure globals.
  *  4. **No outer-involving TEXT binding.** §9.3(1) requires read-compare-
  *     write seeding on `applyOuter`'s first run: compute the value, READ the
  *     current DOM, write only on difference. For an attribute that read is

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
@@ -26,6 +26,7 @@ import type { IRLoopChildComponent } from '../../../types.ts'
 import type { SkeletonSlotPaths } from '../../html-template.ts'
 import type { ReactiveEffectsPlan } from './reactive-effects.ts'
 import type { InnerLoopsPlan } from './inner-loop.ts'
+import type { LazyRowPlanData } from './build-lazy-row.ts'
 
 /** Fields shared by every `LoopPlan` variant. */
 interface LoopPlanCommon {
@@ -174,6 +175,15 @@ interface PlainLoopVariant extends DynamicLoopCommon {
    * `__el` to query against.
    */
   preambleRegions: readonly PreambleRegionPlan[]
+  /**
+   * Lazy row graph plan (`spec/slot-unification.md` §9, L3). Non-null when
+   * `lazyRowEligibility` accepted this loop: the stringifier emits
+   * `mapArrayLazy(...)` with this row plan instead of `mapArray(...)` +
+   * renderItem, and the row carries NO per-row reactive resources.
+   * Undefined for every ineligible loop — those keep today's emission
+   * byte-for-byte (sound-or-loud, `plan/lazy-row-eligibility.ts`).
+   */
+  lazyRow?: LazyRowPlanData
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/branch-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/branch-loop.ts
@@ -15,6 +15,7 @@ import { stringifyEventDelegation } from './event-delegation.ts'
 import { stringifyReactiveEffects } from './reactive-effects.ts'
 import { emitTemplateCloneInline, emitLoopItemElementSetup } from './template-parse.ts'
 import { emitLoopChildRefs } from './loop.ts'
+import { stringifyLazyRowLoop } from './lazy-row.ts'
 import type {
   BranchLoopPlan,
   BranchPlainLoopPlan,
@@ -84,6 +85,27 @@ function emitPlain(lines: string[], plan: BranchPlainLoopPlan): void {
     lines.push(`          })`)
     lines.push(`          return __el`)
     lines.push(`        }, '${markerId}'${loopBfId})`)
+    lines.push(`      }))`)
+    stringifyEventDelegation(lines, eventDelegation)
+    return
+  }
+
+  // Lazy row graph (spec/slot-unification.md §9, L3) — same gate and same
+  // emitter as the top-level plain loop; only the container guard and indent
+  // differ. Ineligible loops fall through to the eager emission below.
+  if (plan.lazyRow) {
+    stringifyLazyRowLoop(lines, {
+      indent: '        ',
+      containerVar,
+      guardContainer: true,
+      markerId,
+      arrayExpr,
+      keyFn,
+      paramHead,
+      indexParam,
+      template,
+      lazyRow: plan.lazyRow,
+    })
     lines.push(`      }))`)
     stringifyEventDelegation(lines, eventDelegation)
     return

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
@@ -1,0 +1,301 @@
+/**
+ * Emit a lazy row graph loop — `mapArrayLazy(...)` + a compiler-built
+ * `LazyRowPlan` object literal (`spec/slot-unification.md` §9, L3).
+ *
+ * This is the alternative to `stringifyPlainLoop`'s `mapArray` + renderItem
+ * emission, taken only when `lazyRowEligibility` said yes (see
+ * `plan/lazy-row-eligibility.ts`). Every ineligible loop keeps today's
+ * emission byte-for-byte — sound-or-loud, no silent third path.
+ *
+ * Output shape:
+ *
+ *     const __tpl_<mid> = document.createElement('template')      // hoisted skeleton, when usable
+ *     __tpl_<mid>.innerHTML = `…`
+ *     const __lzc_<mid> = (__e) => { … }                          // lazy ref claim for ADOPTED rows
+ *     mapArrayLazy(() => <arr>, <container>, <keyFn>, {
+ *       createRow: (__e, <idx>) => { … writes every binding, seeds refs+last … },
+ *       applyItem: (__e) => { … item-driven bindings, dedup against __e.last … },
+ *       applyOuter: (__es, __seed) => { … one loop-level effect body … },
+ *     }, '<markerId>')
+ *
+ * Three shapes carry the plan's obligations (runtime docstring,
+ * `packages/client/src/runtime/map-array-lazy.ts`):
+ *
+ * **`createRow`** — CSR creation. Clones the row, resolves refs from KNOWN
+ * clone paths (the hoisted skeleton's `__p`-style child-index chains, reused
+ * verbatim from #2143 via `pathExpr`) with no scan, writes ALL bindings
+ * (item-driven and outer-involving alike) and seeds `entry.last` so the
+ * loop-level outer effect's dedup is correct from the row's first tick.
+ *
+ * **`applyItem`** — called by the reconciler after `entry.item` changed.
+ * Claims refs lazily through `__lzc_<mid>` (a `qsa`/`lazySlots` scan inside
+ * that ONE row) when `entry.refs` is null, then writes each item-driven
+ * binding behind a per-binding dedup on `entry.last`.
+ *
+ * **`applyOuter`** — the ONE loop-level effect body, emitted only when some
+ * binding is outer-involving. Two details matter:
+ *
+ *  - **Prime reads first.** The effect subscribes to whatever its body reads.
+ *    With an empty entry list the per-row loop reads nothing, so the effect
+ *    would never subscribe and the loop would go permanently dead. The plan
+ *    therefore emits a bare `getter()` statement per reactive outer name
+ *    BEFORE the row loop. The eligibility gate guarantees every reactive
+ *    outer name is a primable zero-arg signal/memo getter.
+ *  - **Read-compare-write seeding (§9.3(1)).** On the first run (`__seed`)
+ *    each binding computes its value, READS the current DOM, and writes only
+ *    on difference — sound even when the outer state is client-only and
+ *    diverges from SSR, with no writes on the consistent path. The DOM read
+ *    is per attribute KIND and pairs with `emitAttrUpdate`'s dispatch
+ *    (`emit-reactive.ts`); any kind this module does not recognise falls back
+ *    to `true` (always write on seed), which is conservative, never wrong.
+ *
+ * Content (text) slots are never outer-involving here — `lazySlots`' writer
+ * is write-only, so there is no DOM read-back to seed against, and the
+ * eligibility gate refuses such loops rather than reintroducing an
+ * unconditional per-row hydration write. Consequently a lazy row's text
+ * bindings are all item-driven, and a loop with NO outer binding emits no
+ * `applyOuter` at all — its rows do literally nothing at hydration.
+ */
+
+import { isBooleanAttr } from '../../../html-constants.ts'
+import { emitAttrUpdate } from '../../emit-reactive.ts'
+import { toHtmlAttrName } from '../../utils.ts'
+import type { SkeletonSlotPaths } from '../../html-template.ts'
+import { claimPlanLiteral, type ClaimSlotSpec } from './claim-plan.ts'
+import { pathExpr } from './skeleton-paths.ts'
+import {
+  emitHoistedTemplateDecl,
+  emitTemplateCloneInline,
+  hoistedCloneExpr,
+} from './template-parse.ts'
+import type { LazyRowAttrBinding, LazyRowPlanData, LazyRowTextBinding } from '../plan/build-lazy-row.ts'
+
+export interface StringifyLazyRowOptions {
+  /** Indent of the `mapArrayLazy(` line itself. */
+  indent: string
+  containerVar: string
+  /** Wrap the call in `if (<containerVar>) …` — branch-scoped loops do. */
+  guardContainer: boolean
+  markerId: string
+  arrayExpr: string
+  keyFn: string
+  paramHead: string
+  indexParam: string
+  /** Per-row interpolated template (the non-hoisted clone source). */
+  template: string
+  skeletonTemplate?: string
+  skeletonPaths?: SkeletonSlotPaths
+  lazyRow: LazyRowPlanData
+}
+
+export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions): void {
+  const { indent, lazyRow, paramHead } = o
+  const mid = o.markerId.replace(/[^A-Za-z0-9_$]/g, '_')
+  const tplVar = `__tpl_${mid}`
+  const claimVar = `__lzc_${mid}`
+  const hasRefs = lazyRow.attrSlotIds.length > 0 || lazyRow.texts.length > 0
+  const hasBindings = lazyRow.attrs.length > 0 || lazyRow.texts.length > 0
+
+  // Hoisted once-per-loop skeleton (perf, #2143): clone an already-parsed
+  // node per row instead of re-running an `innerHTML` parse. The skeleton
+  // omits dynamic ATTRIBUTE VALUES and empties text markers but keeps every
+  // `bf="sN"` attribute and `<!--bf:sN-->` marker, so a slot with no
+  // compile-time path still resolves by scan against the clone — same
+  // per-slot fallback the eager `__p` path takes (`buildSkeletonPathPlan`
+  // simply omits pathless slots).
+  const paths = o.skeletonPaths
+  const useHoisted = Boolean(o.skeletonTemplate)
+
+  if (useHoisted) emitHoistedTemplateDecl(lines, indent, tplVar, o.skeletonTemplate!)
+
+  // Hoisted fresh-clone claim paths for this loop's text slots, REFERENCED
+  // (not inlined) by `createRow`'s claim plan. Two reasons, both load-bearing:
+  //
+  //  1. One array per loop instead of one per row — `createRow` runs per CSR
+  //     row and would otherwise re-allocate every path literal.
+  //  2. These paths describe the SKELETON CLONE, not the server-rendered
+  //     tree, and they are ROW-relative — resolving them from the component
+  //     scope root (which is what an SSR-shape checker can see) is
+  //     meaningless. That is the same situation `ClaimSlotSpec.pathExpr`
+  //     exists for on the eager path (`__existing ? [] : […]`), and the
+  //     claim-plan conformance harness (`adapter-tests/src/
+  //     claim-plan-conformance.ts`) correctly verifies only literal
+  //     `number[]` paths. Adopted (SSR) rows never use these — `__lzc_<mid>`
+  //     claims with `path: []`, the sanctioned marker-scan case.
+  const textPathVar = useHoisted && paths && lazyRow.texts.length > 0 ? `__lzp_${mid}` : null
+  if (textPathVar) {
+    const arrays = lazyRow.texts.map(t => `[${(paths!.textMarkerPaths.get(t.slotId) ?? []).join(', ')}]`)
+    lines.push(`${indent}const ${textPathVar} = [${arrays.join(', ')}]`)
+  }
+
+  // Lazy ref claim for ADOPTED (SSR) rows: one scan inside that row, cached
+  // on `entry.refs`. Shared by applyItem and applyOuter so a row claims once.
+  if (hasRefs) {
+    lines.push(`${indent}const ${claimVar} = (__e) => {`)
+    lines.push(`${indent}  const __el = __e.primaryEl`)
+    lines.push(`${indent}  return [${refParts(lazyRow, '__el', null, null).join(', ')}]`)
+    lines.push(`${indent}}`)
+  }
+
+  const call = `mapArrayLazy(() => ${o.arrayExpr}, ${o.containerVar}, ${o.keyFn}, {`
+  lines.push(`${indent}${o.guardContainer ? `if (${o.containerVar}) ` : ''}${call}`)
+
+  // --- createRow ---------------------------------------------------------
+  const b1 = `${indent}  `
+  const b2 = `${indent}    `
+  lines.push(`${b1}createRow: (__e, ${o.indexParam}) => {`)
+  // Always bound, even with no reactive bindings: the non-hoisted clone
+  // interpolates the per-row template, which reads the param for at least
+  // the `data-key` attribute.
+  lines.push(`${b2}const ${paramHead} = () => __e.item`)
+  const cloneExpr = useHoisted
+    ? hoistedCloneExpr(tplVar, o.skeletonTemplate!)
+    : `(() => { ${emitTemplateCloneInline(o.template)} })()`
+  lines.push(`${b2}const __el = ${cloneExpr}`)
+  if (hasRefs) {
+    lines.push(`${b2}const __r = __e.refs = [${refParts(lazyRow, '__el', useHoisted ? (paths ?? null) : null, textPathVar).join(', ')}]`)
+  }
+  if (hasBindings) {
+    lines.push(`${b2}const __l = __e.last = []`)
+    for (const a of lazyRow.attrs) emitAttrBinding(lines, b2, a, 'create')
+    for (const t of lazyRow.texts) emitTextBinding(lines, b2, t, lazyRow.writerIndex, false)
+  }
+  lines.push(`${b2}return __el`)
+  lines.push(`${b1}},`)
+
+  // --- applyItem ---------------------------------------------------------
+  const itemAttrs = lazyRow.attrs.filter(a => a.readsItem)
+  const itemTexts = lazyRow.texts.filter(t => t.readsItem)
+  if (itemAttrs.length === 0 && itemTexts.length === 0) {
+    lines.push(`${b1}applyItem: () => {},`)
+  } else {
+    lines.push(`${b1}applyItem: (__e) => {`)
+    lines.push(`${b2}const ${paramHead} = () => __e.item`)
+    lines.push(`${b2}const __r = __e.refs ?? (__e.refs = ${claimVar}(__e))`)
+    lines.push(`${b2}const __l = __e.last ?? (__e.last = [])`)
+    for (const a of itemAttrs) emitAttrBinding(lines, b2, a, 'item')
+    for (const t of itemTexts) emitTextBinding(lines, b2, t, lazyRow.writerIndex, true)
+    lines.push(`${b1}},`)
+  }
+
+  // --- applyOuter (only when some binding is outer-involving) -------------
+  const outerAttrs = lazyRow.attrs.filter(a => a.readsOuter)
+  if (outerAttrs.length > 0) {
+    const b3 = `${indent}      `
+    lines.push(`${b1}applyOuter: (__es, __seed) => {`)
+    // Prime the outer reads so this ONE loop-level effect subscribes even
+    // when the entry list is momentarily empty (see module docstring).
+    for (const g of lazyRow.outerPrimeGetters) lines.push(`${b2}${g}()`)
+    lines.push(`${b2}for (const __e of __es) {`)
+    lines.push(`${b3}const ${paramHead} = () => __e.item`)
+    lines.push(`${b3}const __r = __e.refs ?? (__e.refs = ${claimVar}(__e))`)
+    lines.push(`${b3}const __l = __e.last ?? (__e.last = [])`)
+    for (const a of outerAttrs) emitAttrBinding(lines, b3, a, 'outer')
+    lines.push(`${b2}}`)
+    lines.push(`${b1}},`)
+  }
+
+  lines.push(`${indent}}, '${o.markerId}')`)
+}
+
+/**
+ * The `entry.refs` array contents: one element ref per reactive-attr slot
+ * (in `attrSlotIds` order), then — when the row has text slots — the
+ * `lazySlots` writer at `writerIndex`.
+ *
+ * `skeletonPaths` non-null = fresh-clone context (`createRow`): resolve via
+ * compile-time child-index chains, no scan. Null = adopted-row context
+ * (`__lzc_<mid>`): `qsa` + an empty claim path, which A2's marker scan
+ * resolves — the sanctioned "cannot be statically pathed" case for a
+ * server-rendered tree the skeleton does not describe (§5-A3).
+ */
+function refParts(
+  lazyRow: LazyRowPlanData,
+  elVar: string,
+  skeletonPaths: SkeletonSlotPaths | null,
+  textPathVar: string | null,
+): string[] {
+  const parts: string[] = []
+  for (const slotId of lazyRow.attrSlotIds) {
+    const path = skeletonPaths?.elementPaths.get(slotId)
+    parts.push(path ? pathExpr(elVar, path) : `qsa(${elVar}, '[bf="${slotId}"]')`)
+  }
+  if (lazyRow.texts.length > 0) {
+    const slots: ClaimSlotSpec[] = lazyRow.texts.map((t, i) => ({
+      id: t.slotId,
+      kind: 'text',
+      path: [],
+      pathExpr: textPathVar ? `${textPathVar}[${i}]` : undefined,
+    }))
+    parts.push(`lazySlots(${elVar}, ${claimPlanLiteral(slots)})`)
+  }
+  return parts
+}
+
+/** `entry.last`-backed dedup test. `in` (not a truthiness check) so a
+ *  legitimately `undefined` value still records and still writes once. */
+function dedupGuard(ordinal: number): string {
+  return `!(${ordinal} in __l) || !Object.is(__l[${ordinal}], __x)`
+}
+
+function emitAttrBinding(
+  lines: string[],
+  ind: string,
+  a: LazyRowAttrBinding,
+  mode: 'create' | 'item' | 'outer',
+): void {
+  lines.push(`${ind}{ const __t = __r[${a.refIndex}]`)
+  lines.push(`${ind}if (__t) {`)
+  lines.push(`${ind}  const __x = ${a.wrappedExpression}`)
+  const guard = mode === 'create'
+    ? null
+    : mode === 'item'
+      ? dedupGuard(a.ordinal)
+      : `__seed ? (${seedDiffersExpr('__t', a)}) : (${dedupGuard(a.ordinal)})`
+  const writeIndent = guard ? `${ind}    ` : `${ind}  `
+  if (guard) lines.push(`${ind}  if (${guard}) {`)
+  for (const stmt of emitAttrUpdate('__t', a.attrName, '__x', a.meta)) {
+    lines.push(`${writeIndent}${stmt}`)
+  }
+  if (guard) lines.push(`${ind}  }`)
+  lines.push(`${ind}  __l[${a.ordinal}] = __x`)
+  lines.push(`${ind}} }`)
+}
+
+function emitTextBinding(
+  lines: string[],
+  ind: string,
+  t: LazyRowTextBinding,
+  writerIndex: number,
+  dedup: boolean,
+): void {
+  lines.push(`${ind}{ const __x = ${t.wrappedExpression}`)
+  const write = `__r[${writerIndex}]('${t.slotId}', String(__x))`
+  if (dedup) {
+    lines.push(`${ind}if (${dedupGuard(t.ordinal)}) ${write}`)
+  } else {
+    lines.push(`${ind}${write}`)
+  }
+  lines.push(`${ind}__l[${t.ordinal}] = __x }`)
+}
+
+/**
+ * Read-compare-write seeding predicate (§9.3(1)): does the CURRENT DOM
+ * differ from the value `__x` this binding would write? Mirrors
+ * `emitAttrUpdate`'s per-kind dispatch (`emit-reactive.ts`) — the two must
+ * be read together. An unrecognised kind returns `true`, i.e. write on the
+ * seed run unconditionally: conservative, never unsound.
+ */
+function seedDiffersExpr(target: string, a: LazyRowAttrBinding): string {
+  const html = toHtmlAttrName(a.attrName)
+  if (a.attrName === 'dangerouslySetInnerHTML' || html === 'dangerouslySetInnerHTML') return 'true'
+  if (html === 'style') return `${target}.getAttribute('style') !== styleToCss(__x)`
+  if (html === 'class') return `${target}.getAttribute('class') !== (__x != null ? String(__x) : null)`
+  if (html === 'value') return `${target}.value !== String(__x)`
+  if (isBooleanAttr(html)) return `${target}.${html} !== !!(__x)`
+  if (a.meta.presenceOrUndefined) return `${target}.hasAttribute('${html}') !== !!(__x)`
+  return `${target}.getAttribute('${html}') !== (__x != null ? String(__x) : null)`
+}
+
+/** Exported for the emission-shape unit tests. */
+export const __lazyRowInternals = { seedDiffersExpr, dedupGuard }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
@@ -293,7 +293,20 @@ function seedDiffersExpr(target: string, a: LazyRowAttrBinding): string {
   if (html === 'class') return `${target}.getAttribute('class') !== (__x != null ? String(__x) : null)`
   if (html === 'value') return `${target}.value !== String(__x)`
   if (isBooleanAttr(html)) return `${target}.${html} !== !!(__x)`
-  if (a.meta.presenceOrUndefined) return `${target}.hasAttribute('${html}') !== !!(__x)`
+  if (a.meta.presenceOrUndefined) {
+    // Compare the VALUE the writer would produce, not just presence.
+    // `emitAttrUpdate` writes `'true'` for `aria-*` (WAI-ARIA requires an
+    // explicit value) and `''` for everything else, while SSR renders these
+    // as a BARE attribute name (`templateAttrExpr` in `html-template.ts`),
+    // which parses to the empty string. So for `aria-*` the SSR value and
+    // the client's value legitimately differ while presence agrees — a
+    // presence-only check would skip the seed write and leave
+    // `aria-pressed=""` where the eager path produces `aria-pressed="true"`.
+    // `getAttribute` returns null when absent, which is exactly the falsy
+    // expectation, so one comparison covers both directions.
+    const written = html.startsWith('aria-') ? 'true' : ''
+    return `${target}.getAttribute('${html}') !== (__x ? '${written}' : null)`
+  }
   return `${target}.getAttribute('${html}') !== (__x != null ? String(__x) : null)`
 }
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -37,6 +37,7 @@ import { buildSkeletonPathPlan, type SkeletonPathPlan } from './skeleton-paths.t
 import { stringifyComponentLoop } from './component-loop.ts'
 import { stringifyCompositeLoop } from './composite-loop.ts'
 import { claimPlanLiteral, claimWriterVarName, type ClaimSlotSpec } from './claim-plan.ts'
+import { stringifyLazyRowLoop } from './lazy-row.ts'
 import type { LoopChildRefBinding, LoopPlan, PlainLoopPlan, StaticLoopPlan } from '../plan/types.ts'
 
 /**
@@ -179,6 +180,28 @@ export function stringifyPlainLoop(
   // conditional's markers; `insert(__anchor, …)` then owns the content.
   if (anchored) {
     stringifyAnchoredLoop(lines, plan, topIndent, anchorKeyExpr)
+    return
+  }
+
+  // Lazy row graph (spec/slot-unification.md §9, L3): rows carry NO per-row
+  // reactive resources. `plan.lazyRow` is set only when
+  // `lazyRowEligibility` accepted this loop; every other loop falls through
+  // to the eager emission below, byte-for-byte unchanged.
+  if (plan.lazyRow) {
+    stringifyLazyRowLoop(lines, {
+      indent: topIndent,
+      containerVar,
+      guardContainer: false,
+      markerId,
+      arrayExpr,
+      keyFn,
+      paramHead,
+      indexParam,
+      template,
+      skeletonTemplate,
+      skeletonPaths: plan.skeletonPaths,
+      lazyRow: plan.lazyRow,
+    })
     return
   }
 

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -8,7 +8,7 @@ import { isClientBuiltinName } from '../builtins.ts'
 // All exports from @barefootjs/client/runtime that may be used in generated code
 export const RUNTIME_IMPORT_CANDIDATES = [
   'createSignal', 'createMemo', 'createEffect', 'onCleanup', 'onMount',
-  'hydrate', 'insert', 'getLoopChildren', 'getLoopNodes', 'mapArray', 'mapArrayAnchored', 'patchLeaf', 'createDisposableEffect',
+  'hydrate', 'insert', 'getLoopChildren', 'getLoopNodes', 'mapArray', 'mapArrayAnchored', 'mapArrayLazy', 'patchLeaf', 'createDisposableEffect',
   'createComponent', 'renderChild', 'registerComponent', 'registerTemplate', 'initChild', 'upsertChild',
   'createPortal',
   'provideContext', 'createContext', 'useContext',

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 280,
+    "totalFixtures": 282,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 65,
+      "total": 67,
       "cells": {
         "hono": {
-          "pass": 65,
-          "total": 65
+          "pass": 67,
+          "total": 67
         },
         "blade": {
-          "pass": 53,
-          "total": 65,
+          "pass": 55,
+          "total": 67,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 54,
-          "total": 65,
+          "pass": 56,
+          "total": 67,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 53,
-          "total": 65,
+          "pass": 55,
+          "total": 67,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -189,8 +189,8 @@
           ]
         },
         "jinja": {
-          "pass": 53,
-          "total": 65,
+          "pass": 55,
+          "total": 67,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -247,8 +247,8 @@
           ]
         },
         "minijinja": {
-          "pass": 53,
-          "total": 65,
+          "pass": 55,
+          "total": 67,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -305,8 +305,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 54,
-          "total": 65,
+          "pass": 56,
+          "total": 67,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -357,8 +357,8 @@
           ]
         },
         "twig": {
-          "pass": 53,
-          "total": 65,
+          "pass": 55,
+          "total": 67,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -415,8 +415,8 @@
           ]
         },
         "xslate": {
-          "pass": 53,
-          "total": 65,
+          "pass": 55,
+          "total": 67,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 175,
+      "total": 177,
       "cells": {
         "hono": {
-          "pass": 174,
-          "total": 175,
+          "pass": 176,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1433,8 +1433,8 @@
           ]
         },
         "blade": {
-          "pass": 160,
-          "total": 175,
+          "pass": 162,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1509,8 +1509,8 @@
           ]
         },
         "erb": {
-          "pass": 161,
-          "total": 175,
+          "pass": 163,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1579,8 +1579,8 @@
           ]
         },
         "go-template": {
-          "pass": 160,
-          "total": 175,
+          "pass": 162,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1655,8 +1655,8 @@
           ]
         },
         "jinja": {
-          "pass": 160,
-          "total": 175,
+          "pass": 162,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1731,8 +1731,8 @@
           ]
         },
         "minijinja": {
-          "pass": 160,
-          "total": 175,
+          "pass": 162,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1807,8 +1807,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 161,
-          "total": 175,
+          "pass": 163,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1877,8 +1877,8 @@
           ]
         },
         "twig": {
-          "pass": 160,
-          "total": 175,
+          "pass": 162,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1953,8 +1953,8 @@
           ]
         },
         "xslate": {
-          "pass": 160,
-          "total": 175,
+          "pass": 162,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2174,11 +2174,11 @@
       }
     },
     "identifier": {
-      "total": 261,
+      "total": 263,
       "cells": {
         "hono": {
-          "pass": 260,
-          "total": 261,
+          "pass": 262,
+          "total": 263,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2189,8 +2189,8 @@
           ]
         },
         "blade": {
-          "pass": 243,
-          "total": 261,
+          "pass": 245,
+          "total": 263,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2277,8 +2277,8 @@
           ]
         },
         "erb": {
-          "pass": 244,
-          "total": 261,
+          "pass": 246,
+          "total": 263,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2359,8 +2359,8 @@
           ]
         },
         "go-template": {
-          "pass": 243,
-          "total": 261,
+          "pass": 245,
+          "total": 263,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2447,8 +2447,8 @@
           ]
         },
         "jinja": {
-          "pass": 243,
-          "total": 261,
+          "pass": 245,
+          "total": 263,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2535,8 +2535,8 @@
           ]
         },
         "minijinja": {
-          "pass": 243,
-          "total": 261,
+          "pass": 245,
+          "total": 263,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2623,8 +2623,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 244,
-          "total": 261,
+          "pass": 246,
+          "total": 263,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2705,8 +2705,8 @@
           ]
         },
         "twig": {
-          "pass": 243,
-          "total": 261,
+          "pass": 245,
+          "total": 263,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2793,8 +2793,8 @@
           ]
         },
         "xslate": {
-          "pass": 243,
-          "total": 261,
+          "pass": 245,
+          "total": 263,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2946,15 +2946,15 @@
       }
     },
     "literal": {
-      "total": 215,
+      "total": 217,
       "cells": {
         "hono": {
-          "pass": 215,
-          "total": 215
+          "pass": 217,
+          "total": 217
         },
         "blade": {
-          "pass": 204,
-          "total": 215,
+          "pass": 206,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3005,8 +3005,8 @@
           ]
         },
         "erb": {
-          "pass": 204,
-          "total": 215,
+          "pass": 206,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3057,8 +3057,8 @@
           ]
         },
         "go-template": {
-          "pass": 204,
-          "total": 215,
+          "pass": 206,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3109,8 +3109,8 @@
           ]
         },
         "jinja": {
-          "pass": 204,
-          "total": 215,
+          "pass": 206,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3161,8 +3161,8 @@
           ]
         },
         "minijinja": {
-          "pass": 204,
-          "total": 215,
+          "pass": 206,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3213,8 +3213,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 204,
-          "total": 215,
+          "pass": 206,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3265,8 +3265,8 @@
           ]
         },
         "twig": {
-          "pass": 204,
-          "total": 215,
+          "pass": 206,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3317,8 +3317,8 @@
           ]
         },
         "xslate": {
-          "pass": 204,
-          "total": 215,
+          "pass": 206,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3530,11 +3530,11 @@
       }
     },
     "member": {
-      "total": 140,
+      "total": 142,
       "cells": {
         "hono": {
-          "pass": 139,
-          "total": 140,
+          "pass": 141,
+          "total": 142,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3545,8 +3545,8 @@
           ]
         },
         "blade": {
-          "pass": 122,
-          "total": 140,
+          "pass": 124,
+          "total": 142,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3633,8 +3633,8 @@
           ]
         },
         "erb": {
-          "pass": 123,
-          "total": 140,
+          "pass": 125,
+          "total": 142,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3715,8 +3715,8 @@
           ]
         },
         "go-template": {
-          "pass": 122,
-          "total": 140,
+          "pass": 124,
+          "total": 142,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3803,8 +3803,8 @@
           ]
         },
         "jinja": {
-          "pass": 122,
-          "total": 140,
+          "pass": 124,
+          "total": 142,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3891,8 +3891,8 @@
           ]
         },
         "minijinja": {
-          "pass": 122,
-          "total": 140,
+          "pass": 124,
+          "total": 142,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3979,8 +3979,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 123,
-          "total": 140,
+          "pass": 125,
+          "total": 142,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4061,8 +4061,8 @@
           ]
         },
         "twig": {
-          "pass": 122,
-          "total": 140,
+          "pass": 124,
+          "total": 142,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4149,8 +4149,8 @@
           ]
         },
         "xslate": {
-          "pass": 122,
-          "total": 140,
+          "pass": 124,
+          "total": 142,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4250,15 +4250,15 @@
       }
     },
     "object-literal": {
-      "total": 47,
+      "total": 49,
       "cells": {
         "hono": {
-          "pass": 47,
-          "total": 47
+          "pass": 49,
+          "total": 49
         },
         "blade": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4273,8 +4273,8 @@
           ]
         },
         "erb": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4289,8 +4289,8 @@
           ]
         },
         "go-template": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4305,8 +4305,8 @@
           ]
         },
         "jinja": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4321,8 +4321,8 @@
           ]
         },
         "minijinja": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4337,8 +4337,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4353,8 +4353,8 @@
           ]
         },
         "twig": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4369,8 +4369,8 @@
           ]
         },
         "xslate": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7348,15 +7348,15 @@
       }
     },
     "literal:boolean": {
-      "total": 39,
+      "total": 40,
       "cells": {
         "hono": {
-          "pass": 39,
-          "total": 39
+          "pass": 40,
+          "total": 40
         },
         "blade": {
-          "pass": 38,
-          "total": 39,
+          "pass": 39,
+          "total": 40,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7365,8 +7365,8 @@
           ]
         },
         "erb": {
-          "pass": 38,
-          "total": 39,
+          "pass": 39,
+          "total": 40,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7375,8 +7375,8 @@
           ]
         },
         "go-template": {
-          "pass": 38,
-          "total": 39,
+          "pass": 39,
+          "total": 40,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7385,8 +7385,8 @@
           ]
         },
         "jinja": {
-          "pass": 38,
-          "total": 39,
+          "pass": 39,
+          "total": 40,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7395,8 +7395,8 @@
           ]
         },
         "minijinja": {
-          "pass": 38,
-          "total": 39,
+          "pass": 39,
+          "total": 40,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7405,8 +7405,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 38,
-          "total": 39,
+          "pass": 39,
+          "total": 40,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7415,8 +7415,8 @@
           ]
         },
         "twig": {
-          "pass": 38,
-          "total": 39,
+          "pass": 39,
+          "total": 40,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7425,8 +7425,8 @@
           ]
         },
         "xslate": {
-          "pass": 38,
-          "total": 39,
+          "pass": 39,
+          "total": 40,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7499,15 +7499,15 @@
       }
     },
     "literal:number": {
-      "total": 91,
+      "total": 93,
       "cells": {
         "hono": {
-          "pass": 91,
-          "total": 91
+          "pass": 93,
+          "total": 93
         },
         "blade": {
-          "pass": 86,
-          "total": 91,
+          "pass": 88,
+          "total": 93,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7532,8 +7532,8 @@
           ]
         },
         "erb": {
-          "pass": 86,
-          "total": 91,
+          "pass": 88,
+          "total": 93,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7558,8 +7558,8 @@
           ]
         },
         "go-template": {
-          "pass": 86,
-          "total": 91,
+          "pass": 88,
+          "total": 93,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7584,8 +7584,8 @@
           ]
         },
         "jinja": {
-          "pass": 86,
-          "total": 91,
+          "pass": 88,
+          "total": 93,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7610,8 +7610,8 @@
           ]
         },
         "minijinja": {
-          "pass": 86,
-          "total": 91,
+          "pass": 88,
+          "total": 93,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7636,8 +7636,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 86,
-          "total": 91,
+          "pass": 88,
+          "total": 93,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7662,8 +7662,8 @@
           ]
         },
         "twig": {
-          "pass": 86,
-          "total": 91,
+          "pass": 88,
+          "total": 93,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7688,8 +7688,8 @@
           ]
         },
         "xslate": {
-          "pass": 86,
-          "total": 91,
+          "pass": 88,
+          "total": 93,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7727,15 +7727,15 @@
       }
     },
     "literal:string": {
-      "total": 155,
+      "total": 157,
       "cells": {
         "hono": {
-          "pass": 155,
-          "total": 155
+          "pass": 157,
+          "total": 157
         },
         "blade": {
-          "pass": 147,
-          "total": 155,
+          "pass": 149,
+          "total": 157,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7774,8 +7774,8 @@
           ]
         },
         "erb": {
-          "pass": 147,
-          "total": 155,
+          "pass": 149,
+          "total": 157,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7814,8 +7814,8 @@
           ]
         },
         "go-template": {
-          "pass": 147,
-          "total": 155,
+          "pass": 149,
+          "total": 157,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7854,8 +7854,8 @@
           ]
         },
         "jinja": {
-          "pass": 147,
-          "total": 155,
+          "pass": 149,
+          "total": 157,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7894,8 +7894,8 @@
           ]
         },
         "minijinja": {
-          "pass": 147,
-          "total": 155,
+          "pass": 149,
+          "total": 157,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7934,8 +7934,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 147,
-          "total": 155,
+          "pass": 149,
+          "total": 157,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7974,8 +7974,8 @@
           ]
         },
         "twig": {
-          "pass": 147,
-          "total": 155,
+          "pass": 149,
+          "total": 157,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8014,8 +8014,8 @@
           ]
         },
         "xslate": {
-          "pass": 147,
-          "total": 155,
+          "pass": 149,
+          "total": 157,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",


### PR DESCRIPTION
**L3 of the lazy-row-graph stack** (L1 #2406 and L2 #2407 are merged; this now targets `main`). Switches eligible plain loops from `mapArray` + per-row renderItem to `mapArrayLazy` + a compiled row plan, so those rows carry **no per-row reactive graph at all**.

## Eligibility gate

`packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-row-eligibility.ts` — a pure `lazyRowEligibility()` returning `{eligible} | {eligible: false, reason}`, directly unit-tested (47 tests). Every refusal reason is explicit; an ineligible loop keeps today's emission byte-for-byte. Sound-or-loud: no silent third path.

Refusals cover profile mode, non-plain call sites, flatMap/anchored/multi-root shapes, index-keyed loops, conditionals, child refs/components/inner loops, map-callback preambles, and the §9.3(2) hydration-consistency gate on the loop source.

## Binding classification

Built at plan time from real dependency data (`arrayFreeIdentifiers`, text `freeIdentifiers`, and `parseExpression` + `freeIdentifiers()` for attrs — never regex). A binding that reads the item goes into `applyItem`; one that reads outer signals goes into `applyOuter`; one that does both is emitted in both. **Fail-safe: unknown dependencies ⇒ both lists** — every write is dedup-guarded, so double application is idempotent and "both" is never a correctness risk.

## Measured on the real implementation (not the spike)

SSR bench, two runs each, independently re-verified:

| Metric | before (eager) | **this PR** | solid |
|---|---|---|---|
| Post-hydration heap (n=3, forced GC) | 2718.6KB | **1807.6 / 1812.7KB (−33%)** | 2577.9 / 2586.7KB |
| Hydration median (n=10) | 49.1 / 55.8ms | **31.5 / 30.1ms** | 28.9 / 28.4ms |
| Hydration ratio vs solid | 1.28–1.34x | **1.06–1.09x** | 1.00x |
| Client JS (raw / gzip) | 21.6KB / 7.8KB | 21.4KB / 7.8KB | 17.0KB / 6.6KB |
| Interactivity gate | PASS | PASS | PASS |

Heap is now **30% below solid**; the hydration gap against solid closed from ~1.3x to ~1.07x. No bundle-size regression.

## Verification

`packages/jsx` **2792 tests, 0 fail** (independently re-run) · `adapter-tests` 1446/0 · `adapter-hono` 1263/0 · `client`+`test` 627/0 · fixture-hydrate 34/34 (after a client dist rebuild) · site/ui e2e 1124 pass with only the 3 known pre-existing reds (verified neither failing bundle contains `mapArrayLazy`) · `map-body-no-silent-divergence` green with `KNOWN_HOLES` still empty.

**SSR byte-identity invariant holds**: zero existing `expectedHtml`/`.html` goldens changed anywhere in the corpus (the only two `expectedHtml` additions are the new fixtures' own). 7 client-JS goldens changed, each reviewed — all the same `mapArray(…renderItem)` → `mapArrayLazy(…row plan)` substitution on loops the gate accepts.

Two CSR conformance fixtures land here per the same-PR coupling rule: an eligible keyed loop with an outer-involving class binding plus item texts, and an ineligible loop proving fallback. Their corpus-count effect on `ui/support-matrix.lock.json` / `ui/compat.lock.json` is regenerated in a second commit — pure counter increments (+2 totals, +2 passes per adapter), zero gap entries added or removed, i.e. all nine adapters render both new fixtures to reference parity.

## Known limits (documented, follow-up material)

1. **Outer-involving *text* bindings make a loop ineligible.** `lazySlots` is write-only, so §9.3(1)'s read-compare-write seeding has no DOM read-back for content slots; writing unconditionally at seed would reintroduce the per-row hydration write §9 exists to remove. Widening needs a runtime read door.
2. **Opaque outer reads refuse the loop.** A local like `const isSelected = createSelector(selected)` is an ordinary const whose *call* is reactive; the emitter cannot prime that subscription, and an `applyOuter` effect that never subscribes would silently miss updates. Refusing is the sound choice — but it means the krausest DOM-bench component (which uses `createSelector`) is currently ineligible, so the DOM-suite memory number is unchanged by this PR. Priming (or a runtime re-subscribe seam that re-runs `applyOuter` on an empty → non-empty entry-list transition) is the natural next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM