### PR TITLE
feat(jsx): accept outer-involving text bindings in lazy rows (slot unification §9.5c(1))

### DIFF
--- a/.changeset/lazy-row-outer-text.md
+++ b/.changeset/lazy-row-outer-text.md
@@ -1,0 +1,30 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Accept outer-involving TEXT bindings in lazy rows (slot unification §9.5c(1))
+
+The §9.4 eligibility gate refused any lazy-row loop with a text binding that
+read component-scope state: `lazySlots`' writer is write-only, so §9.3(1)'s
+read-compare-write seeding had no DOM read-back for a content slot. The
+runtime now ships `lazyClaimSlots`, the read-capable twin over the SAME claim,
+so that refusal is gone — a loop whose row renders e.g. `{row.label}` next to
+a cell derived from an outer signal is now lazy instead of falling back to the
+eager per-row root + signal + effect emission.
+
+The door is chosen ONCE PER LOOP, never per binding: a loop with at least one
+outer-involving text claims through `lazyClaimSlots(...)` and every text write
+becomes `__r[w].write('sN', v)`; every other loop keeps the single-closure
+`lazySlots(...)` writer and the bare `__r[w]('sN', v)` call form, byte for
+byte. That matters because the door is allocated per ROW — a reader on every
+row of a 1k-row list is measurable, so only loops that need reads pay for one.
+
+The seed guard mirrors the attribute one:
+`__seed ? (__r[w].read('sN') !== String(__x)) : (<entry.last dedup>)`. `read`
+returns `null` when it cannot answer and `null !== String(__x)` is always
+true, so the comparison already fails safe into "write it".
+
+Honest cost: reading a content slot claims that row's plan, so a loop with an
+outer-involving text pays one claim per row at hydration rather than the
+row-pristine zero — inherent to read-compare-write for content, and still far
+cheaper than the eager path it replaces. Attribute-only loops are unaffected.

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2363,6 +2363,28 @@
         "text"
       ]
     },
+    "lazy-row-outer-text": {
+      "kinds": [
+        "array-literal",
+        "binary",
+        "call",
+        "conditional",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "binary:===",
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "local-record-union-index": {
       "kinds": [
         "literal",
@@ -4549,18 +4571,18 @@
     }
   },
   "kindCounts": {
-    "array-literal": 67,
+    "array-literal": 68,
     "array-method": 65,
     "arrow": 63,
-    "binary": 76,
-    "call": 177,
-    "conditional": 21,
-    "identifier": 263,
+    "binary": 77,
+    "call": 178,
+    "conditional": 22,
+    "identifier": 264,
     "index-access": 12,
-    "literal": 217,
+    "literal": 218,
     "logical": 43,
-    "member": 142,
-    "object-literal": 49,
+    "member": 143,
+    "object-literal": 50,
     "template-literal": 29,
     "unary": 22,
     "unsupported": 31
@@ -4597,13 +4619,13 @@
     "binary:-": 11,
     "binary:/": 1,
     "binary:<": 1,
-    "binary:===": 39,
+    "binary:===": 40,
     "binary:>": 11,
     "binary:>=": 1,
     "literal:boolean": 40,
     "literal:null": 22,
-    "literal:number": 93,
-    "literal:string": 157,
+    "literal:number": 94,
+    "literal:string": 158,
     "logical:&&": 7,
     "logical:??": 38,
     "logical:||": 13,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -143,8 +143,10 @@ import { fixture as sortSimple } from './sort-simple'
 import { fixture as filterSortChain } from './filter-sort-chain'
 import { fixture as mapNested } from './map-nested'
 import { fixture as mapDynamicClass } from './map-dynamic-class'
-// Lazy row graph (spec/slot-unification.md §9) — eligible + refused pair
+// Lazy row graph (spec/slot-unification.md §9) — eligible attr, eligible
+// outer TEXT (§9.5c(1) lifted), and refused
 import { fixture as lazyRowOuterClass } from './lazy-row-outer-class'
+import { fixture as lazyRowOuterText } from './lazy-row-outer-text'
 import { fixture as lazyRowIneligibleFallback } from './lazy-row-ineligible-fallback'
 import { fixture as siblingMaps } from './sibling-maps'
 import { fixture as fragmentLoopChildren } from './fragment-loop-children'
@@ -519,6 +521,7 @@ export const jsxFixtures: JSXFixture[] = [
   mapNested,
   mapDynamicClass,
   lazyRowOuterClass,
+  lazyRowOuterText,
   lazyRowIneligibleFallback,
   siblingMaps,
   fragmentLoopChildren,

--- a/packages/adapter-tests/fixtures/lazy-row-outer-text.ts
+++ b/packages/adapter-tests/fixtures/lazy-row-outer-text.ts
@@ -1,0 +1,64 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Lazy row graph (`spec/slot-unification.md` §9) — an eligible row whose
+ * CONTENT slot is outer-involving (§9.5c(1), lifted).
+ *
+ * The sibling `lazy-row-outer-class` covers the attribute half: an
+ * outer-involving `className` seeds against `getAttribute`. This fixture
+ * covers the half that used to make the whole loop ineligible — a TEXT
+ * binding reading the component-scope `selected()` signal. Its §9.3(1)
+ * read-compare-write seed needs a DOM read-back for a content slot, which
+ * `lazyClaimSlots(...).read(id)` now provides, so the emitter claims this
+ * loop's row through the READ-capable door and every text write becomes
+ * `__r[w].write(...)`. `lazy-row-outer-class` stays on the cheap write-only
+ * `lazySlots` door — the choice is per LOOP, and this pair pins both sides.
+ *
+ * The row deliberately mixes both text kinds: `{row.label}` is item-driven
+ * (applyItem only) while the YES/NO cell reads BOTH the item and the outer
+ * signal, so it lands in `applyItem` and `applyOuter` alike.
+ * `String(... ? ... : ...)` rather than a bare ternary because a bare
+ * ternary in child position compiles to a reactive CONDITIONAL, which §9.4
+ * refuses outright (that shape is `lazy-row-ineligible-fallback`'s job).
+ *
+ * Same SSR-bytes obligation as its siblings: this golden reflects the
+ * unchanged template emission — the widening is client-side only.
+ */
+export const fixture = createFixture({
+  id: 'lazy-row-outer-text',
+  description: 'Keyed plain loop whose row text reads an outer signal (lazy row graph, §9.5c(1) lifted)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string }
+export function LazyRowOuterText() {
+  const [rows, setRows] = createSignal<Row[]>([
+    { id: 1, label: 'alpha' },
+    { id: 2, label: 'beta' },
+  ])
+  const [selected, setSelected] = createSignal(2)
+  return (
+    <tbody>
+      {rows().map(row => (
+        <tr key={row.id}>
+          <td>{row.label}</td>
+          <td onClick={() => setSelected(row.id)}>{String(selected() === row.id ? 'YES' : 'NO')}</td>
+        </tr>
+      ))}
+    </tbody>
+  )
+}
+`,
+  expectedHtml: `
+    <tbody bf-s="test" bf="s3">
+      <tr data-key="1">
+        <td><!--bf:s0-->alpha<!--/--></td>
+        <td bf="s2"><!--bf:s1-->NO<!--/--></td>
+      </tr>
+      <tr data-key="2">
+        <td><!--bf:s0-->beta<!--/--></td>
+        <td bf="s2"><!--bf:s1-->YES<!--/--></td>
+      </tr>
+    </tbody>
+  `,
+})

--- a/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
+++ b/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
@@ -171,7 +171,12 @@ describe('lazyRowEligibility — binding refusals', () => {
     expect((decision as { reason: string }).reason).toMatch(/cannot be primed: _p/)
   })
 
-  test('an outer-involving TEXT binding is refused (no DOM read-back for content slots)', () => {
+  // §9.5c(1), LIFTED: content slots now have a DOM read-back
+  // (`lazyClaimSlots(...).read(id)`), so an outer-involving text binding no
+  // longer sinks the loop. This test is the inverse of the refusal it
+  // replaces — if the gate ever starts refusing again, it fails here rather
+  // than as a silent eager-fallback regression.
+  test('an outer-involving TEXT binding is ELIGIBLE (content slots have a DOM read-back)', () => {
     const decision = lazyRowEligibility(args({
       bindings: [{
         kind: 'text',
@@ -189,8 +194,23 @@ describe('lazyRowEligibility — binding refusals', () => {
         ]),
       }),
     }))
+    expect(decision).toEqual({ eligible: true })
+  })
+
+  test('an outer-only TEXT binding whose outer name is OPAQUE is still refused', () => {
+    const decision = lazyRowEligibility(args({
+      bindings: [{
+        kind: 'text',
+        slotId: 's1',
+        readsItem: true,
+        readsOuter: true,
+        reactiveOuterNames: [],
+        opaqueOuterNames: ['isSelected'],
+        referencesIndex: false,
+      }],
+    }))
     expect(decision.eligible).toBe(false)
-    expect((decision as { reason: string }).reason).toMatch(/outer-involving text binding/)
+    expect((decision as { reason: string }).reason).toMatch(/cannot be primed: isSelected/)
   })
 })
 
@@ -408,6 +428,88 @@ describe('lazy row emission — eligible loop', () => {
   test('the lazy claim helper scans inside ONE row and is shared by both apply paths', () => {
     expect(js).toContain('const __lzc_l0 = (__e) => {')
     expect(js).toContain('const __el = __e.primaryEl')
+  })
+
+  /**
+   * No-regression pin for the cheap door. This loop's texts are all
+   * item-driven, so it must keep the single-closure `lazySlots` writer and
+   * the BARE call form — the read-capable door costs an extra closure on
+   * every row and may only be taken by loops that actually seed content.
+   */
+  test('an attr-only-outer loop keeps the write-only lazySlots door and the bare call form', () => {
+    expect(js).toContain('lazySlots(')
+    expect(js).not.toContain('lazyClaimSlots(')
+    expect(js).toContain("__r[1]('s0', String(__x))")
+    expect(js).not.toContain('.write(')
+    expect(js).not.toContain('.read(')
+  })
+})
+
+/**
+ * §9.5c(1) lifted: an outer-involving TEXT binding. The row renders an
+ * item-driven text alongside a text that depends on a component signal, so
+ * the loop needs the READ-capable claim door to seed the second one by
+ * read-compare-write instead of writing blindly at hydration.
+ */
+const ELIGIBLE_OUTER_TEXT = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string }
+export function LazyOuterTextRows() {
+  const [rows, setRows] = createSignal<Row[]>([])
+  const [selected, setSelected] = createSignal(0)
+  return (
+    <tbody>
+      {rows().map(row => (
+        <tr key={row.id}>
+          <td>{row.label}</td>
+          <td>{String(selected() === row.id ? 'YES' : 'NO')}</td>
+        </tr>
+      ))}
+    </tbody>
+  )
+}
+`
+
+describe('lazy row emission — outer-involving TEXT binding (§9.5c(1) lifted)', () => {
+  const js = clientJs(ELIGIBLE_OUTER_TEXT, 'LazyOuterTextRows.tsx')
+
+  test('the loop is eligible — it is no longer refused for having an outer text', () => {
+    expect(js).toContain('mapArrayLazy(')
+    expect(js).not.toMatch(/\bmapArray\(/)
+  })
+
+  test('claims through the READ-capable door and imports it', () => {
+    expect(js).toContain('lazyClaimSlots(')
+    expect(js).not.toMatch(/\blazySlots\(/)
+    expect(js).toMatch(/import \{[^}]*\blazyClaimSlots\b[^}]*\} from '@barefootjs\/client\/runtime'/)
+  })
+
+  test('every text write goes through the door\'s .write() method', () => {
+    expect(js).toContain(".write('s0', String(__x))")
+    expect(js).toContain(".write('s1', String(__x))")
+    // The bare call form belongs to the write-only door and must not survive
+    // alongside the RW one.
+    expect(js).not.toContain("__r[0]('s0'")
+    expect(js).not.toContain("__r[0]('s1'")
+  })
+
+  test('applyOuter seeds the content slot by read-compare-write (§9.3(1))', () => {
+    const applyOuter = js.slice(js.indexOf('applyOuter:'))
+    expect(applyOuter).toContain("__seed ? (__r[0].read('s1') !== String(__x))")
+    // …and falls back to the ordinary entry.last dedup on every later run.
+    expect(applyOuter).toContain(': (!(1 in __l) || !Object.is(__l[1], __x))')
+    expect(applyOuter).toContain('__l[1] = __x')
+  })
+
+  test('the outer text ALSO applies on item change, because it reads the item too', () => {
+    const applyItem = js.slice(js.indexOf('applyItem:'), js.indexOf('applyOuter:'))
+    expect(applyItem).toContain("__r[0].write('s1', String(__x))")
+  })
+
+  test('the item-only text is NOT emitted into applyOuter', () => {
+    const applyOuter = js.slice(js.indexOf('applyOuter:'))
+    expect(applyOuter).not.toContain("'s0'")
   })
 })
 

--- a/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
+++ b/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
@@ -496,9 +496,16 @@ describe('lazy row emission — outer-involving TEXT binding (§9.5c(1) lifted)'
 
   test('applyOuter seeds the content slot by read-compare-write (§9.3(1))', () => {
     const applyOuter = js.slice(js.indexOf('applyOuter:'))
-    expect(applyOuter).toContain("__seed ? (__r[0].read('s1') !== String(__x))")
-    // …and falls back to the ordinary entry.last dedup on every later run.
-    expect(applyOuter).toContain(': (!(1 in __l) || !Object.is(__l[1], __x))')
+    // A real branch, not one ternary guard: the seed path binds the string
+    // ONCE and reuses it for the compare and the write, so a value with a
+    // side-effecting `toString` is not stringified twice.
+    expect(applyOuter).toContain('if (__seed) {')
+    expect(applyOuter).toContain('const __s = String(__x)')
+    expect(applyOuter).toContain("if (__r[0].read('s1') !== __s) __r[0].write('s1', __s)")
+    expect(applyOuter).not.toContain("read('s1') !== String(__x)")
+    // …and falls back to the ordinary entry.last dedup on every later run,
+    // where the string is built only when the write actually happens.
+    expect(applyOuter).toContain('} else if (!(1 in __l) || !Object.is(__l[1], __x))')
     expect(applyOuter).toContain('__l[1] = __x')
   })
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-lazy-row.ts
@@ -46,12 +46,18 @@ export interface LazyRowAttrBinding {
   readsOuter: boolean
 }
 
-/** One reactive outer text of a lazy row. Item-driven only (see §9.4 gate). */
+/** One reactive text (content slot) of a lazy row. */
 export interface LazyRowTextBinding {
   slotId: string
   wrappedExpression: string
   ordinal: number
   readsItem: boolean
+  /**
+   * Reads at least one reactive outer name — emitted into `applyOuter` with
+   * §9.3(1) read-compare-write seeding, which needs the RW claim door
+   * (`LazyRowPlanData.textNeedsRead`).
+   */
+  readsOuter: boolean
 }
 
 export interface LazyRowPlanData {
@@ -59,8 +65,18 @@ export interface LazyRowPlanData {
   attrSlotIds: readonly string[]
   attrs: readonly LazyRowAttrBinding[]
   texts: readonly LazyRowTextBinding[]
-  /** Index into `entry.refs` holding the claimed-slot writer; -1 when no texts. */
+  /** Index into `entry.refs` holding the claimed-slot door; -1 when no texts. */
   writerIndex: number
+  /**
+   * PER-LOOP door selection (§9.3(1) content seeding): true when at least
+   * one text binding is outer-involving and therefore needs `read(id)` to
+   * seed by comparison. The emitter then claims through `lazyClaimSlots`
+   * (the `{ write, read }` door) and every text write becomes
+   * `__r[w].write(...)`; false keeps the single-closure `lazySlots` writer
+   * and the bare `__r[w](...)` call form. One decision for the whole loop —
+   * the door is a per-ROW allocation, so it must not be chosen per binding.
+   */
+  textNeedsRead: boolean
   /** Total `entry.last` slots. */
   lastCount: number
   /**
@@ -190,10 +206,12 @@ export function decideLazyRow(args: BuildLazyRowArgs): {
       slotId: text.slotId,
       wrappedExpression: wrap(text.expression),
       ordinal: ordinal++,
-      // Outer-involving texts are refused by the gate, so an item-only text
-      // that somehow classified as neither still gets applied on item change
-      // (harmless, dedup-guarded) rather than silently never being written.
-      readsItem: true,
+      // A text that classified as NEITHER item- nor outer-driven still gets
+      // applied on item change (harmless, dedup-guarded) rather than
+      // silently never being written. Anything the classifier did place in
+      // a list keeps exactly the classifier's answer.
+      readsItem: c.readsItem || !c.readsOuter,
+      readsOuter: c.readsOuter,
     }
   })
 
@@ -210,9 +228,10 @@ export function decideLazyRow(args: BuildLazyRowArgs): {
       attrs,
       texts,
       writerIndex: texts.length > 0 ? attrSlotIds.length : -1,
+      textNeedsRead: texts.some(t => t.readsOuter),
       lastCount: ordinal,
       outerPrimeGetters,
-      hasOuter: attrs.some(a => a.readsOuter),
+      hasOuter: attrs.some(a => a.readsOuter) || texts.some(t => t.readsOuter),
     },
     decision,
   }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-row-eligibility.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-row-eligibility.ts
@@ -41,17 +41,16 @@
  *     the `inert` set names them only so the refusal can say which one.
  *     Genuinely ignorable are the names that cannot carry a reactive read
  *     at all: literal-derived local / module constants and pure globals.
- *  4. **No outer-involving TEXT binding.** §9.3(1) requires read-compare-
- *     write seeding on `applyOuter`'s first run: compute the value, READ the
- *     current DOM, write only on difference. For an attribute that read is
- *     `getAttribute` / a DOM property on the held element ref. For a content
- *     slot there is no read-back door — `lazySlots`' writer is write-only
- *     (`claim-slots.ts`), and the runtime contract is PINNED for L3. Rather
- *     than write unconditionally at hydration (sound, but it reintroduces
- *     exactly the per-row hydration DOM write §9 exists to remove), an
- *     outer-involving text binding makes the whole loop ineligible. Widening
- *     this needs a runtime read door, i.e. an L5 change to the pinned
- *     contract.
+ *  4. **Outer-involving TEXT bindings are ACCEPTED** (§9.5c(1), lifted).
+ *     §9.3(1) requires read-compare-write seeding on `applyOuter`'s first
+ *     run: compute the value, READ the current DOM, write only on
+ *     difference. For an attribute that read is `getAttribute` / a DOM
+ *     property on the held element ref. For a content slot the read door is
+ *     `lazyClaimSlots`' `read(id)` (`claim-slots.ts`), the read-capable twin
+ *     of `lazySlots` over the SAME claim. The emitter picks the door per
+ *     LOOP — a loop with no outer-involving text keeps the single-closure
+ *     writer — so this widening costs nothing for loops that do not use it
+ *     (see `refParts` in `stringify/lazy-row.ts`).
  *  5. **Loop-source hydration consistency** (§9.3(2)): item-driven bindings
  *     are never evaluated at hydration, so the SSR rows and the first client
  *     `items()` read are TRUSTED to agree. That trust is only sound when
@@ -243,9 +242,6 @@ export function lazyRowEligibility(args: LazyRowEligibilityArgs): LazyRowEligibi
       return NO(
         `binding on slot ${b.slotId} depends on an outer name that cannot be primed: ${b.opaqueOuterNames.join(', ')}`,
       )
-    }
-    if (b.kind === 'text' && b.readsOuter) {
-      return NO(`outer-involving text binding on slot ${b.slotId} (content slots have no DOM read-back for §9.3(1) seeding)`)
     }
   }
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
@@ -289,9 +289,18 @@ function emitAttrBinding(
  *
  * `'outer'` seeds by read-compare-write (§9.3(1)) through the RW door's
  * `read(id)`. `read` returns `null` when it cannot answer (slot never
- * claimed, or not a 'text' slot) and `null !== String(__x)` is always true,
+ * claimed, or not a 'text' slot) and `null !== <the string>` is always true,
  * so the comparison already fails safe into "write it" — no explicit null
  * handling is needed or wanted here.
+ *
+ * The `'outer'` mode emits a real `if`/`else if` rather than one ternary
+ * guard so the seed branch can bind `String(__x)` ONCE and use it for both
+ * the comparison and the write. A ternary would stringify twice on the seed
+ * path, which double-invokes a user value's `toString` — observable when it
+ * has side effects, wasted work when it doesn't. Hoisting the string above
+ * the branch instead would fix that but would also stringify on the
+ * non-seed path even when dedup skips the write, i.e. on every later tick;
+ * the branch keeps exactly one stringification per path taken.
  */
 function emitTextBinding(
   lines: string[],
@@ -303,18 +312,20 @@ function emitTextBinding(
 ): void {
   lines.push(`${ind}{ const __x = ${t.wrappedExpression}`)
   const doorExpr = `__r[${writerIndex}]`
-  const write = rwDoor
-    ? `${doorExpr}.write('${t.slotId}', String(__x))`
-    : `${doorExpr}('${t.slotId}', String(__x))`
-  const guard = mode === 'create'
-    ? null
-    : mode === 'item'
-      ? dedupGuard(t.ordinal)
-      : `__seed ? (${doorExpr}.read('${t.slotId}') !== String(__x)) : (${dedupGuard(t.ordinal)})`
-  if (guard) {
-    lines.push(`${ind}if (${guard}) ${write}`)
+  const writeOf = (valueExpr: string): string =>
+    rwDoor
+      ? `${doorExpr}.write('${t.slotId}', ${valueExpr})`
+      : `${doorExpr}('${t.slotId}', ${valueExpr})`
+
+  if (mode === 'outer') {
+    lines.push(`${ind}if (__seed) {`)
+    lines.push(`${ind}  const __s = String(__x)`)
+    lines.push(`${ind}  if (${doorExpr}.read('${t.slotId}') !== __s) ${writeOf('__s')}`)
+    lines.push(`${ind}} else if (${dedupGuard(t.ordinal)}) ${writeOf('String(__x)')}`)
+  } else if (mode === 'item') {
+    lines.push(`${ind}if (${dedupGuard(t.ordinal)}) ${writeOf('String(__x)')}`)
   } else {
-    lines.push(`${ind}${write}`)
+    lines.push(`${ind}${writeOf('String(__x)')}`)
   }
   lines.push(`${ind}__l[${t.ordinal}] = __x }`)
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
@@ -48,13 +48,11 @@
  *    is per attribute KIND and pairs with `emitAttrUpdate`'s dispatch
  *    (`emit-reactive.ts`); any kind this module does not recognise falls back
  *    to `true` (always write on seed), which is conservative, never wrong.
+ *    CONTENT slots seed the same way through the claim's `read(id)` door
+ *    (§9.5c(1), lifted) — see `refParts` for the per-loop door choice.
  *
- * Content (text) slots are never outer-involving here — `lazySlots`' writer
- * is write-only, so there is no DOM read-back to seed against, and the
- * eligibility gate refuses such loops rather than reintroducing an
- * unconditional per-row hydration write. Consequently a lazy row's text
- * bindings are all item-driven, and a loop with NO outer binding emits no
- * `applyOuter` at all — its rows do literally nothing at hydration.
+ * A loop with NO outer binding emits no `applyOuter` at all — its rows do
+ * literally nothing at hydration.
  */
 
 import { isBooleanAttr } from '../../../html-constants.ts'
@@ -95,6 +93,10 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
   const claimVar = `__lzc_${mid}`
   const hasRefs = lazyRow.attrSlotIds.length > 0 || lazyRow.texts.length > 0
   const hasBindings = lazyRow.attrs.length > 0 || lazyRow.texts.length > 0
+  // ONE per-loop door decision (see `refParts`): the read-capable claim, or
+  // today's write-only writer. Never decided per binding — the door is
+  // allocated once per ROW.
+  const rwDoor = lazyRow.textNeedsRead
 
   // Hoisted once-per-loop skeleton (perf, #2143): clone an already-parsed
   // node per row instead of re-running an `innerHTML` parse. The skeleton
@@ -158,7 +160,7 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
   if (hasBindings) {
     lines.push(`${b2}const __l = __e.last = []`)
     for (const a of lazyRow.attrs) emitAttrBinding(lines, b2, a, 'create')
-    for (const t of lazyRow.texts) emitTextBinding(lines, b2, t, lazyRow.writerIndex, false)
+    for (const t of lazyRow.texts) emitTextBinding(lines, b2, t, lazyRow.writerIndex, 'create', rwDoor)
   }
   lines.push(`${b2}return __el`)
   lines.push(`${b1}},`)
@@ -174,13 +176,14 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
     lines.push(`${b2}const __r = __e.refs ?? (__e.refs = ${claimVar}(__e))`)
     lines.push(`${b2}const __l = __e.last ?? (__e.last = [])`)
     for (const a of itemAttrs) emitAttrBinding(lines, b2, a, 'item')
-    for (const t of itemTexts) emitTextBinding(lines, b2, t, lazyRow.writerIndex, true)
+    for (const t of itemTexts) emitTextBinding(lines, b2, t, lazyRow.writerIndex, 'item', rwDoor)
     lines.push(`${b1}},`)
   }
 
   // --- applyOuter (only when some binding is outer-involving) -------------
   const outerAttrs = lazyRow.attrs.filter(a => a.readsOuter)
-  if (outerAttrs.length > 0) {
+  const outerTexts = lazyRow.texts.filter(t => t.readsOuter)
+  if (outerAttrs.length > 0 || outerTexts.length > 0) {
     const b3 = `${indent}      `
     lines.push(`${b1}applyOuter: (__es, __seed) => {`)
     // Prime the outer reads so this ONE loop-level effect subscribes even
@@ -191,6 +194,7 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
     lines.push(`${b3}const __r = __e.refs ?? (__e.refs = ${claimVar}(__e))`)
     lines.push(`${b3}const __l = __e.last ?? (__e.last = [])`)
     for (const a of outerAttrs) emitAttrBinding(lines, b3, a, 'outer')
+    for (const t of outerTexts) emitTextBinding(lines, b3, t, lazyRow.writerIndex, 'outer', rwDoor)
     lines.push(`${b2}}`)
     lines.push(`${b1}},`)
   }
@@ -201,7 +205,24 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
 /**
  * The `entry.refs` array contents: one element ref per reactive-attr slot
  * (in `attrSlotIds` order), then — when the row has text slots — the
- * `lazySlots` writer at `writerIndex`.
+ * claimed-slot door at `writerIndex`.
+ *
+ * **Which door (per LOOP, never per binding).** `lazySlots` returns a bare
+ * write function; `lazyClaimSlots` returns the `{ write, read }` pair over
+ * the SAME claim, at the cost of an extra closure on EVERY row of the list
+ * (`claim-slots.ts` measured ~40-84KB/1k rows). So the RW door is taken only
+ * when this loop actually has an outer-involving text binding to seed by
+ * read-compare-write (`plan.textNeedsRead`, decided once in
+ * `build-lazy-row.ts`); every other loop keeps today's writer byte-for-byte.
+ *
+ * **Honest cost note.** Reading a text slot CLAIMS that row's whole plan
+ * (§2's claim-once rule — `read` and `write` share `claimRefs`), so a loop
+ * with an outer-involving text pays one claim per row at hydration instead
+ * of the row-pristine zero. That is inherent to read-compare-write for
+ * content: you cannot compare what you have not resolved. It is still far
+ * cheaper than the eager path this replaces, which pays a root + a signal +
+ * an effect per row. Attr-only loops are entirely unaffected — they keep the
+ * write-only door and never claim at seed.
  *
  * `skeletonPaths` non-null = fresh-clone context (`createRow`): resolve via
  * compile-time child-index chains, no scan. Null = adopted-row context
@@ -227,7 +248,8 @@ function refParts(
       path: [],
       pathExpr: textPathVar ? `${textPathVar}[${i}]` : undefined,
     }))
-    parts.push(`lazySlots(${elVar}, ${claimPlanLiteral(slots)})`)
+    const door = lazyRow.textNeedsRead ? 'lazyClaimSlots' : 'lazySlots'
+    parts.push(`${door}(${elVar}, ${claimPlanLiteral(slots)})`)
   }
   return parts
 }
@@ -262,17 +284,35 @@ function emitAttrBinding(
   lines.push(`${ind}} }`)
 }
 
+/**
+ * A content-slot write, in the same three modes as {@link emitAttrBinding}.
+ *
+ * `'outer'` seeds by read-compare-write (§9.3(1)) through the RW door's
+ * `read(id)`. `read` returns `null` when it cannot answer (slot never
+ * claimed, or not a 'text' slot) and `null !== String(__x)` is always true,
+ * so the comparison already fails safe into "write it" — no explicit null
+ * handling is needed or wanted here.
+ */
 function emitTextBinding(
   lines: string[],
   ind: string,
   t: LazyRowTextBinding,
   writerIndex: number,
-  dedup: boolean,
+  mode: 'create' | 'item' | 'outer',
+  rwDoor: boolean,
 ): void {
   lines.push(`${ind}{ const __x = ${t.wrappedExpression}`)
-  const write = `__r[${writerIndex}]('${t.slotId}', String(__x))`
-  if (dedup) {
-    lines.push(`${ind}if (${dedupGuard(t.ordinal)}) ${write}`)
+  const doorExpr = `__r[${writerIndex}]`
+  const write = rwDoor
+    ? `${doorExpr}.write('${t.slotId}', String(__x))`
+    : `${doorExpr}('${t.slotId}', String(__x))`
+  const guard = mode === 'create'
+    ? null
+    : mode === 'item'
+      ? dedupGuard(t.ordinal)
+      : `__seed ? (${doorExpr}.read('${t.slotId}') !== String(__x)) : (${dedupGuard(t.ordinal)})`
+  if (guard) {
+    lines.push(`${ind}if (${guard}) ${write}`)
   } else {
     lines.push(`${ind}${write}`)
   }

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -17,7 +17,10 @@ export const RUNTIME_IMPORT_CANDIDATES = [
   // Claim-plan interpreter (slot unification A2/A3, spec/slot-unification.md)
   // — the "one claim mechanism" that replaced `patchSlotRange` and
   // `updateClientMarker` (both deleted) as the content-slot update door.
-  'claimSlots', 'lazySlots',
+  // `lazyClaimSlots` is the read-capable twin of `lazySlots` over the same
+  // claim — emitted only by lazy loops that seed an outer-involving TEXT
+  // binding by read-compare-write (§9.3(1)).
+  'claimSlots', 'lazySlots', 'lazyClaimSlots',
   // Profile mode (#1690, SR3) — turn-boundary markers around event handlers.
   'beginTurn', 'endTurn',
   // Catalogued `Date` lowering (#2274/#2292) — the client counterpart to

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 282,
+    "totalFixtures": 283,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 67,
+      "total": 68,
       "cells": {
         "hono": {
-          "pass": 67,
-          "total": 67
+          "pass": 68,
+          "total": 68
         },
         "blade": {
-          "pass": 55,
-          "total": 67,
+          "pass": 56,
+          "total": 68,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 56,
-          "total": 67,
+          "pass": 57,
+          "total": 68,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 55,
-          "total": 67,
+          "pass": 56,
+          "total": 68,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -189,8 +189,8 @@
           ]
         },
         "jinja": {
-          "pass": 55,
-          "total": 67,
+          "pass": 56,
+          "total": 68,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -247,8 +247,8 @@
           ]
         },
         "minijinja": {
-          "pass": 55,
-          "total": 67,
+          "pass": 56,
+          "total": 68,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -305,8 +305,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 56,
-          "total": 67,
+          "pass": 57,
+          "total": 68,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -357,8 +357,8 @@
           ]
         },
         "twig": {
-          "pass": 55,
-          "total": 67,
+          "pass": 56,
+          "total": 68,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -415,8 +415,8 @@
           ]
         },
         "xslate": {
-          "pass": 55,
-          "total": 67,
+          "pass": 56,
+          "total": 68,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1026,15 +1026,15 @@
       }
     },
     "binary": {
-      "total": 76,
+      "total": 77,
       "cells": {
         "hono": {
-          "pass": 76,
-          "total": 76
+          "pass": 77,
+          "total": 77
         },
         "blade": {
-          "pass": 67,
-          "total": 76,
+          "pass": 68,
+          "total": 77,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1081,8 +1081,8 @@
           ]
         },
         "erb": {
-          "pass": 68,
-          "total": 76,
+          "pass": 69,
+          "total": 77,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1123,8 +1123,8 @@
           ]
         },
         "go-template": {
-          "pass": 67,
-          "total": 76,
+          "pass": 68,
+          "total": 77,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1171,8 +1171,8 @@
           ]
         },
         "jinja": {
-          "pass": 67,
-          "total": 76,
+          "pass": 68,
+          "total": 77,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1219,8 +1219,8 @@
           ]
         },
         "minijinja": {
-          "pass": 67,
-          "total": 76,
+          "pass": 68,
+          "total": 77,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1267,8 +1267,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 68,
-          "total": 76,
+          "pass": 69,
+          "total": 77,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1309,8 +1309,8 @@
           ]
         },
         "twig": {
-          "pass": 67,
-          "total": 76,
+          "pass": 68,
+          "total": 77,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1357,8 +1357,8 @@
           ]
         },
         "xslate": {
-          "pass": 67,
-          "total": 76,
+          "pass": 68,
+          "total": 77,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 177,
+      "total": 178,
       "cells": {
         "hono": {
-          "pass": 176,
-          "total": 177,
+          "pass": 177,
+          "total": 178,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1433,8 +1433,8 @@
           ]
         },
         "blade": {
-          "pass": 162,
-          "total": 177,
+          "pass": 163,
+          "total": 178,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1509,8 +1509,8 @@
           ]
         },
         "erb": {
-          "pass": 163,
-          "total": 177,
+          "pass": 164,
+          "total": 178,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1579,8 +1579,8 @@
           ]
         },
         "go-template": {
-          "pass": 162,
-          "total": 177,
+          "pass": 163,
+          "total": 178,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1655,8 +1655,8 @@
           ]
         },
         "jinja": {
-          "pass": 162,
-          "total": 177,
+          "pass": 163,
+          "total": 178,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1731,8 +1731,8 @@
           ]
         },
         "minijinja": {
-          "pass": 162,
-          "total": 177,
+          "pass": 163,
+          "total": 178,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1807,8 +1807,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 163,
-          "total": 177,
+          "pass": 164,
+          "total": 178,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1877,8 +1877,8 @@
           ]
         },
         "twig": {
-          "pass": 162,
-          "total": 177,
+          "pass": 163,
+          "total": 178,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1953,8 +1953,8 @@
           ]
         },
         "xslate": {
-          "pass": 162,
-          "total": 177,
+          "pass": 163,
+          "total": 178,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2042,15 +2042,15 @@
       }
     },
     "conditional": {
-      "total": 21,
+      "total": 22,
       "cells": {
         "hono": {
-          "pass": 21,
-          "total": 21
+          "pass": 22,
+          "total": 22
         },
         "blade": {
-          "pass": 19,
-          "total": 21,
+          "pass": 20,
+          "total": 22,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2063,8 +2063,8 @@
           ]
         },
         "erb": {
-          "pass": 19,
-          "total": 21,
+          "pass": 20,
+          "total": 22,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2077,8 +2077,8 @@
           ]
         },
         "go-template": {
-          "pass": 19,
-          "total": 21,
+          "pass": 20,
+          "total": 22,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2091,8 +2091,8 @@
           ]
         },
         "jinja": {
-          "pass": 19,
-          "total": 21,
+          "pass": 20,
+          "total": 22,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2105,8 +2105,8 @@
           ]
         },
         "minijinja": {
-          "pass": 19,
-          "total": 21,
+          "pass": 20,
+          "total": 22,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2119,8 +2119,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 19,
-          "total": 21,
+          "pass": 20,
+          "total": 22,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2133,8 +2133,8 @@
           ]
         },
         "twig": {
-          "pass": 19,
-          "total": 21,
+          "pass": 20,
+          "total": 22,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2147,8 +2147,8 @@
           ]
         },
         "xslate": {
-          "pass": 19,
-          "total": 21,
+          "pass": 20,
+          "total": 22,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2174,11 +2174,11 @@
       }
     },
     "identifier": {
-      "total": 263,
+      "total": 264,
       "cells": {
         "hono": {
-          "pass": 262,
-          "total": 263,
+          "pass": 263,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2189,8 +2189,8 @@
           ]
         },
         "blade": {
-          "pass": 245,
-          "total": 263,
+          "pass": 246,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2277,8 +2277,8 @@
           ]
         },
         "erb": {
-          "pass": 246,
-          "total": 263,
+          "pass": 247,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2359,8 +2359,8 @@
           ]
         },
         "go-template": {
-          "pass": 245,
-          "total": 263,
+          "pass": 246,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2447,8 +2447,8 @@
           ]
         },
         "jinja": {
-          "pass": 245,
-          "total": 263,
+          "pass": 246,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2535,8 +2535,8 @@
           ]
         },
         "minijinja": {
-          "pass": 245,
-          "total": 263,
+          "pass": 246,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2623,8 +2623,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 246,
-          "total": 263,
+          "pass": 247,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2705,8 +2705,8 @@
           ]
         },
         "twig": {
-          "pass": 245,
-          "total": 263,
+          "pass": 246,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2793,8 +2793,8 @@
           ]
         },
         "xslate": {
-          "pass": 245,
-          "total": 263,
+          "pass": 246,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2946,15 +2946,15 @@
       }
     },
     "literal": {
-      "total": 217,
+      "total": 218,
       "cells": {
         "hono": {
-          "pass": 217,
-          "total": 217
+          "pass": 218,
+          "total": 218
         },
         "blade": {
-          "pass": 206,
-          "total": 217,
+          "pass": 207,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3005,8 +3005,8 @@
           ]
         },
         "erb": {
-          "pass": 206,
-          "total": 217,
+          "pass": 207,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3057,8 +3057,8 @@
           ]
         },
         "go-template": {
-          "pass": 206,
-          "total": 217,
+          "pass": 207,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3109,8 +3109,8 @@
           ]
         },
         "jinja": {
-          "pass": 206,
-          "total": 217,
+          "pass": 207,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3161,8 +3161,8 @@
           ]
         },
         "minijinja": {
-          "pass": 206,
-          "total": 217,
+          "pass": 207,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3213,8 +3213,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 206,
-          "total": 217,
+          "pass": 207,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3265,8 +3265,8 @@
           ]
         },
         "twig": {
-          "pass": 206,
-          "total": 217,
+          "pass": 207,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3317,8 +3317,8 @@
           ]
         },
         "xslate": {
-          "pass": 206,
-          "total": 217,
+          "pass": 207,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3530,11 +3530,11 @@
       }
     },
     "member": {
-      "total": 142,
+      "total": 143,
       "cells": {
         "hono": {
-          "pass": 141,
-          "total": 142,
+          "pass": 142,
+          "total": 143,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3545,8 +3545,8 @@
           ]
         },
         "blade": {
-          "pass": 124,
-          "total": 142,
+          "pass": 125,
+          "total": 143,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3633,8 +3633,8 @@
           ]
         },
         "erb": {
-          "pass": 125,
-          "total": 142,
+          "pass": 126,
+          "total": 143,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3715,8 +3715,8 @@
           ]
         },
         "go-template": {
-          "pass": 124,
-          "total": 142,
+          "pass": 125,
+          "total": 143,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3803,8 +3803,8 @@
           ]
         },
         "jinja": {
-          "pass": 124,
-          "total": 142,
+          "pass": 125,
+          "total": 143,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3891,8 +3891,8 @@
           ]
         },
         "minijinja": {
-          "pass": 124,
-          "total": 142,
+          "pass": 125,
+          "total": 143,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3979,8 +3979,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 125,
-          "total": 142,
+          "pass": 126,
+          "total": 143,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4061,8 +4061,8 @@
           ]
         },
         "twig": {
-          "pass": 124,
-          "total": 142,
+          "pass": 125,
+          "total": 143,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4149,8 +4149,8 @@
           ]
         },
         "xslate": {
-          "pass": 124,
-          "total": 142,
+          "pass": 125,
+          "total": 143,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4250,15 +4250,15 @@
       }
     },
     "object-literal": {
-      "total": 49,
+      "total": 50,
       "cells": {
         "hono": {
-          "pass": 49,
-          "total": 49
+          "pass": 50,
+          "total": 50
         },
         "blade": {
-          "pass": 47,
-          "total": 49,
+          "pass": 48,
+          "total": 50,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4273,8 +4273,8 @@
           ]
         },
         "erb": {
-          "pass": 47,
-          "total": 49,
+          "pass": 48,
+          "total": 50,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4289,8 +4289,8 @@
           ]
         },
         "go-template": {
-          "pass": 47,
-          "total": 49,
+          "pass": 48,
+          "total": 50,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4305,8 +4305,8 @@
           ]
         },
         "jinja": {
-          "pass": 47,
-          "total": 49,
+          "pass": 48,
+          "total": 50,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4321,8 +4321,8 @@
           ]
         },
         "minijinja": {
-          "pass": 47,
-          "total": 49,
+          "pass": 48,
+          "total": 50,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4337,8 +4337,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 47,
-          "total": 49,
+          "pass": 48,
+          "total": 50,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4353,8 +4353,8 @@
           ]
         },
         "twig": {
-          "pass": 47,
-          "total": 49,
+          "pass": 48,
+          "total": 50,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4369,8 +4369,8 @@
           ]
         },
         "xslate": {
-          "pass": 47,
-          "total": 49,
+          "pass": 48,
+          "total": 50,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -6900,15 +6900,15 @@
       }
     },
     "binary:===": {
-      "total": 39,
+      "total": 40,
       "cells": {
         "hono": {
-          "pass": 39,
-          "total": 39
+          "pass": 40,
+          "total": 40
         },
         "blade": {
-          "pass": 31,
-          "total": 39,
+          "pass": 32,
+          "total": 40,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6949,8 +6949,8 @@
           ]
         },
         "erb": {
-          "pass": 32,
-          "total": 39,
+          "pass": 33,
+          "total": 40,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6985,8 +6985,8 @@
           ]
         },
         "go-template": {
-          "pass": 31,
-          "total": 39,
+          "pass": 32,
+          "total": 40,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7027,8 +7027,8 @@
           ]
         },
         "jinja": {
-          "pass": 31,
-          "total": 39,
+          "pass": 32,
+          "total": 40,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7069,8 +7069,8 @@
           ]
         },
         "minijinja": {
-          "pass": 31,
-          "total": 39,
+          "pass": 32,
+          "total": 40,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7111,8 +7111,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 32,
-          "total": 39,
+          "pass": 33,
+          "total": 40,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7147,8 +7147,8 @@
           ]
         },
         "twig": {
-          "pass": 31,
-          "total": 39,
+          "pass": 32,
+          "total": 40,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7189,8 +7189,8 @@
           ]
         },
         "xslate": {
-          "pass": 31,
-          "total": 39,
+          "pass": 32,
+          "total": 40,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7499,15 +7499,15 @@
       }
     },
     "literal:number": {
-      "total": 93,
+      "total": 94,
       "cells": {
         "hono": {
-          "pass": 93,
-          "total": 93
+          "pass": 94,
+          "total": 94
         },
         "blade": {
-          "pass": 88,
-          "total": 93,
+          "pass": 89,
+          "total": 94,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7532,8 +7532,8 @@
           ]
         },
         "erb": {
-          "pass": 88,
-          "total": 93,
+          "pass": 89,
+          "total": 94,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7558,8 +7558,8 @@
           ]
         },
         "go-template": {
-          "pass": 88,
-          "total": 93,
+          "pass": 89,
+          "total": 94,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7584,8 +7584,8 @@
           ]
         },
         "jinja": {
-          "pass": 88,
-          "total": 93,
+          "pass": 89,
+          "total": 94,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7610,8 +7610,8 @@
           ]
         },
         "minijinja": {
-          "pass": 88,
-          "total": 93,
+          "pass": 89,
+          "total": 94,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7636,8 +7636,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 88,
-          "total": 93,
+          "pass": 89,
+          "total": 94,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7662,8 +7662,8 @@
           ]
         },
         "twig": {
-          "pass": 88,
-          "total": 93,
+          "pass": 89,
+          "total": 94,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7688,8 +7688,8 @@
           ]
         },
         "xslate": {
-          "pass": 88,
-          "total": 93,
+          "pass": 89,
+          "total": 94,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7727,15 +7727,15 @@
       }
     },
     "literal:string": {
-      "total": 157,
+      "total": 158,
       "cells": {
         "hono": {
-          "pass": 157,
-          "total": 157
+          "pass": 158,
+          "total": 158
         },
         "blade": {
-          "pass": 149,
-          "total": 157,
+          "pass": 150,
+          "total": 158,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7774,8 +7774,8 @@
           ]
         },
         "erb": {
-          "pass": 149,
-          "total": 157,
+          "pass": 150,
+          "total": 158,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7814,8 +7814,8 @@
           ]
         },
         "go-template": {
-          "pass": 149,
-          "total": 157,
+          "pass": 150,
+          "total": 158,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7854,8 +7854,8 @@
           ]
         },
         "jinja": {
-          "pass": 149,
-          "total": 157,
+          "pass": 150,
+          "total": 158,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7894,8 +7894,8 @@
           ]
         },
         "minijinja": {
-          "pass": 149,
-          "total": 157,
+          "pass": 150,
+          "total": 158,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7934,8 +7934,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 149,
-          "total": 157,
+          "pass": 150,
+          "total": 158,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7974,8 +7974,8 @@
           ]
         },
         "twig": {
-          "pass": 149,
-          "total": 157,
+          "pass": 150,
+          "total": 158,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8014,8 +8014,8 @@
           ]
         },
         "xslate": {
-          "pass": 149,
-          "total": 157,
+          "pass": 150,
+          "total": 158,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",


### PR DESCRIPTION
Compiler half of lifting spec §9.5c(1). The runtime half (non-mutating text claim + the `lazyClaimSlots` read door) merged in #2411; this makes the eligibility gate actually use it, so a lazy loop row may now carry a text binding that reads outer signals.

## Changes

- **Gate**: the "content slots have no DOM read-back" refusal is deleted. Everything else about §9.4 is unchanged.
- **Door choice, per loop, at compile time**: if any of a loop's text bindings is outer-involving, `refParts` emits `lazyClaimSlots(...)` and text writes become `.write(...)`; otherwise the loop keeps `lazySlots(...)` and the bare call form **byte-for-byte**. The door is allocated once per ROW, so this is deliberately never a per-binding decision — the same per-row-cost discipline that #2411 had to recover 161KB for.
- **Text seed**: a real `if (__seed) { … } else if (<dedup>) …` branch, so the seed path binds `String(__x)` once and reuses it for both the compare and the write (no double `toString`), while the non-seed path still builds the string only when it actually writes. `read()` returns `null` when it cannot answer and `null !== <string>` is true, so unknown fails safe into "write it" by construction.

## What this actually widens (verified by compiling each shape)

| Row expression | Before | After |
|---|---|---|
| `{prefix() + row.label}` | eager | **lazy** (RW door + seed) |
| `` {`${prefix()}${row.label}`} `` | eager | **lazy** (RW door + seed) |
| `{String(selected() === row.id ? 'YES' : 'NO')}` | eager | **lazy** (RW door + seed) |
| `{selected() === row.id ? 'YES' : 'NO'}` | eager | **still eager** |
| `{row.label}` (item-only) | lazy | lazy, **unchanged door** |

The bare ternary in child position stays eager because it lowers to a reactive **conditional** (`insert()`), which §9.4 refuses separately — not a text binding at all. Worth knowing before reading this as "all outer-involving row text is now lazy": concatenations, template literals and explicit `String(...)` are covered; a bare `cond ? a : b` is a different §9.4 restriction.

## Verification

`packages/jsx` **2802 tests, 0 fail** (independently re-run) · `adapter-tests` 1451/0 · `adapter-hono` 1266/0 · fixture-hydrate 34/34 in real Chromium after a client dist rebuild · site/ui e2e 1124 pass with only the 3 known pre-existing reds · `map-body-no-silent-divergence` green, `KNOWN_HOLES` still empty.

**Zero snapshot diffs and zero SSR golden changes** — the shapes this widens were previously ineligible, so no existing golden covered one, and the attr-only pin proves the existing lazy path is byte-identical.

**Memory** (the failure mode this kind of change causes): DOM 1769.0KB on this branch vs ~1768–1773KB on main across recent runs; SSR post-hydration heap 1812.4 vs 1811.2KB. Both flat, as expected — the bench apps' loops are attr-only or gate-ineligible, so neither takes the new door. That is the door-selection rule doing its job.

One CSR conformance fixture lands here per the same-PR coupling rule. Both lock files move by counters only: `ui/compat.lock.json` `totalFixtures` 282 → 283, and `ui/support-matrix.lock.json` totals/passes +1 per adapter (regenerated in a follow-up commit after building every adapter dist — an earlier attempt ran against stale dists and wrongly reported no diff). Zero gap or divergence entries added in either, i.e. all nine adapters render the new fixture to reference parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM