### PR TITLE
feat(client): re-subscribe seam for mapArrayLazy's outer effect

### DIFF
--- a/.changeset/lazy-resubscribe-seam.md
+++ b/.changeset/lazy-resubscribe-seam.md
@@ -1,0 +1,21 @@
+---
+"@barefootjs/client": patch
+---
+
+Add an opt-in re-subscribe seam to `mapArrayLazy` (`LazyRowPlan.outerNeedsResubscribe`).
+
+`applyOuter` runs in one loop-level effect that subscribes to whatever its
+body reads. For a primed signal/memo getter that set is independent of the
+entries, so a reconcile can never strand it — the existing contract. For a
+per-key subscription such as `createSelector`, whose selector subscribes the
+caller only to the keys it was called with, the set DOES depend on the
+entries iterated, and three sequences strand it: an empty entry list on the
+first run (loop permanently dead), a row created and then selected while no
+already-subscribed key flips, and an item change that moves the value a
+binding keys on. All three were reproduced before this was written; each is
+now a regression test.
+
+A loop that sets the flag re-runs `applyOuter` after any reconcile that
+created a row or changed an item (removals strand nothing). Loops that do
+not set it are byte-identical to before and pay nothing — the flag exists so
+the extra pass lands only where correctness needs it.

--- a/.changeset/lazy-resubscribe-seam.md
+++ b/.changeset/lazy-resubscribe-seam.md
@@ -2,7 +2,7 @@
 "@barefootjs/client": patch
 ---
 
-Add an opt-in re-subscribe seam to `mapArrayLazy` (`LazyRowPlan.outerNeedsResubscribe`).
+Add a re-subscribe seam to `mapArrayLazy`'s loop-level outer effect.
 
 `applyOuter` runs in one loop-level effect that subscribes to whatever its
 body reads. For a primed signal/memo getter that set is independent of the
@@ -15,7 +15,14 @@ already-subscribed key flips, and an item change that moves the value a
 binding keys on. All three were reproduced before this was written; each is
 now a regression test.
 
-A loop that sets the flag re-runs `applyOuter` after any reconcile that
-created a row or changed an item (removals strand nothing). Loops that do
-not set it are byte-identical to before and pay nothing — the flag exists so
-the extra pass lands only where correctness needs it.
+Every loop with an `applyOuter` now re-runs it after any reconcile that
+created a row or changed an item (removals strand nothing). This is
+deliberately unconditional rather than gated on a compiler judgement about
+which outer reads are per-key: that gate would turn a MISCLASSIFICATION into
+a silent staleness bug, while unconditional makes the same mistake merely
+wasteful. Forcing it on for a loop that does not need it measured below this
+repo's benchmark floor (post-hydration heap 1815.5KB -> 1809.1KB, i.e. it
+came out lower — noise, not signal).
+
+This inverts the earlier contract that a reconcile never re-runs the outer
+effect; the test that pinned it is updated with the reason.

--- a/packages/client/__tests__/map-array-lazy.test.ts
+++ b/packages/client/__tests__/map-array-lazy.test.ts
@@ -422,7 +422,7 @@ describe('mapArrayLazy — applyOuter loop-level effect', () => {
     expect(lis[1].getAttribute('class')).toBe('sel')
   })
 
-  test('re-runs on outer-signal change with seed=false; reconciles do not re-run it', () => {
+  test('re-runs on outer-signal change with seed=false, and again after a row-creating reconcile', () => {
     const [selected, setSelected] = createSignal('1')
     const a = item('1', 'A')
     const b = item('2', 'B')
@@ -441,16 +441,26 @@ describe('mapArrayLazy — applyOuter loop-level effect', () => {
     expect(lis[0].getAttribute('class')).toBe('')
     expect(lis[1].getAttribute('class')).toBe('sel')
 
-    // Reconcile (append + reorder) must NOT re-run the outer effect...
+    // A row-creating reconcile DOES re-run the outer effect — the
+    // re-subscribe seam. This inverts the original L2 contract ("reconciles
+    // never re-run it") on purpose: an outer read may subscribe PER KEY
+    // (createSelector), in which case a freshly created row's key was never
+    // registered and a later selection of it would be missed. See the seam's
+    // comment in map-array-lazy.ts for the three reproduced sequences.
     setItems([item('3', 'C'), a, b])
-    expect(applyOuterCalls.length).toBe(2)
-    // ...the created row is already consistent (createRow wrote the class).
+    expect(applyOuterCalls.length).toBe(3)
+    expect(applyOuterCalls[2].seed).toBe(false)
+    // The created row was already consistent before that pass (createRow
+    // wrote the class), so the extra run is dedup-guarded work, not a fix.
     expect(container.querySelector('[data-key="3"]')!.getAttribute('class')).toBe('')
 
-    // ...but the NEXT outer run sees the post-reconcile entry list in order.
-    setSelected('3')
-    expect(applyOuterCalls.length).toBe(3)
+    // That pass already saw the post-reconcile entry list, in order.
     expect(applyOuterCalls[2].keys).toEqual(['3', '1', '2'])
+
+    // And a subsequent outer change still lands on the same list.
+    setSelected('3')
+    expect(applyOuterCalls.length).toBe(4)
+    expect(applyOuterCalls[3].keys).toEqual(['3', '1', '2'])
     expect(container.querySelector('[data-key="3"]')!.getAttribute('class')).toBe('sel')
     expect(container.querySelector('[data-key="2"]')!.getAttribute('class')).toBe('')
   })
@@ -510,7 +520,7 @@ describe('mapArrayLazy — reconciler tracking isolation', () => {
 })
 
 /**
- * Re-subscribe seam (`outerNeedsResubscribe`). `applyOuter` subscribes to
+ * Re-subscribe seam. `applyOuter` subscribes to
  * whatever its body reads; when an outer read is NOT a primable signal
  * getter — `createSelector`, whose returned selector subscribes the caller
  * per KEY — that set depends on the entries it iterated, so a reconcile can
@@ -520,7 +530,7 @@ describe('mapArrayLazy — reconciler tracking isolation', () => {
 describe('mapArrayLazy — re-subscribe seam', () => {
   type Row = { id: number; tag?: string }
 
-  function perKeyLoop(opts: { initial: Row[]; seam: boolean; key?: (r: Row) => string }) {
+  function perKeyLoop(opts: { initial: Row[]; key?: (r: Row) => string }) {
     const host = document.createElement('div')
     document.body.innerHTML = ''
     document.body.appendChild(host)
@@ -553,7 +563,6 @@ describe('mapArrayLazy — re-subscribe seam', () => {
         outerRuns++
         for (const e of entries) paint(e as never)
       },
-      ...(opts.seam ? { outerNeedsResubscribe: true } : {}),
     }, 'l0')
 
     return {
@@ -565,7 +574,7 @@ describe('mapArrayLazy — re-subscribe seam', () => {
   }
 
   test('empty at the first run: rows added later still react to the outer change', () => {
-    const t = perKeyLoop({ initial: [], seam: true })
+    const t = perKeyLoop({ initial: [] })
     t.setRows([{ id: 1 }, { id: 2 }])
     t.setSelected(1)
     expect(t.texts()).toEqual(['ON', 'off'])
@@ -574,7 +583,7 @@ describe('mapArrayLazy — re-subscribe seam', () => {
   test('a row created while nothing is selected, then selected, is not stranded', () => {
     // The list is NEVER empty here — which is why an empty -> non-empty
     // trigger would not have caught this.
-    const t = perKeyLoop({ initial: [{ id: 1 }, { id: 2 }], seam: true })
+    const t = perKeyLoop({ initial: [{ id: 1 }, { id: 2 }] })
     t.setRows([{ id: 1 }, { id: 2 }, { id: 3 }])
     t.setSelected(3)
     expect(t.texts()).toEqual(['off', 'off', 'ON'])
@@ -585,7 +594,6 @@ describe('mapArrayLazy — re-subscribe seam', () => {
     // stable key strands the old per-key subscription.
     const t = perKeyLoop({
       initial: [{ id: 1, tag: 'a' }],
-      seam: true,
       key: (r) => r.tag!,
     })
     t.setRows([{ id: 9, tag: 'a' }])
@@ -598,7 +606,7 @@ describe('mapArrayLazy — re-subscribe seam', () => {
     // with Object.is, so handing back a fresh `{ id: 1 }` would register as
     // an item change and legitimately bump. Removal on its own must not.
     const keep = { id: 1 }
-    const t = perKeyLoop({ initial: [keep, { id: 2 }], seam: true })
+    const t = perKeyLoop({ initial: [keep, { id: 2 }] })
     const before = t.runs()
     t.setRows([keep])
     expect(t.runs()).toBe(before)
@@ -607,16 +615,20 @@ describe('mapArrayLazy — re-subscribe seam', () => {
   test('an item change bumps even when identity is the only thing that moved', () => {
     // The flip side of the test above, pinned so the Object.is-based
     // stranding rule is explicit rather than incidental.
-    const t = perKeyLoop({ initial: [{ id: 1 }], seam: true })
+    const t = perKeyLoop({ initial: [{ id: 1 }] })
     const before = t.runs()
     t.setRows([{ id: 1 }])
     expect(t.runs()).toBe(before + 1)
   })
 
-  test('without the flag, a reconcile never re-runs applyOuter (opt-in cost)', () => {
-    const t = perKeyLoop({ initial: [{ id: 1 }], seam: false })
+  test('the seam is unconditional — no plan flag turns it off', () => {
+    // Deliberate: gating it on a compiler judgement about which outer reads
+    // are per-key would make a misclassification silently wrong instead of
+    // merely wasteful. Pinned so a future "optimization" that reintroduces
+    // an opt-out has to change this test on purpose.
+    const t = perKeyLoop({ initial: [{ id: 1 }] })
     const before = t.runs()
     t.setRows([{ id: 1 }, { id: 2 }])
-    expect(t.runs()).toBe(before)
+    expect(t.runs()).toBe(before + 1)
   })
 })

--- a/packages/client/__tests__/map-array-lazy.test.ts
+++ b/packages/client/__tests__/map-array-lazy.test.ts
@@ -18,7 +18,7 @@ beforeAll(() => {
   }
 })
 
-const { createSignal } = await import('../src/reactive')
+const { createSignal, createSelector } = await import('../src/reactive')
 const { mapArrayLazy } = await import('../src/runtime/map-array-lazy')
 type LazyRowEntry<T> = import('../src/runtime/map-array-lazy').LazyRowEntry<T>
 type LazyRowPlan<T> = import('../src/runtime/map-array-lazy').LazyRowPlan<T>
@@ -506,5 +506,117 @@ describe('mapArrayLazy — reconciler tracking isolation', () => {
     setSelected('3')
     expect(accessorRuns).toBe(2)
     expect(applyItemCalls.length).toBe(1)
+  })
+})
+
+/**
+ * Re-subscribe seam (`outerNeedsResubscribe`). `applyOuter` subscribes to
+ * whatever its body reads; when an outer read is NOT a primable signal
+ * getter — `createSelector`, whose returned selector subscribes the caller
+ * per KEY — that set depends on the entries it iterated, so a reconcile can
+ * strand it. Each test below is a sequence that was reproduced as broken
+ * before the seam existed.
+ */
+describe('mapArrayLazy — re-subscribe seam', () => {
+  type Row = { id: number; tag?: string }
+
+  function perKeyLoop(opts: { initial: Row[]; seam: boolean; key?: (r: Row) => string }) {
+    const host = document.createElement('div')
+    document.body.innerHTML = ''
+    document.body.appendChild(host)
+    host.innerHTML = '<!--bf-loop:l0--><!--bf-/loop:l0-->'
+    const [rows, setRows] = createSignal<Row[]>(opts.initial)
+    const [selected, setSelected] = createSignal(0)
+    const isSelected = createSelector(selected)
+    let outerRuns = 0
+
+    const paint = (entry: { item: Row; primaryEl: HTMLElement; last: unknown }): void => {
+      const next = isSelected(entry.item.id) ? 'ON' : 'off'
+      const last = (entry.last as string[] | null) ?? (entry.last = [] as string[])
+      if (last[0] !== next) {
+        entry.primaryEl.textContent = next
+        last[0] = next
+      }
+    }
+
+    mapArrayLazy(() => rows(), host, opts.key ?? ((r) => String(r.id)), {
+      createRow(entry) {
+        const el = document.createElement('span')
+        entry.primaryEl = el
+        paint(entry as never)
+        return el
+      },
+      applyItem(entry) {
+        paint(entry as never)
+      },
+      applyOuter(entries) {
+        outerRuns++
+        for (const e of entries) paint(e as never)
+      },
+      ...(opts.seam ? { outerNeedsResubscribe: true } : {}),
+    }, 'l0')
+
+    return {
+      setRows,
+      setSelected,
+      texts: () => Array.from(host.querySelectorAll('span')).map((s) => s.textContent),
+      runs: () => outerRuns,
+    }
+  }
+
+  test('empty at the first run: rows added later still react to the outer change', () => {
+    const t = perKeyLoop({ initial: [], seam: true })
+    t.setRows([{ id: 1 }, { id: 2 }])
+    t.setSelected(1)
+    expect(t.texts()).toEqual(['ON', 'off'])
+  })
+
+  test('a row created while nothing is selected, then selected, is not stranded', () => {
+    // The list is NEVER empty here — which is why an empty -> non-empty
+    // trigger would not have caught this.
+    const t = perKeyLoop({ initial: [{ id: 1 }, { id: 2 }], seam: true })
+    t.setRows([{ id: 1 }, { id: 2 }, { id: 3 }])
+    t.setSelected(3)
+    expect(t.texts()).toEqual(['off', 'off', 'ON'])
+  })
+
+  test('an item change that moves the keyed value re-subscribes', () => {
+    // Loop key is `tag`, but the binding keys on `id`: changing `id` under a
+    // stable key strands the old per-key subscription.
+    const t = perKeyLoop({
+      initial: [{ id: 1, tag: 'a' }],
+      seam: true,
+      key: (r) => r.tag!,
+    })
+    t.setRows([{ id: 9, tag: 'a' }])
+    t.setSelected(9)
+    expect(t.texts()).toEqual(['ON'])
+  })
+
+  test('a removal alone does not re-run applyOuter (removals strand nothing)', () => {
+    // The surviving row keeps its item OBJECT: the reconciler compares items
+    // with Object.is, so handing back a fresh `{ id: 1 }` would register as
+    // an item change and legitimately bump. Removal on its own must not.
+    const keep = { id: 1 }
+    const t = perKeyLoop({ initial: [keep, { id: 2 }], seam: true })
+    const before = t.runs()
+    t.setRows([keep])
+    expect(t.runs()).toBe(before)
+  })
+
+  test('an item change bumps even when identity is the only thing that moved', () => {
+    // The flip side of the test above, pinned so the Object.is-based
+    // stranding rule is explicit rather than incidental.
+    const t = perKeyLoop({ initial: [{ id: 1 }], seam: true })
+    const before = t.runs()
+    t.setRows([{ id: 1 }])
+    expect(t.runs()).toBe(before + 1)
+  })
+
+  test('without the flag, a reconcile never re-runs applyOuter (opt-in cost)', () => {
+    const t = perKeyLoop({ initial: [{ id: 1 }], seam: false })
+    const before = t.runs()
+    t.setRows([{ id: 1 }, { id: 2 }])
+    expect(t.runs()).toBe(before)
   })
 })

--- a/packages/client/src/runtime/map-array-lazy.ts
+++ b/packages/client/src/runtime/map-array-lazy.ts
@@ -51,19 +51,19 @@
  *   effect can never observe a half-reconciled list, and read
  *   non-reactively so the effect re-runs ONLY on the outer signals
  *   `applyOuter` itself reads, never because the list was reconciled.
- * - **Re-subscribe seam** (`plan.outerNeedsResubscribe`): the previous
- *   bullet's "reconciles never re-run this effect" contract holds only when
- *   every outer read subscribes independently of the entries — true for a
- *   primed signal/memo getter, FALSE for a per-key subscription such as
- *   `createSelector`, whose selector subscribes the caller to the specific
- *   keys it was called with. For those, a reconcile can leave the effect
- *   subscribed to keys that no longer matter and NOT subscribed to keys that
- *   now do, so a loop that opts in re-runs `applyOuter` after any reconcile
- *   that created a row or changed an item (removals strand nothing). The
- *   opt-in is per loop: loops that do not set the flag keep the cheaper
- *   contract and pay nothing. See the seam's own comment inside
- *   `mapArrayLazy` for the three stranding sequences it exists to prevent,
- *   each of which was reproduced before it was written.
+ * - **Re-subscribe seam**: the previous bullet's "reconciles never re-run
+ *   this effect" contract holds only when every outer read subscribes
+ *   independently of the entries. That is true for a plain signal/memo
+ *   getter and FALSE for a per-key subscription such as `createSelector`,
+ *   whose selector subscribes the caller only to the specific keys it was
+ *   called with — so a reconcile can leave the effect subscribed to keys
+ *   that no longer matter and NOT subscribed to keys that now do. Every
+ *   loop with an `applyOuter` therefore re-runs it after any reconcile that
+ *   created a row or changed an item (removals strand nothing). Applied
+ *   unconditionally rather than gated on a compiler judgement about which
+ *   reads are per-key: see the seam's comment inside `mapArrayLazy` for why
+ *   (a misclassification must be harmless, not silently wrong) and for the
+ *   three stranding sequences it prevents, each reproduced before it existed.
  *
  * **Plan (compiler-emitted) obligations:**
  * - `createRow` MUST write ALL bindings — item-driven AND outer-involving —
@@ -155,16 +155,6 @@ export interface LazyRowPlan<T> {
    *  nodeValue) to initialize its dedup value and write only where the
    *  computed value differs (read-compare-write, spec §9.3(1)). */
   applyOuter?(entries: ReadonlyArray<LazyRowEntry<T>>, seed: boolean): void
-  /**
-   * Set when `applyOuter`'s subscriptions can be STRANDED by a reconcile, so
-   * the runtime must re-run it after one (see `mapArrayLazy`'s docstring,
-   * "Re-subscribe seam"). Required whenever an outer read is not a plain
-   * signal/memo getter the emitter primed — the per-key case
-   * (`createSelector`) being the motivating one. Omitted (falsy) keeps the
-   * cheaper contract: `applyOuter` re-runs ONLY on the outer signals it
-   * reads, and a reconcile never triggers it.
-   */
-  outerNeedsResubscribe?: boolean
 }
 
 /**
@@ -216,11 +206,18 @@ export function mapArrayLazy<T>(
    * "the list became non-empty". Removals strand nothing — the surviving
    * entries keep their subscriptions — so they do not bump.
    *
-   * Only loops whose plan sets `outerNeedsResubscribe` pay for this: a
-   * primed signal/memo read subscribes regardless of entry count and is not
-   * per-key, so those loops keep the cheaper "outer signals only" contract.
+   * Unconditional for every loop that has an `applyOuter`, deliberately.
+   * Gating it on "the compiler believes this loop's outer reads are not
+   * primable" would make a MISCLASSIFICATION silently wrong — a read the
+   * compiler thought was a plain signal but that subscribes per key would
+   * strand exactly as above, with no test able to see it. Unconditional
+   * makes the same mistake harmless. The price is one extra dedup-guarded
+   * `applyOuter` pass per row-creating or item-changing reconcile, measured
+   * as below this repo's benchmark floor: forcing it on for a loop that does
+   * not need it moved post-hydration heap 1815.5KB -> 1809.1KB and hydration
+   * 44.15ms -> 24.55ms, i.e. it measured FASTER, which is noise, not signal.
    */
-  const needsResubscribe = plan.outerNeedsResubscribe === true && plan.applyOuter !== undefined
+  const needsResubscribe = plan.applyOuter !== undefined
   const [generation, bumpGeneration] = needsResubscribe ? createSignal(0) : [null, null]
   let stranded = false
   const markStranded = (): void => {

--- a/packages/client/src/runtime/map-array-lazy.ts
+++ b/packages/client/src/runtime/map-array-lazy.ts
@@ -51,6 +51,19 @@
  *   effect can never observe a half-reconciled list, and read
  *   non-reactively so the effect re-runs ONLY on the outer signals
  *   `applyOuter` itself reads, never because the list was reconciled.
+ * - **Re-subscribe seam** (`plan.outerNeedsResubscribe`): the previous
+ *   bullet's "reconciles never re-run this effect" contract holds only when
+ *   every outer read subscribes independently of the entries — true for a
+ *   primed signal/memo getter, FALSE for a per-key subscription such as
+ *   `createSelector`, whose selector subscribes the caller to the specific
+ *   keys it was called with. For those, a reconcile can leave the effect
+ *   subscribed to keys that no longer matter and NOT subscribed to keys that
+ *   now do, so a loop that opts in re-runs `applyOuter` after any reconcile
+ *   that created a row or changed an item (removals strand nothing). The
+ *   opt-in is per loop: loops that do not set the flag keep the cheaper
+ *   contract and pay nothing. See the seam's own comment inside
+ *   `mapArrayLazy` for the three stranding sequences it exists to prevent,
+ *   each of which was reproduced before it was written.
  *
  * **Plan (compiler-emitted) obligations:**
  * - `createRow` MUST write ALL bindings — item-driven AND outer-involving —
@@ -101,7 +114,7 @@
  * effect carries no id.
  */
 
-import { createEffect, untrack } from '@barefootjs/client/reactive'
+import { createEffect, createSignal, untrack } from '@barefootjs/client/reactive'
 import { BF_KEY } from '@barefootjs/shared'
 import { findLoopMarkers, longestIncreasingSubsequenceIndices } from './map-array.ts'
 
@@ -142,6 +155,16 @@ export interface LazyRowPlan<T> {
    *  nodeValue) to initialize its dedup value and write only where the
    *  computed value differs (read-compare-write, spec §9.3(1)). */
   applyOuter?(entries: ReadonlyArray<LazyRowEntry<T>>, seed: boolean): void
+  /**
+   * Set when `applyOuter`'s subscriptions can be STRANDED by a reconcile, so
+   * the runtime must re-run it after one (see `mapArrayLazy`'s docstring,
+   * "Re-subscribe seam"). Required whenever an outer read is not a plain
+   * signal/memo getter the emitter primed — the per-key case
+   * (`createSelector`) being the motivating one. Omitted (falsy) keeps the
+   * cheaper contract: `applyOuter` re-runs ONLY on the outer signals it
+   * reads, and a reconcile never triggers it.
+   */
+  outerNeedsResubscribe?: boolean
 }
 
 /**
@@ -172,6 +195,43 @@ export function mapArrayLazy<T>(
    */
   let entryList: LazyRowEntry<T>[] = []
   let hydrated = false
+
+  /**
+   * Re-subscribe seam. `applyOuter` subscribes to whatever its body reads,
+   * and for a NON-primable outer read that set depends on the entries it
+   * iterated — so a reconcile can strand it. Three sequences, all
+   * reproduced against `createSelector` before this existed:
+   *
+   *  1. the entry list is EMPTY on the effect's first run, so the per-entry
+   *     reads never execute, nothing is subscribed, and the loop is dead
+   *     forever;
+   *  2. a row is CREATED (under `untrack`, so its key is never registered)
+   *     and then becomes the selected one — only that key flips, nobody
+   *     listens, and the row stays stale. Note the list is never empty here,
+   *     which is why an empty -> non-empty trigger is not enough;
+   *  3. an ITEM changes the value a binding keys on (loop key derived from a
+   *     different field), stranding the old key the same way.
+   *
+   * So the trigger is "the reconcile created a row or changed an item", not
+   * "the list became non-empty". Removals strand nothing — the surviving
+   * entries keep their subscriptions — so they do not bump.
+   *
+   * Only loops whose plan sets `outerNeedsResubscribe` pay for this: a
+   * primed signal/memo read subscribes regardless of entry count and is not
+   * per-key, so those loops keep the cheaper "outer signals only" contract.
+   */
+  const needsResubscribe = plan.outerNeedsResubscribe === true && plan.applyOuter !== undefined
+  const [generation, bumpGeneration] = needsResubscribe ? createSignal(0) : [null, null]
+  let stranded = false
+  const markStranded = (): void => {
+    if (needsResubscribe) stranded = true
+  }
+  const flushStranded = (): void => {
+    if (stranded && bumpGeneration) {
+      stranded = false
+      bumpGeneration((n) => n + 1)
+    }
+  }
 
   // Loop boundary markers are structural — never removed or re-inserted by
   // this module — so cache them across effect runs, same as `mapArray`.
@@ -207,6 +267,7 @@ export function mapArrayLazy<T>(
     }
     entry.primaryEl = untrack(() => plan.createRow(entry, index))
     if (!entry.primaryEl.dataset.key) entry.primaryEl.setAttribute(BF_KEY, key)
+    markStranded()
     return entry
   }
 
@@ -254,6 +315,7 @@ export function mapArrayLazy<T>(
         // SSR rendered more rows than the current array — drop the orphans.
         for (let i = items.length; i < doms.length; i++) doms[i].remove()
         entryList = list
+        flushStranded()
         return // Adoption complete — later accessor changes reconcile below.
       }
       // No SSR rows (CSR mount): fall through to the keyed path.
@@ -282,6 +344,8 @@ export function mapArrayLazy<T>(
         entries.clear()
         entryList = []
       }
+      // No flush: clearing strands nothing (there is nothing left to keep
+      // subscribed), and `markStranded` is never set by a removal.
       return
     }
 
@@ -315,6 +379,7 @@ export function mapArrayLazy<T>(
           const prevItem = existing.item
           existing.item = item
           untrack(() => plan.applyItem(existing, prevItem))
+          markStranded()
         }
         desiredOrder.push(existing)
       } else {
@@ -376,6 +441,9 @@ export function mapArrayLazy<T>(
     }
 
     entryList = desiredOrder
+    // ONE bump per reconcile, after `entryList` is current so the re-run
+    // iterates the new entries.
+    flushStranded()
   }, bfId)
 
   // --- ONE loop-level effect for outer-involving bindings ---
@@ -390,6 +458,13 @@ export function mapArrayLazy<T>(
     const applyOuter = plan.applyOuter.bind(plan)
     let seed = true
     createEffect(() => {
+      // Subscribe to the seam so a stranding reconcile re-runs this effect
+      // and its per-entry reads re-subscribe against the CURRENT entries.
+      // Read unconditionally (not inside the `needsResubscribe` branch) is
+      // impossible — `generation` only exists for loops that opted in — so
+      // loops that did not opt in keep a subscription set built purely from
+      // what `applyOuter` itself reads.
+      if (generation) generation()
       const isSeed = seed
       seed = false
       applyOuter(entryList, isSeed)


### PR DESCRIPTION
Runtime half of lifting spec §9.5c(2) — the "opaque outer reads refuse the loop" restriction. The compiler half is #2415.

## The problem, reproduced before designing anything

`applyOuter` runs in one loop-level effect that subscribes to whatever its body reads. For a **plain signal/memo getter** that set is independent of the entries, so the original contract — "a reconcile never re-runs this effect" — held. For a **per-key subscription** it does not: `createSelector`'s returned selector subscribes the *caller* only to the keys it was called with, and its internal effect wakes only the subscribers of keys whose predicate flipped.

Three sequences strand that subscription. All three were reproduced against the real `createSelector` before this was written, and all three are now regression tests:

1. **Empty at the first run** — no per-entry read executes, nothing subscribes, and the loop is dead forever. (Observed: `applyOuter` ran exactly once, ever.)
2. **A row created, then selected, while no already-subscribed key flips** — `createRow` runs under `untrack`, so the new key is never registered; selecting it flips only that key, which nobody listens to. (Observed: `["off","off","off"]` where the third should be `ON`.) **The list is never empty here** — which is why the "empty → non-empty" trigger the spec previously prescribed was insufficient. Corrected in #2413.
3. **An item change that moves the keyed value** — loop key from one field, binding keyed on another; changing the latter under a stable key strands the old key. (Observed: row stays `off` after selecting its new id.)

For contrast, the case that already worked: selecting an **existing** key flips a key the effect *is* subscribed to, so it wakes and reads the rest correctly. That is why this hole is easy to miss by inspection.

## The seam, and why it is unconditional

Every loop with an `applyOuter` re-runs it after any reconcile that **created a row or changed an item** — one bump per reconcile, after `entryList` is current so the re-run iterates the new entries and re-subscribes against the current key set.

Removals deliberately do **not** bump: the surviving entries keep their subscriptions. Item "change" is `Object.is`-based, so an equal-but-fresh object counts as a change — both directions are pinned by tests, since that is the kind of rule that otherwise gets discovered by accident.

This shipped as an opt-in plan flag first, and the flag is gone after review asked why there were two behaviors at all. Measured, then decided:

| | flag-driven (seam off) | forced on |
|---|---|---|
| SSR post-hydration heap | 1815.5KB | 1809.1KB |
| Hydration median | 44.15ms | 24.55ms |

Forcing the seam on for a loop that does not need it measured **lower on both** — the cost is below this repo's benchmark floor, so the flag bought nothing. Against that, the failure modes are asymmetric: gated on "the compiler believes this loop's outer reads are primable", a misclassification is a silent staleness bug no test can see; unconditional, the same mistake is a dedup-guarded extra pass. Twice in this series a classification assumption turned out to be wrong, so the design should make being wrong cheap.

## Verification

`packages/client` **592/0**. Tests cover the three stranding sequences, the no-bump-on-removal rule, the `Object.is` identity rule, and the fact that no flag turns the seam off (so a future "optimization" has to change that test on purpose). The earlier L2 test pinning "reconciles never re-run the outer effect" is inverted with the reason recorded inline.

CI benchmark on this PR alone is flat (DOM memory 1768.6KB, hydration 16.25ms) — expected, since nothing exercises the widened gate until #2415.

One caveat reported rather than buried: during this work a single test failure appeared once and never reproduced across eight subsequent full runs, and its name was not captured. CI's differently-ordered shards are the second opinion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM