### PR TITLE
ci(benchmark): close two trigger blind spots, add workflow_dispatch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,11 +1,25 @@
 name: Benchmark
 
+# Trigger notes — two blind spots this configuration has, both hit for real:
+#
+#  - `branches: [main]` means a STACKED pull request (one based on another
+#    feature branch) never runs this workflow. Retargeting its base to main
+#    afterwards does NOT re-trigger, so the numbers get checked only if
+#    something is pushed after the retarget. Several PRs in the slot
+#    unification series merged with no benchmark run at all this way.
+#  - the workflow file was absent from its own `paths`, so a change to the
+#    benchmark steps could not test itself. The SSR-heap step below was added
+#    and merged without ever executing because of exactly that.
+#
+# `workflow_dispatch` exists so this can be run on demand against any ref —
+# the escape hatch for both cases, and how a workflow edit gets verified.
 on:
   pull_request:
-    branches: [main]
     paths:
       - 'packages/client/**'
       - 'benchmarks/**'
+      - '.github/workflows/benchmark.yml'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Found while checking why #2415's CI showed no `benchmark` job: the workflow never ran, and the SSR post-hydration heap step that PR added has therefore **never executed**. Two independent trigger gaps, both hit for real in this series.

## 1. Stacked PRs never ran the benchmark

`branches: [main]` restricts the trigger to PRs whose base is `main`. A stacked PR — based on another feature branch — is excluded, and retargeting its base to main afterwards does **not** re-trigger. The numbers were checked only when something happened to be pushed after the retarget.

#2408, #2412 and #2415 each merged with no benchmark run at all this way. For a series whose whole justification was measured memory numbers, that is the coverage it could least afford to lose. Removing the branch filter means a stacked PR gets its numbers too.

## 2. The workflow could not test itself

`.github/workflows/benchmark.yml` was absent from its own `paths`, so a change to the benchmark steps triggered nothing. That is how #2415's new SSR-heap step reached main unexecuted — and its PR body asserted the opposite, that its own CI would exercise it. Adding the file to `paths` fixes that for future edits.

## 3. `workflow_dispatch`

The escape hatch for both cases: the workflow becomes runnable on demand against any ref. It is also how this change itself gets verified — dispatching it on this branch is the first execution of the SSR-heap step, so the numbers that appear will be the proof rather than a claim.

Comments in the workflow record both blind spots and why the dispatch trigger exists, so the next person changing the triggers sees what the previous configuration silently skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_