### PR TITLE
docs(spec): cut slot-unification to the durable rules

### DIFF
--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -144,7 +144,7 @@ import { fixture as filterSortChain } from './filter-sort-chain'
 import { fixture as mapNested } from './map-nested'
 import { fixture as mapDynamicClass } from './map-dynamic-class'
 // Lazy row graph (spec/slot-unification.md §9) — eligible attr, eligible
-// outer TEXT (§9.5c(1) lifted), and refused
+// outer TEXT (§9.5 lifted), and refused
 import { fixture as lazyRowOuterClass } from './lazy-row-outer-class'
 import { fixture as lazyRowOuterText } from './lazy-row-outer-text'
 import { fixture as lazyRowIneligibleFallback } from './lazy-row-ineligible-fallback'

--- a/packages/adapter-tests/fixtures/lazy-row-outer-text.ts
+++ b/packages/adapter-tests/fixtures/lazy-row-outer-text.ts
@@ -2,7 +2,7 @@ import { createFixture } from '../src/types'
 
 /**
  * Lazy row graph (`spec/slot-unification.md` §9) — an eligible row whose
- * CONTENT slot is outer-involving (§9.5c(1), lifted).
+ * CONTENT slot is outer-involving (§9.5, lifted).
  *
  * The sibling `lazy-row-outer-class` covers the attribute half: an
  * outer-involving `className` seeds against `getAttribute`. This fixture
@@ -26,7 +26,7 @@ import { createFixture } from '../src/types'
  */
 export const fixture = createFixture({
   id: 'lazy-row-outer-text',
-  description: 'Keyed plain loop whose row text reads an outer signal (lazy row graph, §9.5c(1) lifted)',
+  description: 'Keyed plain loop whose row text reads an outer signal (lazy row graph, §9.5 lifted)',
   source: `
 'use client'
 import { createSignal } from '@barefootjs/client'

--- a/packages/jsx/src/__tests__/create-selector.test.ts
+++ b/packages/jsx/src/__tests__/create-selector.test.ts
@@ -8,7 +8,7 @@
  * type carries the brand, not the call's return type. These tests pin:
  *   - the classic js-framework-benchmark row compiles with `isSelected(row.id)`
  *     wired through the lazy row graph — ZERO emitted per-row effects, the
- *     loop-level effect living in `mapArrayLazy` (spec §9). Until §9.5c(2)
+ *     loop-level effect living in `mapArrayLazy` (spec §9). Until §9.3a
  *     was lifted this shape was gate-INELIGIBLE (an opaque local whose call
  *     is the reactive read could not be primed) and compiled to one per-row
  *     `createEffect`; the runtime re-subscribe seam replaced that, so the
@@ -83,7 +83,7 @@ describe('createSelector (perf, #2143 gap 5)', () => {
     // `isSelected` is an opaque local (its CALL is the reactive read). Nothing
     // in the emission marks that: the runtime's re-subscribe seam applies to
     // every loop-level outer effect, so the compiler has no judgement to
-    // encode here (§9.5c(2)).
+    // encode here (§9.3a).
     expect(clientJs).not.toContain('outerNeedsResubscribe')
 
     // The hoisted skeleton fast path (#2223) still fires: a single-line

--- a/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
+++ b/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
@@ -155,7 +155,7 @@ describe('lazyRowEligibility — binding refusals', () => {
     expect((decision as { reason: string }).reason).toMatch(/index parameter/)
   })
 
-  // §9.5c(2), LIFTED: an outer name the emitter cannot prime no longer sinks
+  // §9.3a, LIFTED: an outer name the emitter cannot prime no longer sinks
   // the loop. The runtime's unconditional re-subscribe seam keeps
   // the loop-level effect subscribed across reconciles, which is the
   // obligation priming used to carry. Inverted from the refusal it replaces
@@ -175,7 +175,7 @@ describe('lazyRowEligibility — binding refusals', () => {
     expect(decision).toEqual({ eligible: true })
   })
 
-  // §9.5c(1), LIFTED: content slots now have a DOM read-back
+  // §9.5, LIFTED: content slots now have a DOM read-back
   // (`lazyClaimSlots(...).read(id)`), so an outer-involving text binding no
   // longer sinks the loop. This test is the inverse of the refusal it
   // replaces — if the gate ever starts refusing again, it fails here rather
@@ -202,8 +202,8 @@ describe('lazyRowEligibility — binding refusals', () => {
   })
 
   test('an OPAQUE outer name on a TEXT binding is eligible too (seam + read door)', () => {
-    // Both former limits at once: an opaque outer read (§9.5c(2), covered by
-    // the seam) on a content slot (§9.5c(1), covered by the read door).
+    // Both former limits at once: an opaque outer read (§9.3a, covered by
+    // the seam) on a content slot (§9.5, covered by the read door).
     const decision = lazyRowEligibility(args({
       bindings: [{
         kind: 'text',
@@ -298,7 +298,7 @@ describe('classifyLazyBinding — fail-safe', () => {
     expect(c.readsItem).toBe(true)
     expect(c.readsOuter).toBe(true)
     expect(c.opaqueOuterNames).toEqual(['<unknown>'])
-    // …and the gate STILL refuses, even though §9.5c(2) lifted the refusal
+    // …and the gate STILL refuses, even though §9.3a lifted the refusal
     // for opaque NAMES. A name means the identifier set is known and only
     // its primability is not — the seam handles that. This means the set
     // itself is unknown, so `referencesIndex: false` above is an assumption
@@ -344,7 +344,7 @@ describe('classifyLazyBinding — fail-safe', () => {
     })
     expect(c.readsOuter).toBe(true)
     expect(c.opaqueOuterNames.sort()).toEqual(['clsx', 'isSelected'])
-    // Opaque NAMES no longer refuse the loop (§9.5c(2) lifted) — the
+    // Opaque NAMES no longer refuse the loop (§9.3a lifted) — the
     // identifier set is known here, so only primability was missing and the
     // runtime seam supplies that unconditionally. They still land in
     // `opaqueOuterNames` so a refusal elsewhere can name them precisely.
@@ -460,7 +460,7 @@ describe('lazy row emission — eligible loop', () => {
 })
 
 /**
- * §9.5c(1) lifted: an outer-involving TEXT binding. The row renders an
+ * §9.5 lifted: an outer-involving TEXT binding. The row renders an
  * item-driven text alongside a text that depends on a component signal, so
  * the loop needs the READ-capable claim door to seed the second one by
  * read-compare-write instead of writing blindly at hydration.
@@ -485,7 +485,7 @@ export function LazyOuterTextRows() {
 }
 `
 
-describe('lazy row emission — outer-involving TEXT binding (§9.5c(1) lifted)', () => {
+describe('lazy row emission — outer-involving TEXT binding (§9.5 lifted)', () => {
   const js = clientJs(ELIGIBLE_OUTER_TEXT, 'LazyOuterTextRows.tsx')
 
   test('the loop is eligible — it is no longer refused for having an outer text', () => {

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-row-eligibility.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-row-eligibility.ts
@@ -41,7 +41,7 @@
  *     the `inert` set names them only so the refusal can say which one.
  *     Genuinely ignorable are the names that cannot carry a reactive read
  *     at all: literal-derived local / module constants and pure globals.
- *  4. **Outer-involving TEXT bindings are ACCEPTED** (§9.5c(1), lifted).
+ *  4. **Outer-involving TEXT bindings are ACCEPTED** (§9.5, lifted).
  *     §9.3(1) requires read-compare-write seeding on `applyOuter`'s first
  *     run: compute the value, READ the current DOM, write only on
  *     difference. For an attribute that read is `getAttribute` / a DOM
@@ -260,7 +260,7 @@ export function lazyRowEligibility(args: LazyRowEligibilityArgs): LazyRowEligibi
     // loop-level effect must subscribe on its FIRST run, and with an empty
     // entry list the per-entry reads never execute, so it would subscribe to
     // nothing and go permanently dead. The runtime's re-subscribe seam
-    // in `mapArrayLazy` removes that obligation from the compiler (§9.5c(2)):
+    // in `mapArrayLazy` removes that obligation from the compiler (§9.3a):
     // every loop-level outer effect re-runs after a reconcile that created a
     // row or changed an item, so its subscription set is rebuilt against the
     // current entries no matter what the reads turn out to be. Nothing to

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
@@ -49,7 +49,7 @@
  *    (`emit-reactive.ts`); any kind this module does not recognise falls back
  *    to `true` (always write on seed), which is conservative, never wrong.
  *    CONTENT slots seed the same way through the claim's `read(id)` door
- *    (§9.5c(1), lifted) — see `refParts` for the per-loop door choice.
+ *    (§9.5, lifted) — see `refParts` for the per-loop door choice.
  *
  * A loop with NO outer binding emits no `applyOuter` at all — its rows do
  * literally nothing at hydration.

--- a/spec/slot-unification.md
+++ b/spec/slot-unification.md
@@ -1,393 +1,210 @@
 # Slot unification
 
-Status: **implemented (Steps A+B, PRs #2396–#2400; revision history in
-git)**. Root-cure design prompted by the #2389/#2393 review. Revision 2
-replaced the scan-based `updateSlot` door from revision 1 with a
-claim-once model, informed by how SolidJS resolves dynamic positions — and
-identified where BarefootJS's own constraints (multi-backend SSR, byte
-parity) suggested different choices than Solid's. Deferred follow-up work
-is tracked in §8.
+Status: **implemented** — claim infrastructure (Steps A+B, PRs #2396–#2400)
+and the lazy row graph (§9, PRs #2406–#2415) are shipped. Revision history
+is in git.
 
-## 1. Pre-unification inventory
+> **This document is the normative rules, and only those.** It is not an
+> introduction to the architecture — §2 through §4 state the invariants and
+> assume you already know what a slot and a claim are. The three axes the
+> design actually splits along (markers, claim, hydration) are easier to learn
+> in that order than in this document's order.
+>
+> **Measurements live in CI, not here.** Every point-in-time benchmark table
+> this document used to carry went stale within days. Current numbers come
+> from the benchmark workflow's PR comment (`.github/workflows/
+> benchmark.yml`). Only measurements that a design decision still rests on
+> are quoted below, and each says what it is load-bearing for.
 
-The mechanisms below are what existed before Steps A+B. Rows #1–#4 and #9
-were replaced by the claim-plan model (§4) and no longer exist in the
-codebase; rows #5–#8 were kept as-is (§7 non-goals) and remain current.
-Reactive content-update mechanisms, by addressing scheme, as they stood at
-the time this design was proposed:
+## 1. What this replaced
 
-| # | Mechanism | Marker / anchor | Value | Update discipline |
-|---|-----------|-----------------|-------|-------------------|
-| 1 | `$t` + `.textContent` | `<!--bf:sN-->…<!--/-->` pair | text | Text node held from mount, `nodeValue` write |
-| 2 | `__bfText` (dynamic text/JSX slot) | same pair | text \| live `Node` | region clear + splice; caller tracks current node |
-| 3 | `patchSlotRange` (preamble regions, #2389) | same pair | HTML string | range replace, re-scan per patch |
-| 4 | `updateClientMarker` (`@client` exprs) | `<!--bf-client:sN-->` unpaired + zero-width-space Text | text | full rescan on EVERY update |
-| 5 | `patchLeaf` (flatMap descriptor leaves) | element identity (mapArray scope map) | HTML string | attrs diffed, children wholesale |
-| 6 | `insert()` (conditional swap) | `bf-c` attr or `<!--bf-cond-start/end-->` | HTML string + node side channel | replace on branch change only |
-| 7 | `mapArray` / `mapArrayAnchored` | `<!--bf-loop*-->` grammar | keyed list | keyed reconcile, per-item signals |
-| 8 | attr effects | `bf="sN"` attr | string/bool | setAttribute/property |
-| 9 | `reconcileElements` / `reconcileList` | loop pair + `data-key` | elements | **dead — no compiler emission site** |
+Before Steps A+B there were four separate reactive-content mechanisms over
+one marker format, each with its own lookup and ownership rule: a `$t`
+text-effect, `__bfText` (dynamic text/JSX), `patchSlotRange` (preamble
+regions, #2389), and `updateClientMarker` (`@client` exprs, which rescanned
+the DOM on EVERY update). All four are deleted; the claim-plan model (§4)
+replaced them. Two dead reconcilers (`reconcileElements`, `reconcileList`)
+went with them.
 
-Facts that shaped the design:
+`patchLeaf` (element identity + attr sync), `insert` (conditional swap),
+`mapArray` (keyed list), and attr effects (`bf="sN"`) were kept as-is — they
+are subtree lifecycle or a different contract, not content addressing (§7).
 
-- Rows #1–#3 share one marker format with three different lookups and
-  three ownership rules.
-- `insert()` consumes HTML strings only (nodes ride a `__bfSlot` side
-  channel) — content flows as compiler-rendered HTML strings everywhere.
-  The divergence is addressing grammar and per-kind discipline, not a
-  string-world/node-world split.
-- The fault: mechanisms accreted one per compiler feature, instead of one
-  slot concept with an identity contract.
+The fault being cured: mechanisms accreted one per compiler feature, instead
+of one slot concept with an identity contract.
 
 ## 2. Reference point — how SolidJS resolves positions
 
 Solid never reads a marker at update time. Positions are compile-time
-`firstChild.nextSibling…` paths, dereferenced **once** when the template
-is cloned (CSR) or claimed (hydration); updates write through held
-references. Its SSR markers (`<!--#-->`) and hydration keys (`data-hk`
-attributes) exist only to align that one-time claim.
+`firstChild.nextSibling…` paths, dereferenced **once** when the template is
+cloned (CSR) or claimed (hydration); updates write through held references.
+Its SSR markers (`<!--#-->`) and hydration keys (`data-hk`) exist only to
+align that one-time claim.
 
-Adopting the claim-once shape — resolve once, hold references, never scan
-on update — is the core of this proposal. A path is only required to be
-valid at the moment of claim, and at mount the row DOM is always in its
-pristine template shape on both SSR and CSR, so later variable-length
-changes cannot invalidate anything: the claim captures boundary/text
-references and paths are never consulted again. BarefootJS already had
-this shape in embryo: the hoisted `tAfter(__p[i])` path (#2143), later
-generalized by the claim-plan mechanism (§4) that superseded it.
+**Claim-once is the core rule of this design**: resolve a position once,
+hold references, never scan on update. A path only has to be valid at the
+moment of claim, and at mount the row DOM is always in its pristine template
+shape on both SSR and CSR — so later variable-length changes cannot
+invalidate anything already claimed.
+
+A corollary that has already caught one design: **a second position-
+resolution path is a violation even when it looks cheaper.** A claim-free
+"peek" (resolve the marker, read the node, discard the resolution) was
+designed and rejected for exactly this — it re-scans on the next update. The
+fix for whatever motivated the peek belongs at the cause, not beside it.
 
 ## 3. Where BarefootJS's constraints suggest different choices
 
-These are not claims of superiority — they are places where our
-architecture (compile-to-any-backend, SSR/CSR byte parity as an enforced
-invariant, string-template rows) points at design adjustments Solid has no
-reason to make:
+Not claims of superiority — places where our architecture
+(compile-to-any-backend, SSR/CSR byte parity as an enforced invariant,
+string-template rows) points at adjustments Solid has no reason to make:
 
 **(a) Claim plans as compile-time data, not render re-execution.** Solid
 hydrates by re-running the component and walking the DOM in lockstep. Our
-hydrate already adopts without re-render (trust-first-run). If the claim
-plan is emitted as data (per-slot child paths), claim need not happen at
-hydration at all: **row-level lazy claim** — the first write to any slot
-in a row claims the whole row (still pristine at that moment), later
-writes hit held refs. A row that never updates never pays. Requires the
-row-pristine-until-first-write invariant: claims are batched per row, so
-one slot's patch can never shift a sibling slot's un-claimed path.
+hydrate adopts without re-render, so claim need not happen at hydration at
+all: **row-level lazy claim** — the first write to any slot in a row claims
+the whole row (still pristine at that moment), later writes hit held refs. A
+row that never updates never pays. Requires the **row-pristine invariant**:
+claims batch per row, so one slot's patch can never shift a sibling slot's
+un-claimed path.
 
 **(b) Markers become claim-only, then mostly disappear.** With path-based
-claiming, markers are structurally required only where paths cannot
-address: (i) adjacent text slots (the HTML parser merges adjacent text),
-(ii) positions that can be empty (a zero-length region needs a physical
-anchor), (iii) conditional/loop range boundaries. Every other slot's
-marker can be dropped from SSR output — and unlike Solid we need no
-`data-hk`-style per-element keys either, because byte parity guarantees
-the shape the paths were compiled against. Benchmarks currently show our
-HTML document at 318.6KB vs solid's 235.9KB; marker overhead is a
-measurable share of that gap.
+claiming, markers are structurally required only where paths cannot address:
+(i) adjacent text slots (the HTML parser merges adjacent text), (ii)
+positions that can be empty (a zero-length region needs a physical anchor),
+(iii) conditional/loop range boundaries. Every other slot's marker can be
+dropped from SSR output — and unlike Solid we need no `data-hk`-style
+per-element keys either, because byte parity guarantees the shape the paths
+were compiled against.
 
-**(c) Row-granularity effects.** The compiler statically knows which slots
-a row has and what each reads. That permits one effect per row driving a
-compiled slot table, instead of one closure per binding — a memory-shape
-lever (1k-rows memory currently 1755KB vs solid 1480KB) that a runtime-
-composed framework cannot pull.
+(b)'s value routes through **DOM node count** (4,000 comments + 2,001 attrs
+per 1k rows), not the wire: Stage 0 measured raw −54.7KB but only −0.6KB
+gzip. Markers compress too well for a transfer win. Argue (b) from memory
+and parse, never from transfer size.
+
+**(c) Row-granularity effects.** The compiler statically knows which slots a
+row has and what each reads. That permits one effect per row driving a
+compiled slot table instead of one closure per binding — and, per §9, for
+plain rows it permits deleting the per-row reactive graph entirely.
 
 **(d) The claim plan doubles as a cross-backend contract.** A claim plan
-asserts "SSR output has this shape". Conformance can mechanically verify
-every adapter's output against the plans — turning the existing byte-
-parity invariant into a per-slot, per-backend checked guarantee. This axis
-only exists because we have nine SSR backends.
+asserts "SSR output has this shape". Conformance mechanically verifies every
+adapter's output against the plans, turning the byte-parity invariant into a
+per-slot, per-backend checked guarantee. This axis only exists because we
+have nine SSR backends. Shipped with Step B.
 
-All four were hypotheses; Stage 0 measured them (see §5a). The essence of
-(a)+(c) is **pay-per-use**: the reactive graph (per-item signal, per-slot
-effect closures, subscription entries, held DOM wrappers) is built only
-for rows that are actually written to, instead of being paid up front for
-every row at hydration. In a write-heavy app the saving converges toward
-the constant-factor gains (one effect per row instead of N; no
-subscriptions or wrappers for static slots); on static-heavy SSR pages —
-the common case — most of the per-row graph is simply never built.
+The essence of (a)+(c) is **pay-per-use**: the reactive graph (per-item
+signal, per-slot effect closures, subscription entries, held DOM wrappers)
+is built only for rows actually written to, instead of being paid up front
+for every row at hydration.
 
 ## 4. Target architecture
 
 - **One slot concept**: a claimed position with an identity contract —
   `'text'` (held Text node, `nodeValue` writes), `'markup'` (held boundary
   refs, range replace), `Node` (identity splice).
-- **One claim mechanism**: compile-time child paths, generalizing
-  `tAfter`; markers consulted only by the claim, only where (i)–(iii)
-  require them; one ownership rule (nested `bf-s` scopes are opaque).
+- **One claim mechanism**: compile-time child paths; markers consulted only
+  by the claim, only where (i)–(iii) require them; one ownership rule
+  (nested `bf-s` scopes are opaque).
 - **Row-level lazy claim** per (a).
-- `patchLeaf` stays (element identity + attrs-sync is a different
-  contract). `insert`/`mapArray` stay (subtree lifecycle, not content).
+- `patchLeaf`, `insert`, `mapArray` stay (§7).
 
-## 5a. Stage 0 results (measured 2026-07-26, spike PR #2395)
+Three access doors sit on ONE claim (`claimRefs` in `claim-slots.ts`) —
+`claimSlots` (eager, for callers that cannot honor row-pristine),
+`lazySlots` (write-only, the default), `lazyClaimSlots` (read+write, only
+where §9.3(1) seeding needs a DOM read-back). They are accessor bundles, not
+three ways to resolve a position. The split exists because a door is
+allocated per row: giving every claim a reader measured ~40KB/1k rows.
 
-A fourth SSR-bench app prototyped the claim-once model: marker-stripped
-real barefoot SSR output + a hand-written client doing one delegated
-listener at hydration and row-level lazy claim on first write. Same
-interactivity gate, same fencing; two agent runs plus an independent
-re-run, all consistent (CI reproduced the direction independently).
+## 5. Migration — what shipped
 
-| Metric | solid | barefoot | claim prototype |
-|---|---|---|---|
-| Hydration (median, n=10) | 20–26ms | 28–32ms | **22–30ms** |
-| HTML (raw / gzip) | 235.9 / 18.6KB | 318.6 / 19.5KB | **263.9 / 18.9KB** |
-| Post-hydration heap (n=3, stdev ≤4KB) | 2586KB | 2729KB | **1169KB** |
+Compatibility with the pre-unification emitted grammar was explicitly NOT a
+goal (pre-1.0; fixtures and snapshots regenerated wholesale). What survived
+was **verifiability**: Step A kept SSR bytes unchanged so the new client was
+validated against known-good SSR output.
 
-Readings that bind the plan:
+**Step A — claim infrastructure, wholesale (SSR bytes unchanged).** All four
+content mechanisms replaced in one stacked series; old mechanisms deleted,
+not shimmed.
 
-- **Memory is the headline** (−57% vs current, ceiling): the per-row
-  reactive graph costs ~1.6KB/row up front today; lazy claim defers it to
-  first write. The prototype ships no runtime, so the real number lands
-  between the columns — but the headroom is real and perfectly
-  reproducible.
-- **Hydration**: mechanism proven (zero per-row work) but only ~10% at 1k
-  rows — navigation/parse dominates. Not the primary justification.
-- **(b) corrected**: raw −54.7KB matched the marker census byte-for-byte,
-  but gzip saved only 0.6KB — markers compress too well for a transfer
-  win. (b)'s value routes through **DOM node count** (4,000 comments +
-  2,001 attrs per 1k rows) into memory and parse, not the wire.
+- **A1** (#2396): spec.
+- **A2 — runtime** (#2397): claim-plan interpreter + claimed-slot primitives
+  in `@barefootjs/client/runtime`. Unit-tested standalone; no compiler
+  change.
+- **A3 — compiler switch** (#2398): claim plans emitted for every content
+  slot; all four old emission forms and their runtime exports removed;
+  snapshots and CSR/fixture goldens regenerated once. `bf-client:` markers
+  stopped being emitted — the one SSR byte change Step A allowed, since
+  nothing adopted it. Unchanged-value dedup for `'markup'` writes lands
+  here; the trust-first-run that shipped alongside it was removed as a
+  follow-up (§6).
+- **A3b — row-granularity effects** (§3(c)): A3 stacked per-slot effects on
+  top of new per-row claim allocations and CI's DOM benchmark caught a real
+  +16.5% memory regression. Fixed by giving each plain loop row ONE
+  `createEffect` and one mixed-kind `lazySlots` writer. The dominant cost
+  turned out to be claim-mechanism allocation, not effect count — §3(c)'s
+  "remove N-1 effect objects" framing undersold it.
+- **A4 — cleanup** (#2399): dead exports removed.
 
-### Step A measured results (measured 2026-07-26, A4 cleanup)
+**Step B — marker elision** (#2400): dropped markers outside (i)–(iii) from
+SSR and CSR templates for a narrow slice (see §5a), and landed claim-plan
+verification (d) alongside it. Justified by node count/memory, not transfer
+size.
 
-Real numbers from the shipped Step A pipeline (A2 runtime + A3 compiler
-switch + A4 dead-export removal), not the hand-written Stage 0 prototype
-above. `bun run --filter '@barefootjs/client' build`, then
-`bun benchmarks/ssr/apps/barefoot/build.ts`, then
-`bench-ssr.ts` (hydration/bytes) and the adapted `bench-ssr-memory.ts`
-(heap; the Stage 0 spike's fourth `barefoot-claim` column doesn't exist in
-this tree — A2/A3 already put the real claim-plan interpreter into
-`barefoot` itself), each run twice, all in the foreground.
-react/solid/barefoot only.
+## 5a. Step B measured — why the general case is deferred
 
-| Metric | react (run1 / run2) | solid (run1 / run2) | barefoot (run1 / run2) |
-|---|---|---|---|
-| Server render (median, n=20) | 26.05 / 26.19ms | 0.54 / 0.38ms | 11.83 / 8.82ms |
-| Hydration (median, n=10) | 51.45 / 48.40ms | 30.45 / 29.60ms | 39.80 / 38.95ms |
-| HTML (raw / gzip) | 220.0 / 14.9KB (both runs) | 235.9 / 18.6KB (both runs) | 318.6 / 19.5KB (both runs) |
-| Post-hydration heap (n=3, median, stdev ≤7KB) | 3475.7 / 3476.5KB | 2589.3 / 2578.4KB | 3244.9 / 3244.9KB |
-
-Honest read, against this doc's own pre-A baseline (hydration 28–32ms,
-heap 2729KB) quoted in §5a above:
-
-- **These numbers are not directly comparable to the pre-A baseline** —
-  that baseline and this measurement ran in different sandbox
-  environments (different hardware/Chromium build), and the *absolute*
-  hydration and heap numbers moved for react and solid too (react's heap
-  is ~3475KB here, and solid's hydration varies 30.45→29.60ms between
-  this run's own two trials). The same-environment, same-run
-  react/solid/barefoot comparison above is the reliable signal; the
-  cross-environment comparison to §5a's baseline is not.
-- **No memory win yet, and that is expected.** A3's compiler switch
-  replaced the *emission mechanism* (claim plans instead of
-  `$t`/`__bfText`/`patchSlotRange`/`updateClientMarker`) but explicitly
-  kept the per-row reactive graph — row-level lazy claim (the Stage 0
-  prototype's memory story, §5a's −57% ceiling) is deferred past Step A
-  (§6 "Row-pristine invariant"; §5's Step A description). Step A's own
-  goal was verifiability (SSR bytes unchanged) while swapping the update
-  door, not the memory win — so barefoot's heap sitting essentially flat
-  across both runs (3244.9KB, stdev <1KB) and above solid's is the
-  expected outcome of *this* step, not a regression to chase. Step B
-  (marker elision) and a future lazy-claim step are where the Stage 0
-  ceiling gets tested against a real implementation.
-- **HTML bytes are pinned and unchanged from pre-A**, as designed: Step
-  A's only allowed SSR byte change was dropping the dead `bf-client:`
-  marker, and 318.6KB raw / 19.5KB gzip — identical across both runs —
-  matches §5a's barefoot column exactly.
-- **Hydration and server-render times are within normal run-to-run
-  jitter** at 1k rows in this sandbox (e.g. solid's own hydration moves
-  30.45→29.60ms and barefoot's server render moves 11.83→8.82ms between
-  otherwise-identical runs); no claim of improvement or regression over
-  the pre-A baseline is supportable from this data — the claim-plan
-  switch's proven win (per §5a) is architectural (zero per-row
-  reconciliation work once lazy claim lands), not yet visible as a wall-
-  clock delta while the per-row effect graph is still built eagerly.
-
-### Step B measured (measured 2026-07-26)
-
-Step B shipped a deliberately NARROW slice of §3(b)'s elision rule, not
-the general case, and the SSR-bench numbers below reflect exactly that
-scope — reported honestly rather than alongside a benchmark result the
-implementation doesn't actually move.
+Load-bearing for §8's marker-elision follow-up; kept because a runtime
+docstring points here for the reason.
 
 **What shipped**: `client-only-elision.ts` elides the marker pair for
-`/* @client */` text expressions ONLY — the one 'text'-kind slot whose
+`/* @client */` text expressions ONLY — the one `'text'`-kind slot whose
 rendered width is deterministically zero at claim time on every request
-(SSR can never evaluate client-only JS), which is what makes computing a
-real, reusable, hydration-safe compile-time path sound without also
-solving the general problem below. Scope, precisely: not inside any loop
-or conditional branch, not adjacent to loose text/another slot (case (i)),
-and capped at one elided slot per static subtree (the "freeze after
-first" rule in that module's docstring). `todo-app`'s `<strong>{/* @client
-*/ count}</strong>` is the corpus's one hit; its marker pair
-(`<!--bf:s6--><!--/-->`) is gone from both SSR and CSR output, and the
-claim plan carries a real `path`/`markerless: true` instead.
+(SSR can never evaluate client-only JS). Scope: not inside any loop or
+conditional branch, not adjacent to loose text or another slot (case (i)),
+capped at one elided slot per static subtree ("freeze after first").
 
-**Why the general case (ordinary reactive text in loop rows — the
-1k-row bench's actual hot path) is NOT in this PR, deferred loudly**: an
-ordinary `{item.name}`-style slot's rendered width is DATA-DEPENDENT
-(empty or not, per request), so a later sibling's absolute child-index
-path is only valid for the specific width THIS request happened to
-produce — not for every request the compiled function ever serves.
-Working around that (only elide the FIRST width-uncertain slot per
-static subtree, exactly `client-only-elision.ts`'s "freeze" rule, minus
-the `clientOnly` restriction) is the identified path forward, but it
-requires the elision decision to be made where loop-row 'text'-kind
+**Why ordinary reactive text in loop rows — the 1k-row bench's actual hot
+path — is NOT elided**: an ordinary `{item.name}` slot's rendered width is
+DATA-DEPENDENT, so a later sibling's absolute child-index path is only valid
+for the specific width THIS request happened to produce, not for every
+request the compiled function ever serves.
+
+The identified path forward is `client-only-elision.ts`'s freeze rule minus
+the `clientOnly` restriction, decided where loop-row `'text'`-kind
 classification already happens (`collect-elements.ts` /
-`ir-to-client-js/control-flow/plan/loop.ts`, deep inside
-`generateClientJs`) rather than in a standalone pre-pass run before
-`adapter.generate` — `compiler.ts` currently calls `adapter.generate`
-BEFORE `generateClientJs`, and reordering those (verified safe for THIS
-PR's `client-only-elision.ts`, which needs no ir-to-client-js state) has
-not been re-verified against the loop-row planner's own invariants. Real
-follow-up work, not a rounding error.
-
-**Bench result — HTML size is UNCHANGED from A4** (318.6KB / 19.5KB,
-identical to A4's own numbers above), because `benchmarks/ssr/apps/
-barefoot`'s 1,000-row table contains no `/* @client */` expression at all
-— every row's dynamic text is ordinary reactive text, exactly the
-general case deferred above. This PR's elision is real (see `todo-app`)
-but the bench app doesn't exercise it, so the memory/node-count case
-`spec/slot-unification.md` §5a argues for remains a projection, not yet
-a measurement, pending the general-case follow-up.
-
-| Metric | react | solid | barefoot |
-|---|---|---|---|
-| Server render (median, n=20) | 20.70ms | 0.68ms | 8.20ms |
-| Hydration (median, n=10) | 76.85ms | 54.45ms | 67.65ms |
-| Client JS (raw / gzip) | 182.3 / 58.1KB | 17.0 / 6.6KB | 21.8 / 7.9KB |
-| HTML (raw / gzip) | 220.0 / 14.9KB | 235.9 / 18.6KB | 318.6 / 19.5KB |
-
-(Single run, not the two-run A4 protocol — since the HTML/bytes numbers
-are the load-bearing claim here and they're deterministic build outputs,
-not timing-sensitive; hydration/server-render numbers above are
-consistent with A4's jitter range and are not this note's point.)
-
-### Row-granularity effects (A3b) — regression confirmed and fixed (measured 2026-07-27)
-
-A3's compiler switch (above) kept per-slot effect emission — one
-`createEffect` per reactive attr, per reactive text, and per preamble
-region — stacked on top of the NEW per-row claim-plan allocations (a
-`lazySlots` writer closure, its plan-literal array, and the `Map` +
-per-slot refs the first write allocates). CI's quick-mode DOM benchmark
-(`benchmarks/runner/bench-dom.ts`, `benchmarks/apps/barefoot`) caught the
-result as a real regression, confirmed on identical sandbox hardware
-against the pre-migration merge commit (`011126f8`):
-
-| Metric | pre-migration (011126f8) | post-A3 (regressed) | post-A3b (this fix) |
-|---|---|---|---|
-| memory (1k rows) | 1756.9KB | 2046.4KB (+16.5%) | ~1767KB (-13.6% vs regressed) |
-| update10th | 12.00ms (1.00x vanilla) | 12.6-12.7ms (1.09-1.24x, noisy) | 14.1-16.0ms (1.04-1.17x) |
-| shipped JS (raw/gzip) | 23.8 / 8.7KB | 26.0 / 9.3KB | 26.0 / 9.3KB (unchanged — the win is runtime object count, not source bytes) |
-
-Per-row inventory at the regressed commit (`bf build`'s emitted
-`renderItem` for the bench table row — one reactive `class` attr, two
-reactive texts, no preamble region): 3 separate `createEffect` calls
-(unchanged from pre-migration's own 3), PLUS a NEW `lazySlots` call whose
-plan literal (2 `SlotSpec` objects + an array) is allocated fresh every
-row regardless of whether the row ever updates, and whose first write
-(fired synchronously by `createEffect`'s initial run — not deferred in
-practice for a freshly-created row) allocates a `Map` + one
-`ClaimedTextSlot` ref per text slot. The regression's dominant cost was
-this claim-mechanism allocation, not the effect count — §3(c)'s own
-"remove N-1 effect objects" framing undersold the fix's actual ceiling,
-noted honestly here rather than silently.
-
-**The fix** (§3(c), row-granularity effects, implemented): for the plain
-loop-row shape (top-level `mapArray` rows, `stringify/loop.ts`'s
-`stringifyPlainLoop`, and the structurally-identical branch-scoped rows in
-`stringify/branch-loop.ts`'s `emitPlain`) every reactive attr, outer text,
-and preamble region for a row now shares ONE `createEffect` and (for the
-texts/regions) ONE `lazySlots` writer over a mixed `'text'`/`'markup'`
-claim plan — cutting the bench row's 3 effects to 1. Composite loops,
-component loops, the anchored (whole-item-conditional) shape, and static
-(`forEach`) loops are untouched (they never carry preamble regions, and
-this pass only mechanically verified the plain-row shape). Profile mode
-keeps the old per-slot/per-attr emission so `<Component>#binding:<slotId>`
-ids still attribute a re-run to its own binding.
-
-**Result**: memory recovered to within ~0.6% of the pre-migration
-same-hardware baseline (three consistent measurements: two quick-mode runs
-at 1767.3-1769.4KB, one full 3-iteration run at 1767.4KB) — a real,
-reproducible ~279KB/13.6% win over the regressed state, though not
-strictly BELOW the pre-migration number. The residual ~10KB gap is
-mechanically attributable to the claim-mechanism's own allocations (the
-writer closure + `Map` + refs the per-row inventory above describes),
-which the effect-count consolidation does not touch and which was out of
-this pass's explicit scope (design agreed for §3(c) was "one effect per
-row", not "rework claim-plan allocation shape") — a candidate for a future
-pass (e.g. hoisting the plan literal's static `id`/`kind` fields once per
-loop instead of re-allocating them every row), not a shortfall in what
-this fix set out to do.
-
-## 5. Migration — what shipped, two steps of stacked semantic PRs
-
-Compatibility with the pre-unification emitted grammar was explicitly NOT
-a goal (pre-1.0; fixtures and snapshots regenerated wholesale). What
-survived was not compatibility but **verifiability**: Step A kept SSR
-bytes unchanged so the new client was validated against known-good SSR
-output — the existing byte-parity corpus was the debugging baseline. The
-old five-stage coexistence plan (mechanisms folded one at a time) was
-retired in favor of this two-step plan.
-
-**Step A — claim infrastructure, wholesale (SSR bytes unchanged).**
-Replaced all four content mechanisms (`$t`-effect text slots, `__bfText`,
-`patchSlotRange`, `updateClientMarker`) in one series of stacked PRs; old
-mechanisms were deleted, not shimmed:
-
-- **A1** (#2396): spec (this document, revision 3).
-- **A2 — runtime** (#2397): claim-plan interpreter + claimed-slot
-  primitives in `@barefootjs/client/runtime` (claim a row/scope from a
-  compile-time plan; held-ref writes for `'text'`/`'markup'`/`Node`;
-  row-level lazy claim with the row-pristine invariant; eager-claim escape
-  for the streaming/portal paths enumerated in §6). Unit-tested
-  standalone; no compiler change yet.
-- **A3 — compiler switch** (#2398): emit claim plans (data) for every
-  content slot; all four old emission forms and their runtime exports
-  removed; snapshots and CSR/fixture goldens regenerated once. `bf-client:`
-  markers stopped being emitted (its SSR comment was claim-input only;
-  removing it was the one SSR byte change Step A allowed, since nothing
-  adopted it). A follow-up fix (§6) removed trust-first-run for 'markup'
-  slots.
-- **A4 — cleanup** (#2399): removed dead exports (`reconcileElements`,
-  `reconcileList`); re-ran the SSR bench and recorded real (non-ceiling)
-  numbers in §5a.
-
-**Step B — marker elision** (#2400): dropped markers outside (i)–(iii)
-from both SSR and CSR templates through the single doors, for the
-narrow slice described in §5a's "Step B measured" section (`/* @client */`
-text slots outside any loop/conditional, one elided slot per static
-subtree), and landed claim-plan verification (d) alongside it:
-conformance mechanically checks every adapter's output against the plans.
-Justified by node count/memory (§5a), not transfer size. The general case
-(ordinary reactive text in loop rows) was deferred — see §8.
+`ir-to-client-js/control-flow/plan/loop.ts`, inside `generateClientJs`)
+rather than in a pre-pass before `adapter.generate`. `compiler.ts` currently
+calls `adapter.generate` BEFORE `generateClientJs`; reordering those has not
+been re-verified against the loop-row planner's invariants. Real follow-up
+work.
 
 ## 6. Constraints and risks
 
-- **Byte parity**: Step A leaves SSR bytes unchanged (except the dead
-  `bf-client:` comment); Step B changes them through the single doors
-  with a one-shot fixture regeneration.
+- **Byte parity**: Step A left SSR bytes unchanged (except the dead
+  `bf-client:` comment); Step B changes them through the single doors with a
+  one-shot fixture regeneration.
 - **Hydration adoption**: `'text'` keeps create-if-absent. `'markup'` was
-  originally specified to keep trust-first-run (claim records, never
-  patches on first run) — implemented in A3, then REMOVED as an A3
-  follow-up fix: trust-first-run is sound only for the narrow loop-row-reuse
-  case it was lifted from (`patchSlotRange`'s preamble-region reuse, where
-  the row's SSR content and its mount-time recomputation are both derived
-  from the same source data and so cannot disagree), not for the general
-  'markup' slot. A slot whose value comes from client-only state the server
-  can't see (`createSignal(readFromLocalStorage())`; a client-side region
-  swap adopting HTML the server rendered from a different default) can
-  genuinely diverge from the DOM on its first write, and trust-first-run
-  silently discarded that first real value. `'markup'` now patches
-  unconditionally on every write, including the first; only the
-  unchanged-value dedup (§5-A3) survives. See `claim-slots.ts`'s module
-  docstring.
-- **Effect-held references**: emission sites that capture nodes in
-  closures are the audit checklist when their mechanism migrates.
+  originally specified to keep trust-first-run (claim records, never patches
+  on first run) — implemented in A3, then REMOVED. Trust-first-run is sound
+  only for the narrow loop-row-reuse case it was lifted from, where the
+  row's SSR content and its mount-time recomputation derive from the same
+  source data and cannot disagree. A slot whose value comes from client-only
+  state the server can't see (`createSignal(readFromLocalStorage())`; a
+  region swap adopting HTML the server rendered from a different default)
+  can genuinely diverge on its first write, and trust-first-run silently
+  discarded that first real value. `'markup'` now patches unconditionally on
+  every write; only the unchanged-value dedup survives.
+- **Non-mutating text claim**: claiming a marked `'text'` slot must not
+  touch the DOM. It adopts an existing Text node and otherwise holds the
+  anchor Comment as the record of where the node must go, deferring creation
+  to the first write. Without this, `lazyClaimSlots.read` would leave an
+  empty Text node on every row it merely inspected.
 - **Shape drift**: path claiming makes SSR/CSR shape agreement a harder
-  invariant. It is already an enforced invariant (conformance byte
-  parity); (d) strengthens the enforcement rather than adding a new
-  assumption.
-- **Row-pristine invariant** for lazy claim: claims batch per row; any
-  code path that mutates row content before claim (streaming swaps,
-  portals) must either claim eagerly or be excluded — enumerated in A2.
+  invariant. It is already enforced (conformance byte parity); (d)
+  strengthens the enforcement rather than adding an assumption.
+- **Row-pristine invariant** for lazy claim: any code path that mutates row
+  content before claim (streaming swaps, portals) must claim eagerly or be
+  excluded.
 
 ## 7. Non-goals
 
@@ -399,311 +216,164 @@ Justified by node count/memory (§5a), not transfer size. The general case
 
 ## 8. Follow-ups
 
-Work this proposal identified but did not ship, tracked here so it isn't
-re-discovered from scratch:
+Identified but not shipped, tracked so it isn't re-discovered from scratch.
 
-- **Row-granularity effects (§3(c)) — effect-count consolidation DONE;
-  lazy effect-graph construction remains.** Plain loop rows (top-level
-  `mapArray` and the structurally-identical branch-scoped shape) emit ONE
-  `createEffect` per row covering every reactive attr, outer text, and
-  preamble region, sharing one mixed-kind `lazySlots` writer for the
-  texts/regions. Fixed the A3-introduced CSR memory/update regression
-  (§5a's "Row-granularity effects (A3b)" measurement) back to within
-  ~0.6% of the pre-migration baseline. Composite loops, component loops,
-  the anchored (whole-item-conditional) shape, and static (`forEach`)
-  loops were left untouched — out of this pass's mechanically-verified
-  scope (they never carry preamble regions, the shape that made the
-  three-way merge possible). Profile mode keeps the old per-slot/per-attr
-  emission so per-binding profiler ids survive. What did NOT ship is the
-  row-level lazy EFFECT-GRAPH construction that §5a's −57% memory ceiling
-  assumes: every row's reactive graph (signals, subscriptions, the one
-  effect closure) is still built eagerly at hydration regardless of
-  whether that row is ever written to. That deferral is now designed and
-  spike-measured in §9 (lazy row graph) and is being implemented as its
-  own stacked PR series.
-- **General-case marker elision (element-path vocabulary beyond `'text'`
-  slots).** Step B's `client-only-elision.ts` only elides `/* @client */`
-  text slots outside any loop/conditional (§5a "Step B measured" explains
-  why: their SSR-rendered width is the one case that's deterministically
-  zero on every request). Ordinary reactive text in loop rows — the actual
-  1k-row benchmark hot path — stays marker-owned because a later sibling's
-  absolute child-index path is only valid for the specific width THIS
-  request produced. The identified path forward (freeze-after-first,
-  minus the `clientOnly` restriction, decided where loop-row `'text'`-kind
-  classification already happens in `collect-elements.ts` /
-  `ir-to-client-js/control-flow/plan/loop.ts`) needs the elision decision
-  moved inside `generateClientJs` instead of running as a pre-pass before
-  `adapter.generate` — re-verifying that reordering against the loop-row
-  planner's own invariants is real, unstarted work.
-- **Claim-mechanism allocation shape**: §5a's row-granularity measurement
-  section notes a residual ~10KB/1k-rows gap between this fix's result and
-  the pre-migration baseline, attributable to the `lazySlots` writer
-  closure + claim `Map` + per-slot refs every row still allocates (even a
-  row that never updates, since `createEffect`'s synchronous initial run
-  triggers the first write in practice for a freshly-created row). Not
-  addressed here — the design agreed for this pass was effect-count
-  consolidation, not a rework of claim-plan allocation — but a real,
-  mechanically-identified candidate for a future pass (e.g. hoisting each
-  slot's static `id`/`kind` once per loop and only threading a per-row
-  `path`, instead of re-allocating full `SlotSpec` objects every row).
-- **`getComponentProps`/`getPropsUpdateFn` dead-export removal.** Flagged
-  consumer-less in A4's report after `reconcileList` (their only reader)
-  was deleted. Removed in the post-migration cleanup that added this
-  section, along with the now-dead `propsMap`/`propsUpdateMap` bookkeeping
-  those two functions existed to expose (`packages/client/src/runtime/
-  component.ts`).
+- **General-case marker elision** (§5a). The one open item on axis (b), and
+  the only route to closing the HTML-size gap against solid.
+- **Claim-mechanism allocation shape.** Two mechanically identified pieces:
+  (1) every row re-allocates full `SlotSpec` objects even when it never
+  updates — hoisting each slot's static `id`/`kind` once per loop and
+  threading only a per-row `path` recovers ~10KB/1k rows; (2) `applyOuter`'s
+  seed pass materializes each row's whole ref tuple (element handle plus the
+  `lazySlots` writer closure and its plan array) even when the row's
+  outer-involving bindings are all ATTRS and the seed only ever reads the
+  element — splitting the tuple by what the seed actually reads recovers
+  most of ~230KB/1k rows without touching the model.
+- **Widening the lazy-row gate** — see §9.5's refusal table.
 
-## 9. Lazy row graph — §3(c) completion (designed 2026-07-27, spike-measured)
+## 9. Lazy row graph — §3(c) completion
 
-Status: **shipped for eligible plain loops** (L1–L4; measured results in
-§9.5b). §9.5c tracks the gate's restrictions — outer-involving text was
-lifted in #2411/#2412; opaque outer reads remain. Measurement spike: branch
-`claude/lazy-effect-spike` (commit 59d1bef7), full report at
-`benchmarks/results/lazy-effect-spike.md` on that branch.
+Status: **shipped for eligible plain loops.** Landed as a stacked series —
+L1 spec, L2 runtime (`mapArrayLazy`), L3 compiler switch, L4 measure — which
+is what docstrings mean when they cite "L2"/"L3".
 
 ### 9.1 The observation that makes rows non-reactive
 
-A plain loop row's update paths are exactly two, and both are already
-known without per-row reactivity:
+A plain loop row's update paths are exactly two, and both are already known
+without per-row reactivity:
 
-1. **Item-driven changes.** The keyed reconciler (`mapArray`'s diff)
-   detects them itself — `!Object.is(oldItem, newItem)` per key. The
-   per-item signal + per-row effect exist only to RE-DELIVER that
-   knowledge back to the row; the reconciler can call the row's update
-   function directly instead.
-2. **Outer-signal reads** (`class={selected() === row.id ? … : …}`).
-   When an outer signal changes, every row's effect re-runs anyway
-   (they all subscribe to it). ONE loop-level effect iterating all
-   entries does the same total work with per-entry dedup — without N
-   effect objects and N subscription entries.
+1. **Item-driven changes.** The keyed reconciler detects them itself —
+   `!Object.is(oldItem, newItem)` per key. The per-item signal + per-row
+   effect exist only to RE-DELIVER that knowledge back to the row; the
+   reconciler can call the row's update function directly.
+2. **Outer-signal reads** (`class={selected() === row.id ? … : …}`). When an
+   outer signal changes, every row's effect re-runs anyway (they all
+   subscribe to it). ONE loop-level effect iterating all entries does the
+   same total work with per-entry dedup — without N effect objects and N
+   subscription entries.
 
-Event handlers need nothing per row either: delegation to the loop
-container already shipped. So for the plain shape, the per-row reactive
-graph (createRoot + per-item signal + effect + subscriptions) carries no
-information the loop doesn't already have — it can be deleted, not
-deferred.
+Event handlers need nothing per row either: delegation to the loop container
+already shipped. So for the plain shape the per-row reactive graph carries no
+information the loop doesn't already have — it can be **deleted, not
+deferred**.
 
 ### 9.2 The model
 
-Per eligible loop, the compiler emits a **row plan** (functions + data,
-no per-row closures at hydration) consumed by a new runtime entry point
-(`mapArrayLazy`, working name):
+Per eligible loop the compiler emits a **row plan** (functions + data, no
+per-row closures at hydration) consumed by `mapArrayLazy`:
 
 - **Hydration first run**: partition SSR rows (same marker walk as
-  `mapArray`), build plain entries `{ key, startMarker, primaryEl,
-  extras, item, refs: null, last: null }`. `key` comes from the
-  SSR-rendered `data-key` attribute (read, never written). NO root, NO
-  signal, NO effect, NO query, NO claim, NO DOM write per row.
-- **Item-driven updates**: on `!Object.is` the reconciler directly calls
-  the plan's `applyItem(entry)` — claims the row's slot refs lazily on
-  that row's first update (scan inside that one row; cached on
-  `entry.refs`; CSR-created rows record refs from known clone paths with
-  no scan), then writes each item-driven binding through per-binding
-  last-value dedup stored on the entry.
-- **Outer-involving bindings** (any binding whose dependency set includes
-  a signal from outside the row — including mixed item+outer bindings
-  like the selected-class): the compiler emits ONE loop-level
-  `createEffect` that reads the outer signals and applies those bindings
-  to every entry with the same per-binding dedup. Emitted only when such
-  bindings exist. Mixed bindings are also included in `applyItem` (an
-  item change can flip them); dedup makes the overlap idempotent.
-- **CSR creation / removal / reorder**: template clone + direct writes
-  for new rows; disposal is trivial (entries hold no reactive
-  resources); the LIS minimal-move reorder is carried over from
-  `mapArray` unchanged.
+  `mapArray`), build plain entries `{ key, startMarker, primaryEl, extras,
+  item, refs: null, last: null }`. `key` comes from the SSR-rendered
+  `data-key` (read, never written). NO root, NO signal, NO effect, NO query,
+  NO claim, NO DOM write per row.
+- **Item-driven updates**: on `!Object.is` the reconciler calls
+  `applyItem(entry)` directly — claims the row's slot refs lazily on that
+  row's first update (scan inside that one row; cached on `entry.refs`; CSR-
+  created rows record refs from known clone paths with no scan), then writes
+  each binding through per-binding last-value dedup on the entry.
+- **Outer-involving bindings** (dependency set includes a signal from
+  outside the row, including mixed item+outer bindings): ONE loop-level
+  `createEffect` reads the outer signals and applies those bindings to every
+  entry with the same dedup. Emitted only when such bindings exist. Mixed
+  bindings are also in `applyItem`; dedup makes the overlap idempotent.
+- **CSR creation / removal / reorder**: template clone + direct writes for
+  new rows; disposal is trivial (entries hold no reactive resources); the
+  LIS minimal-move reorder carries over from `mapArray` unchanged.
 
 ### 9.3 Soundness — two layers, no trust-first-run regression
 
-The A3 follow-up removed trust-first-run for `'markup'` slots because a
-first write can carry client-only state the server never saw (§6). The
-lazy row graph must not reintroduce that hole. Two distinct consistency
-questions get two distinct answers:
+§6 removed trust-first-run for `'markup'` because a first write can carry
+client-only state the server never saw. The lazy row graph must not
+reintroduce that hole. Two distinct consistency questions, two distinct
+answers:
 
 1. **Outer-involving bindings** (first run of the loop-level effect):
-   **read-compare-write seeding.** The first run computes each entry's
-   value and READS the current DOM (`getAttribute` / `nodeValue`) to
-   seed the dedup state, writing only where computed ≠ DOM. Sound
-   unconditionally — client-only outer state (a `createSignal(
-   readFromLocalStorage())` feeding the binding) diverges from SSR and
-   gets patched on that first run, exactly like today. Cost: O(rows)
-   attribute/text reads at hydration, no writes on the consistent path.
-   (The spike used skip-first-run seeding instead; the production choice
-   is read-compare-write — same asymptotics, unconditionally sound.)
-2. **Item-driven bindings**: their first evaluation is deferred until
-   the reconciler sees an item CHANGE — so hydration-time consistency
-   between the SSR rows and the first client `items()` read is TRUSTED,
-   not verified. That trust is sound only when both derive from the
-   same data. This is a **compile-time eligibility gate** (below), not
-   a runtime check: when the loop's data source is provably
-   hydration-consistent (derived from props / server-serialized values
-   — the `bf-p` protocol makes props identical by construction), lazy
-   adoption is sound; when it is not provable, the loop falls back to
-   the current eager emission. Sound-or-loud: eligibility is a
-   mechanical decision with a defined fallback, never a silent
-   divergence.
+   **read-compare-write seeding.** The first run computes each entry's value
+   and READS the current DOM (`getAttribute` / `nodeValue`) to seed the dedup
+   state, writing only where computed ≠ DOM. Sound unconditionally —
+   client-only outer state diverges from SSR and gets patched on that first
+   run, exactly like today. Cost: O(rows) reads at hydration, no writes on
+   the consistent path.
 
-### 9.4 Eligibility v1 (fallback = current eager emission)
+   Presence-shaped attributes are part of this contract: an attribute SSR
+   renders bare (`aria-expanded` with no value reads back as `""`) must not
+   be seeded by presence alone, or the client writes `"true"` over it and
+   changes meaning. Seed from the read VALUE.
 
-A loop is lazy-eligible when ALL hold; otherwise it keeps today's
-A3b-consolidated eager emission:
+2. **Item-driven bindings**: their first evaluation is deferred until the
+   reconciler sees an item CHANGE — so hydration-time consistency between
+   the SSR rows and the first client `items()` read is TRUSTED, not
+   verified. That trust is sound only when both derive from the same data.
+   This is a **compile-time eligibility gate** (§9.4), not a runtime check:
+   when the loop's data source is provably hydration-consistent (props,
+   literals, and derivations thereof — the `bf-p` protocol makes props
+   identical by construction), lazy adoption is sound; otherwise the loop
+   falls back to eager emission. Sound-or-loud: a mechanical decision with a
+   defined fallback, never a silent divergence.
 
-- Plain loop-row shape — the same boundary A3b drew:
-  `stringifyPlainLoop` and the branch-scoped `emitPlain`. Composite,
-  component, anchored, and static shapes are untouched.
-- Single-root rows. (Multi-root rows need `startMarker` bookkeeping the
-  spike deliberately dropped; widen later.)
-- The loop source passes the hydration-consistency gate (§9.3(2)):
-  its dependency chain reaches only props, literals, and derivations
-  thereof — no client-only environment reads (storage, `Date`-lowered
-  formatting with client timezone, etc.).
-- No row-local reactive declarations (a preamble that creates per-row
-  signals/memos needs per-row reactivity by definition).
-- Keyed with SSR-rendered `data-key` (already emitted by the SSR
-  templates for keyed loops; claim-plan conformance can assert it).
-- Profile mode (`profileComponentName`) is NOT lazy — it keeps the
-  granular eager emission so `#binding:<slotId>` attribution and
-  turn-boundary accounting stay truthful, same policy as A3b.
+### 9.3a The re-subscribe seam
 
-### 9.5 Spike results (2026-07-27, sandbox; independently re-verified)
+`createSelector` subscribes its CALLER **per key**. So `applyOuter` is
+subscribed only to the keys present on its first run, and a reconcile can
+strand that subscription set: add row C (written correctly by `createRow`,
+under `untrack`, so C's key is never registered), then select C — only key C
+flips, nobody is subscribed to it, and C's binding goes stale.
 
-| Measurement | eager barefoot | lazy prototype | solid |
-|---|---|---|---|
-| SSR post-hydration heap (forced GC, n=3, stdev ≤ 1KB) | 2718KB | **1580KB (−42%)** | 2578–2589KB |
-| DOM-suite memory (1k rows created CSR) | 1766KB | **481KB (−73%)** | 1484KB |
-| Hydration median (n=10, two runs) | 49.1 / 55.8ms | 46.9 / 50.0ms | 38.3 / 41.6ms |
-| update10th / select / swap / clear | — | neutral or better in both runs | — |
+An "empty → non-empty" trigger never sees that sequence. The seam must
+re-subscribe whenever the entry set changes membership. Implemented as one
+loop-level generation signal bumped once per reconcile that created a row or
+changed an item (removals do not bump); `applyOuter` reads it first, so its
+subscription set is rebuilt against the current keys. Unconditional — not
+something the compiler opts a loop into, and not something a user chooses.
 
-The memory numbers are the honest framework-shaped bound (full real
-runtime + hydration walker + keyed reconciler attached), unlike Stage
-0's runtime-less 1169KB stunt floor. Hydration time improves only a few
-ms at 1k rows: per-row work is no longer the dominant term —
-navigation/parse and the fixed non-row costs (module eval, `bf-p` JSON
-parse, document scope walk) are, and those are a separate follow-up
-axis. Correctness gates (select A→B→A transitions, update10th
-spot-checks, swap/remove/clear/10k/append/replace) all pass in real
-Chromium; the gate scripts are committed with the spike.
+This also removed the compiler's priming obligation for opaque outer reads.
+Compiler priming was considered and rejected as a general answer:
+`createSelector`'s dependency chain runs through an IMPORT, so provability
+breaks unless framework primitives are catalogued.
 
-### 9.5b Shipped results (measured 2026-07-27, L3 on the real pipeline)
+### 9.4 Eligibility (fallback = eager emission)
 
-The numbers in §9.5 came from the hand-written prototype. The table
-below is the shipped compiler emission, measured on the same sandbox,
-two runs each, and independently re-measured after L3:
+The gate lives in `ir-to-client-js/control-flow/plan/lazy-row-eligibility.ts`
+and is pure/unit-testable. Every refusal carries an explicit `reason`.
 
-| Metric | eager (pre-L3) | **shipped lazy (L3)** | solid |
-|---|---|---|---|
-| SSR post-hydration heap (n=3, forced GC) | 2718.6KB | **1807.6 / 1812.7KB (−33%)** | 2577.9 / 2586.7KB |
-| Hydration median (n=10) | 49.1 / 55.8ms | **31.5 / 30.1ms** | 28.9 / 28.4ms |
-| Hydration ratio vs solid | 1.28–1.34x | **1.06–1.09x** | 1.00x |
-| Client JS (raw / gzip) | 21.6 / 7.8KB | 21.4 / 7.8KB | 17.0 / 6.6KB |
-| Interactivity gate | PASS | PASS | PASS |
+Two refusals are **deliberate policy, not backlog**:
 
-Heap lands 30% BELOW solid, and the hydration gap against solid closed
-from ~1.3x to ~1.07x — a larger hydration win than §9.5 projected,
-because the prototype still paid the eager bundle's unused code paths
-while the shipped emission replaces them. No bundle-size regression
-(marginally smaller: the row plan costs less than the renderItem
-closure + consolidated effect it replaces).
+- **Loop source not provably hydration-consistent** (§9.3(2)), and its
+  sibling "free identifiers unavailable". Do not relax these.
+- **Profile mode** keeps the granular eager emission so `#binding:<slotId>`
+  attribution and turn-boundary accounting stay truthful.
 
-**Where the shipped result differs from the prototype's −42% heap.** The
-prototype claimed nothing at hydration; the shipped emission's
-`applyOuter` seed pass materializes each row's ref tuple (the attr
-element handle plus the row's `lazySlots` writer closure and its plan
-array) so it can read-compare-write the outer-involving class binding.
-That is ~230KB/1k rows of the gap and is a known, mechanically
-identified follow-up: a row whose outer-involving bindings are all
-ATTRS needs only the element handle at seed, never the content-slot
-writer. Splitting the ref tuple by what the seed pass actually reads
-recovers most of the difference without touching the model.
+A third is a **soundness fail-safe**: a binding whose identifier set is
+`UNKNOWN_IDENTIFIERS` refuses, because with nothing to look at the
+classifier reports `referencesIndex: false` as an ASSUMPTION — and emitting
+`applyItem`/`applyOuter` that reference a non-existent index variable is a
+silent bug. Distinct in kind from "name visible but unprimable", which the
+seam (§9.3a) covers.
 
-**DOM-suite memory is unchanged (1768KB) by L3** — not a measurement
-failure but the eligibility gate working as designed: the krausest
-bench component uses `const isSelected = createSelector(selected)`, and
-an opaque local whose CALL is the reactive read cannot be primed by the
-emitter (see the limits below), so that loop keeps the eager emission.
-The prototype's −73% DOM figure therefore remains unrealized in
-shipped code until the gate widens.
+### 9.5 Current gate refusals — the widening backlog
 
-### 9.5c Gate restrictions after L3 — one lifted, one open
+Everything else in the gate is unshipped work, not a design limit. Highest
+value first:
 
-Neither is a silent divergence: each makes the loop ineligible, and the
-loop keeps today's eager emission with an explicit `reason`.
+| Refusal | Why it refuses / what lifting it needs |
+|---|---|
+| `row contains a reactive conditional` | Includes a BARE ternary in child position (`{cond ? a : b}`), which lowers to `insert()` and is refused as a conditional, not as a text binding. Read "outer-involving row text is lazy" with that caveat attached. Directly on the 1k-row hot path. |
+| `index-keyed loop (no explicit key)` | Adoption pairs SSR rows to items by `data-key`, which index-keyed loops do not render. Common in real apps. |
+| `row has a map-callback preamble` | The rule is "any preamble at all", not "a preamble declaring row-local reactivity" — over-broad by construction. |
+| `multi-root (Fragment) row` | Needs the `startMarker`/`extras` bookkeeping the spike deliberately dropped. Not a design wall. |
+| `row has imperative child refs`, `row body is a child component`, `row contains nested child components`, `row contains an inner loop` | Shapes where the row owns lifecycle. Genuinely-needs-per-row-reactivity and doesn't-need-it are mixed together here and need separating. |
+| `flatMap descriptor loop`, `anchored whole-item-conditional loop`, `row has preamble-patched regions`, `destructured loop param without param bindings` | Outside the plain shape A3b drew; each wants its own bookkeeping. |
 
-1. **Outer-involving TEXT bindings — LIFTED** (runtime #2411, compiler
-   #2412). Originally refused: `lazySlots` was a write-only door, so
-   §9.3(1)'s read-compare-write seeding had no DOM read-back for content
-   slots. That turned out to be an API gap, not a design limit — and the
-   obstacle behind it was that claiming a text slot MUTATED the DOM
-   (`textNodeAfterComment` created an empty Text node when SSR rendered
-   the slot empty), so "claim it, then read the held node" would have
-   left a trail of empty Text nodes across every row it inspected.
+Outer-involving TEXT bindings were also refused once and are now lazy
+(#2411/#2412). The obstacle was not the design but the mutating text claim
+(§6) plus a write-only door; fixing the claim made the read door
+(`lazyClaimSlots`) a straight addition, chosen per LOOP so loops without
+outer-involving text pay nothing for the widening. Concatenations, template
+literals, and explicit `String(cond ? a : b)` are lazy; the bare ternary is
+the exception noted above.
 
-   Fixed at the cause: a text claim now adopts an existing Text node and
-   otherwise holds its anchor Comment as the record of where the node
-   must go, deferring creation to the first write that needs it. With
-   claims non-mutating, the read door is a straight addition —
-   `lazyClaimSlots` / `ClaimedSlotsRW`, the read-capable twin of
-   `lazySlots` over the SAME claim. The emitter picks the door per LOOP,
-   so a loop with no outer-involving text keeps the single-closure
-   writer and pays nothing for the widening.
-
-   A claim-free "peek" (resolve the marker, read, discard the
-   resolution) was designed first and rejected: it adds a second
-   position-resolution path and re-scans on the next update, breaking
-   §2's claim-once rule.
-
-   **What this does and does not reach.** Concatenations
-   (`{prefix() + row.label}`), template literals, and explicit
-   `String(cond ? a : b)` are lazy now. A BARE ternary in child position
-   (`{cond ? a : b}`) is still eager — it lowers to a reactive
-   conditional (`insert()`), which §9.4 refuses as a conditional, not as
-   a text binding. Read "outer-involving row text is lazy" with that
-   caveat attached.
-
-2. **Opaque outer reads still refuse the loop.** A local like
-   `const isSelected = createSelector(selected)` is an ordinary const
-   whose CALL is the reactive read. The `applyOuter` effect must
-   subscribe on its FIRST run, and when the entry list is empty at that
-   moment the per-entry reads never execute — so the effect subscribes
-   to nothing and never re-runs, while rows added later (correct at
-   creation via `createRow`) go stale on the next outer change. The
-   emitter cannot synthesize a priming call for an opaque callee, so it
-   refuses.
-
-   Two ways out. **Compiler priming** — emit a priming read where the
-   callee's signal dependencies are statically known — is not a general
-   answer: `createSelector`'s dependency chain runs through an IMPORT,
-   so provability breaks unless framework primitives are catalogued.
-   **A runtime re-subscribe seam** removes the priming obligation from
-   the compiler entirely and is the better direction.
-
-   **Correction to this section's earlier prescription.** It said the
-   seam should "re-run `applyOuter` when the entry list transitions
-   empty → non-empty". That is INSUFFICIENT for a per-key subscription
-   model, which is exactly what `createSelector` implements: its
-   returned selector subscribes the CALLING computation to a per-key
-   set, and its internal effect wakes only the subscribers of keys whose
-   predicate FLIPPED. So with rows A and B present, `applyOuter` is
-   subscribed to keys A and B only; add row C (written correctly by
-   `createRow`, under `untrack`, so C's key is never registered), then
-   select C — only key C flips, nobody is subscribed to it, and C's
-   binding goes stale. An empty → non-empty trigger never sees that
-   sequence. The seam must re-run `applyOuter` whenever the entry
-   SET changes membership (any create or remove), which re-subscribes
-   against the current key set. Cost is one loop-level signal plus an
-   O(rows) dedup-guarded pass on reconciles that add or remove rows —
-   work `applyOuter` already does on any outer change.
-
-### 9.6 Migration — stacked semantic PRs
-
-- **L1 — spec** (this section).
-- **L2 — runtime**: `mapArrayLazy` + entry/row-plan contract in
-  `@barefootjs/client/runtime`, unit-tested standalone (adoption,
-  direct-call updates, lazy ref claim, read-compare-write seeding
-  helper, LIS reuse, dispose-on-remove). No compiler change.
-- **L3 — compiler switch**: eligibility analysis + row-plan emission for
-  eligible plain loops; ineligible loops and profile mode keep the A3b
-  emission; snapshots/CSR goldens regenerated once; a CSR-conformance
-  fixture exercising an eligible loop and an ineligible fallback loop
-  lands in the same PR.
-- **L4 — measure + record** (this): re-ran the DOM/SSR benches on the
-  real implementation; results in §9.5b, shipped limits in §9.5c.
+**Where the gate is currently binding**: the krausest bench component uses
+`const isSelected = createSelector(selected)`. Before the seam that made the
+loop ineligible; it is eligible now, which is why DOM-suite memory moved.
+Loops still refused are the ones in the table above.


### PR DESCRIPTION
`spec/slot-unification.md` had gone stale in four places for the third time in a row. The reason was structural rather than careless: the document carried point-in-time benchmark tables, and those expire within days of being written. Anything measured belongs in CI's benchmark comment, not in a document people read for the rules.

## What changed

**The measurement log is gone** — 709 → 377 lines. Removed: Stage 0's prototype table, Step A's two-run table with its own "these numbers are not comparable to the baseline" disclaimer, Step B's bench table, A3b's regression table, and §9.5/§9.5b's spike-vs-shipped tables.

**What stays is the part that does not expire**: the claim-once rule and its corollary (a second position-resolution path is a violation even when it looks cheaper), the three cases where a marker is structurally required, the two soundness layers, the re-subscribe seam, and the eligibility gate.

Step B's measured note survives in shortened form only because a runtime docstring points at it for the reason the general marker-elision case is deferred.

The header now states plainly that this document is the rules and not an introduction, and that measurements live in CI.

## The four stale statements, corrected

| Was | Now |
|---|---|
| §9.5c heading "one lifted, one open" and §9.5c(2) "Opaque outer reads still refuse the loop" | Both predate the re-subscribe seam, which removed the compiler's priming obligation entirely. Now §9.3a describes the seam rather than a limit. |
| §9.5b "DOM-suite memory is unchanged (1768KB) by L3" | True only while the krausest loop was refused. Verified against real emission, not inferred from the benchmark delta: `benchmarks/apps/barefoot/dist/components/Bench.client.js` now contains `mapArrayLazy`. |
| §9.5b SSR heap 1807KB | Two measurements out of date; the figure is no longer carried here at all. |
| §8 "lazy effect-graph construction remains" / "did not ship" | It shipped. §8 now lists only the two real follow-ups plus gate widening. |

## Reference retargeting

Docstrings and fixtures cited subsections this PR removes. Retargeted `§9.5c(1)` → `§9.5` and `§9.5c(2)` → `§9.3a`, and §9 now records the L1–L4 labels docstrings cite so "L2"/"L3" stay meaningful. All comment-only — `git diff -- packages/` is comments and one fixture `description` string.

## Verification

- `bun test` on the two affected compiler test files — 58 pass, 0 fail
- `bun run lint` — clean
- Rebuilt `@barefootjs/client` and the DOM bench app to confirm the `mapArrayLazy` claim above rather than asserting it
- Checked that no `§9.5c` / `§9.5b` / `§9.6` reference remains anywhere in `packages/*/src`, `spec/`, or `docs/`

Requesting the `no-changeset` label: the only `packages/*/src` edits are doc comments, so there is no consumer-visible change to version.