### PR TITLE
docs(jsx): correct #2417 — the index-keyed refusal is unreachable, not a backlog item

### DIFF
--- a/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
+++ b/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
@@ -534,19 +534,45 @@ describe('lazy row emission — outer-involving TEXT binding (§9.5 lifted)', ()
   })
 })
 
-describe('lazy row emission — ineligible loops fall back', () => {
-  test('an index-keyed loop keeps the eager mapArray emission', () => {
-    const js = clientJs(`
+/**
+ * The gate's `index-keyed loop (no explicit key)` refusal is a FAIL-SAFE that
+ * no compiling program can reach: an unkeyed `.map()` row is BF023 upstream.
+ * Pinned here so the refusal is never mistaken for a widening opportunity —
+ * if unkeyed loops ever become legal, this test fails and says where to look.
+ */
+describe('unkeyed loops never reach the gate', () => {
+  const UNKEYED = `
 'use client'
 import { createSignal } from '@barefootjs/client'
 export function UnkeyedRows() {
   const [rows, setRows] = createSignal<string[]>([])
   return <ul>{rows().map(row => <li>{row}</li>)}</ul>
 }
-`, 'UnkeyedRows.tsx')
-    expect(js).toContain('mapArray(')
-    expect(js).not.toContain('mapArrayLazy(')
+`
+
+  test('an unkeyed .map() row is a BF023 compile error', () => {
+    const result = compileJSX(UNKEYED, 'UnkeyedRows.tsx', { adapter: new TestAdapter() })
+    const errors = result.errors.filter(e => e.severity === 'error')
+    expect(errors.map(e => e.code)).toContain('BF023')
   })
+
+  test('a key whose VALUE is the index is an ordinary keyed loop and stays eligible', () => {
+    // `key={i}` is what the BF023 suggestion tells users to write for static
+    // lists. It is a real key expression, so `loop.key != null` and the gate's
+    // keying branch is not involved at all.
+    const js = clientJs(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function IndexValueKeyed() {
+  const [rows, setRows] = createSignal<string[]>([])
+  return <ul>{rows().map((row, i) => <li key={i}>{row}</li>)}</ul>
+}
+`, 'IndexValueKeyed.tsx')
+    expect(js).toContain('mapArrayLazy(')
+  })
+})
+
+describe('lazy row emission — ineligible loops fall back', () => {
 
   test('a row with a reactive conditional keeps the eager mapArray emission', () => {
     const js = clientJs(`

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-row-eligibility.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-row-eligibility.ts
@@ -222,8 +222,20 @@ export function lazyRowEligibility(args: LazyRowEligibilityArgs): LazyRowEligibi
   //     `mapArrayLazy` deliberately does not carry.
   if (shape.bodyIsMultiRoot) return NO('multi-root (Fragment) row')
 
-  // (3) Keyed via an explicit `key` — adoption pairs SSR rows to items by
-  //     the SSR-rendered `data-key`, which index-keyed loops do not render.
+  // (3) Keyed via an explicit `key`.
+  //
+  //     This is a FAIL-SAFE, not a widening opportunity — do not plan work
+  //     around it. A `.map()` whose row element has no valid `key` is already
+  //     a compile ERROR upstream (BF023 / BF024, `checkLoopKey` in
+  //     `jsx-to-ir.ts`), so no program that compiles cleanly can reach this
+  //     branch through the plain / branch-plain call sites. It stays because
+  //     the gate must not depend on another pass having rejected the input,
+  //     and because a `null` keyFn would silently switch `mapArrayLazy` to
+  //     positional keying — correct in itself, but a decision this function
+  //     should make explicitly rather than inherit.
+  //
+  //     `lazy-row-eligibility.test.ts` pins the BF023 half so that if unkeyed
+  //     loops ever become legal, the test naming this fails and points here.
   if (!shape.hasExplicitKey) return NO('index-keyed loop (no explicit key)')
 
   // (4) No conditionals in the row.

--- a/spec/slot-unification.md
+++ b/spec/slot-unification.md
@@ -344,7 +344,17 @@ Two refusals are **deliberate policy, not backlog**:
 - **Profile mode** keeps the granular eager emission so `#binding:<slotId>`
   attribution and turn-boundary accounting stay truthful.
 
-A third is a **soundness fail-safe**: a binding whose identifier set is
+A third is **unreachable, and must not be planned around**: `index-keyed loop
+(no explicit key)`. A `.map()` whose row element carries no valid `key` is a
+compile ERROR upstream (BF023 / BF024, `checkLoopKey`), so no program that
+compiles cleanly reaches that branch. It stays as a fail-safe because the gate
+must not depend on another pass having rejected its input. Note that `key={i}`
+— what BF023's own suggestion tells users to write for static lists — is an
+ordinary keyed loop and has always been eligible; "index-keyed" here means
+*no key at all*, not *a key whose value is the index*. Both halves are pinned
+in `lazy-row-eligibility.test.ts`.
+
+A fourth is a **soundness fail-safe**: a binding whose identifier set is
 `UNKNOWN_IDENTIFIERS` refuses, because with nothing to look at the
 classifier reports `referencesIndex: false` as an ASSUMPTION — and emitting
 `applyItem`/`applyOuter` that reference a non-existent index variable is a
@@ -359,7 +369,6 @@ value first:
 | Refusal | Why it refuses / what lifting it needs |
 |---|---|
 | `row contains a reactive conditional` | Includes a BARE ternary in child position (`{cond ? a : b}`), which lowers to `insert()` and is refused as a conditional, not as a text binding. Read "outer-involving row text is lazy" with that caveat attached. Directly on the 1k-row hot path. |
-| `index-keyed loop (no explicit key)` | Adoption pairs SSR rows to items by `data-key`, which index-keyed loops do not render. Common in real apps. |
 | `row has a map-callback preamble` | The rule is "any preamble at all", not "a preamble declaring row-local reactivity" — over-broad by construction. |
 | `multi-root (Fragment) row` | Needs the `startMarker`/`extras` bookkeeping the spike deliberately dropped. Not a design wall. |
 | `row has imperative child refs`, `row body is a child component`, `row contains nested child components`, `row contains an inner loop` | Shapes where the row owns lifecycle. Genuinely-needs-per-row-reactivity and doesn't-need-it are mixed together here and need separating. |


### PR DESCRIPTION
**This corrects a claim I introduced in #2417.** That PR's §9.5 "widening backlog — highest value first" table listed:

> `index-keyed loop (no explicit key)` — Adoption pairs SSR rows to items by `data-key`, which index-keyed loops do not render. **Common in real apps.**

The "common in real apps" part is false, and listing it as a work item was wrong. This PR removes that row and records why.

## What is actually true

An unkeyed `.map()` row is a compile **error** upstream — BF023 (BF024 for nested loops) from `checkLoopKey` in `jsx-to-ir.ts` — and `bf build` does not write output for a component with an error-severity diagnostic. So no shipped client JS ever carries the `null` keyFn that would reach this branch.

The other half was a naming confusion: `key={i}` — exactly what BF023's own suggestion tells users to write for static lists — is an **ordinary keyed loop** (`loop.key != null`) and has been lazy-eligible since L3. "index-keyed" in the gate means *no key at all*, not *a key whose value is the index*.

## Evidence

**1. Every unkeyed shape errors, and only unkeyed shapes emit a `null` keyFn.** Seven adversarial shapes, checking `result.errors` against whether the emitted JS contains a `mapArray*(..., null, ...)` call:

| shape | diagnostics | `null` keyFn |
|---|---|---|
| expression body, no key | BF023 | yes |
| block body, no key | BF023 | yes |
| `.filter().map()`, no key | BF023 | yes |
| ternary callback body, no key | BF023 ×2 | yes |
| key passed only via spread (`{...{key: r.id}}`) | BF023 | yes |
| block body with a preamble, no key | BF023 | yes |
| nested inner loop, no key | BF024 | yes |
| **control: `key={r.id}`** | **none** | **no** |

No counterexample: nothing produces a `null` keyFn without a diagnostic, and nothing diagnostic-free produces one. This is seven shapes, not a proof — but it covers the forms a reader would reach for, including the two I expected to slip through (spread-only key, and a block body).

**2. `bf build` does not emit on error.** `packages/cli/src/lib/build.ts:2087` returns `{ kind: 'error' }` when any diagnostic has error severity; the caller at `:702` increments `errorCount`, keeps the previous cache entry, and `continue`s without writing new output.

**3. The boundary of the claim.** `compileJSX` — the library API — returns diagnostics *alongside* emitted files rather than throwing. A direct API consumer that ignores `result.errors` can produce output with a `null` keyFn. So the accurate statement is "unreachable through `bf build`", not "impossible to construct". This is exactly what misled me first: a compiler-only probe emitted client JS happily and I read that as the shape being supported.

## How it surfaced

The CSR-conformance fixture I wrote to cover the widening. The harness refused to compile it:

```
error: Compilation errors in component.tsx:
Missing key attribute in list rendering. Add a key prop for efficient updates
```

## What lands

**No behavior change.** The refusal keeps its place as a fail-safe, with a comment saying why it is unreachable and that it must not be planned around — a gate must not depend on another pass having rejected its input, and a `null` keyFn silently switching `mapArrayLazy` to positional keying is a decision this function should make explicitly rather than inherit.

Two tests replace the old "an index-keyed loop keeps the eager mapArray emission" assertion, which only ever proved the refusal fired:

- `an unkeyed .map() row is a BF023 compile error` — if unkeyed loops ever become legal, this fails and names the branch to revisit
- `a key whose VALUE is the index is an ordinary keyed loop and stays eligible` — pins `key={i}` → `mapArrayLazy`

Spec §9.4 records the finding; §9.5's backlog table drops the row.

## The reverted work, for the record

If the premise ever changes, `mapArrayLazy` needs two changes for `getKey === null`, and both halves matter:

- stop READING `data-key` at adoption — otherwise a literal `data-key={...}` (legal on a row with no `key` prop) is adopted as a key the reconcile path never computes, desynchronising every row on first update
- stop STAMPING it on creation — otherwise the attribute lands on CSR-created rows only, since SSR emits none, so one list's rows disagree with each other

## Verification

- `bun test` on the two affected compiler test files — 58 pass, 0 fail
- `bun test packages/adapter-tests/src/__tests__/{coverage-map,csr-conformance}.test.ts` — 236 pass, 0 fail
- `bun run lint` — clean
- 35 CI checks green
- The gate's decision function is untouched apart from the comment, so no emission diff

`no-changeset` labelled: comment and test changes only.