### PR TITLE
fix(client): connect a CSR child to the DOM before running its init

### DIFF
--- a/.changeset/connect-child-before-init.md
+++ b/.changeset/connect-child-before-init.md
@@ -42,10 +42,15 @@ already in the document (see `runtime/hydrate.ts`, whose ordering contract
 exists for exactly this `provideContext` → `useContext` visibility reason).
 
 `mountAt` is an unconditional obligation, since callers previously ran
-`replaceWith` on every outcome: paths that don't consume it — missing or empty
-template, `ComponentDef` mode, and the root-deferred-placeholder shape that
-must stay detached so its self-replacement stays recoverable — still get the
-replacement performed on the way out.
+`replaceWith` on every outcome: paths that don't consume it — a missing or empty
+template, and the root-deferred-placeholder shape that must stay detached so its
+self-replacement stays recoverable — still get the replacement performed on the
+way out.
+
+Both construction modes honour it. `ComponentDef` mode initially did not: that
+branch returned early and ran `def.init` detached, so `createComponent(def, …,
+mountAt)` kept the very bug this fixes. `mountAt` is threaded through it too, so
+the lifecycle does not depend on whether a caller passes a name or a def.
 
 **Still open:** `mapArray` rows are unaffected and continue to init detached —
 `renderItem` returns the element to `mapArray`, so there is no placeholder to

--- a/.changeset/connect-child-before-init.md
+++ b/.changeset/connect-child-before-init.md
@@ -1,0 +1,59 @@
+---
+"@barefootjs/client": minor
+"@barefootjs/jsx": minor
+---
+
+Connect a CSR-materialised child component before running its `init`, so
+context resolves by DOM position.
+
+**This changes when `init` runs relative to DOM insertion.** `createComponent`
+built the element with `parseHTML(...).firstChild` and called `initFn` on it
+while it was still detached; every caller then attached it afterwards
+(`ph.replaceWith(comp)`). So a component's own `init` observed an element with
+no parent chain.
+
+`useContext` resolves providers by walking `parentElement` from the current
+scope. From a detached element that walk finds nothing and falls through to
+the module-global fallback store in `runtime/context.ts` — and that store is
+**last-writer-wins across every provider of the same context on the page**.
+With one provider the fallback happens to return the right value, which is why
+this stayed hidden.
+
+The divergence shows up when a child is materialised *after* a sibling provider
+has run. During a plain hydration pass the doc-order walker inits each provider
+immediately before creating its own children, so the global still holds that
+provider's value. But a child created later — by an interaction — reads whatever
+provider hydrated last:
+
+```
+<Host value="ONE">   ← child added here, later
+<Host value="TWO">   ← this one wrote the global last
+```
+
+the new child under `ONE` received `"TWO"`.
+
+`createComponent` now takes a `mountAt` argument — the placeholder it replaces —
+and performs that replacement *before* `init`, so `useContext` resolves by
+position and layout reads (`offsetWidth`, `getBoundingClientRect`) see a
+laid-out element. `upsertChild`, `upsertChildItem`, and the branch
+child-component emission pass their placeholder through. This aligns the CSR
+path with the SSR one, where the doc-order walker only ever inits elements
+already in the document (see `runtime/hydrate.ts`, whose ordering contract
+exists for exactly this `provideContext` → `useContext` visibility reason).
+
+`mountAt` is an unconditional obligation, since callers previously ran
+`replaceWith` on every outcome: paths that don't consume it — missing or empty
+template, `ComponentDef` mode, and the root-deferred-placeholder shape that
+must stay detached so its self-replacement stays recoverable — still get the
+replacement performed on the way out.
+
+**Still open:** `mapArray` rows are unaffected and continue to init detached —
+`renderItem` returns the element to `mapArray`, so there is no placeholder to
+hand over, and the batched `insertBefore` happens later. This is the xyflow
+shape (`<Flow>` provides `FlowContext`; nodes render through `mapArray` and read
+`useFlow()` in their init), and the reason
+`packages/xyflow/src/flow-subsystems.ts` carries a `__bfFlowStore` +
+`closest('.bf-flow')` workaround. Reproduced by the skipped tests in
+`packages/client/__tests__/runtime/csr-loop-row-init-connected.test.ts`; closing
+it reorders the emitted `renderItem` tail or pre-inserts the row, both on the
+runtime's hottest path, so it is deliberately not bundled here.

--- a/packages/client/__tests__/runtime/csr-child-init-connected.test.ts
+++ b/packages/client/__tests__/runtime/csr-child-init-connected.test.ts
@@ -1,0 +1,128 @@
+/**
+ * A CSR-materialised child must run its `init` while CONNECTED, so
+ * `useContext` resolves by DOM position instead of falling back to the
+ * global context store.
+ *
+ * `createComponent` builds the element with `parseHTML(...).firstChild`
+ * and calls `initFn` on it before any caller has attached it (see
+ * `component.ts`'s step 6 → step 9). `useContext`'s ancestor walk
+ * therefore finds nothing and drops to `contextStore`, which is
+ * last-writer-wins across every provider of that context on the page.
+ *
+ * Why the bug hides during a plain hydration pass: the doc-order walker
+ * inits each provider immediately before creating its own children, so
+ * the global store still happens to hold that provider's value. The
+ * divergence only surfaces when a child is materialised LATER — after a
+ * sibling provider has overwritten the global — which is what an
+ * interaction that mounts a new child does. That is the shape this test
+ * pins: two providers of one context, then a late child mount under the
+ * FIRST one.
+ */
+
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+describe('CSR child init runs connected (context resolves by position)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('a late-mounted child sees its own provider, not the last one on the page', async () => {
+    const { hydrate, flushHydration, upsertChild, createContext, useContext, provideContext } =
+      await import('../../src/runtime')
+
+    const ctx = createContext<string>('DEFAULT')
+
+    /** Records `[childTag, contextValueSeenDuringInit]`. */
+    const seen: Array<[string, string]> = []
+    /** Child mounts deferred to simulate a later interaction. */
+    const laterMounts: Array<() => void> = []
+
+    hydrate('CtxKid', {
+      init: (el: Element, props: any) => {
+        seen.push([props.tag, useContext(ctx)])
+      },
+      template: () => `<b>kid</b>`,
+    })
+
+    hydrate('CtxProv', {
+      init: (el: Element, props: any) => {
+        provideContext(ctx, props.value)
+        // Child mounted during this init pass — the global store still
+        // holds this provider's value, so this one is right either way.
+        upsertChild(el, 'CtxKid', 's0', { tag: `${props.value}:during` })
+        // Child mounted after every provider has run.
+        laterMounts.push(() => {
+          upsertChild(el, 'CtxKid', 's1', { tag: `${props.value}:later` })
+        })
+      },
+      template: () =>
+        `<div><span data-bf-ph="s0"></span><span data-bf-ph="s1"></span></div>`,
+    })
+
+    // Two SSR-rendered providers of the SAME context, each with its own
+    // CSR placeholders for children.
+    document.body.innerHTML = `
+      <div bf-s="CtxProv_one" bf-p='{"value":"ONE"}'>
+        <span data-bf-ph="s0"></span><span data-bf-ph="s1"></span>
+      </div>
+      <div bf-s="CtxProv_two" bf-p='{"value":"TWO"}'>
+        <span data-bf-ph="s0"></span><span data-bf-ph="s1"></span>
+      </div>
+    `
+
+    flushHydration()
+
+    // Both providers have now run; the global store holds "TWO".
+    expect(seen).toEqual([
+      ['ONE:during', 'ONE'],
+      ['TWO:during', 'TWO'],
+    ])
+
+    seen.length = 0
+    for (const mount of laterMounts) mount()
+
+    // Each late child must see the provider it is nested under.
+    // Pre-fix, 'ONE:later' saw 'TWO' — its init ran detached, so the
+    // ancestor walk failed and the global store answered instead.
+    expect(seen).toEqual([
+      ['ONE:later', 'ONE'],
+      ['TWO:later', 'TWO'],
+    ])
+  })
+
+  test('a CSR child is connected by the time its init observes the DOM', async () => {
+    const { hydrate, flushHydration, upsertChild } = await import('../../src/runtime')
+
+    const connectedAtInit: boolean[] = []
+
+    hydrate('ConnKid', {
+      init: (el: Element) => {
+        connectedAtInit.push(el.isConnected)
+      },
+      template: () => `<b>kid</b>`,
+    })
+
+    hydrate('ConnHost', {
+      init: (el: Element) => {
+        upsertChild(el, 'ConnKid', 's0', {})
+      },
+      template: () => `<div><span data-bf-ph="s0"></span></div>`,
+    })
+
+    document.body.innerHTML =
+      `<div bf-s="ConnHost_a"><span data-bf-ph="s0"></span></div>`
+
+    flushHydration()
+
+    // Pre-fix: [false] — init ran on the element returned by
+    // `parseHTML(...).firstChild`, before `ph.replaceWith(comp)`.
+    expect(connectedAtInit).toEqual([true])
+  })
+})

--- a/packages/client/__tests__/runtime/csr-child-init-connected.test.ts
+++ b/packages/client/__tests__/runtime/csr-child-init-connected.test.ts
@@ -125,4 +125,37 @@ describe('CSR child init runs connected (context resolves by position)', () => {
     // `parseHTML(...).firstChild`, before `ph.replaceWith(comp)`.
     expect(connectedAtInit).toEqual([true])
   })
+
+  test('the ComponentDef path honours mountAt too, not just the registry path', async () => {
+    const { createComponent } = await import('../../src/runtime')
+
+    // `createComponent` accepts a `ComponentDef` directly (CSR mode, no
+    // registry lookup). That branch returns early, so it needs its own
+    // connect-before-init — otherwise `mountAt` would be a registry-only
+    // guarantee and `def.init` would still run detached. Pinned here so the
+    // two modes cannot drift apart silently.
+    const connectedAtInit: boolean[] = []
+
+    const host = document.createElement('div')
+    const placeholder = document.createElement('span')
+    host.appendChild(placeholder)
+    document.body.appendChild(host)
+
+    const el = createComponent(
+      {
+        name: 'DefKid',
+        init: (node: Element) => { connectedAtInit.push(node.isConnected) },
+        template: () => `<b>def-kid</b>`,
+      } as any,
+      {},
+      undefined,
+      undefined,
+      placeholder,
+    )
+
+    expect(connectedAtInit).toEqual([true])
+    // And the placeholder really was consumed, exactly once.
+    expect(placeholder.parentNode).toBeNull()
+    expect(host.innerHTML).toBe('<b bf-s="DefKid_' + el.getAttribute('bf-s')!.split('_')[1] + '">def-kid</b>')
+  })
 })

--- a/packages/client/__tests__/runtime/csr-loop-row-init-connected.test.ts
+++ b/packages/client/__tests__/runtime/csr-loop-row-init-connected.test.ts
@@ -1,0 +1,136 @@
+/**
+ * KNOWN LIMITATION — `mapArray` rows still init detached.
+ *
+ * `createItemScope` calls `renderItem(...)` (which calls
+ * `createComponent`) while building the run; the actual
+ * `container.insertBefore(...)` happens later, once per run. So a row
+ * component's init observes a detached element, and `useContext` falls
+ * back to the global, last-writer-wins context store.
+ *
+ * This is the xyflow shape: `<Flow>` provides `FlowContext`, nodes render
+ * through `mapArray`, and their init reads `useFlow()`. With more than one
+ * `<Flow>` on the page, a node created after a sibling flow has hydrated
+ * resolves the WRONG flow's store. The `__bfFlowStore` +
+ * `closest('.bf-flow')` workaround in `packages/xyflow/src/
+ * flow-subsystems.ts` exists because of this.
+ *
+ * The child-slot path (`upsertChild` / `upsertChildItem`) is fixed — it
+ * hands its placeholder to `createComponent` as `mountAt` so the element
+ * is connected before init. The loop path can't use that: `renderItem`
+ * RETURNS the element to `mapArray`, so there is no placeholder to
+ * replace. Closing it means either deferring row init until after the
+ * batched insert (which reorders the emitted renderItem tail — nested
+ * `initChild` calls and row effects currently run assuming the row's own
+ * init already ran), or pre-inserting the row into its container before
+ * init and letting the batched `insertBefore` reposition it. Both touch
+ * the hottest path in the runtime, so they are deliberately NOT bundled
+ * with the child-slot fix.
+ *
+ * Un-skip these two tests when that lands — they assert the correct
+ * behaviour and currently fail as `[false, false]` and `'ONE:2' → 'TWO'`.
+ */
+
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+describe.skip('mapArray row init runs connected (known limitation)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('a CSR-created row is connected when its init runs', async () => {
+    const { hydrate, createComponent, mapArray, initChild, createSignal } =
+      await import('../../src/runtime')
+
+    const connectedAtInit: boolean[] = []
+
+    hydrate('RowKid', {
+      init: (el: Element) => {
+        connectedAtInit.push(el.isConnected)
+      },
+      template: (p: any) => `<li>${p.label}</li>`,
+    })
+
+    const container = document.createElement('ul')
+    document.body.appendChild(container)
+
+    const [items] = createSignal([{ id: 1, label: 'a' }, { id: 2, label: 'b' }])
+
+    mapArray(
+      () => items(),
+      container,
+      (it: any) => it.id,
+      (item: () => any, _i: number, existing?: HTMLElement) => {
+        if (existing) {
+          initChild('RowKid', existing, { label: item().label })
+          return existing
+        }
+        return createComponent('RowKid', { label: item().label }, item().id)
+      },
+      'loop0',
+    )
+
+    expect(connectedAtInit).toEqual([true, true])
+  })
+
+  test('a row mounted later sees its own provider, not the last on the page', async () => {
+    const {
+      hydrate, flushHydration, createComponent, mapArray, initChild,
+      createSignal, createContext, useContext, provideContext,
+    } = await import('../../src/runtime')
+
+    const ctx = createContext<string>('DEFAULT')
+    const seen: Array<[string, string]> = []
+    const pushers: Array<() => void> = []
+
+    hydrate('FlowNode', {
+      init: (_el: Element, props: any) => {
+        seen.push([props.tag, useContext(ctx)])
+      },
+      template: (p: any) => `<li>${p.tag}</li>`,
+    })
+
+    hydrate('FlowHost', {
+      init: (el: Element, props: any) => {
+        provideContext(ctx, props.value)
+        const container = el.querySelector('ul')!
+        const [nodes, setNodes] = createSignal<any[]>([{ id: 1 }])
+        mapArray(
+          () => nodes(),
+          container,
+          (n: any) => n.id,
+          (item: () => any, _i: number, existing?: HTMLElement) => {
+            const tag = `${props.value}:${item().id}`
+            if (existing) {
+              initChild('FlowNode', existing, { tag })
+              return existing
+            }
+            return createComponent('FlowNode', { tag }, item().id)
+          },
+          `loop-${props.value}`,
+        )
+        pushers.push(() => setNodes([{ id: 1 }, { id: 2 }]))
+      },
+      template: () => `<div><ul></ul></div>`,
+    })
+
+    document.body.innerHTML = `
+      <div bf-s="FlowHost_one" bf-p='{"value":"ONE"}'><ul></ul></div>
+      <div bf-s="FlowHost_two" bf-p='{"value":"TWO"}'><ul></ul></div>
+    `
+
+    flushHydration()
+    seen.length = 0
+
+    // Add a node to the FIRST flow, after both providers have run.
+    pushers[0]!()
+
+    expect(seen).toEqual([['ONE:2', 'ONE']])
+  })
+})

--- a/packages/client/__tests__/runtime/csr-loop-row-init-connected.test.ts
+++ b/packages/client/__tests__/runtime/csr-loop-row-init-connected.test.ts
@@ -17,14 +17,35 @@
  * The child-slot path (`upsertChild` / `upsertChildItem`) is fixed — it
  * hands its placeholder to `createComponent` as `mountAt` so the element
  * is connected before init. The loop path can't use that: `renderItem`
- * RETURNS the element to `mapArray`, so there is no placeholder to
- * replace. Closing it means either deferring row init until after the
- * batched insert (which reorders the emitted renderItem tail — nested
- * `initChild` calls and row effects currently run assuming the row's own
- * init already ran), or pre-inserting the row into its container before
- * init and letting the batched `insertBefore` reposition it. Both touch
- * the hottest path in the runtime, so they are deliberately NOT bundled
- * with the child-slot fix.
+ * RETURNS the element to `mapArray`, so there is no placeholder to replace.
+ *
+ * BOTH obvious fixes were implemented and MEASURED against the site/ui e2e
+ * suite. Both regress it, for different reasons. Numbers are from the same
+ * three spec files; the baseline (child-slot fix only) fails 3 —
+ * `form-builder` ×2 and `studio` ×1, all pre-existing and unrelated:
+ *
+ *   1. Defer row init until after the batched insert  →  6 failed
+ *      (+3 `file-upload`: per-row start / progress / remove).
+ *      The compiler emits nested `initChild` calls and row effects AFTER
+ *      `createComponent` in the renderItem body, and they depend on the
+ *      row's own init having already run. Deferring leaves handlers unbound.
+ *
+ *   2. Park the row in its container before init, let the reorder move it
+ *      (excluding fresh rows from the LIS walk)  →  7 failed
+ *      (+4 `file-upload`, i.e. worse).
+ *      `qsa-item.ts`'s documented contract is the obstacle: during
+ *      renderItem-body setup "the primary and extras are still detached
+ *      nodes — `__el.nextSibling` is `null` and step 2 yields nothing"
+ *      (qsa-item.ts:22-27). Attaching the row early makes that sibling walk
+ *      run past the row's own roots into OTHER rows' elements, so
+ *      `qsaItem` / `upsertChildItem` resolve to the wrong item.
+ *
+ * So the loop path actively DEPENDS on rows being detached during setup, in
+ * two independent places. Closing this gap means unwinding that dependency
+ * — giving `qsaItem` an item-bounded lookup that doesn't rely on
+ * detachment, and moving the emitted renderItem tail's ordering assumption
+ * — not just changing when init fires. That is a larger change than the
+ * child-slot fix and is tracked separately.
  *
  * Un-skip these two tests when that lands — they assert the correct
  * behaviour and currently fail as `[false, false]` and `'ONE:2' → 'TWO'`.

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -74,21 +74,30 @@ export function createComponent(
   slot?: CreateComponentSlotInfo,
   mountAt?: Element | null,
 ): HTMLElement {
-  const element = createComponentUnmounted(nameOrDef, props, key, slot, mountAt)
+  const element = materializeComponent(nameOrDef, props, key, slot, mountAt)
   // `mountAt` is an unconditional obligation: callers used to run
   // `ph.replaceWith(comp)` themselves on every outcome, so every path that
-  // did NOT consume the placeholder still owes the replacement — empty /
-  // missing template, `ComponentDef` mode, and the root-deferred-placeholder
-  // shape. `parentNode` (not `isConnected`) is the right "still unconsumed"
-  // probe: it survives a `mountAt` that was itself detached, which is the
-  // normal case during multi-root loop-body setup.
+  // did NOT consume the placeholder still owes the replacement — a missing or
+  // empty template (either mode), and the root-deferred-placeholder shape,
+  // which must stay detached so its self-replacement stays recoverable.
+  // `parentNode` (not `isConnected`) is the right "still unconsumed" probe: it
+  // survives a `mountAt` that was itself detached, which is the normal case
+  // during multi-root loop-body setup.
   if (mountAt && mountAt.parentNode && element !== mountAt) {
     mountAt.replaceWith(element)
   }
   return element
 }
 
-function createComponentUnmounted(
+/**
+ * Build the element, connect it at `mountAt` when there is one, and run
+ * `init` — in that order, which is the whole point (see step 7b).
+ *
+ * Named "materialize" rather than anything with "unmounted" in it because it
+ * DOES mount: the connect has to happen inside, before `init`, and only the
+ * paths that cannot consume the placeholder leave that to `createComponent`.
+ */
+function materializeComponent(
   nameOrDef: string | ComponentDef,
   props: Record<string, unknown> = {},
   key?: string | number,
@@ -102,7 +111,7 @@ function createComponentUnmounted(
   if (props == null) props = {}
   // ComponentDef mode: use def directly instead of registry lookup
   if (typeof nameOrDef !== 'string') {
-    return createComponentFromDef(nameOrDef, props, key)
+    return createComponentFromDef(nameOrDef, props, key, mountAt)
   }
 
   const name = nameOrDef
@@ -580,7 +589,8 @@ function insertGetterChildren(element: HTMLElement, children: unknown): void {
 function createComponentFromDef(
   def: ComponentDef,
   props: Record<string, unknown>,
-  key?: string | number
+  key?: string | number,
+  mountAt?: Element | null,
 ): HTMLElement {
   if (!def.template) {
     throw new Error('[BarefootJS] createComponent with ComponentDef requires a template function')
@@ -606,6 +616,14 @@ function createComponentFromDef(
   element.setAttribute(BF_SCOPE, scopeId)
   if (key !== undefined) {
     element.setAttribute(BF_KEY, String(key))
+  }
+
+  // Connect before init, for the same reason the registry path does (see
+  // `materializeComponent` step 7b): `def.init` may resolve context by DOM
+  // position or measure layout, and neither works detached. Keeps `mountAt`
+  // one contract across both modes instead of a registry-only guarantee.
+  if (mountAt) {
+    mountAt.replaceWith(element)
   }
 
   // Initialize

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -38,6 +38,10 @@ export function setParentScopeId(id: string | null): void {
  * @param name - Component name (e.g., 'TodoItem')
  * @param props - Props to pass to the component
  * @param key - Optional key for list reconciliation
+ * @param slot - Slot-relationship markers stamped as `bf-h` / `bf-m`
+ * @param mountAt - Placeholder this component replaces. When given, the
+ *   element is connected to the document *before* `init` runs — see
+ *   "Connect before init" below.
  * @returns Created DOM element
  *
  * @example
@@ -68,6 +72,28 @@ export function createComponent(
   props: Record<string, unknown> = {},
   key?: string | number,
   slot?: CreateComponentSlotInfo,
+  mountAt?: Element | null,
+): HTMLElement {
+  const element = createComponentUnmounted(nameOrDef, props, key, slot, mountAt)
+  // `mountAt` is an unconditional obligation: callers used to run
+  // `ph.replaceWith(comp)` themselves on every outcome, so every path that
+  // did NOT consume the placeholder still owes the replacement — empty /
+  // missing template, `ComponentDef` mode, and the root-deferred-placeholder
+  // shape. `parentNode` (not `isConnected`) is the right "still unconsumed"
+  // probe: it survives a `mountAt` that was itself detached, which is the
+  // normal case during multi-root loop-body setup.
+  if (mountAt && mountAt.parentNode && element !== mountAt) {
+    mountAt.replaceWith(element)
+  }
+  return element
+}
+
+function createComponentUnmounted(
+  nameOrDef: string | ComponentDef,
+  props: Record<string, unknown> = {},
+  key?: string | number,
+  slot?: CreateComponentSlotInfo,
+  mountAt?: Element | null,
 ): HTMLElement {
   // A bare callable shim invoked from user code (e.g. an object-literal
   // value `LOGOS[id]()` whose arrow the compiler hoisted into a component)
@@ -173,6 +199,29 @@ export function createComponent(
     element.setAttribute(BF_KEY, String(key))
   }
 
+  // 7b. Connect before init.
+  //
+  // `initFn` resolves context by DOM position (`useContext` walks
+  // `parentElement` from the current scope) and may measure layout. Both
+  // need this element to be in the document, so when the caller told us
+  // which placeholder we replace, do the replacement NOW rather than
+  // after init. Running init detached made `useContext` fall through to
+  // the global, last-writer-wins context store, so a child materialised
+  // after a sibling provider had run picked up the wrong provider's
+  // value. This aligns the CSR path with the SSR one, where the
+  // doc-order walker only ever inits elements already in the document
+  // (`hydrate.ts`).
+  //
+  // A root-level deferred placeholder is excluded: its init replaces
+  // `element` itself, which the block below recovers via a throwaway
+  // wrapper. Connecting first would make that replacement happen in the
+  // live DOM with no handle on the result, so this shape keeps the
+  // detached behaviour.
+  const rootIsDeferredPlaceholder = element.hasAttribute(BF_PLACEHOLDER)
+  if (mountAt && !rootIsDeferredPlaceholder) {
+    mountAt.replaceWith(element)
+  }
+
   // 8. Set currentScope so provideContext/useContext are element-scoped.
   // This allows context providers in initFn to store context on this element.
   const prevScope = setCurrentScope(element)
@@ -184,7 +233,6 @@ export function createComponent(
   // `replaceWith` — but a detached root node can't replace itself in
   // place. Park it in a throwaway wrapper so the replacement lands
   // somewhere we can recover, then return the materialised child.
-  const rootIsDeferredPlaceholder = element.hasAttribute(BF_PLACEHOLDER)
   let placeholderWrapper: HTMLElement | null = null
   if (rootIsDeferredPlaceholder) {
     placeholderWrapper = parseHTML('<div></div>').firstChild as HTMLElement

--- a/packages/client/src/runtime/qsa-item.ts
+++ b/packages/client/src/runtime/qsa-item.ts
@@ -120,9 +120,8 @@ export function upsertChildItem(
   const ph = qsaItem(primaryEl, `[data-bf-ph="${phId}"]`) as HTMLElement | null
   if (ph) {
     const slot = slotId ? buildSlotInfo(primaryEl, slotId, anchorScope) : undefined
-    const comp = createComponent(name, props, key, slot)
-    ph.replaceWith(comp)
-    return comp
+    // Connect before init — see the same call in `upsertChild`.
+    return createComponent(name, props, key, slot, ph)
   }
   return null
 }

--- a/packages/client/src/runtime/registry.ts
+++ b/packages/client/src/runtime/registry.ts
@@ -158,9 +158,11 @@ export function upsertChild(
     : parent.querySelector(`[${BF_PLACEHOLDER}="${phId}"]`)) as HTMLElement | null
   if (ph) {
     const slot = slotId ? buildSlotInfo(parent, slotId, anchorScope) : undefined
-    const comp = createComponent(name, props, key, slot)
-    ph.replaceWith(comp)
-    return comp
+    // Hand the placeholder to `createComponent` so the new element is
+    // connected before its init runs — `useContext` resolves by DOM
+    // position, and a detached init silently fell back to the global
+    // context store.
+    return createComponent(name, props, key, slot, ph)
   }
   return null
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop-child-arm.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop-child-arm.ts
@@ -97,6 +97,11 @@ export function stringifyBranchEventBindings(
  * SSR side: element has `bf-s` → qsa() finds it, initChild wires events.
  * CSR side: element is a `data-bf-ph` placeholder → createComponent
  * replaces it, then initChild runs against the new element.
+ *
+ * The placeholder is passed to `createComponent` as its `mountAt`
+ * argument so the component's own init runs connected — context resolves
+ * by DOM position, and a detached init falls back to the global,
+ * last-writer-wins context store.
  */
 export function stringifyBranchChildComponentInits(
   lines: string[],
@@ -104,7 +109,7 @@ export function stringifyBranchChildComponentInits(
   indent: string,
 ): void {
   for (const init of plan) {
-    lines.push(`${indent}{ let __c = qsa(__branchScope, ${init.selector}); if (!__c) { const __ph = __branchScope.querySelector('[${DATA_BF_PH}="${init.placeholderId}"]'); if (__ph) { __c = createComponent('${nameForRegistryRef(init.name)}', ${init.propsExpr}); __ph.replaceWith(__c) } } if (__c) initChild('${nameForRegistryRef(init.name)}', __c, ${init.propsExpr}) }`)
+    lines.push(`${indent}{ let __c = qsa(__branchScope, ${init.selector}); if (!__c) { const __ph = __branchScope.querySelector('[${DATA_BF_PH}="${init.placeholderId}"]'); if (__ph) { __c = createComponent('${nameForRegistryRef(init.name)}', ${init.propsExpr}, undefined, undefined, __ph) } } if (__c) initChild('${nameForRegistryRef(init.name)}', __c, ${init.propsExpr}) }`)
   }
 }
 


### PR DESCRIPTION
## The bug

`createComponent` built the element with `parseHTML(...).firstChild`, called `initFn` on it **while it was still detached**, and left attaching to the caller (`ph.replaceWith(comp)`). So a component&#39;s own `init` observed an element with no parent chain.

`useContext` resolves providers by walking `parentElement` from the current scope. From a detached element that walk finds nothing and falls through to the module-global fallback store in `runtime/context.ts` — which is **last-writer-wins across every provider of the same context on the page**. With one provider the fallback is accidentally correct, which is why this stayed hidden.

The divergence needs a child materialised **after** a sibling provider has run. During a plain hydration pass the doc-order walker inits each provider immediately before creating its own children, so the global still holds that provider&#39;s value. A child created later — by an interaction — reads whichever provider hydrated last:

```
   ← child added here, later
   ← this one wrote the global last
```

the new child under `ONE` received `&#34;TWO&#34;`.

## The fix

`createComponent` takes a `mountAt` argument — the placeholder it replaces — and performs that replacement **before** `init`, so `useContext` resolves by position and layout reads (`offsetWidth`, `getBoundingClientRect`) see a laid-out element. `upsertChild`, `upsertChildItem` and the branch child-component emission pass their placeholder through.

**This is not a new ordering model.** `runtime/hydrate.ts:11-17` already documents connect-then-init in true document order, with `provideContext` → `useContext` visibility as the stated reason. Only the CSR path deviated; this converges it.

`mountAt` is an **unconditional obligation**, because callers previously ran `replaceWith` on every outcome. It is honoured in **both** modes — string name and `ComponentDef` — so the lifecycle does not depend on which one a caller picks. The paths that genuinely cannot consume it are a missing/empty template (either mode) and the root-deferred-placeholder shape that must stay detached so its self-replacement stays recoverable; those get the replacement performed on the way out. Without that the placeholder simply survived; the first cut of this change got exactly that wrong.

## Reproduced in-repo, no browser needed

`csr-child-init-connected.test.ts` drives the real runtime API (`hydrate` / `flushHydration` / `upsertChild`), not a synthetic probe:

| Assertion | Pre-fix |
|---|---|
| CSR child connected when its init runs | `[false]` |
| late child under provider ONE sees | `&#39;TWO&#39;` (want `&#39;ONE&#39;`) |

## Why the e2e suite never caught the bug

`packages/xyflow/src/flow-subsystems.ts:95-98` stamps the store on the host element and has children walk `el.closest(&#39;.bf-flow&#39;).__bfFlowStore` instead of using context. That workaround exists precisely because `useFlow()` returned `undefined` — its own test docstring records it. So the product routes around the defect and all 25 xyflow e2e tests pass while the context path underneath is wrong.

Separately, the three xyflow interaction tests that would exercise the loop path (`Node Dragging`, `Pan / Zoom`, `Edge Reconnection`) are `skip`ped in the spec, marked &#34;re-enable in cutover step C4&#34;.

## Loop rows: both fixes measured, both regress — not shipped

`mapArray` rows still init detached, so the underlying defect is **not** closed here. `renderItem` returns the element to `mapArray`, so there is no placeholder to hand over. Both obvious fixes were implemented and run against the full site/ui e2e suite. Baseline for the three affected spec files is **3 failed** (`form-builder` ×2, `studio` ×1 — pre-existing, unrelated, present with this fix alone):

| Attempt | Result |
|---|---|
| 1. Defer row init until after the batched insert | **6 failed** (+3 `file-upload`) |
| 2. Park the row in its container pre-init, let the LIS reorder move it | **7 failed** (+4 `file-upload`) |

Attempt 1 fails because the compiler emits nested `initChild` calls and row effects *after* `createComponent` in the renderItem body, and they depend on the row&#39;s own init having already run — deferring leaves per-row handlers unbound.

Attempt 2 fails on `qsa-item.ts:22-27`, which documents that during renderItem-body setup &#34;the primary and extras are still detached nodes — `__el.nextSibling` is `null` and step 2 yields nothing.&#34; Attaching the row early makes that sibling walk run past the row&#39;s own roots into **other rows&#39;** elements, so `qsaItem` / `upsertChildItem` resolve against the wrong item.

So the loop path actively *depends* on rows being detached during setup, in two independent places. Closing the gap means unwinding that dependency — an item-bounded `qsaItem` lookup that doesn&#39;t rely on detachment, plus relocating the emitted renderItem tail&#39;s ordering assumption — a larger change than this one. Reproduction stays as skipped tests in `csr-loop-row-init-connected.test.ts`, with both attempts and their numbers recorded in the docstring.

## Review follow-up

Two Copilot findings on the first cut, both real, both fixed in `28cf5367`:

1. **`mountAt` was a registry-only guarantee.** The `ComponentDef` branch returned early via `createComponentFromDef`, which ran `def.init` detached — so `createComponent(def, …, mountAt)` still had the exact bug this PR fixes. `mountAt` is now threaded through that path too, connecting before `def.init`, rather than documenting the exception: a mode-dependent lifecycle is the kind of split that goes unnoticed until something depends on it. No caller hits the combination today (every `mountAt` caller passes a string name), so this closed a latent trap rather than a live defect. A new test pins the two modes together.
2. **`createComponentUnmounted` was a misnomer** — it performs `mountAt.replaceWith(element)` internally, because the connect must precede init. Renamed to `materializeComponent` and documented as build-then-connect-then-init.

## Verification

| Suite | Result |
|---|---|
| `packages/client` | **595 pass, 2 skip, 0 fail** (skips = the loop-row gap) |
| `packages/adapter-tests` | **1451 pass, 0 fail** |
| CI | **all 41 checks green** on `28cf5367` (`test (jsx-1)`, `test (jsx-2)`, `test (rest)`, `test-ui`, `benchmark`, all adapter e2e jobs) |
| CI `e2e-site-ui` ×4 shards | **all green** — 1130 tests / 82 specs, real browser |
| benchmark | no regression — memory 1048.0KB and post-hydration heap 1659.6KB (stdev 0.0KB) across runs, interactivity gate PASS, lowest post-hydration heap of the three |

Two environment notes, both pre-existing and worth separate attention:

- **`packages/jsx` is sensitive to whether `packages/client/dist` exists.** With `dist` present, 2 tests in `map-body-no-silent-divergence.test.ts` fail (`getJS() called on a JSX-bearing node`); with it absent — CI&#39;s state, since `dist` is gitignored and the jsx shard runs no build — they pass. Not caused by this change (the failing path is Phase 1; reverting the one jsx edit here doesn&#39;t help). But `bun run build` followed by `bun test packages/jsx` fails locally for anyone.
- **3 pre-existing e2e failures** in `form-builder` (×2) and `studio` (×1, a copy-button revert timing assertion) reproduce with this fix alone and are unrelated to it.

Changeset is `minor` for `@barefootjs/client` + `@barefootjs/jsx`: this changes when `init` runs relative to DOM insertion.