### PR TITLE
fix(client): keep a live DOM node intact on a lazy loop row's content slot

### DIFF
--- a/.changeset/lazy-row-node-content.md
+++ b/.changeset/lazy-row-node-content.md
@@ -1,0 +1,59 @@
+---
+"@barefootjs/client": patch
+"@barefootjs/jsx": patch
+---
+
+Keep a live DOM node intact when it lands on a lazy loop row's content slot
+
+A child-position interpolation can evaluate to a real element rather than a
+string:
+
+```tsx
+{_p.renderCell(row.id)}
+```
+
+when the caller passes an inline-JSX arrow — the compiler lifts that into a
+component whose call returns a live Node. In a lazy loop row the value was
+stringified before it ever reached the claim door (`String(__x)` in
+`stringify/lazy-row.ts`), and the row's content slot is claimed as
+`kind: 'text'`, whose writer sets `nodeValue`. A Text node cannot host an
+element, so the element was destroyed: the user saw its serialized markup as
+visible characters, or `[object HTMLDivElement]`, depending on the DOM
+implementation's `toString`.
+
+Two properties made it silent. Nothing overwrote the row afterwards — the
+other Node-bearing shapes are self-healing by accident, since a conditional's
+`insert()` re-renders through `__bfSlot` and a non-loop reactive text
+re-applies through `escapeTextOrNode`, so the wrong value is transient there
+and only the lazy row keeps it. And the eligibility gate ACCEPTS the shape: a
+prop accessor is an opaque outer read, which the re-subscribe seam
+(`spec/slot-unification.md` §9.3a) made eligible, so the row takes the lazy
+path and the destructive write is what ships.
+
+The fix keeps the cheap door and decides on the VALUE, in two halves:
+
+- `textOrNode` (new export, `runtime/claim-slots.ts`) passes a Node through and
+  coerces anything else with `String`, exactly as the previous inline emission
+  did. It is the 'text' door's counterpart to `escapeTextOrNode` — a 'text'
+  write goes through `nodeValue` and must NOT be escaped, but it does need the
+  Node case separated out. `stringify/lazy-row.ts` emits it in place of
+  `String(__x)`.
+- The claim **promotes** a slot from 'text' to 'markup' on its first Node
+  write, reusing the anchor comment the original claim already resolved (so
+  §2's claim-once rule still holds — no second position resolution) and its
+  matching `<!--/-->` as the end boundary. `writeMarkup` already splices Nodes
+  by identity, so every later write on that id — Node or string — is correct.
+  A slot that cannot host a Node (markerless, or missing its end marker) warns
+  and skips the write instead of stringifying an element.
+
+Whether such a call yields a string or a Node is not decidable from the
+expression's syntax — `renderChild(...)` and `_p.renderCell(...)` are both
+`CallExpression` — so this has to be a runtime decision on the value, not a
+compile-time classification. Strings keep the Text-node fast path; the added
+cost is one `instanceof Node` per content write.
+
+The seed comparison fails safe on its own: `read(id)` answers with a string or
+`null`, neither of which is ever `===` a Node, so an outer-involving Node
+binding always writes on its first run. That is the right direction — a Node
+is freshly built on this run and is never the SSR-rendered content by
+identity.

--- a/packages/adapter-tests/fixtures/__snapshots__/ai-chat.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/ai-chat.client.js
@@ -1,4 +1,4 @@
-import { $, __bfSlot, createComponent, createDisposableEffect, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, insert, lazySlots, mapArrayLazy, qsa } from '@barefootjs/client/runtime'
+import { $, __bfSlot, createComponent, createDisposableEffect, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, insert, lazySlots, mapArrayLazy, qsa, textOrNode } from '@barefootjs/client/runtime'
 
 
 export function initAIChatInteractive(__scope, _p = {}) {
@@ -100,7 +100,7 @@ export function initAIChatInteractive(__scope, _p = {}) {
         __l[0] = __x
       } }
       { const __x = msg().content
-      __r[1]('s0', String(__x))
+      __r[1]('s0', textOrNode(__x))
       __l[1] = __x }
       return __el
     },
@@ -117,7 +117,7 @@ export function initAIChatInteractive(__scope, _p = {}) {
         __l[0] = __x
       } }
       { const __x = msg().content
-      if (!(1 in __l) || !Object.is(__l[1], __x)) __r[1]('s0', String(__x))
+      if (!(1 in __l) || !Object.is(__l[1], __x)) __r[1]('s0', textOrNode(__x))
       __l[1] = __x }
     },
   }, 'l0')

--- a/packages/client/__tests__/runtime/lazy-row-node-content.test.ts
+++ b/packages/client/__tests__/runtime/lazy-row-node-content.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Regression: a lazy loop row's content slot must be able to hold a live Node.
+ *
+ * The lazy row graph (`spec/slot-unification.md` §9) claims every row content
+ * slot as `kind: 'text'`, because that is the cheap door — a Text node write
+ * through `nodeValue`, no range bookkeeping. But a child-position
+ * interpolation can evaluate to a real element rather than a string:
+ *
+ *   {_p.renderCell(row.id)}
+ *
+ * where the caller passes an inline-JSX arrow, which the compiler lifts into a
+ * component whose call returns a live Node. A Text node cannot host an
+ * element, so before this fix the emitted `String(__x)` collapsed it — the
+ * user saw the serialized markup as visible text (or `[object
+ * HTMLDivElement]`, depending on the DOM implementation's `toString`), and
+ * nothing ever corrected it. Two properties make that failure silent:
+ *
+ *  - Nothing overwrites the row afterwards. The other Node-bearing shapes are
+ *    self-healing by accident — a conditional's `insert()` re-renders through
+ *    `__bfSlot`, and a non-loop reactive text re-applies through
+ *    `escapeTextOrNode` — so the wrong value is transient there and only the
+ *    lazy row keeps it.
+ *  - The lazy gate ACCEPTS this shape. A prop accessor is an opaque outer
+ *    read, which the re-subscribe seam (§9.3a) made eligible, so the row goes
+ *    down the lazy path and the destructive write is what ships.
+ *
+ * The fix keeps the cheap door and decides on the VALUE: `textOrNode` passes
+ * a Node through instead of stringifying it, and the claim promotes that slot
+ * from 'text' to 'markup' on first Node write, reusing the anchor it already
+ * resolved. Whether such a call yields a string or a Node is not decidable
+ * from the expression's syntax — both are `CallExpression` — so this has to
+ * be a runtime decision, not a compile-time classification.
+ */
+
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { lazySlots } from '../../src/runtime/claim-slots'
+import { writeFileSync, unlinkSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+
+async function compileAndRegister(source: string, filename: string): Promise<string> {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) throw new Error(`Compilation errors:\n${errors.map(e => e.message).join('\n')}`)
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error('No client JS emitted')
+
+  const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+  const rewritten = clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+
+  const dir = mkdtempSync(join(tmpdir(), 'bf-lazy-node-'))
+  const file = join(dir, `${filename.replace(/\W/g, '_')}.mjs`)
+  writeFileSync(file, rewritten)
+  try {
+    await import(file)
+  } finally {
+    try { unlinkSync(file) } catch {}
+  }
+  return clientJs
+}
+
+/**
+ * A keyed plain loop whose row content is a call on a caller-supplied prop —
+ * the eligible-for-lazy shape. `renderCell` returns a live element, which is
+ * what the caller of a `renderX` prop is expected to be able to do.
+ */
+const ROWS = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Props = { renderCell: (id: number) => unknown }
+export function NodeRows(_p: Props) {
+  const [rows, setRows] = createSignal<{ id: number }[]>([])
+  const load = () => setRows([{ id: 1 }])
+  const append = () => setRows([{ id: 1 }, { id: 2 }])
+  return (
+    <div>
+      <button id="load" onClick={load}>load</button>
+      <button id="append" onClick={append}>append</button>
+      <ul id="list">{rows().map(r => (
+        <li key={r.id}>{_p.renderCell(r.id)}</li>
+      ))}</ul>
+    </div>
+  )
+}
+`
+
+describe('lazy row content slot — live Node values', () => {
+  beforeEach(() => { document.body.innerHTML = '' })
+
+  test('a Node-valued row binding renders as an element, not as text', async () => {
+    const js = await compileAndRegister(ROWS, 'NodeRows.tsx')
+    // Precondition: this row really is on the lazy path. If the gate stops
+    // accepting the shape, the assertions below would pass for the wrong
+    // reason (the eager path routes through `__bfSlot`, which never had the
+    // bug), so pin it.
+    expect(js).toContain('mapArrayLazy(')
+    expect(js).toContain('textOrNode(__x)')
+
+    const { createComponent } = await import('../../src/runtime')
+    const el = createComponent('NodeRows', {
+      renderCell: (id: number) => {
+        const b = document.createElement('b')
+        b.className = 'cell'
+        b.textContent = `N${id}`
+        return b
+      },
+    }) as Element
+    document.body.appendChild(el)
+    ;(el.querySelector('#load') as HTMLElement).click()
+
+    const cells = el.querySelectorAll('#list li b.cell')
+    expect(cells.length).toBe(1)
+    expect(cells[0].textContent).toBe('N1')
+    // The failure mode was the element surviving only as characters.
+    expect(el.querySelector('#list')!.innerHTML).not.toContain('&lt;b')
+    expect(el.querySelector('#list')!.innerHTML).not.toContain('[object')
+  })
+
+  test('rows added later get their own elements', async () => {
+    await compileAndRegister(ROWS, 'NodeRows2.tsx')
+    const { createComponent } = await import('../../src/runtime')
+    const el = createComponent('NodeRows', {
+      renderCell: (id: number) => {
+        const b = document.createElement('b')
+        b.className = 'cell'
+        b.textContent = `N${id}`
+        return b
+      },
+    }) as Element
+    document.body.appendChild(el)
+    ;(el.querySelector('#load') as HTMLElement).click()
+    ;(el.querySelector('#append') as HTMLElement).click()
+
+    const cells = [...el.querySelectorAll('#list li b.cell')].map(n => n.textContent)
+    expect(cells).toEqual(['N1', 'N2'])
+  })
+})
+
+describe('claim door — text slot receiving a Node', () => {
+  beforeEach(() => { document.body.innerHTML = '' })
+
+  test('promotes the claim to markup and splices the node', () => {
+    const host = document.createElement('div')
+    host.innerHTML = 'before<!--bf:s0-->old<!--/-->after'
+    document.body.appendChild(host)
+
+    const write = lazySlots(host, [{ id: 's0', kind: 'text', path: [] }])
+    const node = document.createElement('em')
+    node.textContent = 'live'
+    write('s0', node)
+
+    expect(host.querySelector('em')?.textContent).toBe('live')
+    // Boundaries survive every write, and the adopted Text node is gone.
+    expect(host.innerHTML).toBe('before<!--bf:s0--><em>live</em><!--/-->after')
+  })
+
+  test('a later string write on the promoted slot still lands', () => {
+    const host = document.createElement('div')
+    host.innerHTML = '<!--bf:s0-->old<!--/-->'
+    document.body.appendChild(host)
+
+    const write = lazySlots(host, [{ id: 's0', kind: 'text', path: [] }])
+    const node = document.createElement('em')
+    write('s0', node)
+    write('s0', 'plain')
+
+    expect(host.querySelector('em')).toBeNull()
+    expect(host.innerHTML).toBe('<!--bf:s0-->plain<!--/-->')
+  })
+
+  test('the same node written twice is a no-op, not a re-splice', () => {
+    const host = document.createElement('div')
+    host.innerHTML = '<!--bf:s0--><!--/-->'
+    document.body.appendChild(host)
+
+    const write = lazySlots(host, [{ id: 's0', kind: 'text', path: [] }])
+    const node = document.createElement('em')
+    node.textContent = 'x'
+    write('s0', node)
+    const first = host.querySelector('em')
+    write('s0', node)
+
+    expect(host.querySelector('em')).toBe(first)
+    expect(host.querySelectorAll('em').length).toBe(1)
+  })
+
+  test('string values are untouched by the Node branch', () => {
+    const host = document.createElement('div')
+    host.innerHTML = '<!--bf:s0-->old<!--/-->'
+    document.body.appendChild(host)
+
+    const write = lazySlots(host, [{ id: 's0', kind: 'text', path: [] }])
+    // Markup-looking text must stay text — the 'text' door does not parse.
+    write('s0', '<em>not markup</em>')
+
+    expect(host.querySelector('em')).toBeNull()
+    expect(host.textContent).toBe('<em>not markup</em>')
+  })
+})

--- a/packages/client/src/runtime/claim-slots.ts
+++ b/packages/client/src/runtime/claim-slots.ts
@@ -434,6 +434,74 @@ function writeText(slot: ClaimedTextSlot, value: unknown): void {
   node.nodeValue = String(value ?? '')
 }
 
+/**
+ * Pass a live Node through untouched; coerce anything else with `String`.
+ *
+ * The 'text' door's counterpart to {@link escapeTextOrNode}. A 'text' slot
+ * writes through `nodeValue`, which needs no escaping — routing it through
+ * `escapeText` would double-escape — but it DOES need the Node case
+ * separated out, because a Text node cannot host an element and
+ * `String(node)` destroys it: `[object HTMLDivElement]` in a browser, the
+ * serialized markup rendered as visible text under some DOM shims. Wrong
+ * either way, and silently so, which is why the split lives here rather
+ * than at each call site.
+ *
+ * A Node reaches a content slot whenever a child-position interpolation
+ * calls something that builds one — `props.renderRow(item)` handed an
+ * inline-JSX arrow, which the compiler lifts into a component whose call
+ * returns a real element. Whether such a call returns a string or a Node is
+ * not decidable from the expression's syntax (both are `CallExpression`), so
+ * the decision belongs at runtime, on the value.
+ *
+ * `String(value)`, not `String(value ?? '')`: a non-Node value must coerce
+ * exactly as the previous inline `String(...)` emission did. The nullish
+ * collapse stays where it already was, in {@link writeText}.
+ */
+export function textOrNode(value: unknown): string | Node {
+  if (typeof Node !== 'undefined' && value instanceof Node) return value
+  return String(value)
+}
+
+/**
+ * A Node landed on a slot claimed as 'text'. Promote the claim to the
+ * 'markup' contract in place — the anchor comment becomes `start`, its
+ * matching `<!--/-->` becomes `end` — so this and every later write on the
+ * id goes through {@link writeMarkup}, which already splices Nodes by
+ * identity.
+ *
+ * This is a promotion, not a re-claim: the anchor is the SAME comment the
+ * original claim resolved (§2's claim-once rule holds — no second position
+ * resolution). The Text node the claim adopted or created, if any, sits
+ * inside the new range and `clearMarkupRange` removes it on the write.
+ *
+ * `null` when the slot cannot host a Node — a markerless slot (Step B
+ * elision: no anchor to promote from) or a marked slot whose end comment is
+ * missing. Both warn: refusing loudly beats stringifying an element into
+ * visible `[object HTMLDivElement]`.
+ */
+function promoteTextToMarkup(slot: ClaimedTextSlot, id: string): ClaimedMarkupSlot | null {
+  const anchor = slot.ref.nodeType === Node.COMMENT_NODE
+    ? (slot.ref as Comment)
+    // Materialized: `claimOne` adopts/creates the Text node immediately after
+    // the anchor, so the anchor is its previous sibling — unless the slot is
+    // markerless, where there is no anchor at all and `isSlotComment` says so.
+    : isSlotComment(slot.ref.previousSibling, id) ? slot.ref.previousSibling : null
+  if (!anchor) {
+    console.warn(
+      `[barefootjs] slot ${id} was claimed as text and received a Node, but has no anchor marker to promote from; write ignored`,
+    )
+    return null
+  }
+  const end = findMarkupEnd(anchor)
+  if (!end) {
+    console.warn(
+      `[barefootjs] slot ${id} was claimed as text and received a Node, but has no end marker; write ignored`,
+    )
+    return null
+  }
+  return { kind: 'markup', start: anchor, end, last: undefined }
+}
+
 /** Remove every node strictly between `start` and `end` (both survive). */
 function clearMarkupRange(start: Comment, end: Comment): void {
   const parent = end.parentNode
@@ -480,13 +548,24 @@ function writeMarkup(ref: ClaimedMarkupSlot, value: unknown): void {
   ref.last = text
 }
 
-function writeSlot(refs: ReadonlyMap<string, ClaimedSlotRef>, id: string, value: unknown): void {
+function writeSlot(refs: Map<string, ClaimedSlotRef>, id: string, value: unknown): void {
   const ref = refs.get(id)
   if (!ref) {
     console.warn(`[barefootjs] no claimed slot for id ${id}; write ignored`)
     return
   }
   if (ref.kind === 'text') {
+    // A 'text' slot cannot represent an element. Promote once, then fall
+    // through to the markup writer — which is also what makes the read door
+    // answer `null` for this id afterwards, i.e. "cannot answer, write it",
+    // the conservative direction.
+    if (typeof Node !== 'undefined' && value instanceof Node) {
+      const promoted = promoteTextToMarkup(ref, id)
+      if (!promoted) return
+      refs.set(id, promoted)
+      writeMarkup(promoted, value)
+      return
+    }
     writeText(ref, value)
   } else {
     writeMarkup(ref, value)

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -91,7 +91,7 @@ export { patchLeaf } from './patch-leaf.ts'
 // Claim-plan interpreter (slot unification A2/A3, spec/slot-unification.md)
 // — the ONE content-slot update mechanism, wired up by the compiler in A3.
 // Supersedes (deleted) `patchSlotRange` and `updateClientMarker`.
-export { claimSlots, lazySlots, lazyClaimSlots, type SlotSpec, type ClaimPlan, type ClaimedSlots, type ClaimedSlotsRW, type SlotWriter } from './claim-slots.ts'
+export { claimSlots, lazySlots, lazyClaimSlots, textOrNode, type SlotSpec, type ClaimPlan, type ClaimedSlots, type ClaimedSlotsRW, type SlotWriter } from './claim-slots.ts'
 
 // Template registry
 export { registerTemplate, getTemplate, hasTemplate, type TemplateFn } from './template.ts'

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -4380,7 +4380,7 @@ export function Example(_p, __bfKey) { return createComponent('Example', _p, __b
 `;
 
 exports[`docs/core/adapters/hono-adapter.md doc-examples L190 — (no label) 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy } from '@barefootjs/client/runtime'
+"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy, textOrNode } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
   if (!__scope) return
@@ -4443,7 +4443,7 @@ export function initExample(__scope, _p = {}) {
       const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
       const __l = __e.last = []
       { const __x = item()
-      __r[0]('s0', String(__x))
+      __r[0]('s0', textOrNode(__x))
       __l[0] = __x }
       return __el
     },
@@ -4452,7 +4452,7 @@ export function initExample(__scope, _p = {}) {
       const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
       const __l = __e.last ?? (__e.last = [])
       { const __x = item()
-      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', String(__x))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', textOrNode(__x))
       __l[0] = __x }
     },
   }, 'l0')
@@ -4513,7 +4513,7 @@ export function Counter(_p, __bfKey) { return createComponent('Counter', _p, __b
 `;
 
 exports[`docs/core/adapters/go-template-adapter.md doc-examples L168 — (no label) 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy } from '@barefootjs/client/runtime'
+"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy, textOrNode } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
   if (!__scope) return
@@ -4576,7 +4576,7 @@ export function initExample(__scope, _p = {}) {
       const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
       const __l = __e.last = []
       { const __x = item()
-      __r[0]('s0', String(__x))
+      __r[0]('s0', textOrNode(__x))
       __l[0] = __x }
       return __el
     },
@@ -4585,7 +4585,7 @@ export function initExample(__scope, _p = {}) {
       const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
       const __l = __e.last ?? (__e.last = [])
       { const __x = item()
-      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', String(__x))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', textOrNode(__x))
       __l[0] = __x }
     },
   }, 'l0')
@@ -4597,7 +4597,7 @@ export function Example(_p, __bfKey) { return createComponent('Example', _p, __b
 `;
 
 exports[`docs/core/adapters/go-template-adapter.md doc-examples L180 — (no label) 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy } from '@barefootjs/client/runtime'
+"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy, textOrNode } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
   if (!__scope) return
@@ -4660,7 +4660,7 @@ export function initExample(__scope, _p = {}) {
       const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
       const __l = __e.last = []
       { const __x = item().name
-      __r[0]('s0', String(__x))
+      __r[0]('s0', textOrNode(__x))
       __l[0] = __x }
       return __el
     },
@@ -4669,7 +4669,7 @@ export function initExample(__scope, _p = {}) {
       const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
       const __l = __e.last ?? (__e.last = [])
       { const __x = item().name
-      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', String(__x))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', textOrNode(__x))
       __l[0] = __x }
     },
   }, 'l0')
@@ -5089,7 +5089,7 @@ export function StatementExample(_p, __bfKey) { return createComponent('Statemen
 `;
 
 exports[`docs/core/advanced/compiler-internals.md doc-examples L126 — (no label) 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy } from '@barefootjs/client/runtime'
+"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy, textOrNode } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
   if (!__scope) return
@@ -5152,7 +5152,7 @@ export function initExample(__scope, _p = {}) {
       const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
       const __l = __e.last = []
       { const __x = t().name
-      __r[0]('s0', String(__x))
+      __r[0]('s0', textOrNode(__x))
       __l[0] = __x }
       return __el
     },
@@ -5161,7 +5161,7 @@ export function initExample(__scope, _p = {}) {
       const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
       const __l = __e.last ?? (__e.last = [])
       { const __x = t().name
-      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', String(__x))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', textOrNode(__x))
       __l[0] = __x }
     },
   }, 'l0')
@@ -5235,7 +5235,7 @@ export function StatementExample(_p, __bfKey) { return createComponent('Statemen
 `;
 
 exports[`docs/core/advanced/performance.md doc-examples L67 — ✅ Stable key — DOM nodes reused when list changes 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy } from '@barefootjs/client/runtime'
+"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy, textOrNode } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
   if (!__scope) return
@@ -5298,7 +5298,7 @@ export function initExample(__scope, _p = {}) {
       const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
       const __l = __e.last = []
       { const __x = item().name
-      __r[0]('s0', String(__x))
+      __r[0]('s0', textOrNode(__x))
       __l[0] = __x }
       return __el
     },
@@ -5307,7 +5307,7 @@ export function initExample(__scope, _p = {}) {
       const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
       const __l = __e.last ?? (__e.last = [])
       { const __x = item().name
-      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', String(__x))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', textOrNode(__x))
       __l[0] = __x }
     },
   }, 'l0')
@@ -5319,7 +5319,7 @@ export function Example(_p, __bfKey) { return createComponent('Example', _p, __b
 `;
 
 exports[`docs/core/advanced/performance.md doc-examples L70 — ❌ Index key — DOM nodes recreated on reorder 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy } from '@barefootjs/client/runtime'
+"import { $, createComponent, createEffect, createSignal, escapeAttr, escapeText, escapeTextOrNode, hydrate, lazySlots, mapArrayLazy, textOrNode } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
   if (!__scope) return
@@ -5382,7 +5382,7 @@ export function initExample(__scope, _p = {}) {
       const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
       const __l = __e.last = []
       { const __x = item().name
-      __r[0]('s0', String(__x))
+      __r[0]('s0', textOrNode(__x))
       __l[0] = __x }
       return __el
     },
@@ -5391,7 +5391,7 @@ export function initExample(__scope, _p = {}) {
       const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
       const __l = __e.last ?? (__e.last = [])
       { const __x = item().name
-      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', String(__x))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', textOrNode(__x))
       __l[0] = __x }
     },
   }, 'l0')

--- a/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
+++ b/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
@@ -416,8 +416,8 @@ describe('lazy row emission — eligible loop', () => {
     expect(createRow).toContain('__e.refs = [')
     expect(createRow).toContain('__e.last = []')
     expect(createRow).toContain("setAttribute('class'")   // outer-involving
-    expect(createRow).toContain("('s0', String(__x))")     // item text
-    expect(createRow).toContain("('s1', String(__x))")     // item text
+    expect(createRow).toContain("('s0', textOrNode(__x))")     // item text
+    expect(createRow).toContain("('s1', textOrNode(__x))")     // item text
   })
 
   test('applyItem claims refs lazily and dedups against entry.last', () => {
@@ -453,7 +453,7 @@ describe('lazy row emission — eligible loop', () => {
   test('an attr-only-outer loop keeps the write-only lazySlots door and the bare call form', () => {
     expect(js).toContain('lazySlots(')
     expect(js).not.toContain('lazyClaimSlots(')
-    expect(js).toContain("__r[1]('s0', String(__x))")
+    expect(js).toContain("__r[1]('s0', textOrNode(__x))")
     expect(js).not.toContain('.write(')
     expect(js).not.toContain('.read(')
   })
@@ -500,8 +500,8 @@ describe('lazy row emission — outer-involving TEXT binding (§9.5 lifted)', ()
   })
 
   test('every text write goes through the door\'s .write() method', () => {
-    expect(js).toContain(".write('s0', String(__x))")
-    expect(js).toContain(".write('s1', String(__x))")
+    expect(js).toContain(".write('s0', textOrNode(__x))")
+    expect(js).toContain(".write('s1', textOrNode(__x))")
     // The bare call form belongs to the write-only door and must not survive
     // alongside the RW one.
     expect(js).not.toContain("__r[0]('s0'")
@@ -514,9 +514,9 @@ describe('lazy row emission — outer-involving TEXT binding (§9.5 lifted)', ()
     // ONCE and reuses it for the compare and the write, so a value with a
     // side-effecting `toString` is not stringified twice.
     expect(applyOuter).toContain('if (__seed) {')
-    expect(applyOuter).toContain('const __s = String(__x)')
+    expect(applyOuter).toContain('const __s = textOrNode(__x)')
     expect(applyOuter).toContain("if (__r[0].read('s1') !== __s) __r[0].write('s1', __s)")
-    expect(applyOuter).not.toContain("read('s1') !== String(__x)")
+    expect(applyOuter).not.toContain("read('s1') !== textOrNode(__x)")
     // …and falls back to the ordinary entry.last dedup on every later run,
     // where the string is built only when the write actually happens.
     expect(applyOuter).toContain('} else if (!(1 in __l) || !Object.is(__l[1], __x))')
@@ -525,7 +525,7 @@ describe('lazy row emission — outer-involving TEXT binding (§9.5 lifted)', ()
 
   test('the outer text ALSO applies on item change, because it reads the item too', () => {
     const applyItem = js.slice(js.indexOf('applyItem:'), js.indexOf('applyOuter:'))
-    expect(applyItem).toContain("__r[0].write('s1', String(__x))")
+    expect(applyItem).toContain("__r[0].write('s1', textOrNode(__x))")
   })
 
   test('the item-only text is NOT emitted into applyOuter', () => {

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
@@ -294,13 +294,27 @@ function emitAttrBinding(
  * handling is needed or wanted here.
  *
  * The `'outer'` mode emits a real `if`/`else if` rather than one ternary
- * guard so the seed branch can bind `String(__x)` ONCE and use it for both
- * the comparison and the write. A ternary would stringify twice on the seed
- * path, which double-invokes a user value's `toString` — observable when it
- * has side effects, wasted work when it doesn't. Hoisting the string above
- * the branch instead would fix that but would also stringify on the
- * non-seed path even when dedup skips the write, i.e. on every later tick;
- * the branch keeps exactly one stringification per path taken.
+ * guard so the seed branch can bind `textOrNode(__x)` ONCE and use it for
+ * both the comparison and the write. A ternary would coerce twice on the
+ * seed path, which double-invokes a user value's `toString` — observable
+ * when it has side effects, wasted work when it doesn't. Hoisting it above
+ * the branch instead would fix that but would also coerce on the non-seed
+ * path even when dedup skips the write, i.e. on every later tick; the branch
+ * keeps exactly one coercion per path taken.
+ *
+ * `textOrNode` rather than a bare `String(...)` because a child-position
+ * interpolation can evaluate to a live Node (`props.renderRow(item)` handed
+ * an inline-JSX arrow), and `String(node)` destroys it. The helper passes a
+ * Node through so the claim door can promote the slot to 'markup' and splice
+ * it; see `claim-slots.ts`. Whether such a call yields a string or a Node is
+ * not decidable from the expression's syntax — both are `CallExpression` —
+ * so this stays a runtime decision on the value, not a compile-time
+ * classification.
+ *
+ * A Node also makes the seed comparison fail safe on its own: `read(id)`
+ * answers with a string or `null`, neither of which is ever `===` a Node, so
+ * the seed always writes. That is the correct direction — a Node is freshly
+ * built on this run and is never the SSR-rendered content by identity.
  */
 function emitTextBinding(
   lines: string[],
@@ -319,13 +333,13 @@ function emitTextBinding(
 
   if (mode === 'outer') {
     lines.push(`${ind}if (__seed) {`)
-    lines.push(`${ind}  const __s = String(__x)`)
+    lines.push(`${ind}  const __s = textOrNode(__x)`)
     lines.push(`${ind}  if (${doorExpr}.read('${t.slotId}') !== __s) ${writeOf('__s')}`)
-    lines.push(`${ind}} else if (${dedupGuard(t.ordinal)}) ${writeOf('String(__x)')}`)
+    lines.push(`${ind}} else if (${dedupGuard(t.ordinal)}) ${writeOf('textOrNode(__x)')}`)
   } else if (mode === 'item') {
-    lines.push(`${ind}if (${dedupGuard(t.ordinal)}) ${writeOf('String(__x)')}`)
+    lines.push(`${ind}if (${dedupGuard(t.ordinal)}) ${writeOf('textOrNode(__x)')}`)
   } else {
-    lines.push(`${ind}${writeOf('String(__x)')}`)
+    lines.push(`${ind}${writeOf('textOrNode(__x)')}`)
   }
   lines.push(`${ind}__l[${t.ordinal}] = __x }`)
 }

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -20,7 +20,10 @@ export const RUNTIME_IMPORT_CANDIDATES = [
   // `lazyClaimSlots` is the read-capable twin of `lazySlots` over the same
   // claim — emitted only by lazy loops that seed an outer-involving TEXT
   // binding by read-compare-write (§9.3(1)).
-  'claimSlots', 'lazySlots', 'lazyClaimSlots',
+  // `textOrNode` is the 'text' door's Node guard: a child-position value that
+  // turns out to be a live Node must reach the writer as a Node so the claim
+  // can promote to 'markup', never as `String(node)`.
+  'claimSlots', 'lazySlots', 'lazyClaimSlots', 'textOrNode',
   // Profile mode (#1690, SR3) — turn-boundary markers around event handlers.
   'beginTurn', 'endTurn',
   // Catalogued `Date` lowering (#2274/#2292) — the client counterpart to

--- a/spec/slot-unification.md
+++ b/spec/slot-unification.md
@@ -199,6 +199,18 @@ work.
   anchor Comment as the record of where the node must go, deferring creation
   to the first write. Without this, `lazyClaimSlots.read` would leave an
   empty Text node on every row it merely inspected.
+- **A `'text'` slot may still receive a Node.** A child-position
+  interpolation that calls something (`props.renderRow(item)` handed an
+  inline-JSX arrow) can evaluate to a live element, and a Text node cannot
+  host one — `String(node)` destroys it silently. Syntax cannot tell the two
+  apart (`renderChild(...)` and `props.renderRow(...)` are both
+  `CallExpression`), so the decision is made on the VALUE: `textOrNode` passes
+  a Node through, and the claim **promotes** that slot to `'markup'` on the
+  first Node write, reusing the anchor it already resolved (claim-once still
+  holds) plus its matching `<!--/-->`. Strings keep the Text-node fast path.
+  A slot that cannot host a Node — markerless, or missing its end marker —
+  warns and skips rather than stringifying an element.
+
 - **Shape drift**: path claiming makes SSR/CSR shape agreement a harder
   invariant. It is already enforced (conformance byte parity); (d)
   strengthens the enforcement rather than adding an assumption.


### PR DESCRIPTION
## The bug

A child-position interpolation can evaluate to a real element rather than a string:

```tsx
{_p.renderCell(row.id)}
```

when the caller passes an inline-JSX arrow — the compiler lifts that into a component whose call returns a live Node.

In a lazy loop row the value was stringified before it ever reached the claim door (`String(__x)` in `stringify/lazy-row.ts`), and the row's content slot is claimed as `kind: 'text'`, whose writer sets `nodeValue`. A Text node cannot host an element, so the element was **destroyed** — its serialized markup rendered as visible characters, or `[object HTMLDivElement]`, depending on the DOM implementation's `toString`.

Observed before the fix, driving the real runtime:

```
created: <li data-key="1"><!--bf:s2-->&lt;b&gt;N1&lt;/b&gt;<!--/--></li>
                                      ↑ element gone, characters remain
```

## Why it stayed hidden

Two properties, and both are worth stating because each one on its own would have surfaced it.

**Nothing overwrites the row afterwards.** The other Node-bearing shapes are self-healing *by accident*: a conditional's `insert()` re-renders its branch through `__bfSlot`, and a non-loop reactive text re-applies through `escapeTextOrNode`. In those shapes the wrong value is written and then immediately corrected, so it is never observable. Only the lazy row keeps it.

| Shape | Result before this PR |
|---|---|
| non-loop, no conditional | `escapeTextOrNode` overwrites → correct |
| non-loop, conditional | `__bfSlot` overwrites → correct |
| **lazy loop row** | **element destroyed, nothing corrects it** |
| loop row, conditional | `__bfSlot` → correct |

**The eligibility gate ACCEPTS the shape.** A prop accessor is an opaque outer read, which the re-subscribe seam (`spec/slot-unification.md` §9.3a) made eligible — so the row takes the lazy path and the destructive write is what ships. This is not a shape the gate was keeping out.

## The fix

Keep the cheap door; decide on the **value**, in two halves.

**`textOrNode`** (new export, `runtime/claim-slots.ts`) passes a Node through and coerces anything else with `String` — exactly as the previous inline emission did, so non-Node behaviour is unchanged including `null` → `"null"`. It is the 'text' door's counterpart to `escapeTextOrNode`: a 'text' write goes through `nodeValue` and must **not** be escaped, but it does need the Node case separated out. `stringify/lazy-row.ts` emits it in place of `String(__x)`.

**The claim promotes** a slot from `'text'` to `'markup'` on its first Node write, reusing the anchor comment the original claim already resolved — so §2's claim-once rule still holds, there is no second position resolution — plus its matching `<!--/-->` as the end boundary. `writeMarkup` already splices Nodes by identity, so every later write on that id, Node or string, is correct. A slot that genuinely cannot host a Node (markerless, or missing its end marker) **warns and skips** rather than stringifying an element.

Whether such a call yields a string or a Node is not decidable from the expression's syntax — `renderChild(...)` and `_p.renderCell(...)` are both `CallExpression`. So this has to be a runtime decision on the value, not a compile-time classification. Strings keep the Text-node fast path; the added cost is one `instanceof Node` per content write.

The seed comparison fails safe on its own: `read(id)` answers with a string or `null`, neither of which is ever `===` a Node, so an outer-involving Node binding always writes on its first run. That is the correct direction — a Node is freshly built on this run and is never the SSR-rendered content by identity.

## Verification

`packages/client/__tests__/runtime/lazy-row-node-content.test.ts` compiles the real shape and drives the real runtime (`createComponent` / click / reconcile), plus direct claim-door unit tests for promotion, a later string write on a promoted slot, same-node dedup, and markup-looking text staying text.

Reverting either half fails the pins — checked, not assumed: with `String(__x)` restored, 2 of the 6 fail.

| Suite | Result |
|---|---|
| `packages/client` | **601 pass, 2 skip, 0 fail** (595 before, +6 new) |
| `packages/jsx` | **2774 pass, 0 fail** |
| `packages/adapter-tests` | **1451 pass, 0 fail** |
| `tsc --noEmit` (client, jsx) | clean |

**On the regenerated snapshot.** `doc-examples.test.ts.snap` changed 18 lines. Because a golden you regenerate yourself cannot also be the detector for the thing you changed, the diff was read rather than trusted: every line is one of three shapes — the import list gaining `textOrNode`, and the two write forms going `String(__x)` → `textOrNode(__x)`. No other content moved.

## Scope

SSR templates are unchanged; this is a client-JS + runtime change. The remaining `escapeText(<possibly-Node call>)` in the module-level `hydrate` CSR template is **not** touched here: it is reached, but every shape it reaches is one of the self-healing rows in the table above, so it is a latent trap rather than a live defect, and closing it means changing the `template:` return contract to a `{ html, slots }` pair — wider blast radius, separate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_