### PR TITLE
ci: stop auto-committing regenerated expectations; fail on drift instead

### DIFF
--- a/.github/workflows/update-doc-snapshots.yml
+++ b/.github/workflows/update-doc-snapshots.yml
@@ -25,7 +25,7 @@ on:
       - '.github/workflows/update-doc-snapshots.yml'
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: update-doc-snapshots-${{ github.event.pull_request.number }}
@@ -70,11 +70,21 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit and push
+      # TEMPORARILY verify-only — tracked by #2427.
+      #
+      # This job used to regenerate doc-examples snapshots and push the result. It
+      # cannot: `toMatchSnapshot()` in doc-examples.test.ts compares against it,
+      # so auto-committing makes this job the detector for its own subject.
+      # A wrong output is written in as the new expectation and the suite
+      # goes green on top of it. PR #2425 has a worked example — a fixture
+      # added to pin a marker was rewritten to assert the marker's absence.
+      #
+      # Same shape as the `lockfile` job in ci-compat.yml. Restore the
+      # commit step once a check exists that would catch a wrong
+      # regeneration WITHOUT reading the regenerated file — see #2427.
+      - name: Fail if the generated output drifted
         if: steps.diff.outputs.changed == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
-          git commit -m "Update doc-examples snapshots (auto-generated)"
-          git push
+          git --no-pager diff -- packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+          echo "::error::doc-examples snapshots is out of date. Run 'bun test packages/jsx/src/__tests__/doc-examples.test.ts -u' locally and commit the result."
+          exit 1

--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -26,7 +26,7 @@ on:
       - 'packages/adapter-tests/fixtures/**'
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: update-fixtures-${{ github.event.pull_request.number }}
@@ -68,11 +68,21 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit and push
+      # TEMPORARILY verify-only — tracked by #2427.
+      #
+      # This job used to regenerate fixture expectedHtml and push the result. It
+      # cannot: the adapter conformance suites compare against it,
+      # so auto-committing makes this job the detector for its own subject.
+      # A wrong output is written in as the new expectation and the suite
+      # goes green on top of it. PR #2425 has a worked example — a fixture
+      # added to pin a marker was rewritten to assert the marker's absence.
+      #
+      # Same shape as the `lockfile` job in ci-compat.yml. Restore the
+      # commit step once a check exists that would catch a wrong
+      # regeneration WITHOUT reading the regenerated file — see #2427.
+      - name: Fail if the generated output drifted
         if: steps.diff.outputs.changed == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add packages/adapter-tests/fixtures/
-          git commit -m "Update fixture expectedHtml (auto-generated)"
-          git push
+          git --no-pager diff -- packages/adapter-tests/fixtures/
+          echo "::error::fixture expectedHtml is out of date. Run 'bun run packages/adapter-tests/scripts/generate-expected-html.ts' locally and commit the result."
+          exit 1

--- a/.github/workflows/update-meta.yml
+++ b/.github/workflows/update-meta.yml
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/update-meta.yml'
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: update-meta-${{ github.event.pull_request.number }}
@@ -68,11 +68,21 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit and push
+      # TEMPORARILY verify-only — tracked by #2427.
+      #
+      # This job used to regenerate ui/meta and llms.txt and push the result. It
+      # cannot: the drift guard in meta-extract-drift.test.ts compares against it,
+      # so auto-committing makes this job the detector for its own subject.
+      # A wrong output is written in as the new expectation and the suite
+      # goes green on top of it. PR #2425 has a worked example — a fixture
+      # added to pin a marker was rewritten to assert the marker's absence.
+      #
+      # Same shape as the `lockfile` job in ci-compat.yml. Restore the
+      # commit step once a check exists that would catch a wrong
+      # regeneration WITHOUT reading the regenerated file — see #2427.
+      - name: Fail if the generated output drifted
         if: steps.diff.outputs.changed == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add ui/meta/ docs/core/llms.txt
-          git commit -m "Update ui/meta and llms.txt (auto-generated)"
-          git push
+          git --no-pager diff -- ui/meta/ docs/core/llms.txt
+          echo "::error::ui/meta and llms.txt is out of date. Run 'bun run meta:extract' locally and commit the result."
+          exit 1


### PR DESCRIPTION
## The problem

Three PR-time workflows regenerated a committed file and pushed the result. Each regenerates something a test asserts:

| workflow | regenerated | asserted by |
|---|---|---|
| `update-fixtures.yml` | `packages/adapter-tests/fixtures/**` (`expectedHtml`) | the adapter conformance suites |
| `update-doc-snapshots.yml` | `doc-examples.test.ts.snap` | `toMatchSnapshot()` in `doc-examples.test.ts` |
| `update-meta.yml` | `ui/meta/**`, `docs/core/llms.txt` | the drift guard in `meta-extract-drift.test.ts` |

So each job was the detector for its own subject, which cannot work: a wrong output is written in as the new expectation and the suite goes green on top of it.

## It already happened

PR #2425 added a fixture specifically to pin an inner `<!--bf:sN-->` marker inside a conditional branch. `expectedHtml` is generated from the Hono adapter, and Hono was the one renderer not emitting that marker — so the auto-fix commit rewrote the fixture to assert the marker's **absence**:

```diff
- <li data-key="write"><!--bf-cond-start:s0--><!--bf:s1-->Write it<!--/--><!--bf-cond-end:s0--></li>
+ <li data-key="write"><!--bf-cond-start:s0-->Write it<!--bf-cond-end:s0--></li>
```

The check added to pin the behaviour became one that pinned the bug. The rewritten expectation then broke `CSR Conformance Tests` for the same fixture — the only suite that noticed, because the marked-template adapters need external toolchains (Ruby/Python/Go/Perl) and skip rendering when those are unavailable.

## The change

All three now regenerate and **fail on difference**, printing the command to run locally:

```yaml
- name: Fail if the generated output drifted
  if: steps.diff.outputs.changed == 'true'
  run: |
    git --no-pager diff -- <paths>
    echo "::error::<label> is out of date. Run '<cmd>' locally and commit the result."
    exit 1
```

That is the shape the `lockfile` job in `ci-compat.yml` already uses for `ui/compat.lock.json` and `ui/support-matrix.lock.json` — an existing pattern in the same CI, not a new one. `contents: write` drops to `read`, since nothing pushes any more.

## This is a trade, stated plainly

The auto-commit existed for a real reason: it closes the gap where someone edits a fixture or a component and forgets to regenerate. That now becomes a red check the author has to act on. **That is friction, and it is worth paying only while these expectations are under suspicion** — not permanently.

[#2427](https://github.com/piconic-ai/barefootjs/issues/2427) tracks restoring each one, with the condition written down: restore a workflow's auto-commit once a check exists that would catch a wrong regeneration *without reading the regenerated file*. For `expectedHtml` that means renderers comparing against each other rather than against a Hono-derived golden. Doc snapshots are illustrative output rather than behaviour, so they are the safest to restore first.

Each workflow carries a comment pointing at #2427, so the temporary state is not mistaken for the intended design.

## Verification

YAML parses and the job shape is what it should be:

| workflow | permissions | last step |
|---|---|---|
| `update-fixtures` | `contents: read` | `Fail if the generated output drifted` |
| `update-doc-snapshots` | `contents: read` | `Fail if the generated output drifted` |
| `update-meta` | `contents: read` | `Fail if the generated output drifted` |

No `git config` / `git commit` / `git push` remains in any of the three. Nothing about the assertions themselves changes — only who fixes the drift.

CI on this PR is itself the first real check: these three jobs should be green, because nothing in this diff changes generated output.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_