### PR TITLE
perf(jsx): hoist the lazy row graph's claim-plan literal per loop

### DIFF
--- a/.changeset/lazy-row-hoist-claim-plan.md
+++ b/.changeset/lazy-row-hoist-claim-plan.md
@@ -1,0 +1,28 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Hoist the lazy row graph's per-loop claim-plan literal (slot unification §9)
+
+`mapArrayLazy`'s emitted `createRow`/`__lzc_<mid>` claim built a fresh
+`ClaimPlan` array (one `{ id, kind, path }` object per text slot, plus a
+fresh inner `path: []` array in the adopted-row form) on EVERY row, even
+though the plan's contents never vary across rows of the same loop. A
+`ClaimPlan` is `readonly SlotSpec[]` and `claimRefs` only ever reads it —
+`claimSlots`/`claimRefs` build a fresh `Map` per call — so one shared plan
+object is safe for every row.
+
+The stringifier now hoists this as a loop-level const: `__lzs_<mid>` for
+the adopted (SSR) row context, and `__lzsc_<mid>` for the fresh-CSR-clone
+context (only emitted when it differs, i.e. when the loop has a hoisted
+skeleton with compile-time text paths). For a loop with N rows and one
+text slot this removes ~2N object/array allocations; SSR output and
+everything else about the emission (door choice, ref ordering,
+`applyItem`/`applyOuter`/`createRow` bodies) is unchanged.
+
+Measured on `benchmarks/apps/barefoot` with
+`bench-dom.ts --quick --framework=barefoot`: heap for 1k rows
+1053.8KB -> 971.9KB / 970.5KB over two after-runs, ~-82KB (-7.8%).
+`create1k` time stayed inside run-to-run overlap. Emitted JS grows
++29 bytes per lazy loop (+0.1KB gzip on that app) — two const lines per
+loop in exchange for two fewer allocations per row.

--- a/packages/adapter-tests/fixtures/__snapshots__/ai-chat.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/ai-chat.client.js
@@ -83,15 +83,16 @@ export function initAIChatInteractive(__scope, _p = {}) {
   })
   const __tpl_l0 = document.createElement('template')
   __tpl_l0.innerHTML = `<div data-key="" bf="s1"><div class="chat-bubble"><p><!--bf:s0--><!--/--></p></div></div>`
+  const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
   const __lzc_l0 = (__e) => {
     const __el = __e.primaryEl
-    return [qsa(__el, '[bf="s1"]'), lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+    return [qsa(__el, '[bf="s1"]'), lazySlots(__el, __lzs_l0)]
   }
   mapArrayLazy(() => messages(), _s5, (msg) => String(msg.id), {
     createRow: (__e, __idx) => {
       const msg = () => __e.item
       const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
-      const __r = __e.refs = [qsa(__el, '[bf="s1"]'), lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+      const __r = __e.refs = [qsa(__el, '[bf="s1"]'), lazySlots(__el, __lzs_l0)]
       const __l = __e.last = []
       { const __t = __r[0]
       if (__t) {

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -4432,15 +4432,17 @@ export function initExample(__scope, _p = {}) {
   const __tpl_l0 = document.createElement('template')
   __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
   const __lzp_l0 = [[0]]
+  const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
+  const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
     const __el = __e.primaryEl
-    return [lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+    return [lazySlots(__el, __lzs_l0)]
   }
   mapArrayLazy(() => items(), _s1, (item) => String(item), {
     createRow: (__e, __idx) => {
       const item = () => __e.item
       const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
-      const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
+      const __r = __e.refs = [lazySlots(__el, __lzsc_l0)]
       const __l = __e.last = []
       { const __x = item()
       __r[0]('s0', textOrNode(__x))
@@ -4565,15 +4567,17 @@ export function initExample(__scope, _p = {}) {
   const __tpl_l0 = document.createElement('template')
   __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
   const __lzp_l0 = [[0]]
+  const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
+  const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
     const __el = __e.primaryEl
-    return [lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+    return [lazySlots(__el, __lzs_l0)]
   }
   mapArrayLazy(() => items(), _s1, (item) => String(item), {
     createRow: (__e, __idx) => {
       const item = () => __e.item
       const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
-      const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
+      const __r = __e.refs = [lazySlots(__el, __lzsc_l0)]
       const __l = __e.last = []
       { const __x = item()
       __r[0]('s0', textOrNode(__x))
@@ -4649,15 +4653,17 @@ export function initExample(__scope, _p = {}) {
   const __tpl_l0 = document.createElement('template')
   __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
   const __lzp_l0 = [[0]]
+  const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
+  const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
     const __el = __e.primaryEl
-    return [lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+    return [lazySlots(__el, __lzs_l0)]
   }
   mapArrayLazy(() => items().filter(item => item.active), _s1, (item) => String(item.id), {
     createRow: (__e, __idx) => {
       const item = () => __e.item
       const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
-      const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
+      const __r = __e.refs = [lazySlots(__el, __lzsc_l0)]
       const __l = __e.last = []
       { const __x = item().name
       __r[0]('s0', textOrNode(__x))
@@ -5141,15 +5147,17 @@ export function initExample(__scope, _p = {}) {
   const __tpl_l0 = document.createElement('template')
   __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
   const __lzp_l0 = [[0]]
+  const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
+  const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
     const __el = __e.primaryEl
-    return [lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+    return [lazySlots(__el, __lzs_l0)]
   }
   mapArrayLazy(() => todos().filter(t => !t.done).toSorted((a, b) => a.date - b.date), _s1, (t) => String(t.id), {
     createRow: (__e, __idx) => {
       const t = () => __e.item
       const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
-      const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
+      const __r = __e.refs = [lazySlots(__el, __lzsc_l0)]
       const __l = __e.last = []
       { const __x = t().name
       __r[0]('s0', textOrNode(__x))
@@ -5287,15 +5295,17 @@ export function initExample(__scope, _p = {}) {
   const __tpl_l0 = document.createElement('template')
   __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
   const __lzp_l0 = [[0]]
+  const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
+  const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
     const __el = __e.primaryEl
-    return [lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+    return [lazySlots(__el, __lzs_l0)]
   }
   mapArrayLazy(() => items(), _s1, (item) => String(item.id), {
     createRow: (__e, __idx) => {
       const item = () => __e.item
       const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
-      const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
+      const __r = __e.refs = [lazySlots(__el, __lzsc_l0)]
       const __l = __e.last = []
       { const __x = item().name
       __r[0]('s0', textOrNode(__x))
@@ -5371,15 +5381,17 @@ export function initExample(__scope, _p = {}) {
   const __tpl_l0 = document.createElement('template')
   __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
   const __lzp_l0 = [[0]]
+  const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
+  const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
     const __el = __e.primaryEl
-    return [lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+    return [lazySlots(__el, __lzs_l0)]
   }
   mapArrayLazy(() => items(), _s1, (item, i) => String(i), {
     createRow: (__e, i) => {
       const item = () => __e.item
       const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
-      const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
+      const __r = __e.refs = [lazySlots(__el, __lzsc_l0)]
       const __l = __e.last = []
       { const __x = item().name
       __r[0]('s0', textOrNode(__x))

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
@@ -11,6 +11,9 @@
  *
  *     const __tpl_<mid> = document.createElement('template')      // hoisted skeleton, when usable
  *     __tpl_<mid>.innerHTML = `…`
+ *     const __lzp_<mid> = [...]                                   // hoisted fresh-clone text paths, when usable
+ *     const __lzs_<mid> = [{ id, kind: 'text', path: [] }, …]      // hoisted claim plan, ADOPTED-row form
+ *     const __lzsc_<mid> = [{ id, kind: 'text', path: __lzp_<mid>[i] }, …]  // FRESH-CLONE form, only when it differs
  *     const __lzc_<mid> = (__e) => { … }                          // lazy ref claim for ADOPTED rows
  *     mapArrayLazy(() => <arr>, <container>, <keyFn>, {
  *       createRow: (__e, <idx>) => { … writes every binding, seeds refs+last … },
@@ -130,12 +133,43 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
     lines.push(`${indent}const ${textPathVar} = [${arrays.join(', ')}]`)
   }
 
+  // Hoisted claim-plan literal(s) for this loop's text slots (perf): a
+  // `ClaimPlan` is `readonly SlotSpec[]` (`claim-slots.ts:145`) and
+  // `claimRefs` (line 601) only ever READS it — there is no `spec.<field> = `
+  // assignment anywhere in that module, and `claimSlots`/`claimRefs` build a
+  // fresh `Map` per call — so one shared plan object is safe across every
+  // row of the loop instead of a fresh `{ id, kind, path }` object (plus,
+  // when `textPathVar` is null, a fresh inner `path: []` array) per row.
+  // `__lzs_<mid>` is the ADOPTED-row form (`path: []`, resolved by A2's
+  // marker scan); `__lzsc_<mid>` is the FRESH-CLONE form (each slot's path
+  // is a `__lzp_<mid>` lookup) and is only emitted when it differs from the
+  // adopted form — i.e. when `textPathVar` is non-null.
+  let adoptedPlanVar: string | null = null
+  let freshPlanVar: string | null = null
+  if (lazyRow.texts.length > 0) {
+    adoptedPlanVar = `__lzs_${mid}`
+    const adoptedSlots: ClaimSlotSpec[] = lazyRow.texts.map(t => ({ id: t.slotId, kind: 'text', path: [] }))
+    lines.push(`${indent}const ${adoptedPlanVar} = ${claimPlanLiteral(adoptedSlots)}`)
+    if (textPathVar) {
+      freshPlanVar = `__lzsc_${mid}`
+      const freshSlots: ClaimSlotSpec[] = lazyRow.texts.map((t, i) => ({
+        id: t.slotId,
+        kind: 'text',
+        path: [],
+        pathExpr: `${textPathVar}[${i}]`,
+      }))
+      lines.push(`${indent}const ${freshPlanVar} = ${claimPlanLiteral(freshSlots)}`)
+    } else {
+      freshPlanVar = adoptedPlanVar
+    }
+  }
+
   // Lazy ref claim for ADOPTED (SSR) rows: one scan inside that row, cached
   // on `entry.refs`. Shared by applyItem and applyOuter so a row claims once.
   if (hasRefs) {
     lines.push(`${indent}const ${claimVar} = (__e) => {`)
     lines.push(`${indent}  const __el = __e.primaryEl`)
-    lines.push(`${indent}  return [${refParts(lazyRow, '__el', null, null).join(', ')}]`)
+    lines.push(`${indent}  return [${refParts(lazyRow, '__el', null, adoptedPlanVar).join(', ')}]`)
     lines.push(`${indent}}`)
   }
 
@@ -155,7 +189,7 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
     : `(() => { ${emitTemplateCloneInline(o.template)} })()`
   lines.push(`${b2}const __el = ${cloneExpr}`)
   if (hasRefs) {
-    lines.push(`${b2}const __r = __e.refs = [${refParts(lazyRow, '__el', useHoisted ? (paths ?? null) : null, textPathVar).join(', ')}]`)
+    lines.push(`${b2}const __r = __e.refs = [${refParts(lazyRow, '__el', useHoisted ? (paths ?? null) : null, freshPlanVar).join(', ')}]`)
   }
   if (hasBindings) {
     lines.push(`${b2}const __l = __e.last = []`)
@@ -229,12 +263,19 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
  * (`__lzc_<mid>`): `qsa` + an empty claim path, which A2's marker scan
  * resolves — the sanctioned "cannot be statically pathed" case for a
  * server-rendered tree the skeleton does not describe (§5-A3).
+ *
+ * `planVar` is the hoisted claim-plan variable for THIS context (`__lzs_<mid>`
+ * for the adopted-row call site, `__lzsc_<mid>` — or the same `__lzs_<mid>`
+ * when the two forms coincide — for the fresh-clone one), built once by
+ * `stringifyLazyRowLoop` and referenced here rather than rebuilt per row.
+ * `null` iff `lazyRow.texts` is empty, the only case that skips the text part
+ * below.
  */
 function refParts(
   lazyRow: LazyRowPlanData,
   elVar: string,
   skeletonPaths: SkeletonSlotPaths | null,
-  textPathVar: string | null,
+  planVar: string | null,
 ): string[] {
   const parts: string[] = []
   for (const slotId of lazyRow.attrSlotIds) {
@@ -242,14 +283,8 @@ function refParts(
     parts.push(path ? pathExpr(elVar, path) : `qsa(${elVar}, '[bf="${slotId}"]')`)
   }
   if (lazyRow.texts.length > 0) {
-    const slots: ClaimSlotSpec[] = lazyRow.texts.map((t, i) => ({
-      id: t.slotId,
-      kind: 'text',
-      path: [],
-      pathExpr: textPathVar ? `${textPathVar}[${i}]` : undefined,
-    }))
     const door = lazyRow.textNeedsRead ? 'lazyClaimSlots' : 'lazySlots'
-    parts.push(`${door}(${elVar}, ${claimPlanLiteral(slots)})`)
+    parts.push(`${door}(${elVar}, ${planVar})`)
   }
   return parts
 }

--- a/spec/slot-unification.md
+++ b/spec/slot-unification.md
@@ -232,15 +232,41 @@ Identified but not shipped, tracked so it isn't re-discovered from scratch.
 
 - **General-case marker elision** (§5a). The one open item on axis (b), and
   the only route to closing the HTML-size gap against solid.
-- **Claim-mechanism allocation shape.** Two mechanically identified pieces:
-  (1) every row re-allocates full `SlotSpec` objects even when it never
-  updates — hoisting each slot's static `id`/`kind` once per loop and
-  threading only a per-row `path` recovers ~10KB/1k rows; (2) `applyOuter`'s
-  seed pass materializes each row's whole ref tuple (element handle plus the
-  `lazySlots` writer closure and its plan array) even when the row's
+- **Claim-mechanism allocation shape.** Two mechanically identified pieces.
+
+  **(1) Per-row `SlotSpec` re-allocation — SHIPPED.** Every row rebuilt the
+  loop's whole `ClaimPlan` (the array, one `{ id, kind, path }` per text
+  slot, and — in the adopted-row form — a fresh inner `path: []`), even
+  though nothing in it varies across rows. The stringifier now hoists it per
+  loop: `__lzs_<mid>` for the adopted-row context and `__lzsc_<mid>` for the
+  fresh-clone one, the latter emitted only when the two forms differ. Sound
+  because `ClaimPlan` is `readonly SlotSpec[]`, `claimRefs` only reads it,
+  and each call builds its own `Map`.
+
+  Two corrections to this entry's original estimate, both worth keeping:
+  the plan could be hoisted **whole** rather than "static `id`/`kind` hoisted
+  with a per-row `path` threaded through", because the path is itself a loop
+  constant (`[]` for adopted rows, an index into the already-hoisted
+  `__lzp_<mid>` for clones); and the recovery was **~8x the ~10KB/1k rows
+  guessed here**. Measured on `benchmarks/apps/barefoot` (which emits a lazy
+  loop) with `bench-dom.ts --quick --framework=barefoot`: post-create heap
+  for 1k rows **1053.8KB -> 971.9KB / 970.5KB** across two after-runs, i.e.
+  **~-82KB (-7.8%)**. `create1k` time did not move outside run-to-run
+  overlap (75.4ms [74.9-87.9] before; 80.4ms [79.4-82.2] and 77.6ms
+  [76.9-79.2] after). Emitted JS grows slightly — +29 bytes per lazy loop,
+  +0.1KB gzip on the benchmark app — which is the trade: two extra const
+  lines per loop buy 2 fewer allocations per row.
+
+  **(2) `applyOuter`'s seed pass materializes each row's whole ref tuple**
+  (element handle plus the `lazySlots` writer closure) even when the row's
   outer-involving bindings are all ATTRS and the seed only ever reads the
   element — splitting the tuple by what the seed actually reads recovers
-  most of ~230KB/1k rows without touching the model.
+  most of ~230KB/1k rows without touching the model. **Still open**, and
+  piece (1) does not overlap it: (1) removed the plan objects the closure
+  captures, (2) is about not creating the closure at all on rows whose seed
+  never needs it. Needs per-slot lazy `entry.refs`, which interacts with
+  §2's claim-once rule, so it is a separate change measured on top of this
+  one.
 - **Widening the lazy-row gate** — see §9.5's refusal table.
 
 ## 9. Lazy row graph — §3(c) completion


### PR DESCRIPTION
## The problem

`mapArrayLazy`'s emitted claim sites rebuilt the loop's whole `ClaimPlan` on **every row** — the array, one `{ id, kind, path }` object per text slot, and in the adopted-row form a fresh inner `path: []` — even though nothing in it varies across rows of the same loop:

```js
const __lzc_l0 = (__e) => {
  const __el = __e.primaryEl
  return [lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
}                        // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ allocated once per row
```

`lazySlots` already defers the actual claim, so the waste was purely the literal.

## The change

The stringifier hoists it to a loop-level const, alongside the existing `__tpl_<mid>` / `__lzp_<mid>` hoists:

```diff
  const __lzp_l0 = [[0]]
+ const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
+ const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
  const __lzc_l0 = (__e) => {
    const __el = __e.primaryEl
-   return [lazySlots(__el, [{ id: 's0', kind: 'text', path: [] }])]
+   return [lazySlots(__el, __lzs_l0)]
  }
  mapArrayLazy(() => items(), _s1, (item) => String(item), {
    createRow: (__e, __idx) => {
      const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
-     const __r = __e.refs = [lazySlots(__el, [{ id: 's0', kind: 'text', path: __lzp_l0[0] }])]
+     const __r = __e.refs = [lazySlots(__el, __lzsc_l0)]
```

`__lzs_<mid>` is the adopted-row form; `__lzsc_<mid>` is the fresh-clone form, emitted **only when the two differ** (i.e. when the loop has a hoisted skeleton with compile-time text paths) — otherwise both sites share one const. The `ai-chat` fixture in this PR is a live example of the shared case.

Everything else about the emission is untouched: door choice (`lazySlots` vs `lazyClaimSlots`), ref ordering, `writerIndex`, dedup guards, and the `createRow` / `applyItem` / `applyOuter` bodies are byte-for-byte the same apart from the plan argument becoming a variable reference. **SSR output does not change** — no `.html` fixture moved.

## Why it is sound

- `ClaimPlan` is `readonly SlotSpec[]` (`packages/client/src/runtime/claim-slots.ts:145`).
- `claimRefs` (line 601) only reads specs; there is no `spec.<field> = ` assignment anywhere in that module.
- `claimSlots` / `claimRefs` build a fresh `Map` per call.

One shared plan object per loop is therefore safe — no freeze, no clone.

## Measured

`benchmarks/apps/barefoot` emits a lazy loop, so the existing harness covers this. Via `bench-dom.ts --quick --framework=barefoot`, rebuilding the compiler and the app for each side:

| | heap, 1k rows | create1k |
|---|---|---|
| before | 1053.8KB | 75.4ms [74.9–87.9] |
| after (run 1) | 971.9KB | 80.4ms [79.4–82.2] |
| after (run 2) | 970.5KB | 77.6ms [76.9–79.2] |

**~-82KB (-7.8%)**, reproducible across two after-runs. Time did not move outside run-to-run overlap, so this is a memory result, not a speed one.

Emitted JS grows **+29 bytes per lazy loop** (+0.1KB gzip on the benchmark app; 12 loops in the doc-example snapshots, +348 bytes total). That is the trade: two const lines per loop in exchange for two fewer allocations per row.

## Two corrections to spec §8

§8 listed this follow-up as recovering **~10KB/1k rows** by "hoisting each slot's static `id`/`kind` and threading only a per-row `path`". Both halves were off:

- The `path` is **itself a loop constant** (`[]` for adopted rows, an index into the already-hoisted `__lzp_<mid>` for clones), so the plan hoists **whole** — no per-row path threading needed.
- The recovery is **~8× the estimate**.

§8 now carries the measured numbers instead of the guess.

**The neighbouring follow-up is untouched and does not overlap this one.** §8's piece (2) — `applyOuter`'s seed materializing each row's whole ref tuple, ~230KB/1k rows — is about not creating the writer *closure* at all on rows whose seed never needs it. It needs per-slot lazy `entry.refs` and interacts with §2's claim-once rule, so it is a separate change to be measured on top of this one.

## A note on the second commit

`update-expected-html` failed on the first push, correctly. Despite its name, `generate-expected-html.ts` writes **both** `<name>.html` and `<name>.client.js` per fixture, so an emission change leaves the client-JS snapshots stale even when SSR output is untouched. `ai-chat.client.js` is regenerated in the follow-up commit; its diff is only the hoist, and no `.html` fixture moved.

Regenerating by hand is the author's job as of #2428 (tracked by #2427) — this is that policy doing its job on the first PR after the change. The other two generators (`meta:extract`, doc-examples snapshots) were checked for drift in the same pass and are clean.

## Verification

| suite | result |
|---|---|
| `packages/jsx` | 2780 pass / 0 fail (154 snapshots) |
| `packages/client` | 605 pass / 0 fail |
| `packages/adapter-tests` | 1456 pass / 0 fail |
| `biome check` | clean, 432 files |
| `tsc --noEmit` (jsx) | clean |