### PR TITLE
perf(jsx): build a lazy row's content door on first use, not at claim time

### DIFF
--- a/.changeset/lazy-row-defer-content-door.md
+++ b/.changeset/lazy-row-defer-content-door.md
@@ -28,6 +28,10 @@ clones the row, so its door is used immediately and deferring it would only
 add a branch. The deferral is therefore confined to server-rendered rows,
 which is where the allocation was wasted.
 
+With the door gone from the claim, the element refs are the only parts left
+that read the row root — so a row with no reactive ATTRIBUTE now claims to a
+bare `[null]` and no longer binds `__e.primaryEl` at all.
+
 **§2's claim-once rule is preserved.** That rule is about one door resolving
 the whole plan on first access, and each door already enforces it internally —
 `lazySlots`/`lazyClaimSlots` call `claimRefs` once and cache the result.

--- a/.changeset/lazy-row-defer-content-door.md
+++ b/.changeset/lazy-row-defer-content-door.md
@@ -1,0 +1,58 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Build a lazy loop row's content door on first use instead of at claim time,
+so an `applyOuter` that only drives attributes stops allocating one closure
+per row of the list.
+
+A lazy-eligible loop's adopted-row claim (`__lzc_<mid>`) resolved the element
+refs *and* constructed the content door — `lazySlots(__el, __lzs_<mid>)` — in
+one tuple. That tuple is built for every entry the first time either apply
+path touches the row, and `applyOuter`'s seed pass touches **all** of them.
+So a loop whose only outer-involving binding is an attribute (the common
+`className={selected() === row.id ? … : …}` shape) built a door per row at
+hydration and used none of them: nothing writes content until that row's item
+actually changes.
+
+The claim now leaves the door's slot `null` and `applyItem`/`applyOuter`
+materialize it on demand, once per apply body and only when that body has
+content bindings to write:
+
+```js
+const __d = __r[1] ?? (__r[1] = lazySlots(__e.primaryEl, __lzs_l0))
+```
+
+`createRow` is deliberately unchanged: it writes every text on the tick it
+clones the row, so its door is used immediately and deferring it would only
+add a branch. The deferral is therefore confined to server-rendered rows,
+which is where the allocation was wasted.
+
+**§2's claim-once rule is preserved.** That rule is about one door resolving
+the whole plan on first access, and each door already enforces it internally —
+`lazySlots`/`lazyClaimSlots` call `claimRefs` once and cache the result.
+Deferring *construction* moves when that single resolution happens; it does not
+add a second resolution path. A loop with an outer-involving TEXT still claims
+every row at seed, because read-compare-write cannot compare what it has not
+resolved, so the deferral is a no-op there by design.
+
+Measured on the SSR post-hydration heap bench
+(`benchmarks/ssr/bench-ssr-memory.ts` — 1,000 rows, item texts plus an
+outer-signal class): **1630.6KB → 1573.2KB / 1572.9KB** over two after-runs,
+**-57.4KB (-3.5%)**, against a per-run stdev of 0.1-0.6KB with the react and
+solid columns unmoved as controls. Two things about that number are worth
+recording, because the follow-up entry in `spec/slot-unification.md` §8 had
+both wrong. The estimate there (~230KB/1k rows) was too high: it predated the
+per-row claim-plan hoist, and `lazySlots` never scanned eagerly to begin with,
+so what remained was a closure per row rather than a resolved slot map. And the
+DOM suite's memory column — where the previous hoist was measured — cannot
+show this at all, since it creates its rows client-side through `createRow`,
+the path left eager here.
+
+Behavioural coverage is
+`packages/client/__tests__/runtime/lazy-row-adopted-door.test.ts`: real Hono
+SSR markup, hydrated, then an item changed. That sequence is the only one that
+executes the deferred branch — emission tests read the generated text, the
+`createComponent` tests take the eager path, and the conformance suites never
+run a post-hydration update — and it was verified to fail when the door is
+built against the wrong root.

--- a/packages/adapter-tests/fixtures/__snapshots__/ai-chat.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/ai-chat.client.js
@@ -86,7 +86,7 @@ export function initAIChatInteractive(__scope, _p = {}) {
   const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
   const __lzc_l0 = (__e) => {
     const __el = __e.primaryEl
-    return [qsa(__el, '[bf="s1"]'), lazySlots(__el, __lzs_l0)]
+    return [qsa(__el, '[bf="s1"]'), null]
   }
   mapArrayLazy(() => messages(), _s5, (msg) => String(msg.id), {
     createRow: (__e, __idx) => {
@@ -117,8 +117,9 @@ export function initAIChatInteractive(__scope, _p = {}) {
         }
         __l[0] = __x
       } }
+      const __d = __r[1] ?? (__r[1] = lazySlots(__e.primaryEl, __lzs_l0))
       { const __x = msg().content
-      if (!(1 in __l) || !Object.is(__l[1], __x)) __r[1]('s0', textOrNode(__x))
+      if (!(1 in __l) || !Object.is(__l[1], __x)) __d('s0', textOrNode(__x))
       __l[1] = __x }
     },
   }, 'l0')

--- a/packages/client/__tests__/runtime/lazy-row-adopted-door.test.ts
+++ b/packages/client/__tests__/runtime/lazy-row-adopted-door.test.ts
@@ -1,0 +1,174 @@
+/**
+ * The lazy row graph's content door is built on FIRST USE, not at claim time
+ * (`spec/slot-unification.md` §9; `refParts`'s `deferDoor` note in
+ * `jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts`).
+ *
+ * Why that needed its own behavioural test rather than an emission assertion:
+ * an ADOPTED (server-rendered) row's `entry.refs` now holds `null` in the door
+ * slot, and the door is constructed against `__e.primaryEl` and the ADOPTED
+ * claim plan the first time that row writes content. Every existing check
+ * around this either
+ *
+ *  - asserts the emitted TEXT (`lazy-row-eligibility.test.ts`), which cannot
+ *    tell a door that resolves from one that silently resolves to the wrong
+ *    root, or
+ *  - drives `createComponent` (`lazy-row-node-content.test.ts`), which is the
+ *    CSR path where `createRow` still builds the door eagerly, so the deferred
+ *    branch never runs, or
+ *  - compares HTML shapes (`csr-conformance`, `ssr-hydration-contract`), which
+ *    never execute a post-hydration update at all.
+ *
+ * So this renders the real Hono SSR markup, hydrates it, and then changes an
+ * item — the one sequence in which the deferred door is the thing under test.
+ * A regression here (wrong root, wrong plan, door never filled) shows up as a
+ * row whose text stops tracking its item, which is exactly the silent class of
+ * failure the lazy path is prone to.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { renderHonoComponent } from '../../../adapter-hono/src/test-render'
+import { HonoAdapter } from '../../../adapter-hono/src/adapter/hono-adapter'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+
+/**
+ * The shape the deferral targets: a keyed, single-root, conditional-free loop
+ * whose row carries item-driven TEXTS plus one OUTER-involving attribute. The
+ * outer class makes `applyOuter` exist (so every row is claimed at seed) while
+ * giving it no content binding to seed — the case where the door was being
+ * built for every row and used by none.
+ *
+ * `rename` changes an item's label, and `select` moves the outer signal, so
+ * both apply paths are reachable against rows that came from the server.
+ */
+const SOURCE = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string }
+export function AdoptedRows() {
+  const [rows, setRows] = createSignal<Row[]>([
+    { id: 1, label: 'alpha' },
+    { id: 2, label: 'beta' },
+  ])
+  const [selected, setSelected] = createSignal(0)
+  const rename = () => setRows(rs => rs.map(r => (r.id === 2 ? { id: 2, label: 'renamed' } : r)))
+  return (
+    <div>
+      <button id="rename" onClick={rename}>rename</button>
+      <button id="select" onClick={() => setSelected(2)}>select</button>
+      <table>
+        <tbody id="rows">
+          {rows().map(row => (
+            <tr key={row.id} className={selected() === row.id ? 'danger' : 'plain'}>
+              <td class="id">{row.id}</td>
+              <td class="label">{row.label}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+`
+
+function clientJsFor(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) throw new Error(`Compilation errors:\n${errors.map(e => e.message).join('\n')}`)
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error(`No client JS for ${filename}`)
+  return clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+}
+
+async function setup(name: string): Promise<{ js: string; hydrate: () => void }> {
+  const js = clientJsFor(SOURCE, `${name}.tsx`)
+  const dir = mkdtempSync(join(tmpdir(), 'bf-adopted-door-'))
+  const file = join(dir, `${name}.mjs`)
+  writeFileSync(file, js)
+  await import(file)
+
+  document.body.innerHTML = await renderHonoComponent({
+    adapter: new HonoAdapter(),
+    source: SOURCE,
+    props: { __instanceId: 'AdoptedRows_test' },
+  })
+
+  const { rehydrateAll, flushHydration } = await import(runtimePath)
+  return {
+    js,
+    hydrate: () => {
+      rehydrateAll()
+      flushHydration()
+    },
+  }
+}
+
+const labels = (): string[] =>
+  Array.from(document.querySelectorAll('#rows tr td.label')).map(td => td.textContent ?? '')
+
+const classes = (): string[] =>
+  Array.from(document.querySelectorAll('#rows tr')).map(tr => tr.getAttribute('class') ?? '')
+
+describe('lazy row graph — deferred content door on ADOPTED rows', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('an adopted row whose item changes still updates its text', async () => {
+    const { js, hydrate } = await setup('AdoptedRowsText')
+    // Preconditions: without these the assertions below could pass on the
+    // eager path or on an eagerly-built door, i.e. for the wrong reason.
+    expect(js).toContain('mapArrayLazy(')
+    expect(js).toMatch(/return \[qsa\(__el, '\[bf="s\d+"\]'\), null\]/)
+    expect(js).toMatch(/const __d = __r\[\d\] \?\? \(__r\[\d\] = lazySlots\(__e\.primaryEl, __lzs_l0\)\)/)
+
+    hydrate()
+    expect(labels()).toEqual(['alpha', 'beta'])
+
+    ;(document.querySelector('#rename') as HTMLElement).click()
+
+    // The door had to be built here, from `__e.primaryEl` and the adopted
+    // plan, for this to hold.
+    expect(labels()).toEqual(['alpha', 'renamed'])
+  })
+
+  test('the outer class seeds and updates without the door being needed', async () => {
+    const { hydrate } = await setup('AdoptedRowsClass')
+    hydrate()
+    // Seeded by read-compare-write against the server's markup.
+    expect(classes()).toEqual(['plain', 'plain'])
+
+    ;(document.querySelector('#select') as HTMLElement).click()
+    expect(classes()).toEqual(['plain', 'danger'])
+    // Untouched by the class pass — the door stayed unbuilt and no content
+    // was rewritten.
+    expect(labels()).toEqual(['alpha', 'beta'])
+  })
+
+  test('a later item change still lands after the outer pass already claimed the row', async () => {
+    const { hydrate } = await setup('AdoptedRowsBoth')
+    hydrate()
+
+    // Claim every row through applyOuter FIRST (door slot stays null), then
+    // force applyItem to fill that slot on an already-claimed row — the
+    // ordering that would break if the door's absence were mistaken for "this
+    // row has no refs yet".
+    ;(document.querySelector('#select') as HTMLElement).click()
+    ;(document.querySelector('#rename') as HTMLElement).click()
+
+    expect(labels()).toEqual(['alpha', 'renamed'])
+    expect(classes()).toEqual(['plain', 'danger'])
+  })
+})

--- a/packages/client/__tests__/runtime/lazy-row-adopted-door.test.ts
+++ b/packages/client/__tests__/runtime/lazy-row-adopted-door.test.ts
@@ -30,7 +30,7 @@ import { compileJSX } from '../../../jsx/src/compiler'
 import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
 import { renderHonoComponent } from '../../../adapter-hono/src/test-render'
 import { HonoAdapter } from '../../../adapter-hono/src/adapter/hono-adapter'
-import { writeFileSync, mkdtempSync } from 'fs'
+import { writeFileSync, mkdtempSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -97,7 +97,13 @@ async function setup(name: string): Promise<{ js: string; hydrate: () => void }>
   const dir = mkdtempSync(join(tmpdir(), 'bf-adopted-door-'))
   const file = join(dir, `${name}.mjs`)
   writeFileSync(file, js)
-  await import(file)
+  try {
+    // The import registers the component with the runtime; once it resolves the
+    // module is loaded and the file on disk is no longer needed.
+    await import(file)
+  } finally {
+    try { rmSync(dir, { recursive: true, force: true }) } catch {}
+  }
 
   document.body.innerHTML = await renderHonoComponent({
     adapter: new HonoAdapter(),

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -4435,7 +4435,6 @@ export function initExample(__scope, _p = {}) {
   const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
   const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
-    const __el = __e.primaryEl
     return [null]
   }
   mapArrayLazy(() => items(), _s1, (item) => String(item), {
@@ -4571,7 +4570,6 @@ export function initExample(__scope, _p = {}) {
   const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
   const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
-    const __el = __e.primaryEl
     return [null]
   }
   mapArrayLazy(() => items(), _s1, (item) => String(item), {
@@ -4658,7 +4656,6 @@ export function initExample(__scope, _p = {}) {
   const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
   const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
-    const __el = __e.primaryEl
     return [null]
   }
   mapArrayLazy(() => items().filter(item => item.active), _s1, (item) => String(item.id), {
@@ -5153,7 +5150,6 @@ export function initExample(__scope, _p = {}) {
   const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
   const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
-    const __el = __e.primaryEl
     return [null]
   }
   mapArrayLazy(() => todos().filter(t => !t.done).toSorted((a, b) => a.date - b.date), _s1, (t) => String(t.id), {
@@ -5302,7 +5298,6 @@ export function initExample(__scope, _p = {}) {
   const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
   const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
-    const __el = __e.primaryEl
     return [null]
   }
   mapArrayLazy(() => items(), _s1, (item) => String(item.id), {
@@ -5389,7 +5384,6 @@ export function initExample(__scope, _p = {}) {
   const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
   const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
-    const __el = __e.primaryEl
     return [null]
   }
   mapArrayLazy(() => items(), _s1, (item, i) => String(i), {

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -4436,7 +4436,7 @@ export function initExample(__scope, _p = {}) {
   const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
     const __el = __e.primaryEl
-    return [lazySlots(__el, __lzs_l0)]
+    return [null]
   }
   mapArrayLazy(() => items(), _s1, (item) => String(item), {
     createRow: (__e, __idx) => {
@@ -4453,8 +4453,9 @@ export function initExample(__scope, _p = {}) {
       const item = () => __e.item
       const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
       const __l = __e.last ?? (__e.last = [])
+      const __d = __r[0] ?? (__r[0] = lazySlots(__e.primaryEl, __lzs_l0))
       { const __x = item()
-      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', textOrNode(__x))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __d('s0', textOrNode(__x))
       __l[0] = __x }
     },
   }, 'l0')
@@ -4571,7 +4572,7 @@ export function initExample(__scope, _p = {}) {
   const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
     const __el = __e.primaryEl
-    return [lazySlots(__el, __lzs_l0)]
+    return [null]
   }
   mapArrayLazy(() => items(), _s1, (item) => String(item), {
     createRow: (__e, __idx) => {
@@ -4588,8 +4589,9 @@ export function initExample(__scope, _p = {}) {
       const item = () => __e.item
       const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
       const __l = __e.last ?? (__e.last = [])
+      const __d = __r[0] ?? (__r[0] = lazySlots(__e.primaryEl, __lzs_l0))
       { const __x = item()
-      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', textOrNode(__x))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __d('s0', textOrNode(__x))
       __l[0] = __x }
     },
   }, 'l0')
@@ -4657,7 +4659,7 @@ export function initExample(__scope, _p = {}) {
   const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
     const __el = __e.primaryEl
-    return [lazySlots(__el, __lzs_l0)]
+    return [null]
   }
   mapArrayLazy(() => items().filter(item => item.active), _s1, (item) => String(item.id), {
     createRow: (__e, __idx) => {
@@ -4674,8 +4676,9 @@ export function initExample(__scope, _p = {}) {
       const item = () => __e.item
       const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
       const __l = __e.last ?? (__e.last = [])
+      const __d = __r[0] ?? (__r[0] = lazySlots(__e.primaryEl, __lzs_l0))
       { const __x = item().name
-      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', textOrNode(__x))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __d('s0', textOrNode(__x))
       __l[0] = __x }
     },
   }, 'l0')
@@ -5151,7 +5154,7 @@ export function initExample(__scope, _p = {}) {
   const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
     const __el = __e.primaryEl
-    return [lazySlots(__el, __lzs_l0)]
+    return [null]
   }
   mapArrayLazy(() => todos().filter(t => !t.done).toSorted((a, b) => a.date - b.date), _s1, (t) => String(t.id), {
     createRow: (__e, __idx) => {
@@ -5168,8 +5171,9 @@ export function initExample(__scope, _p = {}) {
       const t = () => __e.item
       const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
       const __l = __e.last ?? (__e.last = [])
+      const __d = __r[0] ?? (__r[0] = lazySlots(__e.primaryEl, __lzs_l0))
       { const __x = t().name
-      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', textOrNode(__x))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __d('s0', textOrNode(__x))
       __l[0] = __x }
     },
   }, 'l0')
@@ -5299,7 +5303,7 @@ export function initExample(__scope, _p = {}) {
   const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
     const __el = __e.primaryEl
-    return [lazySlots(__el, __lzs_l0)]
+    return [null]
   }
   mapArrayLazy(() => items(), _s1, (item) => String(item.id), {
     createRow: (__e, __idx) => {
@@ -5316,8 +5320,9 @@ export function initExample(__scope, _p = {}) {
       const item = () => __e.item
       const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
       const __l = __e.last ?? (__e.last = [])
+      const __d = __r[0] ?? (__r[0] = lazySlots(__e.primaryEl, __lzs_l0))
       { const __x = item().name
-      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', textOrNode(__x))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __d('s0', textOrNode(__x))
       __l[0] = __x }
     },
   }, 'l0')
@@ -5385,7 +5390,7 @@ export function initExample(__scope, _p = {}) {
   const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }]
   const __lzc_l0 = (__e) => {
     const __el = __e.primaryEl
-    return [lazySlots(__el, __lzs_l0)]
+    return [null]
   }
   mapArrayLazy(() => items(), _s1, (item, i) => String(i), {
     createRow: (__e, i) => {
@@ -5402,8 +5407,9 @@ export function initExample(__scope, _p = {}) {
       const item = () => __e.item
       const __r = __e.refs ?? (__e.refs = __lzc_l0(__e))
       const __l = __e.last ?? (__e.last = [])
+      const __d = __r[0] ?? (__r[0] = lazySlots(__e.primaryEl, __lzs_l0))
       { const __x = item().name
-      if (!(0 in __l) || !Object.is(__l[0], __x)) __r[0]('s0', textOrNode(__x))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __d('s0', textOrNode(__x))
       __l[0] = __x }
     },
   }, 'l0')

--- a/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
+++ b/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
@@ -457,6 +457,36 @@ describe('lazy row emission — eligible loop', () => {
     expect(js).not.toContain('.write(')
     expect(js).not.toContain('.read(')
   })
+
+  /**
+   * The adopted-row claim resolves ELEMENT refs only; the content door's slot
+   * is left empty for the first content write to fill. `applyOuter` here
+   * drives one CLASS and no text, so it claims all 1,000 rows of a 1,000-row
+   * list at seed WITHOUT ever building a door — the allocation this pins away
+   * (measured on the SSR bench: post-hydration heap 1630.6KB -> 1573.2KB).
+   *
+   * `createRow` is deliberately excluded: it writes every text on the tick it
+   * builds the row, so its door is used immediately and stays eager.
+   */
+  test('the adopted-row claim leaves the content door slot empty', () => {
+    const claim = js.slice(js.indexOf('const __lzc_l0 ='), js.indexOf('mapArrayLazy('))
+    expect(claim).toContain('return [qsa(__el, \'[bf="s2"]\'), null]')
+    expect(claim).not.toContain('lazySlots(')
+  })
+
+  test('an attr-only applyOuter never materializes the door; applyItem does', () => {
+    const applyItem = js.slice(js.indexOf('applyItem:'), js.indexOf('applyOuter:'))
+    const applyOuter = js.slice(js.indexOf('applyOuter:'))
+    expect(applyItem).toContain('const __d = __r[1] ?? (__r[1] = lazySlots(__e.primaryEl, __lzs_l0))')
+    expect(applyOuter).not.toContain('lazySlots(')
+    expect(applyOuter).not.toContain('__r[1]')
+  })
+
+  test('createRow still builds its door eagerly — it writes on the same tick', () => {
+    const createRow = js.slice(js.indexOf('createRow:'), js.indexOf('applyItem:'))
+    expect(createRow).toContain('lazySlots(__el, ')
+    expect(createRow).not.toContain('?? (__r[1] =')
+  })
 })
 
 /**
@@ -515,7 +545,11 @@ describe('lazy row emission — outer-involving TEXT binding (§9.5 lifted)', ()
     // side-effecting `toString` is not stringified twice.
     expect(applyOuter).toContain('if (__seed) {')
     expect(applyOuter).toContain('const __s = textOrNode(__x)')
-    expect(applyOuter).toContain("if (__r[0].read('s1') !== __s) __r[0].write('s1', __s)")
+    // Through `__d`, the door materialized once for this body — a loop with an
+    // outer TEXT cannot avoid claiming at seed (you cannot read-compare-write
+    // what you have not resolved), so here the deferral is a no-op by design.
+    expect(applyOuter).toContain("const __d = __r[0] ?? (__r[0] = lazyClaimSlots(__e.primaryEl, __lzs_l0))")
+    expect(applyOuter).toContain("if (__d.read('s1') !== __s) __d.write('s1', __s)")
     expect(applyOuter).not.toContain("read('s1') !== textOrNode(__x)")
     // …and falls back to the ordinary entry.last dedup on every later run,
     // where the string is built only when the write actually happens.
@@ -525,7 +559,7 @@ describe('lazy row emission — outer-involving TEXT binding (§9.5 lifted)', ()
 
   test('the outer text ALSO applies on item change, because it reads the item too', () => {
     const applyItem = js.slice(js.indexOf('applyItem:'), js.indexOf('applyOuter:'))
-    expect(applyItem).toContain("__r[0].write('s1', textOrNode(__x))")
+    expect(applyItem).toContain("__d.write('s1', textOrNode(__x))")
   })
 
   test('the item-only text is NOT emitted into applyOuter', () => {

--- a/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
+++ b/packages/jsx/src/__tests__/lazy-row-eligibility.test.ts
@@ -566,6 +566,19 @@ describe('lazy row emission — outer-involving TEXT binding (§9.5 lifted)', ()
     const applyOuter = js.slice(js.indexOf('applyOuter:'))
     expect(applyOuter).not.toContain("'s0'")
   })
+
+  /**
+   * This row has no reactive ATTRIBUTE, so with the door deferred the element
+   * refs are gone and the adopted claim is a bare `[null]` — at which point
+   * binding the row root is dead code. Pinned because the binding is emitted
+   * unconditionally the moment anyone forgets that `refParts` decides whether
+   * anything reads it.
+   */
+  test('a text-only adopted claim binds no row root', () => {
+    const claim = js.slice(js.indexOf('const __lzc_l0 ='), js.indexOf('mapArrayLazy('))
+    expect(claim).toContain('return [null]')
+    expect(claim).not.toContain('__el')
+  })
 })
 
 /**

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
@@ -14,7 +14,7 @@
  *     const __lzp_<mid> = [...]                                   // hoisted fresh-clone text paths, when usable
  *     const __lzs_<mid> = [{ id, kind: 'text', path: [] }, …]      // hoisted claim plan, ADOPTED-row form
  *     const __lzsc_<mid> = [{ id, kind: 'text', path: __lzp_<mid>[i] }, …]  // FRESH-CLONE form, only when it differs
- *     const __lzc_<mid> = (__e) => { … }                          // lazy ref claim for ADOPTED rows
+ *     const __lzc_<mid> = (__e) => { … }                          // lazy ref claim for ADOPTED rows (door slot empty)
  *     mapArrayLazy(() => <arr>, <container>, <keyFn>, {
  *       createRow: (__e, <idx>) => { … writes every binding, seeds refs+last … },
  *       applyItem: (__e) => { … item-driven bindings, dedup against __e.last … },
@@ -31,9 +31,10 @@
  * loop-level outer effect's dedup is correct from the row's first tick.
  *
  * **`applyItem`** — called by the reconciler after `entry.item` changed.
- * Claims refs lazily through `__lzc_<mid>` (a `qsa`/`lazySlots` scan inside
- * that ONE row) when `entry.refs` is null, then writes each item-driven
- * binding behind a per-binding dedup on `entry.last`.
+ * Claims refs lazily through `__lzc_<mid>` (a `qsa` scan inside that ONE row)
+ * when `entry.refs` is null, materializes the content door on demand
+ * (`doorAccess`), then writes each item-driven binding behind a per-binding
+ * dedup on `entry.last`.
  *
  * **`applyOuter`** — the ONE loop-level effect body, emitted only when some
  * binding is outer-involving. Two details matter:
@@ -166,10 +167,20 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
 
   // Lazy ref claim for ADOPTED (SSR) rows: one scan inside that row, cached
   // on `entry.refs`. Shared by applyItem and applyOuter so a row claims once.
+  //
+  // The text door slot is left EMPTY here and filled by the first content
+  // write (`doorAccess`). An adopted row is claimed by whichever of
+  // applyItem/applyOuter touches it first, and an `applyOuter` that only
+  // drives ATTRIBUTES never reads or writes a content slot — so building the
+  // door in this function spends one closure per row of the list on something
+  // that stays unused until (and unless) that row's item changes. Deferring
+  // is confined to the adopted path on purpose: `createRow` writes every text
+  // immediately, so its door is used on the same tick it is built and there
+  // is nothing to defer (see the `deferDoor` note on `refParts`).
   if (hasRefs) {
     lines.push(`${indent}const ${claimVar} = (__e) => {`)
     lines.push(`${indent}  const __el = __e.primaryEl`)
-    lines.push(`${indent}  return [${refParts(lazyRow, '__el', null, adoptedPlanVar).join(', ')}]`)
+    lines.push(`${indent}  return [${refParts(lazyRow, '__el', null, adoptedPlanVar, true).join(', ')}]`)
     lines.push(`${indent}}`)
   }
 
@@ -194,7 +205,8 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
   if (hasBindings) {
     lines.push(`${b2}const __l = __e.last = []`)
     for (const a of lazyRow.attrs) emitAttrBinding(lines, b2, a, 'create')
-    for (const t of lazyRow.texts) emitTextBinding(lines, b2, t, lazyRow.writerIndex, 'create', rwDoor)
+    const createDoor = `__r[${lazyRow.writerIndex}]`
+    for (const t of lazyRow.texts) emitTextBinding(lines, b2, t, createDoor, 'create', rwDoor)
   }
   lines.push(`${b2}return __el`)
   lines.push(`${b1}},`)
@@ -210,7 +222,10 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
     lines.push(`${b2}const __r = __e.refs ?? (__e.refs = ${claimVar}(__e))`)
     lines.push(`${b2}const __l = __e.last ?? (__e.last = [])`)
     for (const a of itemAttrs) emitAttrBinding(lines, b2, a, 'item')
-    for (const t of itemTexts) emitTextBinding(lines, b2, t, lazyRow.writerIndex, 'item', rwDoor)
+    if (itemTexts.length > 0) {
+      lines.push(`${b2}const __d = ${doorAccess(lazyRow, lazyRow.writerIndex, adoptedPlanVar)}`)
+      for (const t of itemTexts) emitTextBinding(lines, b2, t, '__d', 'item', rwDoor)
+    }
     lines.push(`${b1}},`)
   }
 
@@ -228,7 +243,10 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
     lines.push(`${b3}const __r = __e.refs ?? (__e.refs = ${claimVar}(__e))`)
     lines.push(`${b3}const __l = __e.last ?? (__e.last = [])`)
     for (const a of outerAttrs) emitAttrBinding(lines, b3, a, 'outer')
-    for (const t of outerTexts) emitTextBinding(lines, b3, t, lazyRow.writerIndex, 'outer', rwDoor)
+    if (outerTexts.length > 0) {
+      lines.push(`${b3}const __d = ${doorAccess(lazyRow, lazyRow.writerIndex, adoptedPlanVar)}`)
+      for (const t of outerTexts) emitTextBinding(lines, b3, t, '__d', 'outer', rwDoor)
+    }
     lines.push(`${b2}}`)
     lines.push(`${b1}},`)
   }
@@ -249,14 +267,27 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
  * read-compare-write (`plan.textNeedsRead`, decided once in
  * `build-lazy-row.ts`); every other loop keeps today's writer byte-for-byte.
  *
+ * **`deferDoor`** (adopted-row claim only). Even the cheap write-only door is
+ * a closure per row, and an `applyOuter` that drives ATTRIBUTES only claims
+ * every row at seed without ever touching a content slot — so the door was
+ * being built 1,000 times for a list of 1,000 rows and used zero times until
+ * some row's item changed. With `deferDoor` the slot holds `null` and the
+ * first content write fills it (`doorAccess`). Measured on the SSR bench's
+ * 1,000-row table (item texts + one outer-signal class, the shape this
+ * describes): post-hydration heap 1630.6KB -> 1573.2KB, -57.4KB, reproduced
+ * twice, against a per-run stdev of 0.1-0.6KB and with react/solid unmoved.
+ *
+ * `createRow` does NOT defer: it writes every text on the tick it builds the
+ * row, so its door is used immediately and a `??=` would only add a branch.
+ *
  * **Honest cost note.** Reading a text slot CLAIMS that row's whole plan
  * (§2's claim-once rule — `read` and `write` share `claimRefs`), so a loop
- * with an outer-involving text pays one claim per row at hydration instead
- * of the row-pristine zero. That is inherent to read-compare-write for
- * content: you cannot compare what you have not resolved. It is still far
- * cheaper than the eager path this replaces, which pays a root + a signal +
- * an effect per row. Attr-only loops are entirely unaffected — they keep the
- * write-only door and never claim at seed.
+ * with an outer-involving TEXT still pays one claim per row at hydration
+ * instead of the row-pristine zero. That is inherent to read-compare-write
+ * for content: you cannot compare what you have not resolved. It is still
+ * far cheaper than the eager path this replaces, which pays a root + a
+ * signal + an effect per row. A loop whose outer bindings are all attributes
+ * now pays neither the claim nor the door.
  *
  * `skeletonPaths` non-null = fresh-clone context (`createRow`): resolve via
  * compile-time child-index chains, no scan. Null = adopted-row context
@@ -276,6 +307,7 @@ function refParts(
   elVar: string,
   skeletonPaths: SkeletonSlotPaths | null,
   planVar: string | null,
+  deferDoor = false,
 ): string[] {
   const parts: string[] = []
   for (const slotId of lazyRow.attrSlotIds) {
@@ -283,10 +315,38 @@ function refParts(
     parts.push(path ? pathExpr(elVar, path) : `qsa(${elVar}, '[bf="${slotId}"]')`)
   }
   if (lazyRow.texts.length > 0) {
-    const door = lazyRow.textNeedsRead ? 'lazyClaimSlots' : 'lazySlots'
-    parts.push(`${door}(${elVar}, ${planVar})`)
+    parts.push(deferDoor ? 'null' : `${doorCtor(lazyRow)}(${elVar}, ${planVar})`)
   }
   return parts
+}
+
+/** The door constructor for this loop — see `refParts`'s "which door" note. */
+function doorCtor(lazyRow: LazyRowPlanData): string {
+  return lazyRow.textNeedsRead ? 'lazyClaimSlots' : 'lazySlots'
+}
+
+/**
+ * How a content write reaches this row's door.
+ *
+ * `createRow` seeds the door itself (fresh-clone plan, used on the same
+ * tick), so there it is a plain slot read. An ADOPTED row's slot is `null`
+ * until the first content write, so applyItem/applyOuter materialize it
+ * on demand against the ADOPTED plan — the only plan an adopted row can
+ * use, and reachable here because a row whose refs `createRow` seeded
+ * always finds a door already in the slot and never evaluates the `??`
+ * right-hand side.
+ *
+ * Emitted ONCE per apply body rather than per binding, and only when that
+ * body actually has content bindings: an `applyOuter` driving attributes
+ * only never mentions the door, which is the whole point of deferring it.
+ */
+function doorAccess(
+  lazyRow: LazyRowPlanData,
+  writerIndex: number,
+  adoptedPlanVar: string | null,
+): string {
+  const slot = `__r[${writerIndex}]`
+  return `${slot} ?? (${slot} = ${doorCtor(lazyRow)}(__e.primaryEl, ${adoptedPlanVar}))`
 }
 
 /** `entry.last`-backed dedup test. `in` (not a truthiness check) so a
@@ -355,12 +415,11 @@ function emitTextBinding(
   lines: string[],
   ind: string,
   t: LazyRowTextBinding,
-  writerIndex: number,
+  doorExpr: string,
   mode: 'create' | 'item' | 'outer',
   rwDoor: boolean,
 ): void {
   lines.push(`${ind}{ const __x = ${t.wrappedExpression}`)
-  const doorExpr = `__r[${writerIndex}]`
   const writeOf = (valueExpr: string): string =>
     rwDoor
       ? `${doorExpr}.write('${t.slotId}', ${valueExpr})`

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
@@ -178,9 +178,14 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
   // immediately, so its door is used on the same tick it is built and there
   // is nothing to defer (see the `deferDoor` note on `refParts`).
   if (hasRefs) {
+    // With the door deferred, the ELEMENT refs are the only parts that read the
+    // row root — so a text-only row (no reactive-attr slot) claims to a bare
+    // `[null]` and the `__el` binding would be dead. `parts` decides, rather
+    // than a second predicate that could drift from `refParts`.
+    const parts = refParts(lazyRow, '__el', null, adoptedPlanVar, true)
     lines.push(`${indent}const ${claimVar} = (__e) => {`)
-    lines.push(`${indent}  const __el = __e.primaryEl`)
-    lines.push(`${indent}  return [${refParts(lazyRow, '__el', null, adoptedPlanVar, true).join(', ')}]`)
+    if (parts.some(p => p.includes('__el'))) lines.push(`${indent}  const __el = __e.primaryEl`)
+    lines.push(`${indent}  return [${parts.join(', ')}]`)
     lines.push(`${indent}}`)
   }
 

--- a/spec/slot-unification.md
+++ b/spec/slot-unification.md
@@ -228,11 +228,16 @@ work.
 
 ## 8. Follow-ups
 
-Identified but not shipped, tracked so it isn't re-discovered from scratch.
+Identified here rather than re-discovered from scratch later. Entries stay
+after they ship when the *estimate* is the reusable part — a number that was
+wrong, and why, is worth as much as the change itself.
 
 - **General-case marker elision** (§5a). The one open item on axis (b), and
   the only route to closing the HTML-size gap against solid.
-- **Claim-mechanism allocation shape.** Two mechanically identified pieces.
+- **Claim-mechanism allocation shape — both pieces SHIPPED.** Kept here
+  because the corrected estimates are the reusable part: the original numbers
+  for both pieces were wrong in opposite directions, and each was measured on
+  the wrong bench at first.
 
   **(1) Per-row `SlotSpec` re-allocation — SHIPPED.** Every row rebuilt the
   loop's whole `ClaimPlan` (the array, one `{ id, kind, path }` per text
@@ -257,16 +262,44 @@ Identified but not shipped, tracked so it isn't re-discovered from scratch.
   +0.1KB gzip on the benchmark app — which is the trade: two extra const
   lines per loop buy 2 fewer allocations per row.
 
-  **(2) `applyOuter`'s seed pass materializes each row's whole ref tuple**
+  **(2) `applyOuter`'s seed pass materialized each row's whole ref tuple**
   (element handle plus the `lazySlots` writer closure) even when the row's
-  outer-involving bindings are all ATTRS and the seed only ever reads the
-  element — splitting the tuple by what the seed actually reads recovers
-  most of ~230KB/1k rows without touching the model. **Still open**, and
-  piece (1) does not overlap it: (1) removed the plan objects the closure
-  captures, (2) is about not creating the closure at all on rows whose seed
-  never needs it. Needs per-slot lazy `entry.refs`, which interacts with
-  §2's claim-once rule, so it is a separate change measured on top of this
-  one.
+  outer-involving bindings were all ATTRS and the seed only ever read the
+  element. **Done** — the adopted-row claim (`__lzc_<mid>`) now leaves the
+  door slot `null` and the first content write fills it (`doorAccess` in
+  `stringify/lazy-row.ts`). `createRow` still builds its door eagerly: it
+  writes every text on the tick it clones the row, so there is nothing to
+  defer on the CSR path.
+
+  The claim-once interaction turned out not to bind. §2's rule is about a
+  single door resolving the whole plan on first access, and each door already
+  enforces that internally (`lazySlots`/`lazyClaimSlots` call `claimRefs`
+  once and cache); deferring the door's CONSTRUCTION changes when that one
+  resolution happens, not how many there are. A loop with an outer-involving
+  TEXT still claims every row at seed, because read-compare-write cannot
+  compare what it has not resolved — the deferral is a no-op there by design,
+  and the win is confined to attr-only-outer loops.
+
+  Two corrections to this entry's original estimate. The **~230KB/1k rows**
+  figure was too high: it was written before piece (1) removed the per-row
+  plan objects, and `lazySlots` never scanned eagerly anyway
+  (`claim-slots.ts:617` defers to the first write), so what remained was one
+  closure per row, not a resolved slot map. And the right benchmark is not
+  the DOM suite: that column creates its 1,000 rows client-side, which is the
+  `createRow` path this change deliberately leaves alone. Measured instead on
+  **SSR post-hydration heap** (`benchmarks/ssr/bench-ssr-memory.ts`, the
+  1,000-row table with item texts plus an outer-signal class):
+  **1630.6KB -> 1573.2KB / 1572.9KB** across two after-runs, i.e.
+  **-57.4KB (-3.5%)**, against a per-run stdev of 0.1-0.6KB and with the
+  react/solid columns unmoved as controls.
+
+  Behavioural coverage is
+  `packages/client/__tests__/runtime/lazy-row-adopted-door.test.ts`: real Hono
+  SSR markup, hydrated, then an item changed. That sequence is the only one
+  that executes the deferred branch — the emission tests read text, the
+  `createComponent` tests take the eager path, and the conformance suites
+  never run a post-hydration update. Verified to fail when the door is built
+  against the wrong root.
 - **Widening the lazy-row gate** — see §9.5's refusal table.
 
 ## 9. Lazy row graph — §3(c) completion

--- a/spec/slot-unification.md
+++ b/spec/slot-unification.md
@@ -269,7 +269,10 @@ wrong, and why, is worth as much as the change itself.
   door slot `null` and the first content write fills it (`doorAccess` in
   `stringify/lazy-row.ts`). `createRow` still builds its door eagerly: it
   writes every text on the tick it clones the row, so there is nothing to
-  defer on the CSR path.
+  defer on the CSR path. A knock-on: with the door gone from the claim, the
+  element refs are the only parts that read the row root, so a row with no
+  reactive ATTRIBUTE claims to a bare `[null]` and stops binding
+  `__e.primaryEl` at all.
 
   The claim-once interaction turned out not to bind. §2's rule is about a
   single door resolving the whole plan on first access, and each door already


### PR DESCRIPTION
Closes the second half of `spec/slot-unification.md` §8's "claim-mechanism allocation shape" follow-up. The first half (hoisting the per-row `ClaimPlan` literal) landed in #2429.

## The waste

A lazy-eligible loop's adopted-row claim resolved the element refs **and** constructed the content door in one tuple:

```js
const __lzc_l0 = (__e) => {
  const __el = __e.primaryEl
  return [qsa(__el, '[bf="s3"]'), lazySlots(__el, __lzs_l0)]
}                                 // ^ one closure per row, often never used
```

That tuple is built for an entry the first time either apply path touches the row, and `applyOuter`'s seed pass touches **all** of them. So a loop whose only outer-involving binding is an attribute — the common `className={selected() === row.id ? 'danger' : ''}` shape, and the one the SSR bench renders — built a door for every row of the list at hydration and used none of them. Nothing writes content until that row's item actually changes.

## The change

The claim leaves the door's slot `null`; `applyItem`/`applyOuter` materialize it on demand, once per apply body and only when that body has content bindings to write:

```js
const __d = __r[1] ?? (__r[1] = lazySlots(__e.primaryEl, __lzs_l0))
```

`createRow` is deliberately untouched — it writes every text on the tick it clones the row, so its door is used immediately and deferring it would only add a branch. Its emitted output is byte-identical. The deferral is confined to server-rendered rows, which is where the allocation was wasted.

Reachability holds because a row whose refs `createRow` seeded always finds a door already in the slot and never evaluates the `??` right-hand side; only adopted rows see `null`, and the adopted claim plan is the only plan they can use.

**§2's claim-once rule is preserved.** That rule is about one door resolving the whole plan on first access, and each door already enforces it internally — `lazySlots`/`lazyClaimSlots` call `claimRefs` once and cache. Deferring *construction* moves when that single resolution happens rather than adding a second resolution path. A loop with an outer-involving TEXT still claims every row at seed, because read-compare-write cannot compare what it has not resolved; the deferral is a no-op there by design.

## Measurement

SSR post-hydration heap (`benchmarks/ssr/bench-ssr-memory.ts` — 1,000 rows, item texts plus an outer-signal class):

| | before | after (run 1) | after (run 2) |
|---|---|---|---|
| barefoot | 1630.6KB | **1573.2KB** | **1572.9KB** |
| react (control) | 3474.8KB | 3474.8KB | 3475.8KB |
| solid (control) | 2578.2KB | 2578.0KB | 2578.0KB |

**-57.4KB (-3.5%)**, reproduced twice, against a per-run stdev of 0.1–0.6KB. SSR output does not change; no `expectedHtml` fixture moved.

### The update path does not regress

`applyItem` gains one nullish check per row per update, so `update10th` was checked directly. Quick mode (3 iterations) showed 12.10ms → 14.10ms with non-overlapping ranges, which looked like a regression; at full iteration counts (warmup 5, measure 10 — same machine, same session) it is not one:

| | median | mean | stdev | range | n |
|---|---|---|---|---|---|
| before | 13.15ms | 14.21ms | 2.12 | 11.9–18.3 | 10 |
| after | **12.65ms** | 12.80ms | 0.88 | 11.8–14.8 | 10 |

Both quick-mode figures fall inside the after-condition's own n=10 spread, so the apparent 2ms was three-iteration noise. That matches the mechanism: rows the DOM suite creates come from `createRow`, so their door is already in the slot and the `??` short-circuits.

The DOM suite's `memory` column is also unmoved — 971.9KB → 972.1KB locally, and 969.8KB on this PR's CI run against 970.5KB from #2429's. That is the expected result rather than a null one: the column creates its rows client-side through the path this change leaves eager.

## Two corrections to the §8 estimate

The spec entry is updated rather than deleted, because the wrong estimate is the reusable part.

- **The ~230KB/1k rows figure was too high.** It predated #2429's removal of the per-row plan objects, and `lazySlots` never scanned eagerly to begin with (`claim-slots.ts:617` defers to the first write) — so what remained was a closure per row, not a resolved slot map.
- **The DOM suite's memory column cannot show this at all.** That is where #2429 was measured, but it creates its 1,000 rows client-side through `createRow`, the path left eager here. The right bench is SSR post-hydration heap.

## Verification

New behavioural coverage: `packages/client/__tests__/runtime/lazy-row-adopted-door.test.ts` renders real Hono SSR markup, hydrates it, then changes an item. That sequence is the only one that executes the deferred branch — the emission tests read the generated text, the `createComponent` tests take the eager path, and `csr-conformance` / `ssr-hydration-contract` never run a post-hydration update at all. Verified to fail when the door is built against the wrong root, so it pins behaviour and not just spelling.

Green locally: `packages/jsx` in full (2742 pass, 0 fail) plus `typecheck:tests`, `adapter-tests` (1456), `packages/client` (605).

Regenerated expectations, both deliberate rather than auto-committed (#2428): the 6 `doc-examples` snapshots (all three lines of the same shape change) and `ai-chat.client.js`, the one shared fixture with a lazy loop carrying texts. The three drift-detection jobs `update-doc-snapshots` / `update-expected-html` / `update-meta` are green, so nothing regenerable was missed.