### PR TITLE
fix(compiler): stop per-specifier type-only imports leaking into the client bundle

### DIFF
--- a/.changeset/type-only-import-leak.md
+++ b/.changeset/type-only-import-leak.md
@@ -1,0 +1,80 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/cli": patch
+---
+
+Stop per-specifier type-only imports from leaking into the client bundle as value imports
+
+`import { paperColor, type Theme } from '../lib/theme'` could put `Theme` — a
+type, with no value binding anywhere — into the generated client JS as a value
+import, and from there into the relative-import inliner's IIFE return:
+
+```js
+const __bf_inline_0 = (() => {
+  function paperColor2(t) { … }
+  return { paperColor: paperColor2, Theme };
+  //                                ^^^^^ never declared — it is a type
+})();
+```
+
+`Theme` has no binding in the IIFE, so the module threw
+`ReferenceError: Theme is not defined` before anything hydrated. The whole
+page's client JS was dead, and because the SSR markup stayed on screen it read
+as "hydration silently never ran" rather than as a load error.
+
+Two independent gaps compounded in `collectExternalImports`
+(`ir-to-client-js/imports.ts`), which decides which specifiers survive into the
+client bundle:
+
+- Only the **declaration-level** `imp.isTypeOnly` was consulted. The analyzer
+  has recorded per-specifier `spec.isTypeOnly` since #1915, but this loop never
+  read it, so `{ type Foo }` was indistinguishable from `{ Foo }`.
+- Usage was decided by a `\bname\b` text scan over the emitted code. A word
+  boundary is not a reference: an object key (`{ Theme: 'テーマ' }`), a string
+  literal (`'Theme'`), a property access (`obj.Theme`) all matched.
+
+Either alone was survivable — the first only mattered if the name happened to
+appear, the second only over-emitted imports whose bindings existed. Together,
+a type name that merely *appeared as a word* became a value import.
+
+The fix closes both halves, plus adds a backstop for anything that still slips
+through:
+
+- **Per-specifier type-only specifiers are skipped** at every site that emits
+  an import into a client bundle: `collectExternalImports`, the state-only
+  module path in `compiler.ts`, and `collectUserDomImports` — where
+  `import { createSignal, type Signal } from '@barefootjs/client'` would
+  otherwise emit `Signal` from the `/runtime` subpath, which does not export it.
+  The two sites that only *read* the flag are guarded too, so a type-only
+  specifier no longer forces a `.client.js` source rewrite or trips the
+  browser-only-API diagnostic.
+- **Usage is a value-reference test, not a text scan.** The new
+  `collectValueReferencedNames` (`value-references.ts`) walks the emitted code
+  with the TypeScript parser and keeps only identifiers in genuine value
+  positions, reusing the `isValueReferenceIdentifier` classifier that the CLI's
+  stripped-import detector already had (now shared, one door, so the two
+  "is this a real use" checks in the pipeline cannot drift apart). A shorthand
+  property (`{ helper }`) counts — it reads the binding. When the text cannot be
+  parsed cleanly the helper answers `null` and callers fall back to the old text
+  scan: narrowing on a partial parse would *drop* a needed import, which is the
+  one direction this must never fail in.
+- **`BF055` — inlined module missing a requested export.** `buildTopLevelIIFE`
+  now compares the names its consumers ask for against the module's export
+  surface and fails the build with the name, the module, and the exact
+  `ReferenceError` it would have produced. The emitted `return` is left
+  unchanged on purpose: the build error is the deliverable, and the throwing
+  artifact stays as the loud signal for anyone who ships past a red build. The
+  check is skipped when the surface is not exhaustively enumerable (an
+  `export * from './other'`), and the surface counts everything a module's
+  `export` clauses legally NAME — re-exports, `export enum`,
+  `export namespace` — so a legal module shape can never produce a false
+  failure. That surface is deliberately wider than the set that populates the
+  namespace IIFE's `return`, which stays restricted to names with a binding in
+  the inlined body. The module source is parsed at most once per module, and
+  not at all when neither the namespace return nor the check needs it —
+  `inlineRelativeImports` is `bf build` hot path.
+
+Note this only ever bit projects that do **not** set `localImportPrefixes` —
+with it set, relative imports leave the loop before the usage test. It is not
+part of `createConfig`'s documented surface for a Hono project, so a stock
+config took the scanning path for every relative import.

--- a/packages/cli/src/__tests__/resolve-imports.test.ts
+++ b/packages/cli/src/__tests__/resolve-imports.test.ts
@@ -818,4 +818,109 @@ console.log(HELP_MESSAGE)
     expect(result).not.toMatch(/^import[^\n]*from '\.\/nonexistent'/m)
     expect(result).toContain('console.log(HELP_MESSAGE)')
   })
+
+  // #2432: the compiler no longer emits per-specifier type-only names as
+  // value imports (see packages/jsx's `collectExternalImports` fix), but
+  // this is the defensive net for anything that still asks an inlined
+  // module for a name it doesn't export — e.g. a stale/hand-edited bundle,
+  // or a name that was simply a typo. Without this check the IIFE `return`
+  // silently references an undeclared name and throws `ReferenceError` at
+  // load.
+  test('BF055 fires when the parent client JS imports a name the inlined module does not export (#2432)', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'theme.ts'), `
+export function paperColor(opts: { paper: string }): string {
+  return opts.paper
+}
+export type Theme = 'light' | 'dark'
+`)
+    const clientJs = `import { paperColor, Theme } from './theme'
+import { createSignal } from '@barefootjs/client'
+console.log(paperColor({ paper: '#fff' }))
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'ThemedBadge-abc.js'), clientJs)
+    const manifest = {
+      ThemedBadge: { clientJs: 'components/ThemedBadge-abc.js', markedTemplate: 'components/ThemedBadge.tsx' },
+    }
+
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].code).toBe('BF055')
+    expect(errors[0].message).toContain('Theme')
+    expect(errors[0].message).toContain('theme.ts')
+  })
+
+  test('no BF055 when the inlined module has a non-exhaustive surface (export * from) (#2432)', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'theme2.ts'), `
+export * from './other'
+export function paperColor(opts: { paper: string }): string {
+  return opts.paper
+}
+`)
+    const clientJs = `import { paperColor, NotLocallyDeclared } from './theme2'
+import { createSignal } from '@barefootjs/client'
+console.log(paperColor({ paper: '#fff' }))
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'StarReexport-abc.js'), clientJs)
+    const manifest = {
+      StarReexport: { clientJs: 'components/StarReexport-abc.js', markedTemplate: 'components/StarReexport.tsx' },
+    }
+
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    // `export * from` makes the surface non-enumerable — the check is
+    // skipped entirely rather than risk a false positive.
+    expect(errors.filter(e => e.code === 'BF055')).toHaveLength(0)
+  })
+
+  test('no BF055 for a name the module only re-exports (#2432)', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'theme3.ts'), `
+export { helper } from './other'
+export function paperColor(opts: { paper: string }): string {
+  return opts.paper
+}
+`)
+    const clientJs = `import { paperColor, helper } from './theme3'
+import { createSignal } from '@barefootjs/client'
+console.log(paperColor({ paper: '#fff' }))
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'ReexportName-abc.js'), clientJs)
+    const manifest = {
+      ReexportName: { clientJs: 'components/ReexportName-abc.js', markedTemplate: 'components/ReexportName.tsx' },
+    }
+
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    // `helper` is named by the module's own `export { helper } from './other'`
+    // clause — `collectExportSurface` is deliberately wider than
+    // `collectExportedNames` so this legal re-export never produces a false
+    // build failure.
+    expect(errors.filter(e => e.code === 'BF055')).toHaveLength(0)
+  })
+
+  test('no BF055 for an exported enum member (#2432)', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'themeEnum.ts'), `
+export enum Color {
+  Light = 'light',
+  Dark = 'dark',
+}
+export function paperColor(opts: { paper: string }): string {
+  return opts.paper
+}
+`)
+    const clientJs = `import { paperColor, Color } from './themeEnum'
+import { createSignal } from '@barefootjs/client'
+console.log(paperColor({ paper: '#fff' }), Color.Light)
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'EnumExport-abc.js'), clientJs)
+    const manifest = {
+      EnumExport: { clientJs: 'components/EnumExport-abc.js', markedTemplate: 'components/EnumExport.tsx' },
+    }
+
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    // `export enum Color` is a genuine value export the earlier declaration-
+    // shape checks missed — asking for it must not produce a spurious BF055.
+    expect(errors.filter(e => e.code === 'BF055')).toHaveLength(0)
+  })
 })

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -2,7 +2,7 @@
 
 import { dirname, resolve } from 'node:path'
 import ts from 'typescript'
-import { createError, ErrorCodes, type CompilerError } from '@barefootjs/jsx'
+import { createError, ErrorCodes, isValueReferenceIdentifier, type CompilerError } from '@barefootjs/jsx'
 import { fileExists, readText, transpile, writeText } from './runtime'
 
 /**
@@ -62,26 +62,61 @@ function shapeFromDecl(decl: ts.ImportDeclaration): ImportShape | null {
 }
 
 /**
- * Collect the set of top-level value-exported names from an inlined
- * module's original TS source. Used to populate the IIFE return for
- * namespace imports (`import * as ns from './x'`), where the parent may
- * reference any exported name via `ns.foo`.
+ * Shared AST walk over a module's top-level `export` clauses, split into
+ * four buckets so different callers can combine them differently:
  *
- * Walks the AST so we naturally handle:
- *   - `export const|let|var name` (including object/array destructuring)
- *   - `export function name`, `export async function name`
- *   - `export class name`
- *   - `export { a, b as c }` (uses the exported alias, i.e. `c`)
- *   - multi-line `export { … }` blocks, trailing commas, comments
+ *   - `localValueExports`  — names this module itself declares and exports
+ *     (`export const|function|class name`, `export { a, b as c }` with no
+ *     `from`). These have a real binding inside the module body. This is
+ *     the ONLY bucket that feeds the namespace-import IIFE return (`import
+ *     * as ns from './x'` surfaces every name via `ns.foo`) — whether the
+ *     transpiled body leaves a reachable binding for an enum/namespace or a
+ *     re-export at that position is unverified, so widening the return with
+ *     the other buckets below could introduce a NEW ReferenceError for
+ *     namespace consumers. Keeping it exactly `localValueExports` is
+ *     pre-existing behaviour and stays untouched.
+ *   - `otherValueExports`  — `export enum X` / `export namespace|module X`
+ *     (skipping ambient `declare` forms where cheap to detect). These ARE
+ *     genuine value exports — an enum/namespace member is a real runtime
+ *     binding — but were originally missed by `localValueExports`'s
+ *     declaration-shape checks, which caused a spurious BF055 on legal code
+ *     (a client bundle legitimately importing an exported enum). Kept
+ *     separate from `localValueExports` because whether the *transpiled*
+ *     body actually preserves a reachable binding at the IIFE's `return`
+ *     position for these shapes hasn't been verified — this bucket is
+ *     surface-only (BF055 validation), never fed into the namespace return.
+ *   - `reExportedNames`    — names named by `export { a, b as c } from './y'`
+ *     or `export * as ns from './y'`. The module body has NO binding for
+ *     these (the re-export line is stripped by `stripImportsAndExports`) —
+ *     they're only ever reachable through the ORIGINAL module `./y`, not
+ *     through this one's IIFE. Surface-only, same reasoning as above.
+ *   - `hasStarReExport`    — true when `export * from './y'` is present.
+ *     A bare star re-export doesn't name anything, so the module's full
+ *     export surface can't be enumerated statically here at all.
  *
- * Skipped intentionally:
- *   - `export type` / `export interface` / `export type { … }` — type-only,
- *     erased at runtime, must not be in the IIFE return
- *   - `export default` — out of scope per #1141
- *   - re-exports (`export { x } from './y'`) — not emitted by transpile here
+ * Type-only exports (`export type`, `export interface`, `export type {…}`,
+ * per-specifier `export { type X }`) are skipped throughout — they're
+ * erased at runtime and can't be value bindings.
+ *
+ * Two callers combine these buckets differently:
+ *   - The namespace-import IIFE return uses `localValueExports` alone (see
+ *     above).
+ *   - BF055 surface validation (`buildTopLevelIIFE`) uses the union of all
+ *     four *named* buckets (`localValueExports ∪ otherValueExports ∪
+ *     reExportedNames`), and skips the check entirely when
+ *     `hasStarReExport` — an un-nameable re-export must never produce a
+ *     false positive.
  */
-function collectExportedNames(source: string): string[] {
-  const names = new Set<string>()
+function collectExportInfo(source: string): {
+  localValueExports: Set<string>
+  otherValueExports: Set<string>
+  reExportedNames: Set<string>
+  hasStarReExport: boolean
+} {
+  const localValueExports = new Set<string>()
+  const otherValueExports = new Set<string>()
+  const reExportedNames = new Set<string>()
+  let hasStarReExport = false
   const sourceFile = ts.createSourceFile(
     'mod.ts',
     source,
@@ -96,9 +131,15 @@ function collectExportedNames(source: string): string[] {
     return mods?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
   }
 
+  function isAmbient(node: ts.Node): boolean {
+    if (!ts.canHaveModifiers(node)) return false
+    const mods = ts.getModifiers(node)
+    return mods?.some(m => m.kind === ts.SyntaxKind.DeclareKeyword) ?? false
+  }
+
   function collectFromBindingName(name: ts.BindingName): void {
     if (ts.isIdentifier(name)) {
-      names.add(name.text)
+      localValueExports.add(name.text)
       return
     }
     // ObjectBindingPattern / ArrayBindingPattern — recurse into elements.
@@ -113,23 +154,48 @@ function collectExportedNames(source: string): string[] {
         collectFromBindingName(d.name)
       }
     } else if (ts.isFunctionDeclaration(stmt) && hasExport(stmt) && stmt.name) {
-      names.add(stmt.name.text)
+      localValueExports.add(stmt.name.text)
     } else if (ts.isClassDeclaration(stmt) && hasExport(stmt) && stmt.name) {
-      names.add(stmt.name.text)
-    } else if (ts.isExportDeclaration(stmt) && !stmt.moduleSpecifier && stmt.exportClause && ts.isNamedExports(stmt.exportClause)) {
-      // `export { a, b as c }` — type-only specifiers (and the whole
-      // `export type { … }` form) are erased; skip them.
+      localValueExports.add(stmt.name.text)
+    } else if (ts.isEnumDeclaration(stmt) && hasExport(stmt) && stmt.name) {
+      // `export enum X { … }` — a genuine value export (surface-only, see
+      // docstring above; not fed into the namespace IIFE return).
+      otherValueExports.add(stmt.name.text)
+    } else if (ts.isModuleDeclaration(stmt) && hasExport(stmt) && ts.isIdentifier(stmt.name)) {
+      // `export namespace X { … }` / `export module X { … }`. Ambient
+      // `declare namespace/module` forms have no runtime binding — skip
+      // them when the `declare` modifier is present.
+      if (!isAmbient(stmt)) otherValueExports.add(stmt.name.text)
+    } else if (ts.isExportDeclaration(stmt)) {
       if (stmt.isTypeOnly) continue
-      for (const el of stmt.exportClause.elements) {
-        if (el.isTypeOnly) continue
-        names.add(el.name.text)
+      if (!stmt.moduleSpecifier) {
+        // `export { a, b as c }` — local re-export of names already bound
+        // in this module.
+        if (stmt.exportClause && ts.isNamedExports(stmt.exportClause)) {
+          for (const el of stmt.exportClause.elements) {
+            if (el.isTypeOnly) continue
+            localValueExports.add(el.name.text)
+          }
+        }
+      } else if (!stmt.exportClause) {
+        // `export * from './y'` — names an unbounded set; can't enumerate.
+        hasStarReExport = true
+      } else if (ts.isNamespaceExport(stmt.exportClause)) {
+        // `export * as ns from './y'`
+        reExportedNames.add(stmt.exportClause.name.text)
+      } else if (ts.isNamedExports(stmt.exportClause)) {
+        // `export { a, b as c } from './y'`
+        for (const el of stmt.exportClause.elements) {
+          if (el.isTypeOnly) continue
+          reExportedNames.add(el.name.text)
+        }
       }
     }
     // TypeAliasDeclaration / InterfaceDeclaration: type-only, ignored.
     // ExportAssignment (`export default`): out of scope per #1141.
   }
 
-  return [...names]
+  return { localValueExports, otherValueExports, reExportedNames, hasStarReExport }
 }
 
 /**
@@ -349,6 +415,30 @@ function buildConsumerBinding(shape: ImportShape | null, topLevelId: string): st
 }
 
 /**
+ * Build the per-request-name BF055 diagnostic: a consumer's named import
+ * asked for a name the module's export surface doesn't contain. The
+ * message + suggestion cover the two real causes — the compiler no longer
+ * emits type-only specifiers as of #2432, so a name that used to slip
+ * through as a phantom import is now either a genuine type import or a
+ * typo/removed export.
+ */
+function buildMissingExportMessage(
+  name: string,
+  modulePath: string,
+): { message: string; suggestion: string } {
+  return {
+    message:
+      `Import \`${name}\` from '${modulePath}' has no matching export in that module. ` +
+      `The client bundle would throw \`ReferenceError: ${name} is not defined\` at load.`,
+    suggestion:
+      `Either \`${name}\` is a TYPE — import it with \`import type { ${name} }\` or ` +
+      `\`import { type ${name} }\` (the compiler no longer emits type-only specifiers ` +
+      `into the client bundle as of #2432) — or it's a typo / removed export: check ` +
+      `'${modulePath}' actually exports \`${name}\`.`,
+  }
+}
+
+/**
  * Build the top-level IIFE wrap for an inlined module. The IIFE returns
  * the union of every name any consumer (parent or transitive) needs from
  * the module: explicit named imports plus, if any consumer used `* as ns`,
@@ -363,26 +453,70 @@ function buildConsumerBinding(shape: ImportShape | null, topLevelId: string): st
  *   })()
  *
  * `originalSource` is the pre-transpile TS source, used by
- * `collectExportedNames` to enumerate all value exports for the namespace
- * case (so type-only exports stay excluded).
+ * `collectExportInfo` to enumerate all value exports for the namespace
+ * case (so type-only exports stay excluded) and to validate named-import
+ * requests for BF055 below. Parsed at most once, and only when needed —
+ * see the call site.
+ *
+ * `modulePath` is the resolved absolute source path, used only for the
+ * BF055 diagnostic location/message below — it does NOT change what gets
+ * emitted. This is a pure diagnostic addition: a name a consumer requested
+ * still ends up in the `return { … }` verbatim even when it's not in the
+ * module's export surface (a failing build is the deliverable here; the
+ * resulting `ReferenceError` stays the loud runtime signal for anyone who
+ * ignores a failed build, e.g. via a stale dist directory).
  */
 function buildTopLevelIIFE(
   topLevelId: string,
   body: string,
   shapesNeeded: ImportShape[],
   originalSource: string,
-): { wrapped: string; hoistedImports: string[] } {
+  modulePath: string,
+): { wrapped: string; hoistedImports: string[]; errors: CompilerError[] } {
   const { body: stripped, hoistedImports } = stripImportsAndExports(body)
 
   // Union of names any consumer needs from this module. If any consumer
   // wants the namespace shape, we have to surface every value export.
   const wantsNamespace = shapesNeeded.some(s => !!s.namespace)
   const namesNeeded = new Set<string>()
-  if (wantsNamespace) {
-    for (const n of collectExportedNames(originalSource)) namesNeeded.add(n)
-  }
+  // Names requested via consumer NAMED shapes specifically — validated
+  // against the export surface below. Namespace-derived names (added below)
+  // come from the module's own exports by construction and need no
+  // validation.
+  const namedRequests = new Set<string>()
   for (const shape of shapesNeeded) {
-    for (const { imported } of shape.named) namesNeeded.add(imported)
+    for (const { imported } of shape.named) {
+      namesNeeded.add(imported)
+      namedRequests.add(imported)
+    }
+  }
+
+  const errors: CompilerError[] = []
+
+  // `originalSource` is parsed AT MOST ONCE per call, and only when
+  // something actually needs it — `inlineRelativeImports` runs inside
+  // `bf build`'s hot path, and CLAUDE.md's rule against extra parses there
+  // applies (#2432 review). Both the namespace-return names and the BF055
+  // surface check come out of this single `collectExportInfo` call.
+  if (wantsNamespace || namedRequests.size > 0) {
+    const info = collectExportInfo(originalSource)
+    if (wantsNamespace) {
+      for (const n of info.localValueExports) namesNeeded.add(n)
+    }
+    if (namedRequests.size > 0 && !info.hasStarReExport) {
+      const surfaceNames = new Set([...info.localValueExports, ...info.otherValueExports, ...info.reExportedNames])
+      const loc = { file: modulePath, start: { line: 1, column: 0 }, end: { line: 1, column: 0 } }
+      for (const name of namedRequests) {
+        if (surfaceNames.has(name)) continue
+        const { message, suggestion } = buildMissingExportMessage(name, modulePath)
+        errors.push(
+          createError(ErrorCodes.INLINED_IMPORT_MISSING_EXPORT, loc, {
+            message,
+            suggestion: { message: suggestion },
+          }),
+        )
+      }
+    }
   }
 
   if (namesNeeded.size === 0) {
@@ -392,6 +526,7 @@ function buildTopLevelIIFE(
     return {
       wrapped: `const ${topLevelId} = (() => {\n${stripped}\nreturn {};\n})();`,
       hoistedImports,
+      errors,
     }
   }
 
@@ -399,6 +534,7 @@ function buildTopLevelIIFE(
   return {
     wrapped: `const ${topLevelId} = (() => {\n${stripped}\nreturn ${ret};\n})();`,
     hoistedImports,
+    errors,
   }
 }
 
@@ -583,54 +719,6 @@ function buildDanglingReferenceMessage(
 }
 
 /**
- * Identifier-position classifier: returns `true` when `id` is being USED
- * as a value (and could therefore be the dangling reference to a stripped
- * import), `false` when it's a declaration name, property key, member-
- * access name, or other non-reference slot.
- *
- * Caveat: this is a syntactic test, not a scope analysis. If a local
- * function parameter happens to share a name with a stripped import,
- * references inside that function's body will count as references to
- * the stripped import (false positive). Acceptable per #1227: a loud
- * build error is a strict improvement over a silent runtime
- * ReferenceError, and shadowing genuine import binding names is rare in
- * practice.
- */
-function isValueReference(id: ts.Identifier): boolean {
-  const parent = id.parent
-  if (!parent) return false
-  if (ts.isPropertyAccessExpression(parent) && parent.name === id) return false
-  if (ts.isPropertyAssignment(parent) && parent.name === id) return false
-  if (
-    (ts.isMethodDeclaration(parent) ||
-      ts.isGetAccessorDeclaration(parent) ||
-      ts.isSetAccessorDeclaration(parent)) &&
-    parent.name === id
-  ) {
-    return false
-  }
-  if (ts.isVariableDeclaration(parent) && parent.name === id) return false
-  if (ts.isFunctionDeclaration(parent) && parent.name === id) return false
-  if (ts.isFunctionExpression(parent) && parent.name === id) return false
-  if (ts.isClassDeclaration(parent) && parent.name === id) return false
-  if (ts.isClassExpression(parent) && parent.name === id) return false
-  if (ts.isParameter(parent) && parent.name === id) return false
-  if (ts.isBindingElement(parent) && (parent.name === id || parent.propertyName === id)) return false
-  if (ts.isLabeledStatement(parent) && parent.label === id) return false
-  if (ts.isBreakOrContinueStatement(parent) && parent.label === id) return false
-  // ImportSpecifier (`{ X }` or `{ X as Y }`) and ExportSpecifier have
-  // only `name`/`propertyName` as Identifier children — written as an
-  // explicit slot check for stylistic consistency with the other
-  // branches above.
-  if (ts.isImportSpecifier(parent) && (parent.name === id || parent.propertyName === id)) return false
-  if (ts.isExportSpecifier(parent) && (parent.name === id || parent.propertyName === id)) return false
-  if (ts.isImportClause(parent) && parent.name === id) return false
-  if (ts.isNamespaceImport(parent) && parent.name === id) return false
-  if (ts.isQualifiedName(parent) && parent.right === id) return false
-  return true
-}
-
-/**
  * Scan the assembled bundle source for value references to any binding
  * name we removed during the walk. Returns one CompilerError per
  * (stripped import × dangling binding) pair. Uses the TypeScript parser
@@ -669,7 +757,7 @@ function detectStrippedReferences(
   // top-down gives source-order positions naturally.
   const firstReference = new Map<string, ts.Identifier>()
   function visit(node: ts.Node): void {
-    if (ts.isIdentifier(node) && isValueReference(node)) {
+    if (ts.isIdentifier(node) && isValueReferenceIdentifier(node)) {
       if (!firstReference.has(node.text)) firstReference.set(node.text, node)
     }
     ts.forEachChild(node, visit)
@@ -1113,14 +1201,16 @@ async function inlineRelativeImports(
   const ordered = topoSort(modules)
   const iifes: string[] = []
   for (const mod of ordered) {
-    const { wrapped, hoistedImports } = buildTopLevelIIFE(
+    const { wrapped, hoistedImports, errors } = buildTopLevelIIFE(
       mod.topLevelId,
       mod.transpiledBody,
       mod.consumerShapes,
       mod.originalSource,
+      mod.path,
     )
     iifes.push(wrapped)
     for (const h of hoistedImports) hoistedAcc.push(h)
+    for (const err of errors) errorAcc.push(err)
   }
 
   const finalContent = iifes.join('\n') + '\n' + parentContent
@@ -1140,10 +1230,13 @@ async function inlineRelativeImports(
  * - `.tsx` imports: strip (separately-compiled `'use client'` component)
  * - Not found / circular: strip
  *
- * Returns the set of diagnostics emitted during resolution. The only
- * error currently produced here is `BF053` — a stripped import whose
- * binding is still referenced in the assembled bundle. See
- * `detectStrippedReferences` and piconic-ai/barefootjs#1227.
+ * Returns the set of diagnostics emitted during resolution:
+ *   - `BF053` — a stripped import whose binding is still referenced in
+ *     the assembled bundle. See `detectStrippedReferences` and
+ *     piconic-ai/barefootjs#1227.
+ *   - `BF055` — an inlined `.ts` module's IIFE `return` was asked for a
+ *     name the module doesn't export. See `buildTopLevelIIFE` and
+ *     piconic-ai/barefootjs#2432.
  */
 export async function resolveRelativeImports(
   options: ResolveRelativeImportsOptions,

--- a/packages/jsx/src/__tests__/ir-to-client-js/imports.test.ts
+++ b/packages/jsx/src/__tests__/ir-to-client-js/imports.test.ts
@@ -287,6 +287,29 @@ describe('collectExternalImports', () => {
     const result = collectExternalImports(ir, code)
     expect(result).toEqual(["import { helper } from 'some-lib'"])
   })
+
+  // These two pin the fallback branch specifically (generated text that does
+  // NOT parse cleanly, so `makeValueUsageTest` falls back to a substring
+  // scan rather than the AST-based value-reference set). #2432: the
+  // fallback used to be a `new RegExp(`\\b${localName}\\b`)` scan, which
+  // silently DROPPED the import for either shape below — `\b` isn't defined
+  // for `$` or non-ASCII characters, and `$` is also a regex metacharacter
+  // (end-of-input anchor) when spliced unescaped into `new RegExp(...)`, so
+  // `\b$fetch\b` could never match `$fetch` at all. Dropping the import is
+  // the one failure direction this helper must never take.
+  test('fallback matches a $-prefixed specifier (#2432)', () => {
+    const ir = makeIR([makeImport('ofetch', ['$fetch'])])
+    const code = 'MyComponent $fetch()'
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual(["import { $fetch } from 'ofetch'"])
+  })
+
+  test('fallback matches a non-ASCII specifier (#2432)', () => {
+    const ir = makeIR([makeImport('some-lib', ['日本語'])])
+    const code = 'MyComponent 日本語()'
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual(["import { 日本語 } from 'some-lib'"])
+  })
 })
 
 describe('collectUserDomImports', () => {

--- a/packages/jsx/src/__tests__/ir-to-client-js/imports.test.ts
+++ b/packages/jsx/src/__tests__/ir-to-client-js/imports.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { collectExternalImports } from '../../ir-to-client-js/imports'
+import { collectExternalImports, collectUserDomImports } from '../../ir-to-client-js/imports'
 import type { ComponentIR, ImportInfo, SourceLocation } from '../../types'
 
 const dummyLoc: SourceLocation = { file: 'test.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } }
@@ -228,5 +228,79 @@ describe('collectExternalImports', () => {
       "import '@barefootjs/chart'",
       "import { z } from 'zod'",
     ])
+  })
+
+  // #2432: `collectExternalImports` used a `\bname\b` text scan to decide
+  // which specifiers survive into the client bundle. That scan never
+  // consulted the per-specifier `isTypeOnly` flag, so a per-specifier
+  // `import { paperColor, type Theme } from '../lib/theme'` re-emitted
+  // `Theme` as a VALUE import whenever the word "Theme" merely appeared in
+  // the generated code (e.g. as an object key) — the CLI's relative-import
+  // inliner then put `Theme` in the IIFE's `return { … }` with no binding,
+  // producing `ReferenceError: Theme is not defined` at load.
+  test('per-specifier type-only specifier is not emitted, while its value sibling is (#2432)', () => {
+    const ir: ReturnType<typeof makeIR> = makeIR([{
+      source: '../lib/theme',
+      specifiers: [
+        { name: 'paperColor', alias: null, isDefault: false, isNamespace: false },
+        { name: 'Theme', alias: null, isDefault: false, isNamespace: false, isTypeOnly: true },
+      ],
+      isTypeOnly: false,
+      loc: dummyLoc,
+    }])
+    const code = "const labels = { Theme: 'テーマ' };\nconst c = paperColor({ paper: '#fff' });"
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual(["import { paperColor } from '../lib/theme'"])
+  })
+
+  test('a value specifier that appears ONLY as an object key is not emitted (#2432)', () => {
+    const ir = makeIR([makeImport('./utils', ['helper'])])
+    const code = 'const o = { helper: 1 };'
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual([])
+  })
+
+  test('a value specifier that appears ONLY inside a string literal is not emitted (#2432)', () => {
+    const ir = makeIR([makeImport('./utils', ['helper'])])
+    const code = "const s = 'helper is a function';"
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual([])
+  })
+
+  test('a value specifier that appears ONLY as a property-access name is not emitted (#2432)', () => {
+    const ir = makeIR([makeImport('./utils', ['helper'])])
+    const code = 'obj.helper();'
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual([])
+  })
+
+  test('a value specifier used via shorthand property IS emitted (#2432)', () => {
+    const ir = makeIR([makeImport('./utils', ['helper'])])
+    const code = 'const o = { helper };'
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual(["import { helper } from './utils'"])
+  })
+
+  test('unparseable generated text falls back to the text scan (#2432)', () => {
+    const ir = makeIR([makeImport('some-lib', ['helper'])])
+    const code = 'MyComponent helper()'
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual(["import { helper } from 'some-lib'"])
+  })
+})
+
+describe('collectUserDomImports', () => {
+  test('per-specifier type-only specifier is not emitted from the runtime subpath (#2432)', () => {
+    const ir = makeIR([{
+      source: '@barefootjs/client',
+      specifiers: [
+        { name: 'createSignal', alias: null, isDefault: false, isNamespace: false },
+        { name: 'Signal', alias: null, isDefault: false, isNamespace: false, isTypeOnly: true },
+      ],
+      isTypeOnly: false,
+      loc: dummyLoc,
+    }])
+    const result = collectUserDomImports(ir)
+    expect(result).toEqual(['createSignal'])
   })
 })

--- a/packages/jsx/src/__tests__/type-only-import-leak.test.ts
+++ b/packages/jsx/src/__tests__/type-only-import-leak.test.ts
@@ -1,0 +1,60 @@
+/**
+ * End-to-end compiler pin for issue #2432's minimal reproduction.
+ *
+ * `collectExternalImports` used to decide which imported specifiers to
+ * re-emit into generated client JS with a `\bname\b` text scan over the
+ * generated code, never consulting the PER-SPECIFIER `isTypeOnly` flag
+ * (only the whole-declaration `import type { ... }` flag). So
+ * `import { paperColor, type Theme } from '../lib/theme'` re-emitted
+ * `Theme` as a VALUE import whenever the word "Theme" merely appeared in
+ * the emitted code — here, as an object key (`{ Theme: 'テーマ' }`).
+ *
+ * The CLI's relative-import inliner then places every requested name in
+ * the target module's top-level IIFE `return { … }`. `Theme` is a
+ * type-only export with no runtime binding, so the `return` referenced an
+ * undeclared name — `ReferenceError: Theme is not defined` at load,
+ * which kills the *entire* page's client JS before hydrate ever runs.
+ * The failure is silent from the user's perspective: the SSR-rendered
+ * markup is already on screen, so the page looks fine even though no
+ * interactivity ever wires up. See piconic-ai/barefootjs#2432.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('type-only import leak (#2432)', () => {
+  test('a per-specifier type-only import is never re-emitted into client JS', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { paperColor, type Theme } from '../lib/theme'
+
+      export function ThemedBadge() {
+        const labels = { Theme: 'テーマ' }
+        const [color, setColor] = createSignal(paperColor({ paper: '#fff' }))
+        return <div title={labels.Theme}>{color()}</div>
+      }
+    `
+
+    const result = compileJSX(source, 'ThemedBadge.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const code = clientJs!.content
+
+    // The value specifier survives as a real import.
+    expect(code).toContain("import { paperColor } from '../lib/theme'")
+
+    // No import statement anywhere in the bundle mentions `Theme` — the
+    // only legal destination for a value import of that name would be a
+    // binding that doesn't exist in the compiled `../lib/theme` module.
+    const importLines = code.split('\n').filter(line => line.trim().startsWith('import'))
+    for (const line of importLines) {
+      expect(line).not.toContain('Theme')
+    }
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -3974,6 +3974,9 @@ function importsBrowserOnlyClientApi(ctx: AnalyzerContext): boolean {
     if (imp.source !== '@barefootjs/client') continue
     if (imp.isTypeOnly) continue
     for (const spec of imp.specifiers) {
+      // A per-specifier type-only import (`import { type onMount }`) is not
+      // a browser-only API use — it has no runtime binding (#2432).
+      if (spec.isTypeOnly) continue
       const importedName = spec.name
       if (BROWSER_ONLY_CLIENT_APIS.has(importedName)) return true
     }

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -18,7 +18,7 @@ import { stripClientBuiltinImports } from './builtins.ts'
 import { generateClientJs, generateClientJsWithSourceMap, analyzeClientNeeds } from './ir-to-client-js/index.ts'
 import { decideClientOnlyElision } from './ir-to-client-js/client-only-elision.ts'
 import { emitModuleLevelDeclarations } from './ir-to-client-js/emit-module-level.ts'
-import { RUNTIME_MODULE, detectUsedImports as detectUsedImportsFromCode } from './ir-to-client-js/imports.ts'
+import { RUNTIME_MODULE, detectUsedImports as detectUsedImportsFromCode, makeValueUsageTest } from './ir-to-client-js/imports.ts'
 import { setActiveComponentScope, computeFileScope } from './ir-to-client-js/component-scope.ts'
 import { generateModuleExports, collectInlineExportedNames } from './module-exports.ts'
 import { applyCssLayerPrefix } from './css-layer-prefixer.ts'
@@ -583,6 +583,7 @@ export function compileJSX(
       // in the generated body (e.g. an initializer that calls an imported
       // helper: `createSignal(defaultValue())`).
       const externalImportLines: string[] = []
+      const isUsedAsValue = makeValueUsageTest(body)
       for (const imp of ctx.imports) {
         if (imp.isTypeOnly) continue
         if (imp.source === '@barefootjs/client' || imp.source === RUNTIME_MODULE) continue
@@ -591,7 +592,7 @@ export function compileJSX(
           continue
         }
         const used = imp.specifiers
-          .filter(s => !s.isDefault && !s.isNamespace && new RegExp(`\\b${s.alias || s.name}\\b`).test(body))
+          .filter(s => !s.isDefault && !s.isNamespace && !s.isTypeOnly && isUsedAsValue(s.alias || s.name))
           .map(s => s.alias ? `${s.name} as ${s.alias}` : s.name)
         if (used.length > 0) {
           externalImportLines.push(`import { ${used.join(', ')} } from '${imp.source}'`)
@@ -638,6 +639,9 @@ export function compileJSX(
       if (imp.isTypeOnly) continue
       if (!imp.source.startsWith('./') && !imp.source.startsWith('../')) continue
       for (const spec of imp.specifiers) {
+        // A type-only specifier must not force a `.client.js` source
+        // rewrite — it has no runtime binding (#2432).
+        if (spec.isTypeOnly) continue
         if (ctx.importedClientSignalNames.has(spec.alias ?? spec.name)) {
           sources.add(imp.source)
           break

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -53,6 +53,14 @@ export const ErrorCodes = {
   // or an undeclared component — fail loud with the import to add.
   BUILTIN_REQUIRES_IMPORT: 'BF054',
 
+  // A relative `.ts` module inlined into a client bundle (`resolveRelativeImports`'s
+  // top-level IIFE wrap) was asked for a name it does not export. The IIFE's
+  // `return { … }` has no binding for that name, so the reference throws
+  // `ReferenceError: <name> is not defined` at load — killing the page's
+  // client JS before hydrate. Fail the build instead of shipping the
+  // dangling reference (#2432).
+  INLINED_IMPORT_MISSING_EXPORT: 'BF055',
+
   // Init statement errors (BF052)
   UNDECLARED_INIT_STATEMENT_REFERENCE: 'BF052',
 
@@ -154,6 +162,9 @@ const errorMessages: Record<ErrorCode, string> = {
 
   [ErrorCodes.STRIPPED_CLIENT_IMPORT_REFERENCED]:
     "Import was stripped from the client bundle but its binding is still referenced. Client components ('use client' .tsx) are not callable as plain functions from imperative .ts modules — render them as JSX from a 'use client' parent instead. If the flagged name is a local shadow rather than the stripped import, please file an issue.",
+
+  [ErrorCodes.INLINED_IMPORT_MISSING_EXPORT]:
+    'An inlined relative import requests a name the target module does not export. The client bundle would throw ReferenceError at load.',
 
   [ErrorCodes.STAGE_REACTIVE_IN_TEMPLATE]:
     'Reactive binding (signal getter or memo) referenced from template scope. The template lambda runs at module scope without the reactive context, so the value cannot be evaluated at SSR. Wrap the JSX expression in /* @client */ to defer it to hydrate, or restructure so the template uses a prop or static value.',

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -320,6 +320,10 @@ export {
 // Errors
 export { ErrorCodes, createError, formatError, generateCodeFrame } from './errors.ts'
 
+// Value-reference classifier (#2432) — shared "is this a real value use"
+// door for import-emission sites and the CLI's stripped-reference scan.
+export { isValueReferenceIdentifier, collectValueReferencedNames } from './value-references.ts'
+
 // Expression Parser
 export { parseExpression, tsNodeToParsedExpr, asCallbackMethodCall, CALLBACK_METHODS, sortComparatorFromArrow, serializeParsedExpr, freeVarsInBody, freeIdentifiers, materializeGetterCalls, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, parseBlockBodyTolerant, foldBlockToExpr, predicateTernaryToLogical, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, hasUnsafeStyleValue, parseProviderObjectLiteral, type ProviderObjectMember, type FoldBlockOptions } from './expression-parser.ts'
 export type { StyleObjectEntry } from './expression-parser.ts'

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -4,6 +4,7 @@
 
 import type { ComponentIR, IRNode } from '../types.ts'
 import { isClientBuiltinName } from '../builtins.ts'
+import { collectValueReferencedNames } from '../value-references.ts'
 
 // All exports from @barefootjs/client/runtime that may be used in generated code
 export const RUNTIME_IMPORT_CANDIDATES = [
@@ -80,7 +81,10 @@ export function collectUserDomImports(ir: ComponentIR): string[] {
   for (const imp of ir.metadata.imports) {
     if (runtimeSources.has(imp.source) && !imp.isTypeOnly) {
       for (const spec of imp.specifiers) {
-        if (!spec.isDefault && !spec.isNamespace) {
+        // Per-specifier type-only (`import { createSignal, type Signal }
+        // from '@barefootjs/client'`) must not emit `Signal` from the
+        // runtime subpath, which does not export it (#2432).
+        if (!spec.isDefault && !spec.isNamespace && !spec.isTypeOnly) {
           // Compile-away built-ins (`<Async>` / `<Region>`) are lowered into
           // the template — never emit their import into the client bundle,
           // where it would be a phantom runtime import (#1915).
@@ -94,6 +98,29 @@ export function collectUserDomImports(ir: ComponentIR): string[] {
 }
 
 /**
+ * Build the "is this local name used as a value in the generated code?"
+ * test used to decide which imported specifiers survive into the client
+ * bundle. Prefers a real value-reference set over the historical
+ * `\bname\b` text scan (#2432: an object key or string literal that
+ * merely spells an imported name used to emit a phantom import). Falls
+ * back to the text scan when the generated text cannot be parsed
+ * cleanly — a partial parse would under-report references and DROP a
+ * needed import. The reference set is computed at most once per call.
+ */
+export function makeValueUsageTest(generatedCode: string): (localName: string) => boolean {
+  let referenced: Set<string> | null | undefined
+  return (localName: string) => {
+    if (referenced === undefined) {
+      referenced = collectValueReferencedNames(generatedCode)
+    }
+    if (referenced !== null) {
+      return referenced.has(localName)
+    }
+    return new RegExp(`\\b${localName}\\b`).test(generatedCode)
+  }
+}
+
+/**
  * Collect external (non-DOM, non-component) imports that are used in generated code.
  * These are third-party libraries like @barefootjs/form, zod, etc. that need to be
  * preserved in client JS output so the browser can resolve them via import map.
@@ -101,6 +128,7 @@ export function collectUserDomImports(ir: ComponentIR): string[] {
 export function collectExternalImports(ir: ComponentIR, generatedCode: string, localImportPrefixes?: string[]): string[] {
   const componentNames = collectComponentNames(ir.root)
   const importLines: string[] = []
+  const isUsedAsValue = makeValueUsageTest(generatedCode)
   for (const imp of ir.metadata.imports) {
     if (imp.isTypeOnly) continue
     if (imp.source === '@barefootjs/client' || imp.source === RUNTIME_MODULE) continue
@@ -117,9 +145,11 @@ export function collectExternalImports(ir: ComponentIR, generatedCode: string, l
     // Skip component names — they are rendered via initChild(), not imported directly.
     const usedSpecs: string[] = []
     for (const spec of imp.specifiers) {
+      // Per-specifier `import { type Foo }` has no value binding — #2432.
+      if (spec.isTypeOnly) continue
       const localName = spec.alias || spec.name
       if (componentNames.has(localName)) continue
-      if (new RegExp(`\\b${localName}\\b`).test(generatedCode)) {
+      if (isUsedAsValue(localName)) {
         usedSpecs.push(spec.alias ? `${spec.name} as ${spec.alias}` : spec.name)
       }
     }

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -103,9 +103,22 @@ export function collectUserDomImports(ir: ComponentIR): string[] {
  * bundle. Prefers a real value-reference set over the historical
  * `\bname\b` text scan (#2432: an object key or string literal that
  * merely spells an imported name used to emit a phantom import). Falls
- * back to the text scan when the generated text cannot be parsed
+ * back to a substring scan when the generated text cannot be parsed
  * cleanly — a partial parse would under-report references and DROP a
  * needed import. The reference set is computed at most once per call.
+ *
+ * The fallback is a plain `includes()`, not a `\bname\b` regex: `\b` is
+ * defined over `[A-Za-z0-9_]`, so a `$`-prefixed name (`$fetch`, as
+ * exported by `ofetch`) or a non-ASCII local both sit outside a word
+ * boundary and would never match — silently dropping the import, the one
+ * failure direction this helper must never take. Worse, splicing
+ * `localName` straight into `new RegExp(...)` treated `$` as the
+ * end-of-input anchor, so `\b$fetch\b` couldn't match `$fetch` at all.
+ * `includes()` is deliberately COARSER than a word-boundary scan (it
+ * matches `helper` inside `helperFoo` too) — that's fine here: the
+ * fallback's only job is "never under-report", and over-keeping an
+ * import whose binding already exists is harmless, while dropping one is
+ * fatal.
  */
 export function makeValueUsageTest(generatedCode: string): (localName: string) => boolean {
   let referenced: Set<string> | null | undefined
@@ -116,7 +129,7 @@ export function makeValueUsageTest(generatedCode: string): (localName: string) =
     if (referenced !== null) {
       return referenced.has(localName)
     }
-    return new RegExp(`\\b${localName}\\b`).test(generatedCode)
+    return generatedCode.includes(localName)
   }
 }
 

--- a/packages/jsx/src/value-references.ts
+++ b/packages/jsx/src/value-references.ts
@@ -1,0 +1,108 @@
+/**
+ * Single door for "is this identifier a VALUE reference in emitted JS".
+ *
+ * Replaces `\bname\b` text scans at the import-emission sites (#2432): a
+ * regex scan can't tell a genuine value reference (`paperColor({ ... })`)
+ * from an object key or string literal that merely spells an imported
+ * name (`{ Theme: 'テーマ' }`). That false match used to make
+ * `collectExternalImports` re-emit a per-specifier type-only import
+ * (`import { paperColor, type Theme } from '../lib/theme'`) as a VALUE
+ * import, which the CLI's relative-import inliner then placed in the IIFE's
+ * `return { … }` with no binding — `ReferenceError: Theme is not defined`
+ * at load, killing the whole page's client JS.
+ *
+ * `packages/cli`'s `detectStrippedReferences` (in `resolve-imports.ts`)
+ * shares the same classifier for its own dangling-reference scan, so the
+ * two "is this a real use" checks in the pipeline can never drift apart.
+ */
+
+import ts from 'typescript'
+
+/**
+ * Identifier-position classifier: returns `true` when `id` is being USED
+ * as a value, `false` when it's a declaration name, property key, member-
+ * access name, or other non-reference slot.
+ *
+ * A ShorthandPropertyAssignment (`{ Theme }`) intentionally counts as a
+ * reference — it reads the binding, it doesn't just spell its name.
+ *
+ * Caveat: this is a syntactic test, not a scope analysis. If a local
+ * function parameter happens to share a name with an imported binding,
+ * references inside that function's body will count as references to
+ * the import (false positive). Acceptable: over-counting a reference
+ * just means we keep an import we didn't strictly need, which is a
+ * strict improvement over the alternative failure direction (dropping a
+ * needed import and producing a `ReferenceError`).
+ */
+export function isValueReferenceIdentifier(id: ts.Identifier): boolean {
+  const parent = id.parent
+  if (!parent) return false
+  if (ts.isPropertyAccessExpression(parent) && parent.name === id) return false
+  if (ts.isPropertyAssignment(parent) && parent.name === id) return false
+  if (
+    (ts.isMethodDeclaration(parent) ||
+      ts.isGetAccessorDeclaration(parent) ||
+      ts.isSetAccessorDeclaration(parent)) &&
+    parent.name === id
+  ) {
+    return false
+  }
+  if (ts.isVariableDeclaration(parent) && parent.name === id) return false
+  if (ts.isFunctionDeclaration(parent) && parent.name === id) return false
+  if (ts.isFunctionExpression(parent) && parent.name === id) return false
+  if (ts.isClassDeclaration(parent) && parent.name === id) return false
+  if (ts.isClassExpression(parent) && parent.name === id) return false
+  if (ts.isParameter(parent) && parent.name === id) return false
+  if (ts.isBindingElement(parent) && (parent.name === id || parent.propertyName === id)) return false
+  if (ts.isLabeledStatement(parent) && parent.label === id) return false
+  if (ts.isBreakOrContinueStatement(parent) && parent.label === id) return false
+  // ImportSpecifier (`{ X }` or `{ X as Y }`) and ExportSpecifier have
+  // only `name`/`propertyName` as Identifier children — written as an
+  // explicit slot check for stylistic consistency with the other
+  // branches above.
+  if (ts.isImportSpecifier(parent) && (parent.name === id || parent.propertyName === id)) return false
+  if (ts.isExportSpecifier(parent) && (parent.name === id || parent.propertyName === id)) return false
+  if (ts.isImportClause(parent) && parent.name === id) return false
+  if (ts.isNamespaceImport(parent) && parent.name === id) return false
+  if (ts.isQualifiedName(parent) && parent.right === id) return false
+  return true
+}
+
+/**
+ * Parse `code` and collect the text of every identifier that is a VALUE
+ * reference per `isValueReferenceIdentifier`.
+ *
+ * Returns `null` when the text did not parse cleanly. `null` means
+ * "cannot answer" — callers MUST fall back to their previous (regex-scan)
+ * behaviour rather than treating it as an empty set. Narrowing on a
+ * partial parse would DROP a needed import, which is the failure
+ * direction we must never take (a phantom missing-import build failure
+ * is recoverable; a silently dead client bundle is not).
+ */
+export function collectValueReferencedNames(code: string): Set<string> | null {
+  let sourceFile: ts.SourceFile
+  try {
+    sourceFile = ts.createSourceFile(
+      'generated.js',
+      code,
+      ts.ScriptTarget.Latest,
+      /*setParentNodes*/ true,
+      ts.ScriptKind.JS,
+    )
+  } catch {
+    return null
+  }
+
+  const diagnostics = (sourceFile as unknown as { parseDiagnostics?: readonly unknown[] }).parseDiagnostics
+  if (diagnostics && diagnostics.length > 0) return null
+
+  const names = new Set<string>()
+  function visit(node: ts.Node): void {
+    if (ts.isIdentifier(node) && isValueReferenceIdentifier(node)) {
+      names.add(node.text)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return names
+}


### PR DESCRIPTION
Closes #2432.

## The bug

`import { paperColor, type Theme } from '../lib/theme'` could re-emit `Theme` — a type with no value binding anywhere — into the generated client JS as a **value** import. The relative-import inliner then faithfully put it in the IIFE's return shape:

```js
const __bf_inline_0 = (() => {
  function paperColor2(t) { … }
  return { paperColor: paperColor2, Theme };
  //                                ^^^^^ never declared — it is a type
})();
```

`Theme` has no binding in the IIFE, so evaluating the module threw `ReferenceError: Theme is not defined` before anything hydrated. The whole page's client JS was dead, and because the SSR markup stayed on screen it read as "hydration silently never ran" rather than as a load error.

Two independent gaps in `collectExternalImports` compounded:

1. **Only the declaration-level `imp.isTypeOnly` was consulted.** The analyzer has recorded per-specifier `spec.isTypeOnly` since #1915, but this loop never read it, so `{ type Foo }` was indistinguishable from `{ Foo }`.
2. **Usage was decided by a `\bname\b` text scan.** A word boundary is not a reference: an object key (`{ Theme: 'テーマ' }`), a string literal (`'Theme'`), a property access (`obj.Theme`) all matched.

Either alone was survivable. Together, a type name that merely *appeared as a word* in the emitted code became a value import.

This only ever bit projects that do **not** set `localImportPrefixes` — with it set, relative imports leave the loop before the usage test. It isn't part of `createConfig`'s documented surface for a Hono project, so a stock config took the scanning path for every relative import.

## The fix

**1. Per-specifier type-only specifiers are skipped at every client-import emission site** — `collectExternalImports`, the state-only module path in `compiler.ts`, and `collectUserDomImports`, where `import { createSignal, type Signal } from '@barefootjs/client'` would otherwise emit `Signal` from the `/runtime` subpath, which does not export it. The two sites that only *read* the flag are guarded too, so a type-only specifier no longer forces a `.client.js` source rewrite (`clientSignalImportSources`) or trips the browser-only-API diagnostic.

**2. Usage is a value-reference test, not a text scan.** New `packages/jsx/src/value-references.ts` walks the emitted code with the TypeScript parser and keeps only identifiers in genuine value positions, reusing the `isValueReference` classifier the CLI's stripped-import detector already had — now shared as one door, so the pipeline's two "is this a real use" checks cannot drift apart. A shorthand property (`{ helper }`) counts; it reads the binding.

When the text can't be parsed cleanly the helper answers `null` and callers **fall back to the old text scan**. Narrowing on a partial parse would *drop* a needed import, which is the one direction this must never fail in: an over-emitted import whose binding exists is harmless, a missing one is a dead bundle.

**3. New `BF055` — inlined module missing a requested export.** `buildTopLevelIIFE` compares the names its consumers ask for against the module's export surface and fails the build with the name, the module, and the exact `ReferenceError` it would have produced, instead of emitting a `return` that throws at load.

Three deliberate constraints:

- The emitted `return` is **unchanged**. The build error is the deliverable; the throwing artifact stays as the loud signal for anyone who ships past a red build (e.g. a stale `dist/`).
- The surface counts everything a module's `export` clauses legally **name** — re-exports, `export enum`, `export namespace` — and the check is skipped entirely when a bare `export * from` makes the surface un-enumerable. A false build failure on legal code would be worse than the over-emission being fixed. That surface is deliberately wider than the set populating the namespace IIFE's `return`, which stays restricted to names with a real binding in the inlined body — widening *that* would introduce a new `ReferenceError` for namespace consumers.
- The module source is parsed **at most once** per module, and not at all when neither the namespace return nor the check needs it. `inlineRelativeImports` is `bf build` hot path, where `CLAUDE.md` rules out extra `ts.createSourceFile` calls.

## Tests

- `packages/jsx/src/__tests__/type-only-import-leak.test.ts` (new) — end-to-end `compileJSX` pin on the issue's minimal reproduction: no import statement in the emitted bundle mentions `Theme`.
- `packages/jsx/src/__tests__/ir-to-client-js/imports.test.ts` — per-specifier type-only skipped while its value sibling survives; object key / string literal / property-access-only names dropped; shorthand property kept; unparseable text falls back to the scan; `collectUserDomImports` drops `type Signal`.
- `packages/cli/src/__tests__/resolve-imports.test.ts` — BF055 fires on a name the inlined module doesn't export, and does **not** fire for a re-exported name, an `export enum`, or a module with `export * from`.

## Verification

| Suite | Result |
|---|---|
| `bun test packages/jsx` | 2792 pass, 0 fail |
| `bun test packages/adapter-tests packages/client packages/test` | 2116 pass, 0 fail |
| `bun test packages/cli/src/__tests__/resolve-imports.test.ts` | 29 pass, 0 fail |
| `bunx biome check packages/cli/src packages/jsx/src` | clean |

The full `packages/cli` suite has 15 failures, all `Cannot find module './runtimes.generated'` in `bf init` tests. That file is untracked in git and produced by a build step, so those fail in any fresh clone independently of this diff.

No adapter conformance fixture is added: this changes neither the accepted expression subset nor any lowering, so `spec/subset-conformance.md`'s change-time coupling rule doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfswY6ca6smhyPJVdhm8qT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfswY6ca6smhyPJVdhm8qT)_