### PR TITLE
test(site/ui): turn the xyflow drag / pan-zoom placeholders into real tests

### DIFF
--- a/site/ui/e2e/xyflow.spec.ts
+++ b/site/ui/e2e/xyflow.spec.ts
@@ -208,6 +208,11 @@ test.describe('xyflow Reference Page', () => {
       const before = translateOf(await node.getAttribute('style'))
       expect(Number.isNaN(before.x)).toBe(false)
 
+      // Scroll first, then measure. `page.mouse` works in viewport
+      // coordinates and does not scroll on its own, so a box taken while the
+      // node sits below the fold names a point no element occupies — the same
+      // trap the wheel test hits, and the reason that one calls `hover()`.
+      await node.scrollIntoViewIfNeeded()
       const box = await node.boundingBox()
       if (!box) throw new Error('node has no bounding box')
       // Grab the node's centre and drag. `steps` matters: the delegated
@@ -224,7 +229,7 @@ test.describe('xyflow Reference Page', () => {
 
       const after = translateOf(await node.getAttribute('style'))
       // Zoom is 1 on first paint, so the store delta is the pointer delta.
-      // Allow a pixel of slack for sub-pixel pointer positions.
+      // Two pixels of slack for sub-pixel pointer positions.
       expect(Math.abs(after.x - before.x - 60)).toBeLessThanOrEqual(2)
       expect(Math.abs(after.y - before.y - 40)).toBeLessThanOrEqual(2)
     })

--- a/site/ui/e2e/xyflow.spec.ts
+++ b/site/ui/e2e/xyflow.spec.ts
@@ -181,24 +181,75 @@ test.describe('xyflow Reference Page', () => {
   })
 
   // ------------------------------------------------------------
-  // Pan / zoom / drag / connection-drag interactivity is gated on the
-  // pointer-paced subsystem attach implemented in cutover step C4.
-  // These describe blocks exist as placeholders so the gap between the
-  // packages/xyflow imperative-era e2e suite and the new JSX-native
-  // suite is visible. They MUST be re-enabled (and assertions filled
-  // in) in C4 — leaving `.skip` past C4 violates the project's
-  // "never leave skip when component work is done" rule.
+  // Pointer-paced interactivity. Cutover step C4 has shipped —
+  // `attachFlowSubsystems` (`packages/xyflow/src/flow-subsystems.ts`)
+  // wires XYPanZoom and a delegated single-node drag through `<Flow>`'s
+  // `ref`, so the drag / pan-zoom placeholders below are now real tests.
   // ------------------------------------------------------------
 
-  test.describe.skip('Node Dragging (re-enable in cutover step C4)', () => {
-    test('drag updates node transform', async () => {
-      // Filled in once the drag handler ships from @barefootjs/xyflow.
+  /** Pull the `scale(N)` factor out of a viewport transform string. */
+  function scaleOf(transform: string | null): number {
+    const m = /scale\(([\d.]+)\)/.exec(transform ?? '')
+    return m ? Number(m[1]) : Number.NaN
+  }
+
+  /** Pull `translate(Xpx, Ypx)` out of a node transform string. */
+  function translateOf(transform: string | null): { x: number; y: number } {
+    const m = /translate\((-?[\d.]+)px,\s*(-?[\d.]+)px\)/.exec(transform ?? '')
+    return m ? { x: Number(m[1]), y: Number(m[2]) } : { x: Number.NaN, y: Number.NaN }
+  }
+
+  test.describe('Node Dragging', () => {
+    test('drag moves the node by the pointer delta', async ({ page }) => {
+      const container = firstScope(page, '[bf-s^="XyflowPreviewDemo_"][bf-r]:not([data-slot])')
+      const node = container.locator('.bf-flow__node').first()
+      await expect(node).toBeAttached()
+
+      const before = translateOf(await node.getAttribute('style'))
+      expect(Number.isNaN(before.x)).toBe(false)
+
+      const box = await node.boundingBox()
+      if (!box) throw new Error('node has no bounding box')
+      // Grab the node's centre and drag. `steps` matters: the delegated
+      // handler is pointer-paced, so a single jump emits no intermediate
+      // `pointermove` and the drag would never accumulate.
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+      await page.mouse.down()
+      await page.mouse.move(box.x + box.width / 2 + 60, box.y + box.height / 2 + 40, { steps: 8 })
+      await page.mouse.up()
+
+      await expect
+        .poll(async () => translateOf(await node.getAttribute('style')).x, { timeout: 2000 })
+        .not.toBe(before.x)
+
+      const after = translateOf(await node.getAttribute('style'))
+      // Zoom is 1 on first paint, so the store delta is the pointer delta.
+      // Allow a pixel of slack for sub-pixel pointer positions.
+      expect(Math.abs(after.x - before.x - 60)).toBeLessThanOrEqual(2)
+      expect(Math.abs(after.y - before.y - 40)).toBeLessThanOrEqual(2)
     })
   })
 
-  test.describe.skip('Pan / Zoom (re-enable in cutover step C4)', () => {
-    test('wheel zoom updates viewport scale', async () => {
-      // Filled in once XYPanZoom wiring ships via the Flow ref callback.
+  test.describe('Pan / Zoom', () => {
+    test('wheel zoom updates the viewport scale', async ({ page }) => {
+      const container = firstScope(page, '[bf-s^="XyflowPreviewDemo_"][bf-r]:not([data-slot])')
+      const pane = container.locator('.bf-flow').first()
+      const viewport = container.locator('.bf-flow__viewport').first()
+      await expect(viewport).toBeAttached()
+
+      const before = scaleOf(await viewport.getAttribute('style'))
+      expect(before).toBeCloseTo(1, 5)
+
+      // `hover()` scrolls the pane into view first. Without it the pane's
+      // centre can sit below the visible viewport, and a wheel aimed there
+      // lands on no element at all (`elementFromPoint` → null) instead of
+      // reaching the d3-zoom listener on the pane.
+      await pane.hover()
+      await page.mouse.wheel(0, -400)
+
+      await expect
+        .poll(async () => scaleOf(await viewport.getAttribute('style')), { timeout: 2000 })
+        .toBeGreaterThan(before)
     })
   })
 
@@ -281,10 +332,16 @@ test.describe('xyflow Reference Page', () => {
     })
   })
 
-  test.describe.skip('Edge Reconnection (re-enable in cutover step C4)', () => {
+  // Still skipped, but NOT on cutover step C4 — that shipped. The real
+  // gap: `attachReconnectionHandler` (`packages/xyflow/src/connection.ts`)
+  // is exported from `@barefootjs/xyflow` and has no caller. The JSX
+  // components render no reconnection grips for it to attach to, so
+  // there is no endpoint to drag. Un-skip once `<SimpleEdge>` renders
+  // the grips and calls the handler.
+  test.describe.skip('Edge Reconnection (no reconnection grips in the JSX renderer yet)', () => {
     test('reconnect handles update edge endpoints', async () => {
-      // Filled in once the reconnect overlay wiring ships from
-      // @barefootjs/xyflow.
+      // Fill in once `<SimpleEdge>` renders grips and wires
+      // `attachReconnectionHandler`.
     })
   })
 })


### PR DESCRIPTION
**Stack 1/N** — base `main`. Independent of the rest; can merge alone.

## Why now

Cutover step C4 has shipped: `attachFlowSubsystems` (`packages/xyflow/src/flow-subsystems.ts`) wires `XYPanZoom` and a delegated single-node drag through `<Flow>`'s `ref`. So the two `describe.skip` blocks were doing exactly what their own comment forbids:

> They MUST be re-enabled (and assertions filled in) in C4 — leaving `.skip` past C4 violates the project's "never leave skip when component work is done" rule.

Both bodies were empty placeholders (`// Filled in once the drag handler ships`), so the suite reported them as skipped coverage of shipped behaviour.

## What the tests assert

- **Node drag** — the node's `translate(Xpx, Ypx)` moves by the pointer delta. Zoom is 1 on first paint so the store delta equals the pointer delta; ±2px slack for sub-pixel pointer positions. `steps: 8` on the move matters: the handler is pointer-paced, and a single jump emits no intermediate `pointermove`.
- **Wheel zoom** — the viewport's `scale()` grows.

## One non-obvious bit

The pan/zoom test calls `pane.hover()` before the wheel. Without it the pane's centre can sit **below the visible viewport**, and a wheel aimed there lands on no element at all rather than reaching the d3-zoom listener on the pane. Confirmed by probe: `document.elementFromPoint` at the pane centre returned `null`, while the same wheel at an in-view point took scale `1 → 1.7411`. `hover()` scrolls first, which removes the dependence on where the page happens to be scrolled.

Worth stating plainly since it looked like a product bug at first: **pan/zoom works.** The reactive `style` binding on the viewport updates correctly; only the test's aim was wrong.

## Edge Reconnection stays skipped — on the real reason

Not C4. `attachReconnectionHandler` (`packages/xyflow/src/connection.ts`) is exported from `@barefootjs/xyflow` and **has no caller**, and the JSX components render no reconnection grips for it to attach to, so there is no endpoint to drag. The skip title and comment now say that, so the next reader doesn't go looking for a shipped C4 step. Un-skip once `<SimpleEdge>` renders the grips and calls the handler.

## Verification

| Run | Result |
|---|---|
| `e2e/xyflow.spec.ts` | 24 passed / 1 skipped |
| Two new tests, `--repeat-each=5` | 10/10 passed |
| biome | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_