### PR TITLE
refactor(xyflow): drop the `__bfFlowStore` host-element escape hatch

### DIFF
--- a/.changeset/drop-host-element-store-hatch.md
+++ b/.changeset/drop-host-element-store-hatch.md
@@ -35,9 +35,17 @@ connected before `init` runs — rather than by giving the store a second lookup
 path. A second path would also have been the wrong shape: it hides the
 ordering bug instead of surfacing it, and only for consumers who know to look.
 
-No behaviour change: removing a write with no readers cannot alter what any
-consumer observes. The unit test is repurposed to pin the removal, so a
-write-only global cannot come back without a reader to justify it. Beyond the
-dead code, the comment claimed a live product defect that did not exist, and
-that misreading fed a wrong priority call — which is the more expensive half of
-what is being removed here.
+`__bfFlowStore` was an undocumented internal expando, never part of
+`@barefootjs/xyflow`'s exported surface and not mentioned in the docs, so
+nothing in this repository changes behaviour. It was on a public DOM element
+though, so code outside this repository could have reached it — if you read
+`el.closest('.bf-flow').__bfFlowStore`, switch to `useFlow()` (or the derived
+`useViewport()` / `useNodes()` / `useEdges()`), which resolves through context
+from any connected descendant of the flow.
+
+The unit test is repurposed to pin the removal, asserting the property is not
+even *present* — a value check would also pass against an attach that stamped
+the key and assigned `undefined`, which is still an expando. Beyond the dead
+code, the comment claimed a live product defect that did not exist, and that
+misreading fed a wrong priority call — which is the more expensive half of what
+is being removed here.

--- a/.changeset/drop-host-element-store-hatch.md
+++ b/.changeset/drop-host-element-store-hatch.md
@@ -1,0 +1,43 @@
+---
+"@barefootjs/xyflow": patch
+---
+
+Drop the `__bfFlowStore` host-element escape hatch — nothing read it, and its premise was false
+
+`attachFlowSubsystems` stamped the flow store onto the host
+`<div class="bf-flow">` so that, per its comment, "descendants that miss
+`FlowContext`" could reach it via `el.closest('.bf-flow').__bfFlowStore`. The
+stated cause was that `<Flow renderNode={Fn}>` hydrates its children as a
+top-level scope outside the `FlowContext.Provider`, leaving `useFlow()` —
+and therefore `useViewport()` / `useNodes()` / `useEdges()` /
+`useNodesInitialized()`, which all call it — returning `undefined`.
+
+Two things were wrong with that.
+
+**Nothing read the property.** The only references in the repository were the
+write itself and a unit test asserting the write. The would-be consumer,
+`FlowNodeTypeBridge`, does not walk the DOM for the store — it tolerates
+`store === undefined` and falls back to `props.forNode`. So this was a
+write-only global on a public DOM element.
+
+**The premise does not hold in the rendered DOM.** Walking up from a
+`.bf-flow__node` in a browser, the provider's context map (`__bfCtx`) sits on
+the `<div class="bf-flow">` host itself — an ancestor of every node — and
+`useContext` resolves by walking `parentElement`. A connected descendant
+therefore finds the store no matter which scope it was hydrated as. Which
+scope the hydration walker chose never mattered; only ancestry does.
+
+The one shape that genuinely returned `undefined` was a child running its
+`init` while its row was still **detached**, so the `parentElement` walk had no
+ancestors to find and fell through to the global last-writer-wins context
+store. That is fixed at the root in the client runtime — loop rows are
+connected before `init` runs — rather than by giving the store a second lookup
+path. A second path would also have been the wrong shape: it hides the
+ordering bug instead of surfacing it, and only for consumers who know to look.
+
+No behaviour change: removing a write with no readers cannot alter what any
+consumer observes. The unit test is repurposed to pin the removal, so a
+write-only global cannot come back without a reader to justify it. Beyond the
+dead code, the comment claimed a live product defect that did not exist, and
+that misreading fed a wrong priority call — which is the more expensive half of
+what is being removed here.

--- a/packages/xyflow/src/__tests__/host-element-store.test.ts
+++ b/packages/xyflow/src/__tests__/host-element-store.test.ts
@@ -1,10 +1,20 @@
 /**
- * `<Flow renderNode={Fn}>` hydrates the rendered bridge as a top-level
- * scope outside Flow's `FlowContext.Provider`, so consumers that look up
- * the store via `useFlow()` get back `undefined`. As an escape hatch,
- * `attachFlowSubsystems` stamps the host `<div class="bf-flow">` with
- * `__bfFlowStore` so children can walk up the DOM and read the store
- * without going through the context system.
+ * `attachFlowSubsystems` must NOT stamp the store onto the host element.
+ *
+ * It used to, as an escape hatch for "descendants that miss `FlowContext`" —
+ * on the premise that `<Flow renderNode={Fn}>` hydrates its children as a
+ * top-level scope outside the `FlowContext.Provider`. That premise does not
+ * hold in the rendered DOM: the provider's context map sits on the
+ * `<div class="bf-flow">` host itself, which is an ancestor of every
+ * `.bf-flow__node`, and `useContext` walks `parentElement` — so any connected
+ * descendant resolves the store regardless of which scope it was hydrated as.
+ * The one shape that genuinely failed was a child initialising while its row
+ * was still detached, fixed at the root in the runtime (#2431).
+ *
+ * Nothing ever read the property, so it was a write-only global whose comment
+ * asserted a live product defect that did not exist — and that misreading fed
+ * a wrong priority call. This test pins the removal so it cannot come back
+ * without a reader to justify it.
  */
 import { beforeAll, describe, expect, test } from 'bun:test'
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
@@ -13,8 +23,8 @@ beforeAll(() => {
   if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register()
 })
 
-describe('attachFlowSubsystems exposes the store on the host element', () => {
-  test('sets `__bfFlowStore` on the element it attaches to', async () => {
+describe('attachFlowSubsystems keeps no second store-lookup path', () => {
+  test('does not stamp `__bfFlowStore` on the host element', async () => {
     // Lazy import so happy-dom globals are in place before xyflow loads.
     const { attachFlowSubsystems } = await import('../flow-subsystems')
     const { createFlowStore } = await import('../store')
@@ -28,6 +38,9 @@ describe('attachFlowSubsystems exposes the store on the host element', () => {
     // biome-ignore lint/suspicious/noExplicitAny: minimal props for unit test
     attachFlowSubsystems(el, store as any, {} as any)
 
-    expect((el as HTMLElement & { __bfFlowStore?: unknown }).__bfFlowStore).toBe(store)
+    expect((el as HTMLElement & { __bfFlowStore?: unknown }).__bfFlowStore).toBeUndefined()
+    // The attach itself still has to have happened — otherwise this test
+    // would pass against a no-op `attachFlowSubsystems`.
+    expect(store.domNode()).toBe(el)
   })
 })

--- a/packages/xyflow/src/__tests__/host-element-store.test.ts
+++ b/packages/xyflow/src/__tests__/host-element-store.test.ts
@@ -38,7 +38,10 @@ describe('attachFlowSubsystems keeps no second store-lookup path', () => {
     // biome-ignore lint/suspicious/noExplicitAny: minimal props for unit test
     attachFlowSubsystems(el, store as any, {} as any)
 
-    expect((el as HTMLElement & { __bfFlowStore?: unknown }).__bfFlowStore).toBeUndefined()
+    // Presence, not value: a `toBeUndefined()` read would also pass if the
+    // attach stamped the property and assigned `undefined` to it, which is
+    // still an expando on a public DOM element.
+    expect(Object.hasOwn(el, '__bfFlowStore')).toBe(false)
     // The attach itself still has to have happened — otherwise this test
     // would pass against a no-op `attachFlowSubsystems`.
     expect(store.domNode()).toBe(el)

--- a/packages/xyflow/src/flow-subsystems.ts
+++ b/packages/xyflow/src/flow-subsystems.ts
@@ -88,14 +88,18 @@ export function attachFlowSubsystems<
   el.style.overflow = 'hidden'
 
   store.setDomNode(el)
-  // Expose the store on the host `<div class="bf-flow">` element so
-  // descendants that miss `FlowContext` — e.g. children passed through
-  // `<Flow renderNode={Fn}>` whose returned JSX is hydrated as a
-  // top-level scope outside of Flow's `FlowContext.Provider` — can
-  // still locate the store via `el.closest('.bf-flow').__bfFlowStore`.
-  // Always-set, even on hot remount, so callers can rely on a single
-  // canonical reference.
-  ;(el as HTMLElement & { __bfFlowStore?: typeof store }).__bfFlowStore = store
+  // No `__bfFlowStore` escape hatch here. This used to stamp the store on
+  // the host element for "descendants that miss `FlowContext`", on the
+  // premise that `<Flow renderNode={Fn}>` hydrates its children as a
+  // top-level scope outside the `FlowContext.Provider`. That premise does
+  // not hold in the rendered DOM: the provider's context map lives on this
+  // very `<div class="bf-flow">`, which is an ancestor of every
+  // `.bf-flow__node`, and `useContext` walks `parentElement` — so any
+  // CONNECTED descendant resolves the store no matter which scope it was
+  // hydrated as, verified in a browser. The one shape that did fail was a
+  // child initialising while its row was still detached, and that is fixed
+  // at the root in the runtime (#2431), not by a second lookup path.
+  // Nothing read the property, so it was a write-only global.
   store.setWidth(el.offsetWidth)
   store.setHeight(el.offsetHeight)
 


### PR DESCRIPTION
#2435 has merged, so this is no longer stacked — base is `main` and the diff is the single commit.

## What it removes

`attachFlowSubsystems` stamped the flow store onto the host `<div class="bf-flow">` so that, per its comment, "descendants that miss `FlowContext`" could reach it via `el.closest('.bf-flow').__bfFlowStore`. The stated cause was that `<Flow renderNode={Fn}>` hydrates its children as a top-level scope outside the `FlowContext.Provider`, leaving `useFlow()` — and with it `useViewport()` / `useNodes()` / `useEdges()` / `useNodesInitialized()`, which all call it — returning `undefined`.

## Two things were wrong with that

**Nothing read the property.** Across `packages/`, `ui/` and `site/`, the only references were the write itself and a unit test asserting the write. The would-be consumer, `FlowNodeTypeBridge`, does not walk the DOM for the store — it tolerates `store === undefined` and falls back to `props.forNode`. So this was a write-only global on a public DOM element.

**The premise does not hold in the rendered DOM.** Walking up from a `.bf-flow__node` in a real browser:

```
div.bf-flow__node   ← __bfCtx
div.bf-flow__nodes
div.bf-flow__viewport
div.bf-flow         ← __bfCtx
```

The provider's context map sits on the `.bf-flow` host itself, an ancestor of every node, and `useContext` resolves by walking `parentElement`. A connected descendant therefore finds the store no matter which scope it was hydrated as. Which scope the hydration walker picked never mattered — only ancestry does.

The one shape that genuinely returned `undefined` was a child running `init` while its row was still **detached**: no ancestors to walk, so the lookup fell through to the global last-writer-wins context store. That is fixed at the root in the client runtime (#2431) — loop rows are connected before `init` — rather than by giving the store a second lookup path. A second path is also the wrong shape: it hides the ordering bug instead of surfacing it, and only for consumers who happen to know to look.

## Why this is worth a PR rather than a footnote

The dead write is the cheap half. The expensive half is that its comment asserted a live product defect that did not exist, and that assertion fed a wrong priority call in the hydration work — it was cited as evidence that the loop-row ordering bug was hurting production. Removing the code removes the misleading claim with it.

## Verification

| Check | Result |
|---|---|
| `packages/xyflow` unit | 46 pass / 0 fail |
| `e2e/xyflow.spec.ts` (after rebuilding xyflow + site) | 24 passed / 1 skipped |
| biome | clean |

No behaviour change is possible: a write with no readers cannot alter what any consumer observes. The unit test is repurposed to pin the removal — it asserts the property is absent **and** that the attach still happened (`store.domNode() === el`), so it cannot pass against a no-op `attachFlowSubsystems`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM