### PR TITLE
fix(compiler): stop treating a class field name as a value reference

### DIFF
--- a/.changeset/value-reference-class-fields.md
+++ b/.changeset/value-reference-class-fields.md
@@ -1,0 +1,46 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/cli": patch
+---
+
+Stop treating a class field name as a value reference
+
+`isValueReferenceIdentifier` excluded object-literal keys, method names and
+accessor names, but not `ts.PropertyDeclaration` — a class field. So in
+
+```js
+class Widget { helper = 1 }
+```
+
+the field name `helper` was classified as a read of a binding called `helper`.
+It isn't; it's a member key, exactly like the `{ helper: 1 }` case one branch
+above it.
+
+The two callers of this classifier are hurt very differently by an over-report,
+which is what makes this worth a patch rather than a tidy-up:
+
+- **`detectStrippedReferences` (cli) — a false build error.** BF053 fires when a
+  relative import was stripped from a client bundle but its binding is still
+  referenced. With the gap, a stripped binding whose name merely *coincided*
+  with a class field name anywhere in the assembled bundle failed the build,
+  pointing the developer at a reference that does not exist. Legal code, red
+  build. Inlined `.ts` helper modules are arbitrary user code, so a class with a
+  field named after some unrelated stripped import is not a contrived shape.
+- **`makeValueUsageTest` (jsx) — a redundant import.** The client bundle kept an
+  import it didn't need. Harmless, since the binding does exist, but it defeats
+  the point of the reference-based check that replaced the old text scan.
+
+A **computed** field name stays a reference: in `class C { [helper] = 1 }` the
+brackets make `helper` a genuine read, and the exclusion is guarded on
+`parent.name === id`, which the computed form doesn't satisfy (its `name` is a
+`ComputedPropertyName` node, not the identifier). Both directions are pinned by
+tests. `new.target` is excluded for the same reason as the field name — `target`
+sits in keyword position and is not a binding either.
+
+The classifier also now states its contract, since #2432 exported it as public
+API: it classifies positions in **JavaScript** source, which is what both
+callers parse (`ts.ScriptKind.JS`). Identifiers in TypeScript type positions —
+`const x: Foo`, `interface` / `type` / `enum` declaration names — are still
+reported as value references, so it must not be pointed at TypeScript source.
+Every exclusion branch is really a BF053 misfire that can't happen anymore,
+which is the lens to read that list through.

--- a/packages/cli/src/__tests__/resolve-imports.test.ts
+++ b/packages/cli/src/__tests__/resolve-imports.test.ts
@@ -562,6 +562,46 @@ stillUsed()
     expect(errors[0].message).not.toContain('use client')
   })
 
+  // #2432 follow-up: a stripped binding whose name merely coincides with a
+  // class field name must NOT fire BF053 — the field name is a member
+  // key, not a read of the stripped import.
+  test('does not error when stripped binding name only appears as a class field name (#2432 follow-up)', async () => {
+    const clientJs = `import { helper } from './nonexistent'
+class Widget { helper = 1 }
+console.log(new Widget())
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'ClassField-aaa.js'), clientJs)
+    const manifest = {
+      ClassField: { clientJs: 'components/ClassField-aaa.js', markedTemplate: 'components/ClassField.tsx' },
+    }
+
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'ClassField-aaa.js')).text()
+    expect(result).not.toContain('nonexistent')
+    expect(errors.filter(e => e.code === 'BF053')).toHaveLength(0)
+  })
+
+  // #2432 follow-up: sibling positive case — same shape, but the stripped
+  // binding IS genuinely called, so BF053 must still fire. Proves the
+  // class-field exclusion narrowed the check without disabling it.
+  test('still errors when stripped binding is genuinely called alongside a same-named class field (#2432 follow-up)', async () => {
+    const clientJs = `import { helper } from './nonexistent'
+class Widget { helper = 1 }
+helper()
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'ClassFieldCalled-aaa.js'), clientJs)
+    const manifest = {
+      ClassFieldCalled: { clientJs: 'components/ClassFieldCalled-aaa.js', markedTemplate: 'components/ClassFieldCalled.tsx' },
+    }
+
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const bf053 = errors.filter(e => e.code === 'BF053')
+    expect(bf053).toHaveLength(1)
+    expect(bf053[0].message).toContain('helper')
+  })
+
   test('recursively inlines transitive .ts imports', async () => {
     // Leaf module — depended on by the middle layer
     writeFileSync(resolve(COMPONENTS_DIR, 'leaf.ts'), `

--- a/packages/jsx/src/__tests__/ir-to-client-js/imports.test.ts
+++ b/packages/jsx/src/__tests__/ir-to-client-js/imports.test.ts
@@ -310,6 +310,24 @@ describe('collectExternalImports', () => {
     const result = collectExternalImports(ir, code)
     expect(result).toEqual(["import { 日本語 } from 'some-lib'"])
   })
+
+  // #2432 follow-up: a class field name is a member key, not a read — the
+  // same treatment as an object-literal key above.
+  test('a specifier that appears ONLY as a class field name is not emitted (#2432 follow-up)', () => {
+    const ir = makeIR([makeImport('./utils', ['helper'])])
+    const code = 'class Widget { helper = 1 }'
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual([])
+  })
+
+  // #2432 follow-up: a COMPUTED class field name (`[helper]`) IS a read of
+  // the binding — pins that the class-field exclusion didn't over-exclude.
+  test('a specifier that appears as a COMPUTED class field name IS emitted (#2432 follow-up)', () => {
+    const ir = makeIR([makeImport('./utils', ['helper'])])
+    const code = 'class Widget { [helper] = 1 }'
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual(["import { helper } from './utils'"])
+  })
 })
 
 describe('collectUserDomImports', () => {

--- a/packages/jsx/src/__tests__/value-references.test.ts
+++ b/packages/jsx/src/__tests__/value-references.test.ts
@@ -70,6 +70,17 @@ describe('collectValueReferencedNames', () => {
     expect(result?.has('target')).toBe(false)
   })
 
+  // Both halves of the MetaProperty exclusion are pinned: `new.target`
+  // above, and `import.meta` here — the one Copilot flagged as uncovered
+  // on #2439. `import.meta.url` also incidentally covers the
+  // property-access half (`url` is excluded too).
+  test('import.meta: "meta" is NOT a reference', () => {
+    const result = collectValueReferencedNames('const u = import.meta.url;')
+    expect(result).not.toBeNull()
+    expect(result?.has('meta')).toBe(false)
+    expect(result?.has('url')).toBe(false)
+  })
+
   test('unparseable text returns null ("cannot answer")', () => {
     const result = collectValueReferencedNames('const x = ;;; {{{ ]]]')
     expect(result).toBeNull()

--- a/packages/jsx/src/__tests__/value-references.test.ts
+++ b/packages/jsx/src/__tests__/value-references.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for `packages/jsx/src/value-references.ts` — the single-door
+ * "is this identifier a VALUE reference" classifier shared by
+ * `collectExternalImports` (jsx) and `detectStrippedReferences` (cli).
+ *
+ * There was no direct test file for this module before this one. It was
+ * added as a follow-up to #2432: a Copilot review on the original PR
+ * flagged that `ts.PropertyDeclaration` (class field) names were not
+ * excluded, so a class field like `helper` in `class C { helper = 1 }`
+ * was misclassified as a value reference. Harmless for the jsx-side
+ * caller (an extra kept import), but a false BF053 build error for the
+ * cli-side caller when the same name is a stripped import binding.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { collectValueReferencedNames } from '../value-references'
+
+describe('collectValueReferencedNames', () => {
+  test('class field name only is NOT a reference', () => {
+    const result = collectValueReferencedNames('class C { helper = 1 }')
+    expect(result).not.toBeNull()
+    expect(result?.has('helper')).toBe(false)
+  })
+
+  test('static class field name only is NOT a reference', () => {
+    const result = collectValueReferencedNames('class C { static helper = 1 }')
+    expect(result).not.toBeNull()
+    expect(result?.has('helper')).toBe(false)
+  })
+
+  test('computed class field name IS a reference (does not over-exclude)', () => {
+    const result = collectValueReferencedNames('class C { [helper] = 1 }')
+    expect(result).not.toBeNull()
+    expect(result?.has('helper')).toBe(true)
+  })
+
+  test('class method name is NOT a reference', () => {
+    const result = collectValueReferencedNames('class C { helper() {} }')
+    expect(result).not.toBeNull()
+    expect(result?.has('helper')).toBe(false)
+  })
+
+  test('object-literal key is NOT a reference', () => {
+    const result = collectValueReferencedNames('const o = { helper: 1 };')
+    expect(result).not.toBeNull()
+    expect(result?.has('helper')).toBe(false)
+  })
+
+  test('property access name is NOT a reference', () => {
+    const result = collectValueReferencedNames('obj.helper();')
+    expect(result).not.toBeNull()
+    expect(result?.has('helper')).toBe(false)
+  })
+
+  test('shorthand property IS a reference (reads the binding)', () => {
+    const result = collectValueReferencedNames('const o = { helper };')
+    expect(result).not.toBeNull()
+    expect(result?.has('helper')).toBe(true)
+  })
+
+  test('a genuine call IS a reference', () => {
+    const result = collectValueReferencedNames('helper();')
+    expect(result).not.toBeNull()
+    expect(result?.has('helper')).toBe(true)
+  })
+
+  test('new.target: "target" is NOT a reference', () => {
+    const result = collectValueReferencedNames('function f() { return new.target; }')
+    expect(result).not.toBeNull()
+    expect(result?.has('target')).toBe(false)
+  })
+
+  test('unparseable text returns null ("cannot answer")', () => {
+    const result = collectValueReferencedNames('const x = ;;; {{{ ]]]')
+    expect(result).toBeNull()
+  })
+})

--- a/packages/jsx/src/value-references.ts
+++ b/packages/jsx/src/value-references.ts
@@ -26,13 +26,26 @@ import ts from 'typescript'
  * A ShorthandPropertyAssignment (`{ Theme }`) intentionally counts as a
  * reference — it reads the binding, it doesn't just spell its name.
  *
+ * CONTRACT: this classifies identifier positions in **JavaScript** source.
+ * Both current callers parse with `ts.ScriptKind.JS` —
+ * `collectValueReferencedNames` below, and `detectStrippedReferences` in
+ * `packages/cli/src/lib/resolve-imports.ts`, which parses the assembled
+ * bundle. TypeScript-only positions are deliberately NOT handled: an
+ * identifier in a type position (`const x: Foo = …`, a
+ * `TypeReferenceNode`) is still reported as a value reference, and so are
+ * `interface` / `type` / `enum` declaration names. Do not point this at
+ * TypeScript source — it would over-report there.
+ *
  * Caveat: this is a syntactic test, not a scope analysis. If a local
  * function parameter happens to share a name with an imported binding,
  * references inside that function's body will count as references to
- * the import (false positive). Acceptable: over-counting a reference
- * just means we keep an import we didn't strictly need, which is a
- * strict improvement over the alternative failure direction (dropping a
- * needed import and producing a `ReferenceError`).
+ * the import (false positive). For the import-emission caller
+ * (`makeValueUsageTest` in `ir-to-client-js/imports.ts`), over-counting is
+ * the safe direction — an extra import whose binding exists is harmless.
+ * It is NOT safe for the BF053 caller (`detectStrippedReferences`): there,
+ * an over-reported reference to a stripped binding is a false build
+ * error on legal code. That asymmetry is why every exclusion branch below
+ * matters — each one is a case that would otherwise misfire BF053.
  */
 export function isValueReferenceIdentifier(id: ts.Identifier): boolean {
   const parent = id.parent
@@ -47,6 +60,15 @@ export function isValueReferenceIdentifier(id: ts.Identifier): boolean {
   ) {
     return false
   }
+  // Class field name (`class C { helper = 1 }`, including `static helper
+  // = 1`): the name is a member key, not a read. The `parent.name === id`
+  // guard is what preserves the computed case — in `class C { [helper] =
+  // 1 }` the name is a ComputedPropertyName, not `id` itself, so `helper`
+  // (inside the brackets) still falls through and counts as a reference.
+  if (ts.isPropertyDeclaration(parent) && parent.name === id) return false
+  // `new.target` / `import.meta`: `target`/`meta` sits in keyword
+  // position, not a binding.
+  if (ts.isMetaProperty(parent) && parent.name === id) return false
   if (ts.isVariableDeclaration(parent) && parent.name === id) return false
   if (ts.isFunctionDeclaration(parent) && parent.name === id) return false
   if (ts.isFunctionExpression(parent) && parent.name === id) return false


### PR DESCRIPTION
Follow-up to #2432 / #2433, from [Copilot's second review](https://github.com/piconic-ai/barefootjs/pull/2433#pullrequestreview-4820398649) (filed as low-confidence — it's correct).

## The gap

`isValueReferenceIdentifier` excludes object-literal keys, method names and accessor names, but not `ts.PropertyDeclaration` — a class field. Verified by probe against the merged code:

| source | classified as a value reference | correct? |
|---|---|---|
| `class C { helper = 1 }` | **yes** | no — member key |
| `class C { static helper = 1 }` | **yes** | no — member key |
| `class C { helper() {} }` | no | ✓ |
| `class C { [helper] = 1 }` | yes | ✓ — computed name *is* a read |
| `new.target` | **yes** (`target`) | no — keyword position |

`class Widget { helper = 1 }` is plain JS, and it named `helper` exactly the way `{ helper: 1 }` does one branch above in the same function.

## Why this is a patch and not a tidy-up

The two callers are hurt asymmetrically by an over-report:

- **`detectStrippedReferences` (cli) — a false build error.** BF053 fires when a relative import was stripped from a client bundle but its binding is still referenced. With the gap, a stripped binding whose name merely *coincided* with a class field name anywhere in the assembled bundle failed the build, pointing the developer at a reference that does not exist. Legal code, red build. Inlined `.ts` helper modules are arbitrary user code, so a class with a field named after some unrelated stripped import is not a contrived shape.
- **`makeValueUsageTest` (jsx) — a redundant import.** Harmless, since the binding does exist, but it defeats the point of the reference-based check that replaced the old text scan in #2433.

## The fix

Two exclusion branches, both guarded on `parent.name === id`:

- `ts.isPropertyDeclaration` — class field name, `static` included. The guard is what preserves the computed case: in `class C { [helper] = 1 }` the `name` is a `ComputedPropertyName` node rather than the identifier, so `helper` falls through and stays a reference. Both directions are pinned by tests, since over-excluding here would drop a needed import.
- `ts.isMetaProperty` — `target` in `new.target`, `meta` in `import.meta`. Keyword position, not a binding.

The classifier also now states its **contract**, since #2432 exported it as public API: it classifies positions in **JavaScript** source, which is what both callers parse (`ts.ScriptKind.JS`). Identifiers in TypeScript type positions — `const x: Foo`, `interface` / `type` / `enum` declaration names — are still reported as value references, so it must not be pointed at TypeScript source. The exclusion list reads best through the BF053 lens: each branch is a misfire that can no longer happen.

## Tests

- `packages/jsx/src/__tests__/value-references.test.ts` (new — the module had no direct test file): class field plain + `static` excluded, computed class field included, method / object key / property access excluded, shorthand property and a real call included, `new.target` excluded, unparseable text returns `null`.
- `packages/jsx/src/__tests__/ir-to-client-js/imports.test.ts`: a specifier occurring only as a class field name is not emitted; as a computed class field name it is.
- `packages/cli/src/__tests__/resolve-imports.test.ts`: a stripped binding occurring only as a class field name produces **zero** BF053, and the sibling positive case where the same name is genuinely called still fires exactly one — the pair proves the check was narrowed, not disabled.

## Verification

| Suite | Result |
|---|---|
| `bun test packages/jsx` | 2806 pass, 0 fail |
| `bun test packages/jsx/src/__tests__/value-references.test.ts .../ir-to-client-js/` | 53 pass, 0 fail |
| `bun test packages/cli/src/__tests__/resolve-imports.test.ts` | 32 pass, 0 fail |
| `bunx biome check packages/jsx/src packages/cli/src` | clean |

The full `packages/cli` suite has 15 failures in this environment, all `Cannot find module './runtimes.generated'` in `bf init` tests — that file is untracked and produced by a build step, so it fails in any fresh clone independently of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfswY6ca6smhyPJVdhm8qT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfswY6ca6smhyPJVdhm8qT)_