### PR TITLE
fix(client): break the item-root sibling walk instead of returning from it

### DIFF
--- a/.changeset/item-roots-break-not-return.md
+++ b/.changeset/item-roots-break-not-return.md
@@ -1,0 +1,38 @@
+---
+"@barefootjs/client": patch
+---
+
+Keep a multi-root item's extras reachable when its primary is already attached
+
+`itemRootElements` (`qsa-item.ts`) yields an item's roots in three steps: the
+primary, then its siblings up to a loop-boundary comment, then the CSR-only
+`__bfExtras` stash holding extras that are not siblings yet. Step 2 ended with
+`return`, which ends the generator — so hitting a boundary skipped step 3
+entirely.
+
+That was invisible in every shipped path. Nothing attaches a row before its
+`renderItem` body runs, and with a detached primary `nextSibling` is `null`:
+the walk never executes and control reaches the stash regardless. Attach the
+primary first and the very first sibling is a boundary comment, the generator
+ends, and `upsertChildItem` reports the item's child placeholders as missing —
+leaving them unreplaced in the DOM.
+
+`break` bounds the sibling walk without ending the generator. The boundary's
+purpose is preserved: the walk still stops there, and the only thing consulted
+afterwards is the item's own stash, which `mapArray` deletes once the body has
+returned (`map-array.ts`), so no element is ever yielded twice.
+
+This ships on its own as a no-op: with nothing attaching rows early, the `break`
+is never reached before the stash would have been read anyway. It is a
+prerequisite for the connect-before-init work on rows whose root is a template
+clone — a child inside such a row runs `init` against a detached element, and
+`useContext` resolves by walking `parentElement`, so it falls through to the
+global last-writer-wins store and reads another provider's value. Fixing that
+means attaching the row before the body's tail, which is exactly the case this
+`return` broke.
+
+Worth recording because the previous comment here explained the detachment
+dependency as the sibling walk "running past the item's own roots into a
+neighbouring item's elements". That is not what happened: the walk stopped
+correctly at the boundary and then gave up before the stash. The failure was
+measured, not deduced, and the comment is corrected to match.

--- a/packages/client/__tests__/runtime/item-roots-attached-primary.test.ts
+++ b/packages/client/__tests__/runtime/item-roots-attached-primary.test.ts
@@ -1,0 +1,95 @@
+/**
+ * A multi-root item's `__bfExtras` stash must stay reachable when the primary
+ * is already in the DOM.
+ *
+ * `itemRootElements` (`qsa-item.ts`) yields the primary, then walks its
+ * siblings until a loop-boundary comment, then reads the stash for extras that
+ * are not siblings yet. The walk has to end with `break`: a `return` ends the
+ * generator and skips the stash.
+ *
+ * That distinction is invisible today, because nothing attaches a row before
+ * its body runs — with a detached primary `nextSibling` is `null`, the walk
+ * never runs, and the stash is reached anyway. It decides the outcome the
+ * moment a row IS attached first, which is the direction the connect-before-
+ * init work is going (`csr-loop-row-init-connected.test.ts`). Without this,
+ * the first sibling an attached primary sees is a boundary comment, the
+ * generator ends, and the item's child placeholders are never replaced.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { BF_LOOP_START, BF_LOOP_END } from '@barefootjs/shared'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+describe('itemRootElements reaches the extras stash with an attached primary', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  /**
+   * Build one multi-root item the way the compiler emits a Fragment row: a
+   * primary plus one extra, with the child's placeholder on the EXTRA so the
+   * lookup has to get past the primary to find it.
+   */
+  async function renderItems(attachPrimaryFirst: boolean) {
+    const { hydrate, mapArray, createSignal, upsertChildItem } = await import('../../src/runtime')
+
+    hydrate('Chip', { init: () => {}, template: () => `<span>chip</span>` })
+
+    const ul = document.createElement('ul')
+    document.body.appendChild(ul)
+    ul.appendChild(document.createComment(`${BF_LOOP_START}:loop0`))
+    const end = document.createComment(`${BF_LOOP_END}:loop0`)
+    ul.appendChild(end)
+
+    const placedIn: string[] = []
+    const [items] = createSignal([{ id: '1' }, { id: '2' }])
+
+    mapArray(
+      () => items(),
+      ul,
+      (it: { id: string }) => String(it.id),
+      (item: () => { id: string }, _i: number, existing?: HTMLElement) => {
+        if (existing) return existing
+        const tpl = document.createElement('template')
+        tpl.innerHTML =
+          `<li class="p${item().id}">${item().id}</li>` +
+          `<li class="x${item().id}"><div data-bf-ph="s0"></div></li>`
+        const primary = tpl.content.firstElementChild!.cloneNode(true) as HTMLElement
+        const extras: HTMLElement[] = []
+        let sib = tpl.content.firstElementChild!.nextElementSibling
+        while (sib) {
+          extras.push(sib.cloneNode(true) as HTMLElement)
+          sib = sib.nextElementSibling
+        }
+        ;(primary as unknown as { __bfExtras: HTMLElement[] }).__bfExtras = extras
+
+        // The case under test: the primary is in the DOM before the body's
+        // tail runs, so its first sibling is the loop's end marker.
+        if (attachPrimaryFirst) ul.insertBefore(primary, end)
+
+        const child = upsertChildItem(primary, 'Chip', 's0', {})
+        placedIn.push(child ? (child.parentElement?.className ?? 'no-parent') : 'NOT FOUND')
+        return primary
+      },
+      'loop0',
+    )
+
+    return { placedIn, html: ul.innerHTML }
+  }
+
+  test('detached primary — the stash is reached because the walk never runs', async () => {
+    const { placedIn } = await renderItems(false)
+    expect(placedIn).toEqual(['x1', 'x2'])
+  })
+
+  test('attached primary — the stash is still reached after the walk breaks', async () => {
+    const { placedIn, html } = await renderItems(true)
+    // Fails as ['NOT FOUND', 'NOT FOUND'] if the boundary check `return`s.
+    expect(placedIn).toEqual(['x1', 'x2'])
+    // And the placeholders really were replaced, not merely reported found.
+    expect(html).not.toContain('data-bf-ph="s0"')
+  })
+})

--- a/packages/client/src/runtime/qsa-item.ts
+++ b/packages/client/src/runtime/qsa-item.ts
@@ -20,18 +20,22 @@
  *      cannot escape into a neighbouring item or into nodes outside the
  *      loop.
  *   3. The CSR-only `__bfExtras` stash. During renderItem-body setup
- *      (between the template clone and the function's return), the
- *      primary and extras are still detached nodes — `__el.nextSibling`
- *      is `null` and step 2 yields nothing. Reading `__bfExtras` lets
- *      lookups reach the still-pending extras before `mapArray` inserts
- *      them into the DOM.
+ *      (between the template clone and the function's return), the extras
+ *      are not siblings yet. Reading `__bfExtras` lets lookups reach them
+ *      before `mapArray` inserts them into the DOM.
  *
- * Step 3's reliance on the primary being detached during setup is why
- * `createItemScope` un-parks a row that turns out to carry extras: the
- * connect-before-init mount point applies to `createComponent` row roots,
- * which are single-root by construction and so never reach this module. An
- * attached primary would make step 2's sibling walk run past the item's own
- * roots into a neighbouring item's elements before step 3 is ever consulted.
+ * Step 3 must stay reachable whether or not the primary is attached, which
+ * is why step 2 ends its walk with `break` rather than `return`. Only the
+ * sibling walk is bounded; ending the generator there would skip the stash.
+ *
+ * This used to be a `return`, and the difference was invisible: with a
+ * detached primary `nextSibling` is `null`, so the walk never runs and
+ * control reaches the stash regardless. Attaching the primary made the very
+ * first sibling a boundary comment, which ended the generator before the
+ * stash was consulted and left the item's child placeholders unreplaced.
+ * Measured, not deduced — and note this is NOT the failure the earlier
+ * comment here described: the walk never ran past the item into a
+ * neighbouring one, it stopped correctly and then gave up too early.
  */
 
 import { BF_LOOP_ITEM, BF_LOOP_START, BF_LOOP_END } from '@barefootjs/shared'
@@ -51,10 +55,16 @@ function* itemRootElements(primaryEl: Element): Iterable<Element> {
       // Hard stops: another item starts, or the loop range ends. The
       // BF_LOOP_START check defends against a sibling loop block whose
       // start marker happens to follow ours.
+      // `break`, not `return`: stop the SIBLING walk, but still fall through
+      // to the `__bfExtras` stash below. A `return` ends the generator, and
+      // the stash is the only way to reach extras that are not siblings yet.
+      // That difference is invisible while the primary is detached — then
+      // `nextSibling` is `null`, this loop never runs, and control reaches the
+      // stash anyway — and decides the outcome the moment it is attached.
       if (v === BF_LOOP_ITEM
           || v === BF_LOOP_START || v.startsWith(startPrefix)
           || v === BF_LOOP_END || v.startsWith(endPrefix)) {
-        return
+        break
       }
     } else if (n.nodeType === Node.ELEMENT_NODE) {
       yield n as Element


### PR DESCRIPTION
Stage 1 of two. Independent of #2437; base `main`.

## The one-word change

`itemRootElements` (`qsa-item.ts`) yields a multi-root item's roots in three steps:

1. the primary
2. its siblings, up to a loop-boundary comment
3. the CSR-only `__bfExtras` stash — extras that are not siblings yet

Step 2 ended with `return`, which ends the **generator**, so hitting a boundary skipped step 3.

## Why nobody has hit it

Nothing attaches a row before its `renderItem` body runs. With a detached primary, `nextSibling` is `null`: the walk never executes and control falls through to the stash regardless. The `return` and a `break` are indistinguishable in every shipped path.

Attach the primary first and the very first sibling is a boundary comment → the generator ends → `upsertChildItem` reports the item's child placeholders as missing and leaves them unreplaced.

Measured, not deduced:

| primary | child placement |
|---|---|
| detached (today) | `x1`, `x2` — found via the stash |
| attached before the tail, `return` | **`NOT FOUND`**, `data-bf-ph="s0"` still in the DOM |
| attached before the tail, `break` | `x1`, `x2` |

## Why `break` is safe

The boundary's purpose is that a lookup must not escape into a neighbouring item. That still holds — the sibling walk stops at the boundary exactly as before. The only thing consulted afterwards is **this item's own** stash, and `mapArray` deletes it once the body has returned, so no element is ever yielded twice.

## Why it is worth landing alone

It ships as a **no-op**: with nothing attaching rows early, the `break` is never reached before the stash would have been read anyway. Landing it separately keeps the behavioural change in stage 2 down to one thing.

Stage 2 is connect-before-init for rows whose root is a template clone. A child inside such a row runs `init` against a detached element; `useContext` resolves by walking `parentElement`, so it falls through to the global last-writer-wins store and reads **another provider's** value — verified with two providers on one page: the child in list A reads `B`, and reads `A` once the row is attached first. Attaching the row before the body's tail is exactly the case this `return` broke, so stage 2 cannot land without this.

## One correction

The module comment explained the detachment dependency as the walk "running past the item's own roots into a neighbouring item's elements". That is not what happened — it stopped correctly at the boundary and then gave up before the stash. The comment is corrected to describe the real mechanism.

## Verification

| Check | Result |
|---|---|
| new test, `return` restored | fails as `['NOT FOUND','NOT FOUND']` |
| new test, with `break` | 2 pass |
| `packages/client` | 614 pass / 1 skip / 0 fail |
| adapter + CSR conformance | 1504 pass / 0 fail |
| biome | clean |

The new test asserts both that the child is reported found **and** that the placeholder is really gone from the DOM, so it cannot pass on a lookup that reports success without doing the replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_