### PR TITLE
feat(router): reconcile `<head>` page metadata; document that head resources are not managed

### DIFF
--- a/.changeset/router-head-metadata.md
+++ b/.changeset/router-head-metadata.md
@@ -11,7 +11,8 @@ route's `<meta name="description">`, `og:`/`twitter:` cards, and
 unlike the tab title.
 
 A swap now brings a **closed allowlist** of page metadata in line with the
-incoming document, with no option to turn on. Present in both → replaced
+incoming document. It always runs — there is no flag to disable it. Present in
+both → replaced
 (skipped when the nodes are already equal, so metadata shared across routes
 causes no DOM churn); only incoming → added; only current → removed, so nothing
 leaks forward into later routes.

--- a/.changeset/router-head-metadata.md
+++ b/.changeset/router-head-metadata.md
@@ -1,0 +1,33 @@
+---
+"@barefootjs/router": minor
+---
+
+Reconcile `<head>` page metadata across a soft navigation
+
+A swap used to write `document.title` and nothing else in `<head>` — and only
+because the route announcement reads it. So a soft navigation left the previous
+route's `<meta name="description">`, `og:`/`twitter:` cards, and
+`<link rel="canonical">` in place: wrongness you cannot see in development,
+unlike the tab title.
+
+A swap now brings a **closed allowlist** of page metadata in line with the
+incoming document, with no option to turn on. Present in both → replaced
+(skipped when the nodes are already equal, so metadata shared across routes
+causes no DOM churn); only incoming → added; only current → removed, so nothing
+leaks forward into later routes.
+
+| head node | key |
+| --- | --- |
+| `<meta name="description \| keywords \| robots \| author \| theme-color">` | `name` |
+| `<meta property="og:*">` / `<meta name="twitter:*">` | `name` or `property` |
+| `<link rel="canonical \| alternate \| prev \| next">` | `rel` + `hreflang`/`type`/`media` |
+
+Anything outside that table is never read, replaced, or removed — runtime-
+injected analytics tags, CSP `<meta http-equiv>`, `<link rel=preconnect>`, and a
+multi-token `rel="alternate stylesheet"` are all safe by construction. Opt a
+node out with `data-bf-head="false"`.
+
+Head **resources** (`<link rel="stylesheet">`, `<script>`, `<style>`) remain
+untouched: a resource's lifetime isn't derivable from the incoming document, so
+route-scoped CSS belongs inside the region, where it enters and leaves with the
+swap.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - 'packages/chart/**'
       - 'packages/xyflow/**'
       - 'packages/adapter-tests/**'
+      - 'packages/router/**'
       # site/ui is the Hono adapter's end-to-end target, so Hono changes must
       # re-run this workflow's e2e-site-ui job (ci-hono.yml no longer duplicates it).
       - 'packages/adapter-hono/**'
@@ -33,6 +34,7 @@ on:
       - 'packages/chart/**'
       - 'packages/xyflow/**'
       - 'packages/adapter-tests/**'
+      - 'packages/router/**'
       # site/ui is the Hono adapter's end-to-end target, so Hono changes must
       # re-run this workflow's e2e-site-ui job (ci-hono.yml no longer duplicates it).
       - 'packages/adapter-hono/**'
@@ -72,7 +74,7 @@ jobs:
           - group: jsx-2
             run: bun test $(bun scripts/ci/shard-test-files.ts packages/jsx 2 2)
           - group: rest
-            run: bun test packages/client packages/test packages/adapter-tests
+            run: bun test packages/client packages/test packages/adapter-tests packages/router
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/integrations/hono/blog.tsx
+++ b/integrations/hono/blog.tsx
@@ -36,13 +36,23 @@ const importMap = JSON.stringify({
   },
 })
 
-const blogRenderer = jsxRenderer(({ children, title }) => {
+const blogRenderer = jsxRenderer(({ children, title, description, canonical }) => {
   return (
     <html lang="en" data-theme="dark">
       <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>{title ?? 'Barefoot Blog'}</title>
+        {/*
+          Per-route metadata, so a soft navigation has something to reconcile
+          besides the title (#2438). The router replaces these against the
+          incoming document and removes any that the next route omits — an
+          ordinary server render, no client-side metadata API. `charset` and
+          `viewport` sit outside the allowlist and are never touched.
+        */}
+        <meta name="description" content={description ?? 'A BarefootJS router showcase.'} />
+        <meta property="og:title" content={title ?? 'Barefoot Blog'} />
+        <link rel="canonical" href={canonical ?? BASE} />
         <script type="importmap" dangerouslySetInnerHTML={{ __html: importMap }} />
         <link rel="stylesheet" href={`${BASE_PATH}/shared/styles/blog.css`} />
       </head>
@@ -88,6 +98,9 @@ blog.get('/', (c) => {
   const tag = c.req.query('tag')
   const items = listItems
   const title = tag ? `#${tag} — Barefoot Blog` : 'Barefoot Blog — Latest posts'
+  const description = tag
+    ? `Every Barefoot Blog post tagged #${tag}.`
+    : `The latest ${items.length} posts from the Barefoot Blog.`
   return c.render(
     <>
       <PostList items={items} tags={allTags} base={BASE} />
@@ -96,7 +109,7 @@ blog.get('/', (c) => {
           list and a post — it keeps playing instead of resetting on "← All posts". */}
       <NowPlaying />
     </>,
-    { title },
+    { title, description, canonical: BASE },
   )
 })
 
@@ -123,6 +136,10 @@ blog.get('/posts/:slug', (c) => {
       nextSlug={next?.slug}
       nextTitle={next?.title}
     />,
-    { title: `${p.title} — Barefoot Blog` },
+    {
+      title: `${p.title} — Barefoot Blog`,
+      description: `${p.title} — post ${position} of ${total}, tagged ${p.tags.map((t) => `#${t}`).join(' ')}.`,
+      canonical: `${BASE}/posts/${p.slug}`,
+    },
   )
 })

--- a/integrations/hono/e2e/blog.spec.ts
+++ b/integrations/hono/e2e/blog.spec.ts
@@ -83,3 +83,39 @@ test('v2 nested: the outer toolbar region persists while the inner content swaps
   expect(await page.locator('.reader-toolbar .v').innerText()).toBe('3') // outer region kept
   expect(await marker(page, '.reader-toolbar')).toBe('KEEP') // same node
 })
+
+test('v2.5: head metadata is reconciled across a soft navigation', async ({ page }) => {
+  const meta = (sel: string) => page.getAttribute(sel, 'content')
+  const canonical = () => page.getAttribute('link[rel="canonical"]', 'href')
+
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  expect(await meta('meta[name="description"]')).toContain('latest')
+  expect(await canonical()).toBe(BLOG)
+  // Mark the shell so the assertions below can't be satisfied by a full reload.
+  await mark(page, 'header.shell')
+
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.island.like', { timeout: 3000 })
+
+  expect(await marker(page, 'header.shell')).toBe('KEEP') // soft navigation, not a reload
+  const title = await page.title()
+  expect(title).toContain('Barefoot Blog')
+  // The article's metadata replaced the index's, in place.
+  const description = await meta('meta[name="description"]')
+  expect(description).toContain('post 1 of')
+  expect(await meta('meta[property="og:title"]')).toBe(title)
+  expect(await canonical()).toContain('/posts/')
+  expect(await page.locator('meta[name="description"]').count()).toBe(1)
+  expect(await page.locator('link[rel="canonical"]').count()).toBe(1)
+
+  // …and back again, so the reconciliation is not one-directional.
+  await page.click('.post .back')
+  await page.waitForSelector('.sortable-list li', { timeout: 3000 })
+  expect(await marker(page, 'header.shell')).toBe('KEEP')
+  expect(await meta('meta[name="description"]')).toContain('latest')
+  expect(await canonical()).toBe(BLOG)
+
+  // Outside the allowlist: untouched throughout.
+  expect(await meta('meta[name="viewport"]')).toContain('width=device-width')
+  expect(await page.locator('link[rel="stylesheet"]').count()).toBeGreaterThan(0)
+})

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -57,33 +57,60 @@ setup step.
   existing state (scroll-restoration libs, framework state).
 - **A11y**: focus moves into the swapped region (its first heading) and the new
   title is announced via a polite live region.
+- **Head metadata**: title, description, `og:`/`twitter:`, canonical and friends
+  are reconciled against the incoming page; head *resources* are not (see below).
 - **Persistence** (`data-bf-permanent`): an element marked
   `<div data-bf-permanent="player">` keeps its *live* node across a swap — its
   state, media playback, scroll, and hydrated scope survive — matched between
   documents by the attribute value (or `id`). A no-op when no element is marked;
   pass `morph: false` for a plain swap.
 
-## `<head>` is not managed
+## `<head>`: metadata is reconciled, resources are not
 
-A swap replaces the region and nothing else — **`<head>` is never
-reconciled**. `document.title` is the one exception, and only because the route
-announcement reads it. Across a soft navigation:
+A region is a **body** subtree, so `<head>` is not swapped wholesale. It splits
+in two, and the split is the whole contract.
 
-| head node | after navigating |
+### Page metadata — reconciled on every swap, no opt-in
+
+Page metadata is page-scoped by definition, so the router brings a closed
+allowlist of it in line with the incoming document. There is no option to turn
+on: a stale `<meta name="description">` is wrongness you *cannot see* in
+development (unlike the tab title), and this package doesn't leave that class
+opt-in.
+
+| head node | key |
 | --- | --- |
-| `<title>` | updated (for the announcement) |
-| `<link rel="stylesheet">` | the previous route's |
-| `<link rel="canonical">` | the previous route's |
-| `<meta name="description">` | the previous route's |
+| `<title>` | — |
+| `<meta name="description \| keywords \| robots \| author \| theme-color">` | `name` |
+| `<meta property="og:*">` / `<meta name="twitter:*">` | `name` or `property` |
+| `<link rel="canonical \| alternate \| prev \| next">` | `rel` + `hreflang`/`type`/`media` |
 
-The `<meta>` / canonical rows are harmless in practice (crawlers don't soft-
-navigate). A **route-scoped stylesheet** in `<head>` is not: navigating *into*
-the route renders it unstyled (a reload "fixes" it, which points the
-investigation at caching or the build instead of at navigation), and navigating
-*out* leaves the sheet linked, so its rules then apply to every route after it.
+A key in both documents is replaced (skipped when the nodes are already equal,
+so metadata shared across routes causes no DOM churn); a key only in the
+incoming page is added; a key only in the live page is **removed**, so it can't
+leak forward into every later route.
 
-Put a route-scoped stylesheet **inside** the region, where it enters and leaves
-with the swap:
+Anything whose key isn't in that table is never read, replaced, or removed —
+runtime-injected analytics tags, CSP `<meta http-equiv>`, `<link rel=preconnect>`
+and friends are safe by construction. (This is the deliberate difference from
+Turbo, which removes every untracked head element.) Opt a node out with
+`data-bf-head="false"` when the page itself owns it.
+
+### Head resources — untouched
+
+`<link rel="stylesheet">`, `<script>`, and `<style>` in `<head>` are left alone
+in both directions. Not an oversight: a resource's lifetime isn't derivable from
+the incoming document. The shell, a `[data-bf-permanent]` node, a portal, or an
+island that outlives the region may still depend on a sheet the next page's head
+doesn't list, so "absent downstream" is no evidence of "no longer needed".
+
+That makes a **route-scoped stylesheet in `<head>`** the one real trap:
+navigating *into* the route renders it unstyled (a reload "fixes" it, which
+points the investigation at caching or the build instead of at navigation), and
+navigating *out* leaves the sheet linked, so its rules then apply to every route
+after it.
+
+Put it **inside** the region, where it enters and leaves with the swap:
 
 ```tsx
 <Region>
@@ -93,9 +120,11 @@ with the swap:
 ```
 
 `rel="stylesheet"` is body-ok per HTML, so this is valid — and it is the right
-placement under a region-swap contract, not a workaround: no head handling, no
-per-link opt-out, and the route keeps soft navigation. Sheets that are genuinely
-global stay in `<head>`, where never touching them is exactly what you want.
+placement under a region-swap contract, not a workaround. It gets both orderings
+right *by construction* (the sheet is inserted with the content it styles and
+removed with it), with no load awaited in the navigation path. Sheets that are
+genuinely global stay in `<head>`, where never touching them is exactly what you
+want.
 
 ## Scope
 

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -70,13 +70,13 @@ setup step.
 A region is a **body** subtree, so `<head>` is not swapped wholesale. It splits
 in two, and the split is the whole contract.
 
-### Page metadata — reconciled on every swap, no opt-in
+### Page metadata — reconciled on every swap, always
 
 Page metadata is page-scoped by definition, so the router brings a closed
-allowlist of it in line with the incoming document. There is no option to turn
-on: a stale `<meta name="description">` is wrongness you *cannot see* in
-development (unlike the tab title), and this package doesn't leave that class
-opt-in.
+allowlist of it in line with the incoming document. This always runs and there
+is no flag to disable it: a stale `<meta name="description">` is wrongness you
+*cannot see* in development (unlike the tab title), and this package doesn't
+leave that class opt-in.
 
 | head node | key |
 | --- | --- |

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -63,6 +63,40 @@ setup step.
   documents by the attribute value (or `id`). A no-op when no element is marked;
   pass `morph: false` for a plain swap.
 
+## `<head>` is not managed
+
+A swap replaces the region and nothing else — **`<head>` is never
+reconciled**. `document.title` is the one exception, and only because the route
+announcement reads it. Across a soft navigation:
+
+| head node | after navigating |
+| --- | --- |
+| `<title>` | updated (for the announcement) |
+| `<link rel="stylesheet">` | the previous route's |
+| `<link rel="canonical">` | the previous route's |
+| `<meta name="description">` | the previous route's |
+
+The `<meta>` / canonical rows are harmless in practice (crawlers don't soft-
+navigate). A **route-scoped stylesheet** in `<head>` is not: navigating *into*
+the route renders it unstyled (a reload "fixes" it, which points the
+investigation at caching or the build instead of at navigation), and navigating
+*out* leaves the sheet linked, so its rules then apply to every route after it.
+
+Put a route-scoped stylesheet **inside** the region, where it enters and leaves
+with the swap:
+
+```tsx
+<Region>
+  {isEditor ? <link rel="stylesheet" href="/editor.css" /> : null}
+  {children}
+</Region>
+```
+
+`rel="stylesheet"` is body-ok per HTML, so this is valid — and it is the right
+placement under a region-swap contract, not a workaround: no head handling, no
+per-link opt-out, and the route keeps soft navigation. Sheets that are genuinely
+global stay in `<head>`, where never touching them is exactly what you want.
+
 ## Scope
 
 A **single authored region** (the broadest `[bf-region]` match), correct by

--- a/packages/router/__tests__/router.test.ts
+++ b/packages/router/__tests__/router.test.ts
@@ -421,3 +421,67 @@ describe('@barefootjs/router v0', () => {
     ;(window.location as unknown as { assign: typeof origAssign }).assign = origAssign
   })
 })
+
+// --- `<head>` is not managed (#2438) ---------------------------------------
+//
+// The router swaps `[bf-region]` and nothing else; `<head>` is out of scope
+// (`document.title` is written only because the route announcement reads it —
+// see `announceNavigation`). These pin the contract the README documents, and
+// the placement that follows from it: a route-scoped stylesheet belongs
+// *inside* the region, where it enters and leaves with the swap.
+describe('@barefootjs/router — head is not managed', () => {
+  function pageWithHead(head: string, body: string, title = 'Page'): string {
+    return `<!doctype html><html><head><title>${title}</title>${head}</head>
+      <body><header id="hdr">shell</header><main bf-region>${body}</main></body></html>`
+  }
+
+  afterEach(() => {
+    for (const el of Array.from(document.head.querySelectorAll('link, meta'))) el.remove()
+  })
+
+  test('a `<link>` in the incoming `<head>` is neither added nor removed; only the title is written', async () => {
+    // The live page carries a route-scoped sheet in `<head>` — the mistake the
+    // issue reports. The incoming page's head lists a different one.
+    document.head.insertAdjacentHTML('beforeend', '<link id="old-css" rel="stylesheet" href="/page-1.css"><meta name="description" content="page 1">')
+    mockFetch((url) =>
+      url.includes('/blog/2')
+        ? pageWithHead('<link id="new-css" rel="stylesheet" href="/page-2.css"><meta name="description" content="page 2">', '<p>page 2 body</p>', 'page 2')
+        : null,
+    )
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+    clickLink('next')
+    await flush()
+
+    expect(region().textContent).toContain('page 2 body')
+    // Head untouched in both directions: the outgoing sheet still applies and
+    // the incoming one never arrives.
+    expect(document.getElementById('old-css')).not.toBeNull()
+    expect(document.getElementById('new-css')).toBeNull()
+    expect(document.head.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('page 1')
+    // The one head node the router does write, for the announcement.
+    expect(document.title).toBe('page 2')
+  })
+
+  test('a route-scoped `<link>` inside the region enters and leaves with the swap', async () => {
+    mockFetch((url) => {
+      if (url.includes('/editor')) return pageWithHead('', '<link rel="stylesheet" href="/editor.css"><div class="head">editor</div>', 'editor')
+      if (url.includes('/blog/2')) return pageWithHead('', '<p>page 2 body</p>', 'page 2')
+      return null
+    })
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+
+    // Navigating *in*: the sheet arrives with the region content.
+    await navigate('/editor')
+    await flush()
+    expect(region().querySelector('link[href="/editor.css"]')).not.toBeNull()
+    // …and stays out of the head, so nothing accumulates there.
+    expect(document.head.querySelector('link[href="/editor.css"]')).toBeNull()
+
+    // Navigating *out*: the sheet is torn down with the region, so its rules
+    // stop applying to every subsequent route.
+    await navigate('/blog/2')
+    await flush()
+    expect(region().querySelector('link[href="/editor.css"]')).toBeNull()
+    expect(document.querySelector('link[href="/editor.css"]')).toBeNull()
+  })
+})

--- a/packages/router/__tests__/router.test.ts
+++ b/packages/router/__tests__/router.test.ts
@@ -514,6 +514,45 @@ describe('@barefootjs/router — head metadata reconciliation', () => {
     expect(document.head.querySelector('meta[name="description"]:not([data-bf-head])')?.getAttribute('content')).toBe('page 2')
   })
 
+  test('key attributes are case- and whitespace-insensitive, so a slot is replaced in place', async () => {
+    // The same logical slot, spelled differently on each side (`hreflang` is a
+    // BCP 47 tag and `type` a MIME type — both case-insensitive). Keyed
+    // verbatim the two miss each other, and the slot is rebuilt (old removed,
+    // new appended at the end of `<head>`) instead of replaced where it stands.
+    document.head.insertAdjacentHTML(
+      'beforeend',
+      '<link rel="Alternate" hreflang=" en-US " type="TEXT/HTML" href="/en/blog/1">' +
+        '<meta name="keywords" content="barefoot">',
+    )
+    mockFetch((url) =>
+      url.includes('/blog/2')
+        ? pageWithHead(
+            '<link rel="alternate" hreflang="en-us" type="text/html" href="/en/blog/2">' +
+              '<meta name="keywords" content="barefoot">',
+            '<p>page 2 body</p>',
+            'page 2',
+          )
+        : null,
+    )
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+    clickLink('next')
+    await flush()
+
+    // One slot, carrying the incoming value — true either way, since a missed
+    // key still removes the stale node rather than leaving a duplicate.
+    const alternates = Array.from(document.head.querySelectorAll('link')).filter(
+      (el) => (el.getAttribute('rel') ?? '').trim().toLowerCase() === 'alternate',
+    )
+    expect(alternates.length).toBe(1)
+    expect(alternates[0].getAttribute('href')).toBe('/en/blog/2')
+    // The part that needs the normalization: it kept its position. A missed key
+    // appends, which would put it after the `keywords` meta it preceded.
+    const order = Array.from(document.head.children)
+    expect(order.indexOf(alternates[0])).toBeLessThan(
+      order.indexOf(document.head.querySelector('meta[name="keywords"]') as Element),
+    )
+  })
+
   test('metadata identical across routes is left alone (no DOM churn)', async () => {
     document.head.insertAdjacentHTML('beforeend', '<meta property="og:site_name" content="Example">')
     // Mark the live node so survival is checked by identity, not by value.

--- a/packages/router/__tests__/router.test.ts
+++ b/packages/router/__tests__/router.test.ts
@@ -422,14 +422,14 @@ describe('@barefootjs/router v0', () => {
   })
 })
 
-// --- `<head>` is not managed (#2438) ---------------------------------------
+// --- `<head>`: metadata reconciled, resources not (#2438) ------------------
 //
-// The router swaps `[bf-region]` and nothing else; `<head>` is out of scope
-// (`document.title` is written only because the route announcement reads it —
-// see `announceNavigation`). These pin the contract the README documents, and
-// the placement that follows from it: a route-scoped stylesheet belongs
-// *inside* the region, where it enters and leaves with the swap.
-describe('@barefootjs/router — head is not managed', () => {
+// Two tiers, and the split is the point. Page metadata is page-scoped by
+// definition, so it is reconciled on every swap with no opt-in — a stale
+// `<meta name="description">` is wrongness you cannot see in development.
+// Head *resources* have no derivable lifetime, so they stay untouched, and a
+// route-scoped stylesheet belongs inside the region instead.
+describe('@barefootjs/router — head metadata reconciliation', () => {
   function pageWithHead(head: string, body: string, title = 'Page'): string {
     return `<!doctype html><html><head><title>${title}</title>${head}</head>
       <body><header id="hdr">shell</header><main bf-region>${body}</main></body></html>`
@@ -439,27 +439,125 @@ describe('@barefootjs/router — head is not managed', () => {
     for (const el of Array.from(document.head.querySelectorAll('link, meta'))) el.remove()
   })
 
-  test('a `<link>` in the incoming `<head>` is neither added nor removed; only the title is written', async () => {
-    // The live page carries a route-scoped sheet in `<head>` — the mistake the
-    // issue reports. The incoming page's head lists a different one.
-    document.head.insertAdjacentHTML('beforeend', '<link id="old-css" rel="stylesheet" href="/page-1.css"><meta name="description" content="page 1">')
+  test('allowlisted metadata is replaced, added, and removed', async () => {
+    document.head.insertAdjacentHTML(
+      'beforeend',
+      '<meta name="description" content="page 1">' +
+        '<meta property="og:title" content="Page 1">' +
+        '<meta name="robots" content="noindex">' + // absent downstream → removed
+        '<link rel="canonical" href="https://example.test/blog/1">',
+    )
     mockFetch((url) =>
       url.includes('/blog/2')
-        ? pageWithHead('<link id="new-css" rel="stylesheet" href="/page-2.css"><meta name="description" content="page 2">', '<p>page 2 body</p>', 'page 2')
+        ? pageWithHead(
+            '<meta name="description" content="page 2">' +
+              '<meta property="og:title" content="Page 2">' +
+              '<meta name="twitter:card" content="summary">' + // new → added
+              '<link rel="canonical" href="https://example.test/blog/2">',
+            '<p>page 2 body</p>',
+            'page 2',
+          )
         : null,
     )
     router = startRouter({ rehydrate: () => {}, dispose: () => {} })
     clickLink('next')
     await flush()
 
+    const meta = (sel: string) => document.head.querySelector(sel)?.getAttribute('content') ?? null
+    expect(meta('meta[name="description"]')).toBe('page 2')
+    expect(meta('meta[property="og:title"]')).toBe('Page 2')
+    expect(meta('meta[name="twitter:card"]')).toBe('summary')
+    // Present before, absent in the incoming page → gone, so it can't leak
+    // forward into every later route.
+    expect(document.head.querySelector('meta[name="robots"]')).toBeNull()
+    expect(document.head.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe('https://example.test/blog/2')
+    // Exactly one of each — replaced in place, not appended alongside.
+    expect(document.head.querySelectorAll('meta[name="description"]').length).toBe(1)
+    expect(document.head.querySelectorAll('link[rel="canonical"]').length).toBe(1)
+    expect(document.title).toBe('page 2')
+  })
+
+  test('nodes outside the allowlist are never read, replaced, or removed', async () => {
+    // A runtime-injected analytics tag and a CSP meta: absent from every
+    // server render, and swept away by a "remove everything untracked" merge.
+    document.head.insertAdjacentHTML(
+      'beforeend',
+      '<meta id="rum" name="x-analytics-session" content="abc123">' +
+        '<meta id="csp" http-equiv="content-security-policy" content="default-src \'self\'">' +
+        '<link id="preconnect" rel="preconnect" href="https://cdn.example.test">' +
+        '<link id="alt-sheet" rel="alternate stylesheet" href="/high-contrast.css">',
+    )
+    mockFetch((url) => (url.includes('/blog/2') ? pageWithHead('<meta name="description" content="page 2">', '<p>page 2 body</p>', 'page 2') : null))
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+    clickLink('next')
+    await flush()
+
+    expect(document.getElementById('rum')?.getAttribute('content')).toBe('abc123')
+    expect(document.getElementById('csp')).not.toBeNull()
+    expect(document.getElementById('preconnect')).not.toBeNull()
+    // Multi-token `rel` is a resource, so it falls outside the allowlist even
+    // though the `alternate` token appears in it.
+    expect(document.getElementById('alt-sheet')).not.toBeNull()
+  })
+
+  test('`data-bf-head="false"` opts a node out in both directions', async () => {
+    document.head.insertAdjacentHTML('beforeend', '<meta id="mine" name="description" content="owned by the page" data-bf-head="false">')
+    mockFetch((url) => (url.includes('/blog/2') ? pageWithHead('<meta name="description" content="page 2">', '<p>page 2 body</p>', 'page 2') : null))
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+    clickLink('next')
+    await flush()
+
+    // The opted-out node keeps its value…
+    expect(document.getElementById('mine')?.getAttribute('content')).toBe('owned by the page')
+    // …and is not treated as the slot the incoming description replaces, so
+    // the incoming one is appended rather than dropped.
+    expect(document.head.querySelector('meta[name="description"]:not([data-bf-head])')?.getAttribute('content')).toBe('page 2')
+  })
+
+  test('metadata identical across routes is left alone (no DOM churn)', async () => {
+    document.head.insertAdjacentHTML('beforeend', '<meta property="og:site_name" content="Example">')
+    // Mark the live node so survival is checked by identity, not by value.
+    const before = document.head.querySelector('meta[property="og:site_name"]') as unknown as { __kept: boolean }
+    before.__kept = true
+    mockFetch((url) =>
+      url.includes('/blog/2') ? pageWithHead('<meta property="og:site_name" content="Example">', '<p>page 2 body</p>', 'page 2') : null,
+    )
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+    clickLink('next')
+    await flush()
+
+    // Same live node, not a replacement carrying the same value.
+    const after = document.head.querySelector('meta[property="og:site_name"]') as unknown as { __kept?: boolean }
+    expect(after.__kept).toBe(true)
+  })
+})
+
+describe('@barefootjs/router — head resources are not managed', () => {
+  function pageWithHead(head: string, body: string, title = 'Page'): string {
+    return `<!doctype html><html><head><title>${title}</title>${head}</head>
+      <body><header id="hdr">shell</header><main bf-region>${body}</main></body></html>`
+  }
+
+  afterEach(() => {
+    for (const el of Array.from(document.head.querySelectorAll('link, meta'))) el.remove()
+  })
+
+  test('a `<link rel="stylesheet">` in `<head>` is neither added nor removed', async () => {
+    // The live page carries a route-scoped sheet in `<head>` — the mistake the
+    // issue reports. The incoming page's head lists a different one.
+    document.head.insertAdjacentHTML('beforeend', '<link id="old-css" rel="stylesheet" href="/page-1.css">')
+    mockFetch((url) =>
+      url.includes('/blog/2') ? pageWithHead('<link id="new-css" rel="stylesheet" href="/page-2.css">', '<p>page 2 body</p>', 'page 2') : null,
+    )
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+    clickLink('next')
+    await flush()
+
     expect(region().textContent).toContain('page 2 body')
-    // Head untouched in both directions: the outgoing sheet still applies and
-    // the incoming one never arrives.
+    // Untouched in both directions: the outgoing sheet still applies and the
+    // incoming one never arrives. Hence the in-region placement below.
     expect(document.getElementById('old-css')).not.toBeNull()
     expect(document.getElementById('new-css')).toBeNull()
-    expect(document.head.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('page 1')
-    // The one head node the router does write, for the announcement.
-    expect(document.title).toBe('page 2')
   })
 
   test('a route-scoped `<link>` inside the region enters and leaves with the swap', async () => {

--- a/packages/router/src/head.ts
+++ b/packages/router/src/head.ts
@@ -15,7 +15,7 @@
  * and a stale `<meta name="description">` is *invisible* wrongness: unlike the
  * tab title you cannot see it in development. That is the class this package
  * refuses to leave opt-in (spec/router.md, "correct by default"), so it is
- * reconciled on every swap with no option to turn on.
+ * reconciled on every swap, always — there is no flag to disable it.
  *
  * The reconciled set is a **closed allowlist**, which is the deliberate
  * difference from Turbo's `provisionalElements` (everything untracked, so
@@ -37,6 +37,16 @@ const META_PREFIXES = ['og:', 'twitter:']
  */
 const LINK_RELS = new Set(['canonical', 'alternate', 'prev', 'next'])
 
+/**
+ * Fold an attribute to its comparable form. Every attribute in a key is
+ * case-insensitive, and incidental whitespace (`hreflang=" en-US "`) must not
+ * split one logical slot into two — a split key would append a duplicate on
+ * every navigation instead of replacing the node.
+ */
+function norm(value: string | null): string {
+  return (value ?? '').trim().toLowerCase()
+}
+
 /** Opt-out for a node the page itself owns: `<meta name="robots" data-bf-head="false">`. */
 function optedOut(el: Element): boolean {
   return el.getAttribute('data-bf-head') === 'false'
@@ -54,19 +64,22 @@ function headKey(el: Element): string | null {
   if (optedOut(el)) return null
   const tag = el.tagName.toLowerCase()
   if (tag === 'meta') {
-    const id = (el.getAttribute('name') ?? el.getAttribute('property') ?? '').trim().toLowerCase()
+    const id = norm(el.getAttribute('name') ?? el.getAttribute('property'))
     if (!id) return null
     if (!META_NAMES.has(id) && !META_PREFIXES.some((p) => id.startsWith(p))) return null
     return `meta:${id}`
   }
   if (tag === 'link') {
-    const rel = (el.getAttribute('rel') ?? '').trim().toLowerCase()
+    const rel = norm(el.getAttribute('rel'))
     if (!LINK_RELS.has(rel)) return null
     // `alternate` is repeatable — a locale, a feed, a print sheet are distinct
-    // slots, so the discriminating attributes are part of the key.
-    const hreflang = el.getAttribute('hreflang') ?? ''
-    const type = el.getAttribute('type') ?? ''
-    const media = el.getAttribute('media') ?? ''
+    // slots, so the discriminating attributes are part of the key. All three
+    // are case-insensitive (BCP 47 tags, MIME types, media queries), so they
+    // are normalized: `hreflang="en-US"` and `en-us` are one slot, not two
+    // that would accumulate a duplicate on every navigation.
+    const hreflang = norm(el.getAttribute('hreflang'))
+    const type = norm(el.getAttribute('type'))
+    const media = norm(el.getAttribute('media'))
     return `link:${rel}|${hreflang}|${type}|${media}`
   }
   return null

--- a/packages/router/src/head.ts
+++ b/packages/router/src/head.ts
@@ -1,0 +1,132 @@
+/**
+ * `<head>` metadata reconciliation across a soft navigation (#2438).
+ *
+ * A region is a **body** subtree, so a swap leaves `<head>` alone — and for
+ * *resources* (`<link rel="stylesheet">`, `<script>`, `<style>`) that is the
+ * contract, not a gap: a resource's lifetime depends on what still needs it
+ * (the shell, a `[data-bf-permanent]` node, a portal, an island that outlives
+ * the region), which the incoming document is no evidence for. Turbo reaches
+ * the same conclusion from the other side — it never removes a stylesheet
+ * unless the author writes `data-turbo-track="dynamic"`. Route-scoped sheets
+ * belong *inside* the region, where both orderings are right by construction.
+ *
+ * **Page metadata is the opposite case.** It is page-scoped by definition,
+ * costs no load, has no layout effect or ordering hazard, and is idempotent —
+ * and a stale `<meta name="description">` is *invisible* wrongness: unlike the
+ * tab title you cannot see it in development. That is the class this package
+ * refuses to leave opt-in (spec/router.md, "correct by default"), so it is
+ * reconciled on every swap with no option to turn on.
+ *
+ * The reconciled set is a **closed allowlist**, which is the deliberate
+ * difference from Turbo's `provisionalElements` (everything untracked, so
+ * runtime-injected analytics/CSP nodes get caught in the sweep). Here anything
+ * whose key isn't listed below is never read, never replaced, and never
+ * removed.
+ */
+
+/** `<meta name>` / `<meta property>` values reconciled by exact match. */
+const META_NAMES = new Set(['description', 'keywords', 'robots', 'author', 'theme-color'])
+
+/** …and by prefix, for the two social-card namespaces. */
+const META_PREFIXES = ['og:', 'twitter:']
+
+/**
+ * `<link rel>` values reconciled. Matched against the **whole** `rel`, not its
+ * tokens, so a multi-token `rel="alternate stylesheet"` — a resource, with a
+ * resource's unknowable lifetime — falls outside the allowlist by construction.
+ */
+const LINK_RELS = new Set(['canonical', 'alternate', 'prev', 'next'])
+
+/** Opt-out for a node the page itself owns: `<meta name="robots" data-bf-head="false">`. */
+function optedOut(el: Element): boolean {
+  return el.getAttribute('data-bf-head') === 'false'
+}
+
+/**
+ * The identity a node is matched by across the two documents, or `null` when it
+ * is outside the allowlist (i.e. not ours to touch).
+ *
+ * `name` and `property` collapse into one key space on purpose: a page that
+ * writes `<meta property="og:title">` where the previous one wrote
+ * `<meta name="og:title">` still means the same slot.
+ */
+function headKey(el: Element): string | null {
+  if (optedOut(el)) return null
+  const tag = el.tagName.toLowerCase()
+  if (tag === 'meta') {
+    const id = (el.getAttribute('name') ?? el.getAttribute('property') ?? '').trim().toLowerCase()
+    if (!id) return null
+    if (!META_NAMES.has(id) && !META_PREFIXES.some((p) => id.startsWith(p))) return null
+    return `meta:${id}`
+  }
+  if (tag === 'link') {
+    const rel = (el.getAttribute('rel') ?? '').trim().toLowerCase()
+    if (!LINK_RELS.has(rel)) return null
+    // `alternate` is repeatable — a locale, a feed, a print sheet are distinct
+    // slots, so the discriminating attributes are part of the key.
+    const hreflang = el.getAttribute('hreflang') ?? ''
+    const type = el.getAttribute('type') ?? ''
+    const media = el.getAttribute('media') ?? ''
+    return `link:${rel}|${hreflang}|${type}|${media}`
+  }
+  return null
+}
+
+/** Index a head's allowlisted nodes by key, keeping duplicates in document order. */
+function indexHead(head: Element): Map<string, Element[]> {
+  const byKey = new Map<string, Element[]>()
+  for (const el of head.querySelectorAll('meta, link')) {
+    const key = headKey(el)
+    if (!key) continue
+    const bucket = byKey.get(key)
+    if (bucket) bucket.push(el)
+    else byKey.set(key, [el])
+  }
+  return byKey
+}
+
+/**
+ * Bring the live `<head>`'s allowlisted metadata in line with `incomingDoc`.
+ *
+ * - key in both → replace in place (skipped when the nodes are already equal,
+ *   so metadata shared across routes causes no DOM churn)
+ * - key only incoming → appended
+ * - key only current → removed, so it can't leak forward into every later route
+ *   the way an unmanaged `<link rel="stylesheet">` does
+ *
+ * Duplicates under one key are collapsed to the incoming node — a page with two
+ * `<meta name="description">` is malformed, and leaving the extra behind would
+ * defeat the reconciliation.
+ *
+ * `<title>` is **not** handled here: the router writes it alongside this call
+ * because the route announcement (`announceNavigation`) needs the same string.
+ *
+ * Ordering-free — no load, no layout effect — so the caller may run it at any
+ * point around the swap.
+ */
+export function reconcileHead(incomingDoc: Document): void {
+  const head = document.head
+  const incomingHead = incomingDoc.head
+  if (!head || !incomingHead) return
+
+  const current = indexHead(head)
+  const incoming = indexHead(incomingHead)
+  if (current.size === 0 && incoming.size === 0) return
+
+  for (const [key, nodes] of incoming) {
+    const live = current.get(key)
+    const replacement = document.importNode(nodes[0], true)
+    if (!live) {
+      head.append(replacement)
+      continue
+    }
+    const [first, ...duplicates] = live
+    if (!first.isEqualNode(replacement)) first.replaceWith(replacement)
+    for (const dup of duplicates) dup.remove()
+  }
+
+  for (const [key, nodes] of current) {
+    if (incoming.has(key)) continue
+    for (const node of nodes) node.remove()
+  }
+}

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -297,6 +297,11 @@ export async function navigate(url: string, options: NavigateOptions = {}): Prom
       current.replaceChildren(fragment)
       swapped.push({ region: current, outgoing })
     }
+    // The only `<head>` node a swap writes, and only because the route
+    // announcement below reads it (`announceNavigation`). `<head>` is otherwise
+    // not reconciled — that is the contract, not an oversight (#2438): a region
+    // is a body subtree, so route-scoped `<link rel="stylesheet">` belongs
+    // inside the region, where it enters and leaves with the swap.
     if (title !== null) document.title = title
 
     // Refresh the per-region baselines to the server render now displayed: from

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -10,6 +10,7 @@
 
 import { BF_REGION } from '@barefootjs/shared'
 import { loadPage } from './cache.ts'
+import { reconcileHead } from './head.ts'
 import {
   captureRegionBaselines,
   collectModuleScripts,
@@ -297,12 +298,16 @@ export async function navigate(url: string, options: NavigateOptions = {}): Prom
       current.replaceChildren(fragment)
       swapped.push({ region: current, outgoing })
     }
-    // The only `<head>` node a swap writes, and only because the route
-    // announcement below reads it (`announceNavigation`). `<head>` is otherwise
-    // not reconciled — that is the contract, not an oversight (#2438): a region
-    // is a body subtree, so route-scoped `<link rel="stylesheet">` belongs
-    // inside the region, where it enters and leaves with the swap.
+    // Commit the page's identity: the title (also handed to the route
+    // announcement below) and the allowlisted `<head>` metadata — description,
+    // canonical, og:/twitter: (`reconcileHead`, #2438). Head *resources*
+    // (`<link rel="stylesheet">`, scripts) stay unmanaged by contract, not by
+    // oversight: their lifetime isn't derivable from the incoming document, so
+    // a route-scoped stylesheet belongs inside the region, where it enters and
+    // leaves with the swap. Both are ordering-free, so they sit with the
+    // synchronous swaps rather than in the awaited tail.
     if (title !== null) document.title = title
+    reconcileHead(incomingDoc)
 
     // Refresh the per-region baselines to the server render now displayed: from
     // the incoming keys (matched regions), else recaptured from the live DOM

--- a/spec/router.md
+++ b/spec/router.md
@@ -171,5 +171,17 @@ at `@barefootjs/client/runtime` (`disposeScope`/`rehydrateScope`). Neither may s
   the owned-content diff is HTML-structural, so a region split across one of these is not
   yet guaranteed.
 - No scroll restoration; modulepreload links/dedupe set are session-lived (cap later).
+- **`<head>` is not reconciled** ([#2438](https://github.com/piconic-ai/barefootjs/issues/2438)).
+  A region is a *body* subtree; `document.title` is written in step 6 only because the route
+  announcement reads it (`announceNavigation`), not as the start of head management. So
+  route-scoped `<link rel="stylesheet">` belongs **inside** the region — `rel="stylesheet"` is
+  body-ok per HTML, and the sheet then enters and leaves with the swap, needing no head
+  handling and no per-link opt-out. This is the sanctioned placement, not a workaround; it is
+  documented in the router README and pinned by the "head is not managed" tests
+  (`packages/router/__tests__/router.test.ts`). A head-reconciliation opt-in
+  (`startRouter({ head: … })`, or honouring a `bf-head` marker) is deferred, not planned: it
+  earns its keep only for sheets an app genuinely cannot move (emitted by a framework layout),
+  and it must add incoming sheets **before** the swap and remove outgoing ones **after**, or
+  the page paints unstyled in one direction and loses its styles for a frame in the other.
 - **Non-goals:** client route manifest / loader protocol / fragment endpoint; RSC-style
   boundary or non-HTML payload; client-owned Suspense protocol; navigation/content-negotiation header.

--- a/spec/router.md
+++ b/spec/router.md
@@ -160,6 +160,23 @@ at `@barefootjs/client/runtime` (`disposeScope`/`rehydrateScope`). Neither may s
   cross-adapter `region-boundary` fixture (stable id), `router-regions.test.ts` (nested /
   sibling / divergence), and the `integrations/router-blog` example (hand-authored sibling
   + compiled nested regions, verified in a real browser).
+- **v2.5 — head metadata reconciliation.** ✅ Shipped ([#2438](https://github.com/piconic-ai/barefootjs/issues/2438)).
+  A swap reconciles a **closed allowlist** of page metadata against the incoming document
+  (`reconcileHead`, `packages/router/src/head.ts`): `description`/`keywords`/`robots`/`author`/
+  `theme-color`, the `og:` and `twitter:` namespaces, and `rel=canonical|alternate|prev|next`.
+  Present in both → replaced (skipped when already equal); only incoming → added; only current
+  → **removed**, so nothing leaks forward. `data-bf-head="false"` opts a node out.
+
+  **Default-on with no option, deliberately.** Metadata is page-scoped by definition, costs no
+  load, has no layout effect or ordering hazard, and is idempotent — while a stale
+  `<meta name="description">` is *invisible* wrongness (unlike the tab title, you cannot see it
+  in development). That is exactly the class "correct by default" above exists for. The
+  allowlist being **closed** is the deliberate divergence from Turbo's `provisionalElements`,
+  which removes every untracked head element and so can sweep away runtime-injected analytics
+  or CSP nodes. And because the incoming document is already parsed for the region diff, this
+  is a bounded node diff over data in hand — no manifest, no payload, no fetch. (Next's App
+  Router routes the same job through the RSC payload and has carried soft-navigation metadata
+  bugs across many releases; the document-diff position is the easier one.)
 
 ## Limitations & non-goals
 
@@ -171,17 +188,20 @@ at `@barefootjs/client/runtime` (`disposeScope`/`rehydrateScope`). Neither may s
   the owned-content diff is HTML-structural, so a region split across one of these is not
   yet guaranteed.
 - No scroll restoration; modulepreload links/dedupe set are session-lived (cap later).
-- **`<head>` is not reconciled** ([#2438](https://github.com/piconic-ai/barefootjs/issues/2438)).
-  A region is a *body* subtree; `document.title` is written in step 6 only because the route
-  announcement reads it (`announceNavigation`), not as the start of head management. So
-  route-scoped `<link rel="stylesheet">` belongs **inside** the region — `rel="stylesheet"` is
-  body-ok per HTML, and the sheet then enters and leaves with the swap, needing no head
-  handling and no per-link opt-out. This is the sanctioned placement, not a workaround; it is
-  documented in the router README and pinned by the "head is not managed" tests
-  (`packages/router/__tests__/router.test.ts`). A head-reconciliation opt-in
-  (`startRouter({ head: … })`, or honouring a `bf-head` marker) is deferred, not planned: it
-  earns its keep only for sheets an app genuinely cannot move (emitted by a framework layout),
-  and it must add incoming sheets **before** the swap and remove outgoing ones **after**, or
-  the page paints unstyled in one direction and loses its styles for a frame in the other.
+- **Head *resources* are not reconciled** ([#2438](https://github.com/piconic-ai/barefootjs/issues/2438);
+  head *metadata* is — see v2.5 above). `<link rel="stylesheet">`, `<script>` and `<style>` in
+  `<head>` are left untouched in both directions, because a resource's lifetime is not
+  derivable from the incoming document: the shell, a `[data-bf-permanent]` node, a portal, or
+  an island outliving the region may still need a sheet the next page's head omits. So
+  route-scoped CSS belongs **inside** the region — `rel="stylesheet"` is body-ok per HTML, and
+  the sheet then enters and leaves with the swap, getting both orderings right by construction
+  with no load awaited in the nav path. A head-stylesheet opt-in is deferred, and the shape is
+  constrained: it must add incoming sheets **before** the swap and remove outgoing ones
+  **after**, or the page paints unstyled in one direction and loses its styles for a frame in
+  the other. Both precedents converge on the removal half needing an author signal — Turbo
+  never removes a sheet unless it carries `data-turbo-track="dynamic"`; Remix removes them
+  automatically and has open issues where the outgoing route goes unstyled mid-transition. So
+  if it ever ships it is a **per-element `data-bf-head` marker**, never a global
+  `startRouter({ head: … })` option: scope is a property of the element, not of the app.
 - **Non-goals:** client route manifest / loader protocol / fragment endpoint; RSC-style
   boundary or non-HTML payload; client-owned Suspense protocol; navigation/content-negotiation header.


### PR DESCRIPTION
Closes #2438.

## What

`<head>` splits in two, and the split is the whole contract.

**Page metadata is now reconciled on every swap.** It always runs — there is no flag to disable it. Before, a swap wrote `document.title` and nothing else, and only because the route announcement reads it. So a soft navigation kept the previous route's `<meta name="description">`, `og:`/`twitter:` cards, and `<link rel="canonical">`. That is *invisible* wrongness: unlike the tab title you cannot see it in development, which is exactly the class the spec's "correct by default" rule exists for. It also isn't only a crawler concern — share sheets, in-app webviews, browser/extension UI, and RUM tools all read the live DOM.

**Head resources stay untouched, and that is a contract, not a gap.** A resource's lifetime isn't derivable from the incoming document: the shell, a `[data-bf-permanent]` node, a portal, or an island outliving the region may still need a sheet the next page's head omits, so "absent downstream" is no evidence of "no longer needed". Route-scoped CSS belongs *inside* the region, where both orderings are right by construction and no load is awaited in the navigation path.

```tsx
<Region>
  {isEditor ? <link rel="stylesheet" href="/editor.css" /> : null}
  {children}
</Region>
```

## The reconciled set

A **closed allowlist**, keyed by identity:

| head node | key |
| --- | --- |
| `<title>` | — (unchanged; also feeds the announcement) |
| `<meta name="description \| keywords \| robots \| author \| theme-color">` | `name` |
| `<meta property="og:*">` / `<meta name="twitter:*">` | `name` or `property` |
| `<link rel="canonical \| alternate \| prev \| next">` | `rel` + `hreflang`/`type`/`media` |

Present in both → replaced (skipped when the nodes are already equal, so metadata shared across routes causes no DOM churn); only incoming → added; only current → **removed**, so nothing leaks forward into later routes. Key attributes are folded (trim + lowercase) since `rel`, `hreflang`, `type` and `media` are all case-insensitive.

Anything outside the table is never read, replaced, or removed. That closedness is the deliberate divergence from Turbo's `provisionalElements`, which removes every untracked head element and can sweep away runtime-injected analytics or CSP nodes. A multi-token `rel="alternate stylesheet"` falls outside by construction — it's a resource. `data-bf-head="false"` opts a node out.

## Why this is cheap here

The incoming document is already parsed for the region diff, so this is a bounded node diff over data in hand: no route manifest, no payload, no fetch, no await, no layout effect. Next's App Router routes the same job through the RSC payload and has carried soft-navigation metadata bugs across many releases ([discussion #67663](https://github.com/vercel/next.js/discussions/67663)); Turbo does it document-diff style with no manifest at all. The document-diff position is the easy one.

## Why not head stylesheets

Both precedents converge on the removal half needing an author signal:

- **Turbo** adds new stylesheets and blocks the body swap on their load, but never removes one unless the author writes `data-turbo-track="dynamic"` — so it still leaks sheets forward by default.
- **Remix / React Router** removes them automatically, and has open issues where the outgoing route goes unstyled mid-transition ([#10160](https://github.com/remix-run/remix/issues/10160)) and where a `React.lazy` component loses its styles ([#9630](https://github.com/remix-run/remix/issues/9630)) — precisely the ordering hazard #2438 predicted.

In-region placement already *is* the author signal, and a better one: it needs no new API and gets both orderings right by construction. The spec records that if an opt-in ever ships it is a **per-element `data-bf-head` marker**, never a global `startRouter({ head: … })` option — scope is a property of the element, not of the app.

## Changes

- **`packages/router/src/head.ts`** (new) — `reconcileHead(incomingDoc)`: the allowlist, keying, and the replace/add/remove pass.
- **`packages/router/src/router.ts`** — call it beside the `document.title` write. Ordering-free, so it sits with the synchronous swaps rather than the awaited tail.
- **`packages/router/README.md`** — the section reframed as the two tiers, with the allowlist table and the in-region recipe.
- **`spec/router.md`** — a shipped **v2.5** phase for metadata (including why it is unconditional and why the allowlist is closed), and the resource half rewritten as a scoped limitation with the constrained opt-in shape.
- **`packages/router/__tests__/router.test.ts`** — 7 tests: replace/add/remove, allowlist non-interference (analytics, CSP, preconnect, alternate-stylesheet), `data-bf-head="false"`, key normalization, no-churn on equal nodes, plus the two resource-tier pins.
- **`integrations/hono/blog.tsx` + `e2e/blog.spec.ts`** — the router showcase now serves per-route `description` / `og:title` / `canonical`, with a Chromium e2e test walking index → post → index.
- **`.github/workflows/ci.yml`** — `packages/router` was in no workflow's path filter and no test group, so its tests had never run in CI. Added to both. Happy to split this out if you'd rather it landed separately.

## Testing

`bun test packages/router` — 53 pass, biome and `tsgo --noEmit` clean. `bunx playwright test e2e/blog.spec.ts` in `integrations/hono` — 6 pass in Chromium.

Both new layers verified non-vacuous by commenting out the `reconcileHead` call: the two unit reconciliation tests fail (the two non-interference tests keep passing, as expected), and the e2e test fails with the description still on the index's value. The key-normalization test fails against the un-normalized key and passes after.

Observed in the browser across a soft navigation, with the shell node marked to prove it wasn't a reload:

| | index | after → post | after ← index |
| --- | --- | --- | --- |
| `description` | The latest 10 posts… | Where this goes next — post 1 of 10… | The latest 10 posts… |
| `canonical` | `/blog` | `/blog/posts/where-this-goes` | `/blog` |
| `viewport` (outside allowlist) | unchanged | unchanged | unchanged |
| `meta[name=description]` count | 1 | 1 | 1 |