### PR TITLE
fix(jsx,client): connect a composite loop row before its children init

### DIFF
--- a/.changeset/mount-composite-loop-rows.md
+++ b/.changeset/mount-composite-loop-rows.md
@@ -1,0 +1,59 @@
+---
+"@barefootjs/client": patch
+"@barefootjs/jsx": patch
+---
+
+Connect a composite loop row before its children initialise
+
+A loop row whose root is user markup (`items.map(it => <li><Chip/></li>)`) is a
+template clone written inline in the emitted body, so no runtime function sits
+between "make a row" and "the element exists" and there was nothing to hand a
+destination to. `mapArray` first saw the element as `renderItem`'s return
+value — after `upsertChild` had already run the row's children's `init`
+against a detached element.
+
+`useContext` resolves by walking `parentElement`. A detached element has no
+ancestors to walk, so the lookup fell through to the global, last-writer-wins
+context store and returned whichever provider on the page wrote last. No error,
+no warning — a plausible wrong value. With one provider of a context on the
+page it is invisible, because the global holds the same value; put two on one
+page and rows in the first list start reading the second's.
+
+Measured, with providers `A` and `B` and a row in `A`'s list: the child read
+`B`. With the row connected first it reads `A`.
+
+The compiler now emits `mountRowRoot(clone)`, which consumes the same ambient
+mount point `createComponent` row roots already use (#2431), for the one loop
+variant that initialises anything inside the row — composite, i.e. nested
+components and/or inner loops. A plain row has no nested `init`, so it has
+nothing that could resolve wrongly and is left alone; the high-volume
+`mapArrayLazy` emission is untouched.
+
+Four things attaching a row earlier could have broken, all checked:
+
+- **The reorder.** A fresh row is mounted at the end of the loop range and the
+  LIS walk moves it to its final position. Front-insert, reorder, append and
+  removal all reconcile to the right order.
+- **Multi-root rows.** A Fragment row is a clone, so it takes this path, and
+  `qsa-item.ts`'s lookup used to give up on an attached primary before reading
+  the extras stash. That is fixed separately; here the primary mounts, the
+  children init connected, and each primary still travels with its own extras
+  through a reorder.
+- **Cross-row lookups.** Rows are attached while later rows are still being
+  built, so a lookup that escaped its own row would now land in a real
+  neighbour. Each row gets exactly its own child.
+- **A body that throws after mounting.** This one did regress, and is fixed: a
+  detached row could never be left on screen, but a mounted one can, so the
+  mount is recorded on the mount point and undone before the error propagates.
+
+Left alone deliberately: `createItemScope` still un-parks a row that turns out
+to carry extras. By then the mount has already done its job — the tail ran
+connected — and un-parking keeps the reorder from marking a row stationary
+before its extras and per-item marker exist.
+
+No SSR output change: the hydration branch adopts a row that came from server
+markup and is in the document by construction, so it never mounts. This is also
+why the change has no CSR-conformance fixture — that layer evaluates the
+`template:` lambda and compares HTML, and neither the template nor the HTML
+moves here. The behaviour lives in the renderItem body, so the coverage does
+too, in `packages/client/__tests__/runtime/`.

--- a/packages/client/__tests__/runtime/composite-row-mount.test.ts
+++ b/packages/client/__tests__/runtime/composite-row-mount.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Connect-before-init for template-clone loop rows, and the things that
+ * attaching a row early could plausibly break.
+ *
+ * Each body below mirrors what the compiler emits for a composite row: clone,
+ * `mountRowRoot`, then the tail that initialises the row's children. The point
+ * of the mount is that the tail runs against a connected element — `useContext`
+ * resolves by walking `parentElement`, so a child that inits inside a detached
+ * row finds no ancestors and falls through to the global last-writer-wins
+ * context store, silently reading another provider's value.
+ *
+ * The rest of these are the adversarial cases. Attaching a row earlier than
+ * before puts it in front of the reconciler, the multi-root lookup, and the
+ * duplicate-key and failure paths, all of which previously only ever saw
+ * detached rows.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { BF_LOOP_START, BF_LOOP_END } from '@barefootjs/shared'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+/** A loop container with real range markers, as SSR emits them. */
+function loopContainer() {
+  const ul = document.createElement('ul')
+  document.body.appendChild(ul)
+  ul.appendChild(document.createComment(`${BF_LOOP_START}:l0`))
+  ul.appendChild(document.createComment(`${BF_LOOP_END}:l0`))
+  return ul
+}
+
+describe('composite loop rows connect before their tail runs', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('a row reads its OWN provider, not the last one on the page', async () => {
+    const {
+      hydrate, mapArray, createSignal, createContext, useContext, provideContext,
+      upsertChild, setCurrentScope, mountRowRoot,
+    } = await import('../../src/runtime')
+
+    const ctx = createContext<string>('DEFAULT')
+    const seen: string[] = []
+    hydrate('Chip', {
+      init: () => { seen.push(useContext(ctx) as string) },
+      template: () => `<span>c</span>`,
+    })
+
+    // Two providers of the same context. B provides last, so it owns the
+    // global fallback that a detached lookup would land on.
+    function host(label: string) {
+      const h = document.createElement('div')
+      document.body.appendChild(h)
+      const ul = document.createElement('ul')
+      h.appendChild(ul)
+      const prev = setCurrentScope(h)
+      provideContext(ctx, label)
+      setCurrentScope(prev)
+      return ul
+    }
+    const ulA = host('A')
+    host('B')
+
+    const [items] = createSignal([{ id: '1' }])
+    mapArray(() => items(), ulA, (it: { id: string }) => it.id,
+      (item: () => { id: string }, _i: number, existing?: HTMLElement) => {
+        if (existing) return existing
+        const tpl = document.createElement('template')
+        tpl.innerHTML = `<li data-key="${item().id}"><div data-bf-ph="s0"></div></li>`
+        const el = mountRowRoot(tpl.content.firstElementChild!.cloneNode(true) as HTMLElement) as HTMLElement
+        upsertChild(el, 'Chip', 's0', {})
+        return el
+      }, 'l0')
+
+    // Reads 'B' — the wrong provider — if the row inits detached.
+    expect(seen).toEqual(['A'])
+  })
+
+  test('each row gets its own child, not a neighbour\'s', async () => {
+    const { hydrate, mapArray, createSignal, upsertChild, mountRowRoot } =
+      await import('../../src/runtime')
+    hydrate('Chip', { init: () => {}, template: (p: { n: string }) => `<span>${p.n}</span>` })
+
+    const ul = loopContainer()
+    const [items] = createSignal([{ id: '1' }, { id: '2' }, { id: '3' }])
+    mapArray(() => items(), ul, (it: { id: string }) => it.id,
+      (item: () => { id: string }, _i: number, existing?: HTMLElement) => {
+        if (existing) return existing
+        const tpl = document.createElement('template')
+        tpl.innerHTML = `<li data-key="${item().id}"><div data-bf-ph="s0"></div></li>`
+        const el = mountRowRoot(tpl.content.firstElementChild!.cloneNode(true) as HTMLElement) as HTMLElement
+        upsertChild(el, 'Chip', 's0', { n: item().id })
+        return el
+      }, 'l0')
+
+    // Rows are attached while later rows are still being built, so a lookup
+    // that escaped its own row would land in one of these.
+    const rows = [...ul.querySelectorAll('li')]
+    expect(rows.map((r) => r.querySelectorAll('span').length)).toEqual([1, 1, 1])
+    expect(rows.map((r) => r.querySelector('span')?.textContent)).toEqual(['1', '2', '3'])
+  })
+
+  test('a multi-root row inits connected and keeps its extras paired through a reorder', async () => {
+    const { hydrate, mapArray, createSignal, upsertChildItem, mountRowRoot } =
+      await import('../../src/runtime')
+    const connectedAtInit: boolean[] = []
+    hydrate('Chip', {
+      init: (el: Element) => { connectedAtInit.push(el.isConnected) },
+      template: () => `<span>c</span>`,
+    })
+
+    const ul = loopContainer()
+    const [items, setItems] = createSignal([{ id: '1' }, { id: '2' }])
+    mapArray(() => items(), ul, (it: { id: string }) => it.id,
+      (item: () => { id: string }, _i: number, existing?: HTMLElement) => {
+        if (existing) return existing
+        const tpl = document.createElement('template')
+        tpl.innerHTML =
+          `<li class="p${item().id}"><div data-bf-ph="s0"></div></li>` +
+          `<li class="x${item().id}">x</li>`
+        const el = tpl.content.firstElementChild!.cloneNode(true) as HTMLElement
+        const extras: HTMLElement[] = []
+        let sib = tpl.content.firstElementChild!.nextElementSibling
+        while (sib) { extras.push(sib.cloneNode(true) as HTMLElement); sib = sib.nextElementSibling }
+        ;(el as unknown as { __bfExtras: HTMLElement[] }).__bfExtras = extras
+        mountRowRoot(el)
+        upsertChildItem(el, 'Chip', 's0', {})
+        return el
+      }, 'l0')
+
+    expect(connectedAtInit).toEqual([true, true])
+
+    const shape = () => [...ul.querySelectorAll('li')].map((e) => e.className)
+    expect(shape()).toEqual(['p1', 'x1', 'p2', 'x2'])
+    setItems([{ id: '2' }, { id: '1' }])
+    // Each primary must still travel with its own extra.
+    expect(shape()).toEqual(['p2', 'x2', 'p1', 'x1'])
+  })
+
+  test('reconciled order survives front-insert, reorder, append and removal', async () => {
+    const { hydrate, mapArray, createSignal, upsertChild, mountRowRoot } =
+      await import('../../src/runtime')
+    hydrate('Chip', { init: () => {}, template: () => `<span>c</span>` })
+
+    const ul = loopContainer()
+    const [items, setItems] = createSignal([{ id: '1' }])
+    mapArray(() => items(), ul, (it: { id: string }) => it.id,
+      (item: () => { id: string }, _i: number, existing?: HTMLElement) => {
+        if (existing) return existing
+        const tpl = document.createElement('template')
+        tpl.innerHTML = `<li data-key="${item().id}"><div data-bf-ph="s0"></div></li>`
+        const el = mountRowRoot(tpl.content.firstElementChild!.cloneNode(true) as HTMLElement) as HTMLElement
+        upsertChild(el, 'Chip', 's0', {})
+        return el
+      }, 'l0')
+
+    const order = () => [...ul.querySelectorAll('li')].map((e) => e.getAttribute('data-key'))
+    expect(order()).toEqual(['1'])
+    // A fresh row belongs at the FRONT, but is mounted at the end of the range
+    // first — the reorder has to move it.
+    setItems([{ id: '9' }, { id: '1' }])
+    expect(order()).toEqual(['9', '1'])
+    setItems([{ id: '1' }, { id: '9' }, { id: '7' }])
+    expect(order()).toEqual(['1', '9', '7'])
+    setItems([{ id: '7' }])
+    expect(order()).toEqual(['7'])
+  })
+
+  test('a duplicate key collapses without leaving the discarded row attached', async () => {
+    const { hydrate, mapArray, createSignal, upsertChild, mountRowRoot } =
+      await import('../../src/runtime')
+    hydrate('Chip', { init: () => {}, template: () => `<span>c</span>` })
+
+    const ul = loopContainer()
+    const [items] = createSignal([{ id: 'dup' }, { id: 'dup' }])
+    mapArray(() => items(), ul, (it: { id: string }) => it.id,
+      (item: () => { id: string }, _i: number, existing?: HTMLElement) => {
+        if (existing) return existing
+        const tpl = document.createElement('template')
+        tpl.innerHTML = `<li data-key="${item().id}"><div data-bf-ph="s0"></div></li>`
+        const el = mountRowRoot(tpl.content.firstElementChild!.cloneNode(true) as HTMLElement) as HTMLElement
+        upsertChild(el, 'Chip', 's0', {})
+        return el
+      }, 'l0')
+
+    // Both rows mount; the second wins the key. The loser must not linger.
+    expect(ul.querySelectorAll('li').length).toBe(1)
+  })
+
+  test('a body that throws after mounting leaves no half-built row behind', async () => {
+    const { mapArray, createSignal, mountRowRoot } = await import('../../src/runtime')
+
+    const ul = loopContainer()
+    const [items] = createSignal([{ id: '1' }])
+    expect(() => {
+      mapArray(() => items(), ul, (it: { id: string }) => it.id,
+        (item: () => { id: string }, _i: number, existing?: HTMLElement) => {
+          if (existing) return existing
+          const tpl = document.createElement('template')
+          tpl.innerHTML = `<li data-key="${item().id}">boom</li>`
+          mountRowRoot(tpl.content.firstElementChild!.cloneNode(true) as HTMLElement)
+          throw new Error('tail failed')
+        }, 'l0')
+    }).toThrow('tail failed')
+
+    // A detached row could never be left on screen; a mounted one can, so the
+    // mount is undone on the way out.
+    expect(ul.querySelectorAll('li').length).toBe(0)
+  })
+
+  test('an inner loop inside the row does not strand the outer mount point', async () => {
+    const { hydrate, mapArray, createSignal, upsertChild, mountRowRoot } =
+      await import('../../src/runtime')
+    const outerConnected: boolean[] = []
+    hydrate('Chip', {
+      init: (el: Element) => { outerConnected.push(el.isConnected) },
+      template: () => `<span>c</span>`,
+    })
+
+    const ul = loopContainer()
+    const [items] = createSignal([{ id: '1' }])
+    mapArray(() => items(), ul, (it: { id: string }) => it.id,
+      (item: () => { id: string }, _i: number, existing?: HTMLElement) => {
+        if (existing) return existing
+        const tpl = document.createElement('template')
+        tpl.innerHTML = `<li data-key="${item().id}"><ul class="inner"></ul><div data-bf-ph="s0"></div></li>`
+        const el = mountRowRoot(tpl.content.firstElementChild!.cloneNode(true) as HTMLElement) as HTMLElement
+
+        // A whole inner list runs between the mount and the outer row's own
+        // child init — its teardown must not blank the outer point.
+        const inner = el.querySelector('ul.inner') as HTMLElement
+        const [innerItems] = createSignal([{ id: 'a' }, { id: 'b' }])
+        mapArray(() => innerItems(), inner, (x: { id: string }) => x.id,
+          (x: () => { id: string }, _j: number, ex?: HTMLElement) => {
+            if (ex) return ex
+            const t2 = document.createElement('template')
+            t2.innerHTML = `<li class="inner-row">${x().id}</li>`
+            return mountRowRoot(t2.content.firstElementChild!.cloneNode(true) as HTMLElement) as HTMLElement
+          }, 'l1')
+
+        upsertChild(el, 'Chip', 's0', {})
+        return el
+      }, 'l0')
+
+    expect(outerConnected).toEqual([true])
+    expect(ul.querySelectorAll('.inner-row').length).toBe(2)
+  })
+})

--- a/packages/client/__tests__/runtime/csr-loop-row-init-connected.test.ts
+++ b/packages/client/__tests__/runtime/csr-loop-row-init-connected.test.ts
@@ -1,6 +1,5 @@
 /**
- * Loop rows init CONNECTED — the `createComponent` row shape (fixed), and the
- * template-clone row shape (still open).
+ * Loop rows init CONNECTED — both row shapes.
  *
  * A loop row has no placeholder to replace, so it could not use the
  * `mountAt` "connect before init" contract that the child-slot path
@@ -19,14 +18,14 @@
  * participates in the LIS walk like any other attached scope, and the LIS
  * argument never depended on new rows being absent from it.
  *
- * STILL OPEN for rows whose root is a TEMPLATE CLONE (composite / plain
- * loops — an inline-markup or Fragment loop body). There is no
- * `createComponent` for the row root to hand a mount point to; the clone is
- * only handed to `mapArray` as `renderItem`'s return value, by which time
- * the row's nested `upsertChild` children have already initialised against a
- * detached row. Closing that requires the emitted body to hand the element
- * over BEFORE its tail runs — a compiler-side change. Pinned by the skipped
- * test at the bottom.
+ * ALSO FIXED for rows whose root is a TEMPLATE CLONE. There is no
+ * `createComponent` to hand a mount point to, and `mapArray` first sees the
+ * clone as `renderItem`'s return value — too late, the row's nested children
+ * have already initialised. So the compiler emits `mountRowRoot(clone)`, which
+ * consumes the same ambient point, for the one variant that initialises
+ * something inside the row (composite: nested components and/or inner loops).
+ * A plain row has no nested init and is left alone, which keeps the
+ * high-volume `mapArrayLazy` emission untouched.
  *
  * WHY THE TWO EARLIER ATTEMPTS FAILED (both measured by running site/ui e2e
  * locally; the counts below are deltas against whatever that same local run
@@ -55,9 +54,16 @@
  * three components in that e2e baseline (`file-upload-demo`,
  * `form-builder-demo`, `studio-canvas`) emits `qsaItem`, `upsertChildItem`,
  * or `__bfExtras` at all, because the multi-root path only applies to
- * Fragment loop bodies. Multi-root rows never take the `createComponent` row
- * path either, so `createItemScope` un-parks a row that turns out to carry
- * extras rather than leaving it half-inserted.
+ * Fragment loop bodies.
+ *
+ * That reliance DID have to be dealt with for the clone shape, since a
+ * Fragment row is a clone. Its sibling walk ended with `return`, which skipped
+ * the stash the moment the primary was attached; it is a `break` now, so the
+ * stash stays reachable either way (`item-roots-attached-primary.test.ts`).
+ * `createItemScope` still un-parks a row that turns out to carry extras — the
+ * mount has already done its job by then (the tail ran connected), and
+ * un-parking keeps the reorder from marking a row stationary before its extras
+ * and per-item marker exist.
  */
 
 import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
@@ -256,22 +262,21 @@ describe('mapArray row init runs connected', () => {
 })
 
 /**
- * KNOWN LIMITATION — a composite / plain loop row (template clone) still
- * initialises its nested children detached. See the header: the row root is
- * never handed to `mapArray` until `renderItem` returns, so there is no
- * mount point to give it, and `upsertChild` connects the child relative to a
- * still-detached row.
+ * A composite loop row — root is a template clone, not a `createComponent` —
+ * hands its element over with `mountRowRoot` before the body's tail runs, so
+ * the row's nested children also initialise connected.
  *
- * Un-skip when the emitted renderItem body hands its element over before the
- * tail runs. Currently fails as `[false, false]`.
+ * The body below mirrors what the compiler emits for this shape: clone, mount,
+ * then `upsertChild`. Drop the `mountRowRoot` call and this fails as
+ * `[false, false]`, which is what it did before the emitter added it.
  */
-describe.skip('composite loop row nested child init runs connected (known limitation)', () => {
+describe('composite loop row nested child init runs connected', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
   })
 
   test('a nested child of a template-cloned row is connected at init', async () => {
-    const { hydrate, mapArray, createSignal, upsertChild } = await import('../../src/runtime')
+    const { hydrate, mapArray, createSignal, upsertChild, mountRowRoot } = await import('../../src/runtime')
 
     const connectedAtInit: boolean[] = []
 
@@ -292,7 +297,9 @@ describe.skip('composite loop row nested child init runs connected (known limita
         if (existing) return existing
         const tpl = document.createElement('template')
         tpl.innerHTML = `<li><span data-bf-ph="Inner"></span></li>`
-        const el = tpl.content.firstElementChild!.cloneNode(true) as HTMLElement
+        const el = mountRowRoot(
+          tpl.content.firstElementChild!.cloneNode(true) as HTMLElement,
+        ) as HTMLElement
         upsertChild(el, 'Inner', null, {})
         return el
       },

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -25,8 +25,14 @@ export function setParentScopeId(id: string | null): void {
   _parentScopeId = id
 }
 
-/** Where `mapArray` wants a fresh loop row connected before its `init` runs. */
-export type RowMountPoint = { container: Node; anchor: Node | null }
+/**
+ * Where `mapArray` wants a fresh loop row connected before its `init` runs.
+ *
+ * `mounted` is written back by `mountRowRoot` so the caller can undo the
+ * connection if the rest of the row's body then throws — see `createItemScope`.
+ * Without it a half-built row stays visible, which detached rows never did.
+ */
+export type RowMountPoint = { container: Node; anchor: Node | null; mounted?: Element | null }
 
 // Ambient mount point for a loop row.
 //
@@ -58,6 +64,35 @@ function takeRowMountPoint(): RowMountPoint | null {
   const p = _rowMountPoint
   _rowMountPoint = null
   return p
+}
+
+/**
+ * Connect a loop row whose root is a template clone, before the emitted
+ * renderItem body's tail runs.
+ *
+ * The tail is where the row's nested children initialise (`upsertChild` and
+ * friends), and `useContext` resolves by walking `parentElement` — so a child
+ * that inits inside a detached row finds no ancestors and falls through to the
+ * global last-writer-wins context store, reading whichever provider on the page
+ * wrote last. `createComponent` row roots already avoid this by consuming the
+ * same ambient (step 7b); a clone root has no runtime function in the middle,
+ * so the compiler emits this call for it instead.
+ *
+ * Take-and-clear, like the `createComponent` path: a nested `createComponent`
+ * driven by this row's own children must not re-use the row's mount point.
+ *
+ * No-op when there is no ambient point — the hydration branch never calls this
+ * (its row came from SSR markup and is already in the document), and a loop
+ * runtime that does not hand one down leaves the row exactly as it was.
+ */
+export function mountRowRoot(el: Element): Element {
+  const p = takeRowMountPoint()
+  if (p) {
+    p.container.insertBefore(el, p.anchor)
+    // Record it so the row can be un-mounted if the body throws after this.
+    p.mounted = el
+  }
+  return el
 }
 
 /**

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -99,6 +99,7 @@ export { registerTemplate, getTemplate, hasTemplate, type TemplateFn } from './t
 // Component creation
 export {
   createComponent,
+  mountRowRoot,
   renderChild,
   parseHTML,
   escapeAttr,

--- a/packages/client/src/runtime/map-array.ts
+++ b/packages/client/src/runtime/map-array.ts
@@ -20,7 +20,7 @@
 
 import { createSignal, createEffect, createRoot } from '@barefootjs/client/reactive'
 import { hydratedScopes } from './hydration-state.ts'
-import { setRowMountPoint } from './component.ts'
+import { setRowMountPoint, type RowMountPoint } from './component.ts'
 import {
   BF_KEY,
   BF_LOOP_START,
@@ -234,7 +234,7 @@ function createItemScope<T>(
   existingPrimary?: HTMLElement,
   existingExtras?: HTMLElement[],
   existingStart?: Comment | null,
-  rowMount?: { container: Node; anchor: Node | null } | null,
+  rowMount?: RowMountPoint | null,
 ): ItemScope<T> {
   let primaryEl!: HTMLElement
   let dispose!: () => void
@@ -246,10 +246,11 @@ function createItemScope<T>(
     dispose = d
     const [itemAccessor, itemSetter] = createSignal(item)
     setItem = itemSetter
-    // Fresh row: hand the mount point to the row's own `createComponent` so
-    // its `init` observes a connected element. A renderItem body that clones a
-    // template instead of calling `createComponent` (composite / plain loops)
-    // leaves it unconsumed, hence the restore below rather than a plain clear.
+    // Fresh row: hand the mount point down so the row's own root — whether a
+    // `createComponent` call or a `mountRowRoot(clone)` — observes a connected
+    // element when the body's tail initialises its children. A body that does
+    // neither (a plain loop's clone) leaves the point unconsumed, hence the
+    // restore below rather than a plain clear.
     //
     // Only touch the ambient when we are the one setting it, and put back what
     // was there rather than `null`: this row's `init` can drive a nested
@@ -259,8 +260,16 @@ function createItemScope<T>(
     const prevRowMount = ownsRowMount ? setRowMountPoint(rowMount) : null
     try {
       primaryEl = renderItem(itemAccessor, index, existingPrimary)
+    } catch (err) {
+      // A row that connected itself and then failed to finish would stay
+      // visible as a half-built row. Detached rows never could, so undo the
+      // connection before rethrowing and keep the failure mode as it was.
+      const parked = rowMount?.mounted
+      if (parked?.parentNode) parked.remove()
+      throw err
     } finally {
       if (ownsRowMount) setRowMountPoint(prevRowMount)
+      if (rowMount) rowMount.mounted = null
     }
     if (existingPrimary) {
       extras = existingExtras ?? []

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
@@ -119,6 +119,10 @@ export function stringifyCompositeLoop(lines: string[], plan: CompositeLoopPlan)
     bodyIsMultiRoot,
     indent: bodyIndent,
     singleRootLayout: 'multiline',
+    // Composite is exactly the variant that initialises something inside the
+    // row — nested components, inner loops, or both — so it is exactly the
+    // variant whose tail needs the row already connected.
+    mountRow: true,
   })
   emitComponentAndEventSetup(lines, bodyIndent, '__el', compsArr, eventsArr, loopParam, loopParamBindings, bodyIsMultiRoot)
   if (innerLoops.length > 0) {

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/template-parse.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/template-parse.ts
@@ -251,9 +251,23 @@ export function emitLoopItemElementSetup(
     indent: string
     /** Single-root layout: 'inline' (plain / branch-plain) or 'multiline' (composite). */
     singleRootLayout: 'inline' | 'multiline'
+    /**
+     * Emit `mountRowRoot(__el)` on the FRESH branch, connecting the row at the
+     * mount point `mapArray` handed down before the body's tail runs.
+     *
+     * Only bodies that initialise something inside the row need it — the tail
+     * is where `useContext` would otherwise resolve against a detached element
+     * and fall through to the global last-writer-wins store. A row with no
+     * nested init has nothing to resolve, so plain loops leave this off and
+     * their emission (and the `mapArrayLazy` measurements) are untouched.
+     *
+     * Never on the hydration branch: that row came from SSR markup and is in
+     * the document already.
+     */
+    mountRow?: boolean
   },
 ): void {
-  const { template, bodyIsMultiRoot, indent, singleRootLayout } = opts
+  const { template, bodyIsMultiRoot, indent, singleRootLayout, mountRow } = opts
   const innerIndent = indent + '  '
   if (bodyIsMultiRoot) {
     lines.push(`${indent}let __el, __extras`)
@@ -264,17 +278,22 @@ export function emitLoopItemElementSetup(
       lines.push(ln)
     }
     lines.push(`${innerIndent}__el.__bfExtras = __extras`)
+    // After the stash: `mountRowRoot` attaches the primary, and an attached
+    // primary makes `itemRootElements`' sibling walk the first thing a lookup
+    // sees — it must find the stash already in place behind it.
+    if (mountRow) lines.push(`${innerIndent}mountRowRoot(__el)`)
     lines.push(`${indent}}`)
     return
   }
   if (singleRootLayout === 'inline') {
     const cloneExpr = emitTemplateCloneInline(template)
-    lines.push(`${indent}const __el = __existing ?? (() => { ${cloneExpr} })()`)
+    const clone = `__existing ?? (() => { ${cloneExpr} })()`
+    lines.push(`${indent}const __el = ${mountRow ? `__existing ?? mountRowRoot((() => { ${cloneExpr} })())` : clone}`)
     return
   }
-  lines.push(`${indent}const __el = __existing ?? (() => {`)
+  lines.push(`${indent}const __el = __existing ?? ${mountRow ? 'mountRowRoot(' : ''}(() => {`)
   for (const ln of emitTemplateCloneLines(template, innerIndent)) lines.push(ln)
-  lines.push(`${indent}})()`)
+  lines.push(`${indent}})()${mountRow ? ')' : ''}`)
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -11,6 +11,11 @@ export const RUNTIME_IMPORT_CANDIDATES = [
   'createSignal', 'createMemo', 'createEffect', 'onCleanup', 'onMount',
   'hydrate', 'insert', 'getLoopChildren', 'getLoopNodes', 'mapArray', 'mapArrayAnchored', 'mapArrayLazy', 'patchLeaf', 'createDisposableEffect',
   'createComponent', 'renderChild', 'registerComponent', 'registerTemplate', 'initChild', 'upsertChild',
+  // Connects a template-clone loop row before the body's tail runs, so a child
+  // that inits inside it resolves context against real ancestors rather than
+  // falling through to the global store. The clone-root counterpart of the
+  // mount point `createComponent` consumes for component-root rows.
+  'mountRowRoot',
   'createPortal',
   'provideContext', 'createContext', 'useContext',
   'forwardProps', 'applyRestAttrs', 'splitProps', 'spreadAttrs', 'styleToCss', 'escapeAttr', 'escapeText', 'escapeTextOrNode',


### PR DESCRIPTION
Stage 2 of two. #2440 (stage 1) has merged; this needs it.

## The defect

A loop row whose root is user markup (`items.map(it => <li><Chip/></li>)`) is a template clone written **inline in the emitted body**, so no runtime function sits between "make a row" and "the element exists" — there is nothing to hand a destination to. `mapArray` first sees the element as `renderItem`'s return value, by which time `upsertChild` has already run the row's children's `init` against a detached element.

`useContext` resolves by walking `parentElement`. A detached element has no ancestors, so the lookup falls through to the global last-writer-wins context store and returns whichever provider on the page wrote last. No error, no warning — a **plausible wrong value**. Invisible with one provider (the global holds the same value); wrong the moment there are two.

Measured, providers `A` and `B`, row in `A`'s list:

| row | child reads |
|---|---|
| detached (before) | **`B`** |
| connected first | `A` |

## The change

The compiler emits `mountRowRoot(clone)`, which consumes the same ambient mount point `createComponent` row roots already use (#2431), for the one loop variant that initialises anything inside the row — **composite** (nested components and/or inner loops).

A plain row has no nested `init`, so nothing can resolve wrongly and it is left alone. That keeps the high-volume `mapArrayLazy` emission — and its measurements — untouched. Verified per shape: plain and component-root rows emit no `mountRowRoot`; composite, two-child, Fragment and conditional-child rows do.

## Adversarial pass

Attaching a row earlier puts it in front of machinery that previously only ever saw detached rows. Four candidates, all checked, all now pinned in `composite-row-mount.test.ts`:

- **The reorder.** A fresh row mounts at the end of the range and the LIS walk moves it. Front-insert, reorder, append and removal all reconcile correctly.
- **Multi-root rows.** A Fragment row is a clone, so it takes this path. Children init connected and each primary still travels with its own extras through a reverse. (This is what stage 1 unblocked.)
- **Cross-row lookups.** Rows are attached while later rows are still being built, so an escaping lookup would land in a real neighbour. Each row gets exactly its own child.
- **Duplicate keys.** The losing row does not linger in the DOM.

**One did regress, and is fixed here.** A body that throws after mounting used to leave nothing on screen; now it could leave a half-built row. `mountRowRoot` records what it attached on the mount point and `createItemScope` undoes it before rethrowing.

Left alone deliberately: `createItemScope` still un-parks a row that turns out to carry extras. By then the mount has done its job — the tail ran connected — and un-parking keeps the reorder from marking a row stationary before its extras and per-item marker exist.

## Two things the adversarial pass surfaced that are worth stating

**There are no composite conformance fixtures — none.** That is why 1504 conformance tests passed without a single snapshot changing. I did not add one, because it would not test this: CSR conformance evaluates the `template:` lambda and compares HTML, and neither the template nor the HTML moves here. The behaviour is in the renderItem body, so the coverage is in `packages/client/__tests__/runtime/`. Worth its own issue if cross-adapter composite coverage is wanted for other reasons.

**A type error survived the whole test suite.** `createItemScope`'s `rowMount` parameter was an inline object type rather than `RowMountPoint`, so adding `mounted` did not type-check — but `bun test` runs TS without checking types, and 622 client tests passed anyway. Only `build:types` caught it. Fixed by using the shared type.

## Bundle size — the one deterministic metric that moves

The CI benchmark shows the SSR app's client JS going `8.2KB → 8.3KB` gzip. That is real, not rounding noise. Measured directly on `packages/client/dist/runtime/index.js`, this commit against its parent:

| | gzip |
|---|---|
| parent | 22,859 B |
| this change | 22,962 B |
| | **+103 B (+0.45%)** |

That is `mountRowRoot` plus its export. The DOM suite's shipped JS is **unchanged** at 27.6KB / 9.7KB — that bench app is a plain (`mapArrayLazy`) loop, never references the helper, and tree-shakes it away. So the cost lands only on bundles that actually contain a composite loop.

Every other stable metric is flat: memory 969.8KB (within the 967.7–971.3KB band seen across recent runs) and post-hydration heap 1493.6KB (identical to #2440, stdev 0.0KB). The timing columns are not usable for regression judgement here — an earlier run of a byte-identical tree moved `replace1k` from 1.00x to 1.67x.

## Verification

| Check | Result |
|---|---|
| `packages/client` | 622 pass / 0 fail (was 614 + 1 skip — the composite pin is un-skipped) |
| `packages/jsx` | 2807 pass / 0 fail |
| adapter + CSR conformance | 1504 pass / 0 fail |
| `build:types` (client) | clean |
| biome | clean |
| `site/ui` e2e, this branch | 3 failed |
| `site/ui` e2e, same branch with the change stashed and rebuilt | **the same 3** |

The 3 are the known local-environment failures (`form-builder` ×2, `studio:53`) that CI does not reproduce. A 4th (`studio:71`) appeared once and turned out to be flaky **on the baseline too** — 4/5 on baseline, 5/5 with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM