### PR TITLE
test(adapter-tests): cover a child component nested inside a composite loop row

### DIFF
--- a/.changeset/composite-row-child-divergences.md
+++ b/.changeset/composite-row-child-divergences.md
@@ -1,0 +1,35 @@
+---
+"@barefootjs/blade": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/rust": patch
+"@barefootjs/twig": patch
+"@barefootjs/xslate": patch
+---
+
+Declare the composite-loop-row nested-child render divergence
+
+A new conformance fixture (`composite-row-child-component`) covers a shape the
+corpus had no coverage for: a signal-driven `.map()` whose row root is a plain
+element and whose subtree contains a child component. Every one of these
+adapters diverges from the Hono reference on it, so each declares the
+divergence in its exported `renderDivergences`.
+
+No adapter behaviour changes — the divergences pre-date the fixture, which is
+why they had gone unrecorded. What changes is the published declaration, and
+with it the compatibility-matrix page, which now reports the gap instead of
+implying parity.
+
+Seven of the eight (blade, erb, jinja, mojolicious, rust, twig, xslate) share
+one cause: the nested child renders through the runtime's `render_child`, which
+mints its own `Badge_<random>` scope id instead of deriving the parent-scope +
+mount-slot id (`<parent>_s0`) Hono emits. Content is correct; only `bf-s`
+diverges. Tracked in
+https://github.com/piconic-ai/barefootjs/issues/2444.
+
+Go is a different, worse failure: one hoisted child-props field is built on the
+parent outside the loop with no per-row data and passed for every row, so every
+row renders the child with zero-value props. Tracked in
+https://github.com/piconic-ai/barefootjs/issues/2445.

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -19,4 +19,14 @@ export const renderDivergences: RenderDivergences = {
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
+
+  // #2444: a child component nested inside a dynamic loop row whose root
+  // is a plain element (`composite` loop plan + `nestedComponents`) is
+  // rendered through the runtime's `render_child`, which mints its own
+  // `Badge_<random>` scope id instead of deriving the parent-scope +
+  // mount-slot id (`test_s0`) the Hono reference emits. Content is
+  // correct; only `bf-s` diverges. Same class as the `grandchild-
+  // composition` CSR skip.
+  'composite-row-child-component':
+    'a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)',
 }

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -19,4 +19,14 @@ export const renderDivergences: RenderDivergences = {
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
+
+  // #2444: a child component nested inside a dynamic loop row whose root
+  // is a plain element (`composite` loop plan + `nestedComponents`) is
+  // rendered through the runtime's `render_child`, which mints its own
+  // `Badge_<random>` scope id instead of deriving the parent-scope +
+  // mount-slot id (`test_s0`) the Hono reference emits. Content is
+  // correct; only `bf-s` diverges. Same class as the `grandchild-
+  // composition` CSR skip.
+  'composite-row-child-component':
+    'a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)',
 }

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -29,4 +29,14 @@ export const renderDivergences: RenderDivergences = {
   // production). `buildDynamicChildLoopSeeding` (this package's
   // `test-render.ts`) now replicates that documented contract for a
   // signal-backed dynamic child-component loop.
+
+  // #2445: a child component nested inside a dynamic loop row whose root
+  // is a plain element gets ONE hoisted `BadgeSlot0 BadgeProps` field on
+  // the parent, built outside the loop with no per-row data, and the
+  // template passes `$.BadgeSlot0` for every row — so every row renders
+  // the child with zero-value props. The sibling shape (row root IS the
+  // child component) already emits a per-row slice; see the `todo-app-ssr`
+  // note above on `.TodoItems []TodoItemProps`.
+  'composite-row-child-component':
+    'a child component nested inside a dynamic loop row receives one hoisted props value built outside `{{range}}`, so every row renders the child with zero-value props (https://github.com/piconic-ai/barefootjs/issues/2445)',
 }

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -19,4 +19,14 @@ export const renderDivergences: RenderDivergences = {
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
+
+  // #2444: a child component nested inside a dynamic loop row whose root
+  // is a plain element (`composite` loop plan + `nestedComponents`) is
+  // rendered through the runtime's `render_child`, which mints its own
+  // `Badge_<random>` scope id instead of deriving the parent-scope +
+  // mount-slot id (`test_s0`) the Hono reference emits. Content is
+  // correct; only `bf-s` diverges. Same class as the `grandchild-
+  // composition` CSR skip.
+  'composite-row-child-component':
+    'a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)',
 }

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -19,4 +19,14 @@ export const renderDivergences: RenderDivergences = {
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
+
+  // #2444: a child component nested inside a dynamic loop row whose root
+  // is a plain element (`composite` loop plan + `nestedComponents`) is
+  // rendered through the runtime's `render_child`, which mints its own
+  // `Badge_<random>` scope id instead of deriving the parent-scope +
+  // mount-slot id (`test_s0`) the Hono reference emits. Content is
+  // correct; only `bf-s` diverges. Same class as the `grandchild-
+  // composition` CSR skip.
+  'composite-row-child-component':
+    'a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)',
 }

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -21,4 +21,14 @@ export const renderDivergences: RenderDivergences = {
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
+
+  // #2444: a child component nested inside a dynamic loop row whose root
+  // is a plain element (`composite` loop plan + `nestedComponents`) is
+  // rendered through the runtime's `render_child`, which mints its own
+  // `Badge_<random>` scope id instead of deriving the parent-scope +
+  // mount-slot id (`test_s0`) the Hono reference emits. Content is
+  // correct; only `bf-s` diverges. Same class as the `grandchild-
+  // composition` CSR skip.
+  'composite-row-child-component':
+    'a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)',
 }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1188,6 +1188,19 @@
         "text"
       ]
     },
+    "composite-row-child-component": {
+      "kinds": [
+        "call",
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "condition-position-ternary": {
       "kinds": [
         "call",
@@ -4595,13 +4608,13 @@
     "array-method": 65,
     "arrow": 63,
     "binary": 77,
-    "call": 179,
+    "call": 180,
     "conditional": 22,
-    "identifier": 265,
+    "identifier": 266,
     "index-access": 12,
     "literal": 219,
     "logical": 43,
-    "member": 144,
+    "member": 145,
     "object-literal": 51,
     "template-literal": 29,
     "unary": 22,

--- a/packages/adapter-tests/fixtures/composite-row-child-component.ts
+++ b/packages/adapter-tests/fixtures/composite-row-child-component.ts
@@ -1,0 +1,56 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Composite loop row (`useElementReconciliation` + `nestedComponents`):
+ * a signal-driven `.map()` whose row ROOT is a plain element and whose
+ * subtree contains a child component. Rows are string-template built,
+ * then each nested child is initialised via `upsertChild`.
+ *
+ * The child is declared in the SAME file on purpose — a sibling-module
+ * child used inside a loop is refused by every DSL adapter with BF103.
+ *
+ * Before this fixture the composite-plus-nested-child combination had NO
+ * coverage: of the five fixtures that select the composite plan, all five
+ * had `nestedComponents === 0`, and no client-JS snapshot contained both
+ * `mapArray` and `upsertChild`.
+ *
+ * Hono is the only adapter that matches today. The rest are declared as
+ * render divergences and skipped:
+ *   - #2444 — every DSL adapter (and the CSR template lambda) mints a
+ *     random `Badge_<id>` scope id via `render_child` instead of deriving
+ *     `<parent>_s0`. Content is correct; only `bf-s` diverges.
+ *   - #2445 — Go hoists ONE `BadgeSlot0` props value outside `{{range}}`
+ *     with no per-row data, so every row renders an empty badge.
+ */
+export const fixture = createFixture({
+  id: 'composite-row-child-component',
+  description: 'Dynamic loop row root is an element containing a child component',
+  componentName: 'CompositeRowChildComponent',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number; label: string }
+function Badge(props: { text: string }) {
+  return <span class="badge">{props.text}</span>
+}
+export function CompositeRowChildComponent(props: { items: Item[] }) {
+  const [rows, setRows] = createSignal<Item[]>(props.items)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={row.label} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  props: { items: [{ id: 1, label: 'one' }, { id: 2, label: 'two' }] },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li data-key="1"><span bf-s="test_s0" bf="s1" class="badge"><!--bf:s0-->one<!--/--></span></li>
+      <li data-key="2"><span bf-s="test_s0" bf="s1" class="badge"><!--bf:s0-->two<!--/--></span></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -386,6 +386,7 @@ import { fixture as siblingLoopsKeyIsolation } from './sibling-loops-key-isolati
 import { fixture as conditionalReturnNull } from './conditional-return-null'
 import { fixture as jsxElementProp } from './jsx-element-prop'
 import { fixture as grandchildComposition } from './grandchild-composition'
+import { fixture as compositeRowChildComponent } from './composite-row-child-component'
 import { fixture as childPrimitiveProps } from './child-primitive-props'
 import { fixture as preWhitespace } from './pre-whitespace'
 import { fixture as tableDynamicRows } from './table-dynamic-rows'
@@ -716,6 +717,7 @@ export const jsxFixtures: JSXFixture[] = [
   conditionalReturnNull,
   jsxElementProp,
   grandchildComposition,
+  compositeRowChildComponent,
   childPrimitiveProps,
   preWhitespace,
   tableDynamicRows,

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -360,6 +360,14 @@
       }
     }
   ],
+  "composite-row-child-component": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
   "conditional-return-button": [
     {
       "name": "gen:variant:empty",

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -239,6 +239,12 @@ describe('CSR Conformance Tests', () => {
     //     parent's scope id (`test_s0`) in CSR instead of deriving
     //     `test_s0_s0` as SSR does.
     'grandchild-composition',
+    //   - `composite-row-child-component`: a child component nested inside
+    //     a dynamic loop row (row root is a plain element) gets a fresh
+    //     random `Badge_<id>` scope id in CSR instead of the parent-derived
+    //     `test_s0` SSR emits. Same class as `grandchild-composition`
+    //     above; tracked with the SSR-side half in #2444.
+    'composite-row-child-component',
     //   - `nested-fragments`: a multi-root fragment attaches `bf-s` to its
     //     first element in CSR, while SSR carries the scope on a
     //     `<!--bf-scope:...-->` comment the normalizer strips.

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -19,4 +19,14 @@ export const renderDivergences: RenderDivergences = {
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
+
+  // #2444: a child component nested inside a dynamic loop row whose root
+  // is a plain element (`composite` loop plan + `nestedComponents`) is
+  // rendered through the runtime's `render_child`, which mints its own
+  // `Badge_<random>` scope id instead of deriving the parent-scope +
+  // mount-slot id (`test_s0`) the Hono reference emits. Content is
+  // correct; only `bf-s` diverges. Same class as the `grandchild-
+  // composition` CSR skip.
+  'composite-row-child-component':
+    'a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)',
 }

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -19,4 +19,14 @@ export const renderDivergences: RenderDivergences = {
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
+
+  // #2444: a child component nested inside a dynamic loop row whose root
+  // is a plain element (`composite` loop plan + `nestedComponents`) is
+  // rendered through the runtime's `render_child`, which mints its own
+  // `Badge_<random>` scope id instead of deriving the parent-scope +
+  // mount-slot id (`test_s0`) the Hono reference emits. Content is
+  // correct; only `bf-s` diverges. Same class as the `grandchild-
+  // composition` CSR skip.
+  'composite-row-child-component':
+    'a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)',
 }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,8 +1814,42 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 284,
+    "totalFixtures": 285,
     "fixtures": {
+      "composite-row-child-component": {
+        "blade": {
+          "kind": "render",
+          "reason": "a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "a child component nested inside a dynamic loop row receives one hoisted props value built outside `{{range}}`, so every row renders the child with zero-value props (https://github.com/piconic-ai/barefootjs/issues/2445)"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)"
+        }
+      },
       "date-method-uncatalogued": {
         "blade": {
           "kind": "refusal",
@@ -2829,6 +2863,10 @@
       }
     },
     "docs": {
+      "composite-row-child-component": {
+        "description": "Dynamic loop row root is an element containing a child component",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/composite-row-child-component.ts"
+      },
       "date-method-uncatalogued": {
         "description": "Method call on a Date-typed prop refuses with BF021 (no catalogued lowering)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/date-method-uncatalogued.ts"

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 179,
+      "total": 180,
       "cells": {
         "hono": {
-          "pass": 178,
-          "total": 179,
+          "pass": 179,
+          "total": 180,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1434,8 +1434,12 @@
         },
         "blade": {
           "pass": 164,
-          "total": 179,
+          "total": 180,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1510,8 +1514,12 @@
         },
         "erb": {
           "pass": 165,
-          "total": 179,
+          "total": 180,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1580,8 +1588,12 @@
         },
         "go-template": {
           "pass": 164,
-          "total": 179,
+          "total": 180,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1656,8 +1668,12 @@
         },
         "jinja": {
           "pass": 164,
-          "total": 179,
+          "total": 180,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1732,8 +1748,12 @@
         },
         "minijinja": {
           "pass": 164,
-          "total": 179,
+          "total": 180,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1808,8 +1828,12 @@
         },
         "mojolicious": {
           "pass": 165,
-          "total": 179,
+          "total": 180,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1878,8 +1902,12 @@
         },
         "twig": {
           "pass": 164,
-          "total": 179,
+          "total": 180,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1954,8 +1982,12 @@
         },
         "xslate": {
           "pass": 164,
-          "total": 179,
+          "total": 180,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2174,11 +2206,11 @@
       }
     },
     "identifier": {
-      "total": 265,
+      "total": 266,
       "cells": {
         "hono": {
-          "pass": 264,
-          "total": 265,
+          "pass": 265,
+          "total": 266,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2190,8 +2222,12 @@
         },
         "blade": {
           "pass": 247,
-          "total": 265,
+          "total": 266,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2278,8 +2314,12 @@
         },
         "erb": {
           "pass": 248,
-          "total": 265,
+          "total": 266,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2360,8 +2400,12 @@
         },
         "go-template": {
           "pass": 247,
-          "total": 265,
+          "total": 266,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2448,8 +2492,12 @@
         },
         "jinja": {
           "pass": 247,
-          "total": 265,
+          "total": 266,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2536,8 +2584,12 @@
         },
         "minijinja": {
           "pass": 247,
-          "total": 265,
+          "total": 266,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2624,8 +2676,12 @@
         },
         "mojolicious": {
           "pass": 248,
-          "total": 265,
+          "total": 266,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2706,8 +2762,12 @@
         },
         "twig": {
           "pass": 247,
-          "total": 265,
+          "total": 266,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2794,8 +2854,12 @@
         },
         "xslate": {
           "pass": 247,
-          "total": 265,
+          "total": 266,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3530,11 +3594,11 @@
       }
     },
     "member": {
-      "total": 144,
+      "total": 145,
       "cells": {
         "hono": {
-          "pass": 143,
-          "total": 144,
+          "pass": 144,
+          "total": 145,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3546,8 +3610,12 @@
         },
         "blade": {
           "pass": 126,
-          "total": 144,
+          "total": 145,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3634,8 +3702,12 @@
         },
         "erb": {
           "pass": 127,
-          "total": 144,
+          "total": 145,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3716,8 +3788,12 @@
         },
         "go-template": {
           "pass": 126,
-          "total": 144,
+          "total": 145,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3804,8 +3880,12 @@
         },
         "jinja": {
           "pass": 126,
-          "total": 144,
+          "total": 145,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3892,8 +3972,12 @@
         },
         "minijinja": {
           "pass": 126,
-          "total": 144,
+          "total": 145,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3980,8 +4064,12 @@
         },
         "mojolicious": {
           "pass": 127,
-          "total": 144,
+          "total": 145,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4062,8 +4150,12 @@
         },
         "twig": {
           "pass": 126,
-          "total": 144,
+          "total": 145,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4150,8 +4242,12 @@
         },
         "xslate": {
           "pass": 126,
-          "total": 144,
+          "total": 145,
           "gaps": [
+            {
+              "fixture": "composite-row-child-component",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [


### PR DESCRIPTION
## The gap

The composite loop plan — row root is a plain element, `useElementReconciliation` — combined with a **nested child component** had no conformance fixture.

Measured over the 284-fixture corpus: five fixtures select the composite plan, and all five have `nestedComponents === 0` (inner loops only). No client-JS snapshot in the corpus contains both `mapArray` and `upsertChild`. So the path that initialises a child component inside a string-template-built row was never exercised, and a change to it could not move any snapshot.

## The fixture

[`composite-row-child-component`](``https://github.com/piconic-ai/barefootjs/blob/claude/tagged-todo-ssr-hydration-dhvwi8-composite-fixture/packages/adapter-tests/fixtures/composite-row-child-component.ts)`` — a signal-driven `.map()` over `rows()`. Each row is an `li` element carrying `key={row.id}`, whose only child is the `Badge` component receiving `text={row.label}`. So the row root is plain markup and the child component sits inside it.

The child is declared in the **same file** deliberately: a sibling-module child used inside a loop is refused by every DSL adapter with `BF103`, so an imported child would test the refusal instead of the shape.

## What it exposes (declared, not fixed)

Hono is the only adapter that matches. Two pre-existing divergences surface, filed as known limitations. (Angle brackets below are written as guillemets — GitHub's sanitizer strips them from PR bodies.)

| Adapters | Divergence | Issue |
|---|---|---|
| blade, erb, jinja, mojolicious, minijinja, twig, xslate + CSR | the nested child renders through the runtime's `render_child`, which mints its own `Badge_«random»` scope id instead of deriving the parent-scope + mount-slot id (`«parent»_s0`) Hono emits. Content is correct; only `bf-s` diverges. Same class as the existing `grandchild-composition` CSR skip. | #2444 |
| go-template | one hoisted `BadgeSlot0 BadgeProps` field on the parent, built outside the loop with no per-row data, passed as `$.BadgeSlot0` for every row — so every row renders an empty badge. Wrong content, not just a divergent id. The sibling shape (row root *is* the child component) already emits a per-row slice, per the `todo-app-ssr` note in that package. | #2445 |

Each is declared in the adapter's `render-divergences.ts`, which drives that package's `skipJsx` and publishes to `ui/compat.lock.json` + the docs compatibility-matrix page. The reason strings carry the full tracking-issue URL, so the `compat-issue-freshness` job covers them. CSR is skipped in `csr-conformance.test.ts`. Graduating means deleting those entries.

## Verification

- Confirmed against real runtimes: **erb**, **jinja**, **mojolicious**, **minijinja**, and **CSR** — every one rendered `bf-s="Badge_*"` where `test_s0` was expected.
- **blade**, **twig**, **xslate**, **go-template**: read off the emitted templates, since those runtimes are absent from the environment this was written in (local Go is `1.24.7` against a harness needing 1.25 or newer). Their conformance runs skip via `onRenderError` there rather than fail, so the divergence entries are what keeps CI honest once the runtimes are present.
- The `renderDivergences` consistency gate (`packages/compat/src/__tests__/render-divergences.test.ts`) passes for all 8, which independently confirms each entry names a real fixture, doesn't overlap that adapter's pins, and compiles clean.

Regenerated artifacts: `coverage-map.json`, `generated-data-points.json` (the fixture gains one `gen:items:empty` point), `ui/compat.lock.json`, `ui/support-matrix.lock.json`.

## Tests

All green locally: 9 adapter suites (hono 1272, erb 1167, jinja 1195, mojolicious 1365, minijinja 1194, go-template 1456, blade 1195, twig 1203, xslate 1196), `packages/adapter-tests` (1460), `packages/compat` (199).

A changeset (patch, 8 adapter packages) covers the change to the exported `renderDivergences` value. No adapter behaviour moves; what changes is the published declaration, and with it the compatibility-matrix page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM