### PR TITLE
Go: fix per-row props for a child component nested inside a composite loop row (#2445)

### DIFF
--- a/.changeset/composite-row-child-per-row-props.md
+++ b/.changeset/composite-row-child-per-row-props.md
@@ -15,9 +15,19 @@ Fixed by reapplying a loop-dependent prop per row, at template-execution
 time, via a new `bf_with_props` runtime helper — the props-argument sibling
 of the existing `bf_with_children` helper, which already does this for
 per-row JSX children on the same shared instance. A prop that doesn't depend
-on the row is unaffected and stays on the constructor-only path.
+on the row is unaffected and stays on the constructor-only path. A per-row
+prop shaped as a ternary or single interpolation (`row.on ? "yes" : "no"`)
+is also supported; a prop that routes into the child's rest bag, or whose
+expression is otherwise unsupported, safely stays on the constructor-only
+path instead of emitting a broken pipeline argument.
 
 The `composite-row-child-component` conformance fixture's render divergence
 for this adapter is graduated (deleted from `render-divergences.ts`); the
 sibling scope-id divergence tracked in #2444 (every other template-string
 adapter) is unrelated and untouched.
+
+Known follow-up (#2448): `bf_with_props` overrides the child's
+already-constructed Props instance, so a field the child DERIVES from the
+overridden prop (a memo, or a prop-shadowing signal's initial value) still
+reflects the one-shot constructor's value, not the per-row one — only the
+directly-overridden field itself is correct per row.

--- a/.changeset/composite-row-child-per-row-props.md
+++ b/.changeset/composite-row-child-per-row-props.md
@@ -1,0 +1,23 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix per-row props for a child component nested inside a composite dynamic loop row (#2445)
+
+A child component nested inside a signal-driven `.map()` row whose root is a
+plain element (`<li><Badge text={row.label}/></li>`) got ONE hoisted
+`<Name>SlotN` props value, built once outside `{{range}}` — every row shared
+the same instance, so a prop that read the row (`text={row.label}`) rendered
+the same (always zero-value) content on every row instead of that row's own
+value.
+
+Fixed by reapplying a loop-dependent prop per row, at template-execution
+time, via a new `bf_with_props` runtime helper — the props-argument sibling
+of the existing `bf_with_children` helper, which already does this for
+per-row JSX children on the same shared instance. A prop that doesn't depend
+on the row is unaffected and stays on the constructor-only path.
+
+The `composite-row-child-component` conformance fixture's render divergence
+for this adapter is graduated (deleted from `render-divergences.ts`); the
+sibling scope-id divergence tracked in #2444 (every other template-string
+adapter) is unrelated and untouched.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -2746,6 +2746,13 @@ func WithChildren(props interface{}, children template.HTML) (interface{}, error
 // that pair — the prop routes elsewhere (e.g. a rest bag) and the base
 // instance's constructor-built value stands, mirroring WithChildren's
 // "props type without a Children field" passthrough.
+//
+// KNOWN LIMITATION (#2448): this overrides fields on the ALREADY-CONSTRUCTED
+// instance — it does not re-run New<Child>Props. A field the child derives
+// FROM the overridden prop at construction time (a memo, or a prop-shadowing
+// signal's initial value) keeps whatever the one-shot constructor computed
+// and does not update per row; only the directly-overridden field is
+// correct per row. Tracked as a follow-up, not fixed by #2445.
 func WithProps(props interface{}, kv ...interface{}) (interface{}, error) {
 	if len(kv)%2 != 0 {
 		return nil, fmt.Errorf("bf_with_props: odd number of key/value arguments (%d)", len(kv))

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -176,6 +176,13 @@ func FuncMap() template.FuncMap {
 		// injects the result into the child's Children field.
 		"bf_with_children": WithChildren,
 
+		// Per-row props for a child component nested inside a composite
+		// loop row (#2445): the parent's once-per-slot instance is shared
+		// across rows, so a prop that depends on the row is reapplied as a
+		// copy inside {{range}}, the props-argument sibling of
+		// bf_with_children.
+		"bf_with_props": WithProps,
+
 		// Scope comment for fragment roots
 		"bfScopeComment":    ScopeComment,
 		"bfScopeCommentEnd": ScopeCommentEnd,
@@ -2724,6 +2731,80 @@ func WithChildren(props interface{}, children template.HTML) (interface{}, error
 		return props, fmt.Errorf("bf_with_children: unsupported Children field type %s", target.Type())
 	}
 	return copyPtr.Elem().Interface(), nil
+}
+
+// WithProps returns a shallow copy of a component Props struct with the
+// given fields overridden (#2445): a child component nested inside a
+// COMPOSITE loop row (row root is a plain element, not the child itself) is
+// constructed ONCE outside `{{range}}` — every row shares that instance for
+// scope/parent/mount identity — so a prop that depends on the row
+// (`text={row.label}`) has to be applied per row, at template-execution
+// time, the same way WithChildren applies per-row JSX children to that
+// shared instance. `kv` is a flat name/value list ("Text", .Label, "Count",
+// .N, ...). The props value stays by-value semantics: the caller's original
+// is untouched. A name with no matching settable field is left alone for
+// that pair — the prop routes elsewhere (e.g. a rest bag) and the base
+// instance's constructor-built value stands, mirroring WithChildren's
+// "props type without a Children field" passthrough.
+func WithProps(props interface{}, kv ...interface{}) (interface{}, error) {
+	if len(kv)%2 != 0 {
+		return nil, fmt.Errorf("bf_with_props: odd number of key/value arguments (%d)", len(kv))
+	}
+	v := reflect.ValueOf(props)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return props, nil
+	}
+	copyPtr := reflect.New(v.Type())
+	copyPtr.Elem().Set(v)
+	for i := 0; i < len(kv); i += 2 {
+		name, ok := kv[i].(string)
+		if !ok {
+			return nil, fmt.Errorf("bf_with_props: field name at position %d must be a string, got %T", i, kv[i])
+		}
+		target := copyPtr.Elem().FieldByName(name)
+		if !target.IsValid() || !target.CanSet() {
+			continue
+		}
+		if err := setStructFieldValue(target, kv[i+1]); err != nil {
+			return nil, fmt.Errorf("bf_with_props: field %s: %w", name, err)
+		}
+	}
+	return copyPtr.Elem().Interface(), nil
+}
+
+// setStructFieldValue assigns val into target, a settable struct field
+// obtained via reflect.Value.FieldByName. Mirrors WithChildren's
+// Interface/String branches (a String-kind target covers both `string` and
+// `template.HTML` fields, via String() rather than reflect.Convert — Go's
+// int-to-string conversion produces a rune, not a decimal string) and adds
+// the general assignable/convertible fallback for other field kinds
+// (numeric widening, etc.).
+func setStructFieldValue(target reflect.Value, val interface{}) error {
+	if val == nil {
+		target.Set(reflect.Zero(target.Type()))
+		return nil
+	}
+	switch {
+	case target.Kind() == reflect.Interface:
+		target.Set(reflect.ValueOf(val))
+		return nil
+	case target.Kind() == reflect.String:
+		target.SetString(String(val))
+		return nil
+	}
+	rv := reflect.ValueOf(val)
+	switch {
+	case rv.Type().AssignableTo(target.Type()):
+		target.Set(rv)
+	case rv.Type().ConvertibleTo(target.Type()):
+		target.Set(rv.Convert(target.Type()))
+	default:
+		return fmt.Errorf("cannot assign %T to %s", val, target.Type())
+	}
+	return nil
 }
 
 // PortalHTML parses and executes a template string with the provided data.

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -2230,3 +2230,118 @@ func TestFormatDateUnresolvableTZ(t *testing.T) {
 		t.Errorf("FormatDate(Asia/Tokyo) = (%q, %v), want (\"2024-01-02\", nil)", s, err)
 	}
 }
+
+// #2445: bf_with_props is the props-argument sibling of bf_with_children —
+// a child component nested inside a composite loop row shares ONE
+// constructor-built Props instance across rows, so a prop that depends on
+// the row is reapplied per row via this helper inside {{range}}.
+func TestWithProps(t *testing.T) {
+	type BadgeProps struct {
+		ScopeID string
+		Text    string
+		Count   int
+		Note    interface{}
+	}
+
+	t.Run("overrides a string field and leaves the original untouched", func(t *testing.T) {
+		original := BadgeProps{ScopeID: "test_s0", Text: "one"}
+		got, err := WithProps(original, "Text", "two")
+		if err != nil {
+			t.Fatalf("WithProps returned error: %v", err)
+		}
+		copy, ok := got.(BadgeProps)
+		if !ok {
+			t.Fatalf("WithProps returned %T, want BadgeProps", got)
+		}
+		if copy.Text != "two" {
+			t.Errorf("copy.Text = %q, want %q", copy.Text, "two")
+		}
+		if copy.ScopeID != "test_s0" {
+			t.Errorf("copy.ScopeID = %q, want unchanged %q", copy.ScopeID, "test_s0")
+		}
+		if original.Text != "one" {
+			t.Errorf("original.Text = %q, want unchanged %q (by-value semantics)", original.Text, "one")
+		}
+	})
+
+	t.Run("overrides multiple fields, including a numeric one", func(t *testing.T) {
+		got, err := WithProps(BadgeProps{}, "Text", "hi", "Count", 5)
+		if err != nil {
+			t.Fatalf("WithProps returned error: %v", err)
+		}
+		copy := got.(BadgeProps)
+		if copy.Text != "hi" || copy.Count != 5 {
+			t.Errorf("WithProps(Text, Count) = %+v, want Text=hi Count=5", copy)
+		}
+	})
+
+	t.Run("sets an interface-typed field", func(t *testing.T) {
+		got, err := WithProps(BadgeProps{}, "Note", 42)
+		if err != nil {
+			t.Fatalf("WithProps returned error: %v", err)
+		}
+		copy := got.(BadgeProps)
+		if copy.Note != 42 {
+			t.Errorf("copy.Note = %v, want 42", copy.Note)
+		}
+	})
+
+	t.Run("nil value zeroes the field", func(t *testing.T) {
+		got, err := WithProps(BadgeProps{Note: "was set"}, "Note", nil)
+		if err != nil {
+			t.Fatalf("WithProps returned error: %v", err)
+		}
+		copy := got.(BadgeProps)
+		if copy.Note != nil {
+			t.Errorf("copy.Note = %v, want nil", copy.Note)
+		}
+	})
+
+	t.Run("unknown field name passes through unchanged for that pair", func(t *testing.T) {
+		original := BadgeProps{Text: "kept"}
+		got, err := WithProps(original, "NoSuchField", "ignored")
+		if err != nil {
+			t.Fatalf("WithProps returned error: %v", err)
+		}
+		copy := got.(BadgeProps)
+		if copy.Text != "kept" {
+			t.Errorf("copy.Text = %q, want unchanged %q", copy.Text, "kept")
+		}
+	})
+
+	t.Run("odd key/value arity errors", func(t *testing.T) {
+		if _, err := WithProps(BadgeProps{}, "Text"); err == nil {
+			t.Error("WithProps with odd kv count: want error, got nil")
+		}
+	})
+
+	t.Run("non-string field name errors", func(t *testing.T) {
+		if _, err := WithProps(BadgeProps{}, 1, "x"); err == nil {
+			t.Error("WithProps with non-string field name: want error, got nil")
+		}
+	})
+
+	t.Run("non-struct props pass through unchanged", func(t *testing.T) {
+		got, err := WithProps("not a struct", "Text", "x")
+		if err != nil {
+			t.Fatalf("WithProps returned error: %v", err)
+		}
+		if got != "not a struct" {
+			t.Errorf("WithProps(non-struct) = %v, want passthrough", got)
+		}
+	})
+
+	t.Run("string-kind target covers template.HTML too", func(t *testing.T) {
+		type HTMLProps struct {
+			Body template.HTML
+		}
+		got, err := WithProps(HTMLProps{}, "Body", "<b>hi</b>")
+		if err != nil {
+			t.Fatalf("WithProps returned error: %v", err)
+		}
+		copy := got.(HTMLProps)
+		if copy.Body != template.HTML("<b>hi</b>") {
+			t.Errorf("copy.Body = %q, want %q", copy.Body, "<b>hi</b>")
+		}
+	})
+}

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4166,6 +4166,160 @@ export function TodoList(props: { todos?: Todo[] }) {
   })
 })
 
+// #2445: a child component nested inside a composite loop row (row root is a
+// plain element, #2130's shape) gets ONE hoisted `.{Name}SlotN` props value
+// built outside `{{range}}` (see the describe block above) — correct for a
+// prop that doesn't depend on the row, but stale for one that does
+// (`text={row.label}` read the same value on every row, always the zero
+// value, since the constructor has no per-row data to give it). Fixed by
+// reapplying the row-dependent prop per row, at template-execution time,
+// via `bf_with_props` — the props-argument sibling of `bf_with_children`.
+describe('GoTemplateAdapter - #2445 composite loop row: per-row child prop', () => {
+  // These compile through `compileJSX` directly (not the `compileToIR` +
+  // `adapter.generate(ir)` two-step other tests in this file use) because
+  // the fixture's child (`Badge`) is a SAME-FILE sibling of the parent
+  // (a sibling-MODULE child inside a loop is refused by BF103) — the debug
+  // `ir.json` `compileToIR` reads back only carries one component's IR, and
+  // `IRProp.freeIdentifiers` (a `Set`) doesn't survive that JSON round trip
+  // anyway. `compileJSX`'s own `types`/`markedTemplate` outputs already
+  // combine both components' generated code in one pass, matching how the
+  // real pipeline (and the `composite-row-child-component` fixture) compiles
+  // this shape.
+  test('a prop reading the row is reapplied per row via bf_with_props', () => {
+    const result = compileJSX(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number; label: string }
+function Badge(props: { text: string }) {
+  return <span class="badge">{props.text}</span>
+}
+export function CompositeRowChildComponent(props: { items: Item[] }) {
+  const [rows] = createSignal<Item[]>(props.items)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={row.label} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    const types = result.files.find(f => f.type === 'types')!.content
+    const template = result.files.find(f => f.type === 'markedTemplate')!.content
+
+    // Range still iterates the real collection — this is the #2130 shape,
+    // not the wrapper-slice one — and the shared base instance is still
+    // built once, carrying the (correct) constructor-derived scope id.
+    expect(template).toContain(':= .Rows}}')
+    expect(types).toContain('BadgeSlot0 BadgeProps')
+    expect(types).toContain('BadgeSlot0: NewBadgeProps(BadgeInput{')
+
+    // The row-dependent prop is reapplied per row, inside `{{range}}`.
+    expect(template).toContain('{{template "Badge" (bf_with_props $.BadgeSlot0 "Text" .Label)}}')
+  })
+
+  // Negative pin — the whole point of the loop-dependence gate: a prop that
+  // does NOT read the row is left on the constructor-only path, so this
+  // fix doesn't touch (and can't regress) the corpus of composite-loop
+  // fixtures whose nested-child props are static/prop-derived.
+  test('a prop NOT reading the row stays on the constructor-only path', () => {
+    const result = compileJSX(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number; label: string }
+function Badge(props: { text: string }) {
+  return <span class="badge">{props.text}</span>
+}
+export function CompositeRowChildComponent(props: { items: Item[]; title: string }) {
+  const [rows] = createSignal<Item[]>(props.items)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={props.title} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    const template = result.files.find(f => f.type === 'markedTemplate')!.content
+    expect(template).toContain('{{template "Badge" $.BadgeSlot0}}')
+    expect(template).not.toContain('bf_with_props')
+  })
+
+  // Composition pin: a nested child with both a per-row prop AND JSX
+  // children nests `bf_with_props` inside `bf_with_children` — the shared
+  // base instance is overridden with the row's prop value first, then that
+  // result has its per-row children injected.
+  test('a per-row prop composes with per-row JSX children', () => {
+    const result = compileJSX(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number; label: string; hint: string }
+function Badge(props: { title: string; children?: any }) {
+  return <span class="badge" title={props.title}>{props.children}</span>
+}
+export function CompositeRowChildComponent(props: { items: Item[] }) {
+  const [rows] = createSignal<Item[]>(props.items)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge title={row.hint}>{row.label}</Badge>
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    const template = result.files.find(f => f.type === 'markedTemplate')!.content
+    expect(template).toContain(
+      '(bf_with_children (bf_with_props $.BadgeSlot1 "Title" .Hint) (bf_tmpl "',
+    )
+  })
+
+  // End-to-end on real Go: each row's Badge must render that row's OWN
+  // label, not the same (previously always-empty) value for every row.
+  test('each row renders its own label on real Go', async () => {
+    let html: string
+    try {
+      html = await renderGoTemplateComponent({
+        source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number; label: string }
+function Badge(props: { text: string }) {
+  return <span class="badge">{props.text}</span>
+}
+export function CompositeRowChildComponent(props: { items: Item[] }) {
+  const [rows] = createSignal<Item[]>(props.items)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={row.label} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart(),
+        adapter: new GoTemplateAdapter(),
+        props: { items: [{ id: 1, label: 'one' }, { id: 2, label: 'two' }] },
+      })
+    } catch (err) {
+      if (err instanceof GoNotAvailableError) return
+      throw err
+    }
+    expect(html).toContain('>one<')
+    expect(html).toContain('>two<')
+    expect(html).toContain('class="badge"')
+  })
+})
+
 // #2228: a `.filter(t => …).map(todo => <Child todo={todo} .../>)` loop whose
 // body is a single child component ranges the WRAPPER slice (`.TodoItems`,
 // `.{ChildName}s` — see #2130 above), so `{{if}}`'s dot context for the

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4318,6 +4318,167 @@ export function CompositeRowChildComponent(props: { items: Item[] }) {
     expect(html).toContain('>two<')
     expect(html).toContain('class="badge"')
   })
+
+  // A per-row prop shaped as a ternary (`row.on ? "yes" : "no"`) parses to a
+  // ParsedExpr `template-literal` whose sole part is the ternary — the
+  // shared `templateLiteral()` emitter wraps that single dynamic part's
+  // already-bare `(bf_ternary ...)` pipeline value in a `{{...}}` shell for
+  // TEXT-position embedding (#2335). `loopRowChildPropOverrides` needs the
+  // BARE value (a function-argument position, not text), so it must unwrap
+  // this specific single-part shape rather than refuse it as a fragment.
+  test('a ternary per-row prop unwraps to a bare bf_ternary pipeline argument', () => {
+    const result = compileJSX(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number; on: boolean }
+function Badge(props: { text: string }) {
+  return <span class="badge">{props.text}</span>
+}
+export function CompositeRowChildComponent(props: { items: Item[] }) {
+  const [rows] = createSignal<Item[]>(props.items)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={row.on ? "yes" : "no"} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    expect(result.errors ?? []).toEqual([])
+    const template = result.files.find(f => f.type === 'markedTemplate')!.content
+    expect(template).toContain(
+      '{{template "Badge" (bf_with_props $.BadgeSlot0 "Text" (bf_ternary (bf_truthy .On) "yes" "no"))}}',
+    )
+  })
+
+  // A multi-part template literal (mixed literal text and interpolation,
+  // `` `#${row.id} ${row.label}` ``) has no single-pipeline-value reduction
+  // the way a single-part ternary does — refuse it loudly (BF101) instead
+  // of silently emitting the stale constructor-only value (the #2445 bug
+  // this whole fix exists to close).
+  test('a multi-part template-literal per-row prop is refused with BF101, not silently stale', () => {
+    const result = compileJSX(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number; label: string }
+function Badge(props: { text: string }) {
+  return <span class="badge">{props.text}</span>
+}
+export function CompositeRowChildComponent(props: { items: Item[] }) {
+  const [rows] = createSignal<Item[]>(props.items)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={\`#\${row.id} \${row.label}\`} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    expect((result.errors ?? []).some(e => e.code === 'BF101')).toBe(true)
+    const template = result.files.find(f => f.type === 'markedTemplate')!.content
+    expect(template).not.toContain('bf_with_props')
+  })
+
+  // A prop whose expression `convertExpressionToGo` itself refuses (an
+  // inline object literal isn't a supported value shape) must not ALSO
+  // clobber the child with a bad `bf_with_props` pipeline argument built
+  // from the `""` error sentinel — that would either silently blank a
+  // string field or fail at template EXECUTE time for a non-string one.
+  // The existing BF101 from the unsupported expression is enough; the prop
+  // simply stays on the (already-existing, unchanged) constructor path.
+  test('an unsupported per-row prop expression does not also emit a bad pipeline argument', () => {
+    const result = compileJSX(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number; label: string }
+function Badge(props: { opts: any }) {
+  return <span class="badge">{JSON.stringify(props.opts)}</span>
+}
+export function CompositeRowChildComponent(props: { items: Item[] }) {
+  const [rows] = createSignal<Item[]>(props.items)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge opts={{ align: row.label }} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(1)
+    const template = result.files.find(f => f.type === 'markedTemplate')!.content
+    expect(template).toContain('{{template "Badge" $.BadgeSlot0}}')
+    expect(template).not.toContain('bf_with_props')
+  })
+
+  // A prop that routes into the child's rest bag (not a declared param) has
+  // no named Go field for `bf_with_props` to override — it must stay on the
+  // constructor path rather than emit a pipeline argument that can only
+  // ever no-op at the runtime helper's unknown-field passthrough. Requires
+  // `registerChildComponentShape` (normally the CLI's cross-file pre-pass,
+  // #2131) so the adapter actually knows `Badge`'s rest-bag shape.
+  test('a rest-bag-routed per-row prop stays on the constructor path', () => {
+    // Mirrors the `registerChildComponentShape` pattern the `#2087` test
+    // above uses: a bare `compileJSX` never calls that hook (only the CLI's
+    // cross-file pre-pass, #2131, does), so this builds each component's IR
+    // directly and registers `Badge`'s rest-bag shape before generating the
+    // parent — the real order `renderGoTemplateComponent` / `bf build` use.
+    const source = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number; label: string }
+function Badge({ text, ...rest }: { text: string; [key: string]: unknown }) {
+  return <span class="badge" {...rest}>{text}</span>
+}
+export function CompositeRowChildComponent(props: { items: Item[] }) {
+  const [rows] = createSignal<Item[]>(props.items)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text="static" tone={row.label} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart()
+
+    const badgeCtx = analyzeComponent(source, 'test.tsx', 'Badge')
+    const badgeIR: ComponentIR = {
+      version: '0.1',
+      metadata: buildMetadata(badgeCtx),
+      root: jsxToIR(badgeCtx)!,
+      errors: [],
+    }
+    const rootCtx = analyzeComponent(source, 'test.tsx', 'CompositeRowChildComponent')
+    const rootIR: ComponentIR = {
+      version: '0.1',
+      metadata: buildMetadata(rootCtx),
+      root: jsxToIR(rootCtx)!,
+      errors: [],
+    }
+
+    const adapter = new GoTemplateAdapter()
+    adapter.registerChildComponentShape(badgeIR)
+    adapter.generateTypes(badgeIR)
+    adapter.generateTypes(rootIR)
+    const template = adapter.generate(rootIR, { skipScriptRegistration: true }).template
+
+    // `tone` isn't a declared `Badge` param, so it routes into the rest bag
+    // (`emitChildField`'s rule) — no named Go field for `bf_with_props` to
+    // override, so the call stays the bare shared-instance reference.
+    expect(template).toContain('{{template "Badge" $.BadgeSlot0}}')
+    expect(template).not.toContain('bf_with_props')
+  })
 })
 
 // #2228: a `.filter(t => …).map(todo => <Child todo={todo} .../>)` loop whose

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4413,7 +4413,13 @@ export function CompositeRowChildComponent(props: { items: Item[] }) {
   )
 }
 `.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
-    expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(1)
+    const bf101s = (result.errors ?? []).filter(e => e.code === 'BF101')
+    expect(bf101s).toHaveLength(1)
+    // Copilot review (PR #2451): the error must point at the prop's own
+    // source location, not `convertExpressionToGo`'s internal `makeLoc()`
+    // placeholder (always line 1, column 0) — the loop-dependence gate
+    // repoints it before continuing.
+    expect(bf101s[0]!.loc.start.line).toBeGreaterThan(1)
     const template = result.files.find(f => f.type === 'markedTemplate')!.content
     expect(template).toContain('{{template "Badge" $.BadgeSlot0}}')
     expect(template).not.toContain('bf_with_props')

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -5013,20 +5013,36 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * fixture's emitted template byte-identical (no fixture in the corpus
    * reaches this method with a loop-dependent prop today).
    *
+   * KNOWN LIMITATION (#2448, tracked separately from #2445, which this
+   * method fixes): `bf_with_props` overrides fields on the ALREADY-CONSTRUCTED
+   * shared instance — it does not re-run `New<Child>Props`. A field the
+   * child derives FROM the overridden prop at construction time (a memo,
+   * or a prop-shadowing signal's initial value) keeps whatever the
+   * one-shot constructor computed and does not update per row. Only the
+   * directly-overridden field itself is correct per row.
+   *
    * Returns the space-joined `"Field" value "Field2" value2 …` argument list
    * for `bf_with_props`, or null when nothing needs overriding (caller keeps
    * the bare `$.<Name>SlotN` reference).
    */
   private loopRowChildPropOverrides(comp: IRComponent): string | null {
+    const childShape = this.childComponentShapes.get(comp.name)
     const args: string[] = []
     for (const prop of comp.props) {
       // Client-only props never reach SSR output; `key`/`children` aren't
-      // Props-struct fields; event handlers have no Go field; a hyphenated
-      // name can't be a Go field (same guard as `emitChildField`).
+      // Props-struct fields; event handlers have no Go field (same
+      // `isEventHandler` predicate `jsx-to-ir.ts` uses for component props);
+      // a hyphenated name can't be a Go field (same guard as `emitChildField`).
       if (prop.clientOnly) continue
       if (prop.name === 'key' || prop.name === 'children') continue
-      if (/^on[A-Z]/.test(prop.name)) continue
+      if (prop.name.startsWith('on') && prop.name.length > 2) continue
       if (prop.name.includes('-')) continue
+      // A prop that routes into the child's rest bag (`emitChildField`'s
+      // same routing rule) has no named Go field to override — `bf_with_props`
+      // would silently no-op the pair via its unknown-field passthrough.
+      // Leave it on the constructor-only path (unchanged from before this
+      // fix) rather than emit a pipeline argument that can never land.
+      if (childShape?.restBagField && !childShape.paramNames.has(prop.name)) continue
       // `literal` / `boolean-shorthand` / `boolean-attr` carry no runtime
       // expression to re-evaluate per row; `spread` / `jsx-children` are
       // handled elsewhere (`emitSpreadBagInits`, `queueLoopBodyChildrenDefine`).
@@ -5034,16 +5050,50 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       const free = prop.freeIdentifiers
       if (!free || ![...free].some(name => this.isLoopShadowedName(name))) continue
       const exprOut: { parsed?: ParsedExpr } = {}
-      const go = this.convertExpressionToGo(prop.value.expr, exprOut, prop.value.parsed)
-      if (this.isTemplateFragment(go, exprOut.parsed?.kind)) {
-        // A `{{if}}`/template-literal fragment can't be a bare pipeline
-        // argument — refuse loudly rather than silently dropping the prop
-        // (the #2445 bug was exactly a silent drop one level up).
+      const errorCountBefore = this.state.errors.length
+      let go = this.convertExpressionToGo(prop.value.expr, exprOut, prop.value.parsed)
+      if (this.state.errors.length > errorCountBefore) {
+        // `convertExpressionToGo` already pushed its own BF101 for an
+        // unsupported expression and returned the `""` sentinel — using it
+        // here would silently clobber the field with an empty string (or,
+        // for a non-string field, fail at template EXECUTE time instead of
+        // this compile time). Leave the prop on the constructor path; the
+        // reported error already surfaces the real problem.
+        continue
+      }
+      // A ternary / single-interpolation template literal with STRING-typed
+      // branches (`row.on ? "yes" : "no"`, `${row.x}` alone) parses to a
+      // ParsedExpr `template-literal` whose sole part is non-string —
+      // `templateLiteral()` wraps that one dynamic part's already-bare
+      // pipeline value (e.g. `(bf_ternary ...)`, #2335) in a bare `{{...}}`
+      // shell meant for TEXT-position embedding. A multi-part template
+      // literal (mixed literal text and interpolation) has no such reduction
+      // and stays refused below. Unwrap the single-part case back to the
+      // bare pipeline value this call site (a function ARGUMENT position,
+      // not a text position) needs.
+      const singlePartTemplateLiteral =
+        exprOut.parsed?.kind === 'template-literal' &&
+        exprOut.parsed.parts.length === 1 &&
+        exprOut.parsed.parts[0].type !== 'string' &&
+        go.startsWith('{{') &&
+        go.endsWith('}}')
+      if (singlePartTemplateLiteral) {
+        go = go.slice(2, -2)
+      }
+      // Skip the fragment re-check for the just-unwrapped single-part case —
+      // `kind` is still (accurately) `template-literal`, which would
+      // otherwise re-trip `isTemplateFragment`'s `kind === 'template-literal'`
+      // branch on the ALREADY-unwrapped bare value.
+      if (!singlePartTemplateLiteral && this.isTemplateFragment(go, exprOut.parsed?.kind)) {
+        // A genuine multi-part `{{if}}...{{end}}`-shaped fragment can't be a
+        // bare pipeline argument — refuse loudly rather than silently
+        // dropping the prop (the #2445 bug was exactly a silent drop one
+        // level up).
         this.state.errors.push({
           code: 'BF101',
           severity: 'error',
           message: `Prop '${prop.name}' on <${comp.name}> nested inside a dynamic loop row reads the row but can't be lowered to a Go template pipeline argument`,
-          loc: this.makeLoc(),
+          loc: prop.loc,
         })
         continue
       }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -5058,7 +5058,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // here would silently clobber the field with an empty string (or,
         // for a non-string field, fail at template EXECUTE time instead of
         // this compile time). Leave the prop on the constructor path; the
-        // reported error already surfaces the real problem.
+        // reported error already surfaces the real problem. `loc` defaults
+        // to `convertExpressionToGo`'s own `this.makeLoc()` placeholder —
+        // repoint the newly-pushed error(s) at the prop's real source
+        // location, same as the fragment-refusal error below.
+        for (let i = errorCountBefore; i < this.state.errors.length; i++) {
+          this.state.errors[i].loc = prop.loc
+        }
         continue
       }
       // A ternary / single-interpolation template literal with STRING-typed

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4994,6 +4994,65 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
+   * #2445: per-row Go pipeline arguments for a child component nested inside
+   * a COMPOSITE loop row (row root is a plain element — `<li><Badge
+   * text={row.label}/></li>` — as opposed to the wrapper-slice case where the
+   * loop body IS the component). `collectStaticChildInstancesRecursive`
+   * registers such a child as an ordinary once-per-slot instance
+   * (`$.<Name>SlotN`), built ONCE outside `{{range}}` by
+   * `emitStaticChildInstances` — correct for props that don't depend on the
+   * row, but stale for one that does (`text={row.label}` reads the same
+   * value on every row). A loop-dependent prop is therefore re-applied per
+   * row, at template-execution time, via the `bf_with_props` runtime helper
+   * (the props-argument sibling of `bf_with_children`, which already does
+   * this for per-row JSX children on the same shared instance).
+   *
+   * A prop with no loop-bound free identifier (`IRProp.freeIdentifiers`, IR-
+   * build-time computed, #1267) is left on the constructor path — it's
+   * already correct there, and skipping it keeps every currently-passing
+   * fixture's emitted template byte-identical (no fixture in the corpus
+   * reaches this method with a loop-dependent prop today).
+   *
+   * Returns the space-joined `"Field" value "Field2" value2 …` argument list
+   * for `bf_with_props`, or null when nothing needs overriding (caller keeps
+   * the bare `$.<Name>SlotN` reference).
+   */
+  private loopRowChildPropOverrides(comp: IRComponent): string | null {
+    const args: string[] = []
+    for (const prop of comp.props) {
+      // Client-only props never reach SSR output; `key`/`children` aren't
+      // Props-struct fields; event handlers have no Go field; a hyphenated
+      // name can't be a Go field (same guard as `emitChildField`).
+      if (prop.clientOnly) continue
+      if (prop.name === 'key' || prop.name === 'children') continue
+      if (/^on[A-Z]/.test(prop.name)) continue
+      if (prop.name.includes('-')) continue
+      // `literal` / `boolean-shorthand` / `boolean-attr` carry no runtime
+      // expression to re-evaluate per row; `spread` / `jsx-children` are
+      // handled elsewhere (`emitSpreadBagInits`, `queueLoopBodyChildrenDefine`).
+      if (prop.value.kind !== 'expression') continue
+      const free = prop.freeIdentifiers
+      if (!free || ![...free].some(name => this.isLoopShadowedName(name))) continue
+      const exprOut: { parsed?: ParsedExpr } = {}
+      const go = this.convertExpressionToGo(prop.value.expr, exprOut, prop.value.parsed)
+      if (this.isTemplateFragment(go, exprOut.parsed?.kind)) {
+        // A `{{if}}`/template-literal fragment can't be a bare pipeline
+        // argument — refuse loudly rather than silently dropping the prop
+        // (the #2445 bug was exactly a silent drop one level up).
+        this.state.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `Prop '${prop.name}' on <${comp.name}> nested inside a dynamic loop row reads the row but can't be lowered to a Go template pipeline argument`,
+          loc: this.makeLoc(),
+        })
+        continue
+      }
+      args.push(`${JSON.stringify(capitalizeFieldName(prop.name))} ${wrapIfMultiToken(go)}`)
+    }
+    return args.length > 0 ? args.join(' ') : null
+  }
+
+  /**
    * Resolve `IDENT['key']` / `IDENT["key"]` where `IDENT` is a module-scope
    * object-literal const and the key is a string literal — a compile-time-static
    * lookup (the icon registry's `strokePaths['chevron-down']`). Returns the
@@ -6013,17 +6072,27 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     } else if (this.inLoop && comp.slotId) {
       // Non-wrapper loop (component nested inside an element item, #2130):
       // the range iterates the REAL collection, so `.` is the raw datum and
-      // carries none of the child's props. Call through the parent's
-      // once-per-slot instance via the root context (`$` — the define's own
-      // data, i.e. the parent's Props), injecting per-item content through a
-      // loop-body children define executed with the datum (`.`). The shared
-      // instance means identical child scope IDs across rows — the same
+      // carries none of the child's props by default. Call through the
+      // parent's once-per-slot instance via the root context (`$` — the
+      // define's own data, i.e. the parent's Props). Two kinds of per-row
+      // content have to reach that shared instance at template-execution
+      // time: JSX children, injected via a loop-body children define
+      // executed with the datum (`bf_with_children`), and any PROP that
+      // reads the row (`text={row.label}`, #2445) — the instance is built
+      // ONCE outside `{{range}}`, so a loop-dependent prop is stale there
+      // and is reapplied per row via `bf_with_props`
+      // (`loopRowChildPropOverrides`). The shared BASE instance (built once)
+      // still carries identical child scope IDs across rows — the same
       // contract the wrapper machinery's `bodyChildInstances` already uses.
       const suffix = slotIdToFieldSuffix(comp.slotId)
+      const overrides = this.loopRowChildPropOverrides(comp)
       const loopBodyDefine = this.queueLoopBodyChildrenDefine(comp)
+      const base = overrides
+        ? `(bf_with_props $.${comp.name}${suffix} ${overrides})`
+        : `$.${comp.name}${suffix}`
       templateCall = loopBodyDefine
-        ? `{{template "${comp.name}" (bf_with_children $.${comp.name}${suffix} (bf_tmpl "${loopBodyDefine}" .))}}`
-        : `{{template "${comp.name}" $.${comp.name}${suffix}}}`
+        ? `{{template "${comp.name}" (bf_with_children ${base} (bf_tmpl "${loopBodyDefine}" .))}}`
+        : `{{template "${comp.name}" ${base}}}`
     } else if (this.inLoop) {
       // Loop-nested component without a slotId: no parent field to route
       // through — legacy passthrough of the current dot.

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -30,13 +30,12 @@ export const renderDivergences: RenderDivergences = {
   // `test-render.ts`) now replicates that documented contract for a
   // signal-backed dynamic child-component loop.
 
-  // #2445: a child component nested inside a dynamic loop row whose root
-  // is a plain element gets ONE hoisted `BadgeSlot0 BadgeProps` field on
-  // the parent, built outside the loop with no per-row data, and the
-  // template passes `$.BadgeSlot0` for every row — so every row renders
-  // the child with zero-value props. The sibling shape (row root IS the
-  // child component) already emits a per-row slice; see the `todo-app-ssr`
-  // note above on `.TodoItems []TodoItemProps`.
-  'composite-row-child-component':
-    'a child component nested inside a dynamic loop row receives one hoisted props value built outside `{{range}}`, so every row renders the child with zero-value props (https://github.com/piconic-ai/barefootjs/issues/2445)',
+  // #2445 graduated: a child component nested inside a dynamic loop row
+  // whose root is a plain element still gets ONE hoisted `<Name>SlotN`
+  // props value built outside the loop (see the `todo-app-ssr` note above
+  // for why that's fine when nothing in it depends on the row), but a
+  // loop-dependent prop is now reapplied per row, at template-execution
+  // time, via the `bf_with_props` runtime helper — the props-argument
+  // sibling of `bf_with_children`, which already does this for per-row
+  // JSX children on the same shared instance.
 }

--- a/packages/adapter-tests/fixtures/composite-row-child-component.ts
+++ b/packages/adapter-tests/fixtures/composite-row-child-component.ts
@@ -19,8 +19,13 @@ import { createFixture } from '../src/types'
  *   - #2444 — every DSL adapter (and the CSR template lambda) mints a
  *     random `Badge_<id>` scope id via `render_child` instead of deriving
  *     `<parent>_s0`. Content is correct; only `bf-s` diverges.
- *   - #2445 — Go hoists ONE `BadgeSlot0` props value outside `{{range}}`
- *     with no per-row data, so every row renders an empty badge.
+ *   - Go template graduated (#2445): the shared `BadgeSlot0` props instance
+ *     built outside `{{range}}` is now overridden per row, at
+ *     template-execution time, via the `bf_with_props` runtime helper —
+ *     see `packages/adapter-go-template/runtime/bf.go`. A NARROWER residual
+ *     gap (a child field DERIVED from the overridden prop, e.g. a memo,
+ *     doesn't update per row — this fixture's `Badge` has no such field) is
+ *     tracked separately as #2448, not by a divergence entry here.
  */
 export const fixture = createFixture({
   id: 'composite-row-child-component',

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1825,10 +1825,6 @@
           "kind": "render",
           "reason": "a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)"
         },
-        "go-template": {
-          "kind": "render",
-          "reason": "a child component nested inside a dynamic loop row receives one hoisted props value built outside `{{range}}`, so every row renders the child with zero-value props (https://github.com/piconic-ai/barefootjs/issues/2445)"
-        },
         "jinja": {
           "kind": "render",
           "reason": "a child component nested inside a dynamic loop row gets a random `Name_<id>` scope id from `render_child` instead of the parent-derived `<parent>_s0` the reference emits (https://github.com/piconic-ai/barefootjs/issues/2444)"

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1587,13 +1587,9 @@
           ]
         },
         "go-template": {
-          "pass": 164,
+          "pass": 165,
           "total": 180,
           "gaps": [
-            {
-              "fixture": "composite-row-child-component",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2399,13 +2395,9 @@
           ]
         },
         "go-template": {
-          "pass": 247,
+          "pass": 248,
           "total": 266,
           "gaps": [
-            {
-              "fixture": "composite-row-child-component",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3787,13 +3779,9 @@
           ]
         },
         "go-template": {
-          "pass": 126,
+          "pass": 127,
           "total": 145,
           "gaps": [
-            {
-              "fixture": "composite-row-child-component",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [


### PR DESCRIPTION
## Summary

Fixes #2445: in the Go-template adapter, a child component nested inside a signal-driven `.map()` row whose root is a **plain element** (`<li><Badge text={row.label}/></li>`, as opposed to the sibling shape where the loop body *is* the child component) got exactly one hoisted `<Name>SlotN` props struct value, built once by the constructor outside `{{range}}`. Every row therefore called the child with the same shared instance, so a prop that depends on the row (`text={row.label}`) rendered the same (always zero-value) content on every row instead of that row's own value.

- Adds a `bf_with_props` Go runtime helper (`packages/adapter-go-template/runtime/bf.go`) — the props-argument sibling of the existing `bf_with_children` helper — that reflection-copies a Props struct and overrides named fields.
- Adds `loopRowChildPropOverrides` in the Go adapter: for each prop on a loop-nested child, only a prop whose free identifiers (IR-build-time-computed) are loop-bound gets reapplied per row via `bf_with_props`, inside `{{range}}`; everything else stays on the existing constructor-only path, so previously-passing fixtures emit byte-identical templates.
- Wires the override into `renderComponent`'s existing `#2130` composite-loop-row branch, composing with the existing `bf_with_children` (JSX-children) wrapping when both apply.
- Graduates the `composite-row-child-component` render divergence for this adapter (`render-divergences.ts`) and regenerates `ui/compat.lock.json` / `ui/support-matrix.lock.json` accordingly.

An Opus-driven design/plan pass and a separate Opus adversarial review pass (see review notes below) both fed into this implementation; the review surfaced and this PR fixes four real gaps beyond the original report:
- A per-row prop shaped as a ternary/single interpolation (`row.on ? "yes" : "no"`) now unwraps correctly to a bare pipeline argument instead of hitting a spurious BF101.
- An unsupported prop expression no longer also emits a broken `bf_with_props` pipeline argument on top of its own diagnostic.
- A prop that routes into the child's rest bag now correctly stays on the constructor-only path instead of emitting a guaranteed no-op.
- The BF101 diagnostic now points at the prop's own source location.

One narrower, separate limitation was found and intentionally **not** folded into this fix (would require re-running the child's constructor per row, a larger change): a field the child *derives* from the overridden prop (e.g. a memo) doesn't update per row. This is documented in both the Go and TS doc comments and tracked as a follow-up in #2448.

## Test plan

- [x] `bun test packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts` — full suite, 1421 pass / 19 skip / 0 fail (includes real Go 1.25.6 end-to-end execution, not just structural pins)
- [x] `bun test packages/compat/src/__tests__/` — 175 pass / 0 fail
- [x] New Go unit tests for `bf_with_props`/`WithProps` in `runtime/bf_test.go`
- [x] New TS tests: the original reported shape, a negative pin (non-loop-dependent prop unaffected), a JSX-children composition pin, ternary/template-literal handling, unsupported-expression safety, rest-bag routing, and a real-`go run` end-to-end render
- [x] `go vet ./...` and `go test ./...` clean on the runtime package
- [x] Full monorepo `bun run build` and the adapter's own typecheck clean
- [x] Biome lint clean on changed files

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_016Q1S2dfdMw7sJ4pjgUs96g


---
_Generated by [Claude Code](https://claude.ai/code/session_016Q1S2dfdMw7sJ4pjgUs96g)_