### PR TITLE
Lower a .map() preamble's value declarations to per-row template locals (#2447)

### DIFF
--- a/.changeset/preamble-value-declarations-dsl.md
+++ b/.changeset/preamble-value-declarations-dsl.md
@@ -1,0 +1,76 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/erb": patch
+"@barefootjs/blade": patch
+"@barefootjs/twig": patch
+"@barefootjs/jinja": patch
+"@barefootjs/xslate": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/rust": patch
+"@barefootjs/go-template": patch
+---
+
+Lower a `.map()` callback preamble's value declarations to per-row template locals (#2447)
+
+A block-body `.map()` whose preamble computes a value used in the row —
+
+```tsx
+{rows().map(row => {
+  const cls = row.done ? 'done' : 'open'
+  return <li key={row.id} class={cls}>{row.label}</li>
+})}
+```
+
+— carried that preamble only as JS text, which a template language cannot
+execute. Every DSL adapter emitted the row anyway, reading a name it never
+assigned: ERB read `v[:cls]` (an unseeded vars-Hash key), Go read `$.Cls` (a
+parent-struct field, the same hoisted-to-parent defect class as #2445), and
+Blade / Twig / Jinja / minijinja / Kolon / Mojo each read a bare undefined
+local. All eight rendered `class=""`, with no diagnostic. Hono and CSR were
+correct throughout, so the divergence only showed up against a real DSL
+runtime.
+
+Fixed by giving the preamble a second, backend-neutral carrier:
+`MapCallbackPreamble.declarations`, one `{ name, valueParsed }` per
+declaration. Each adapter emits it as a per-row local in its own syntax
+(`{% set %}`, `@php()`, `<%- … -%>`, `: my $x = …;`, `{{$x := …}}`) through the
+same `ParsedExpr` door it already uses for the loop array, the filter
+predicate, and the sort comparator — no new expression path, and no
+per-adapter interpretation of the JS text. Declarations render in source
+order, so a later initializer sees an earlier local; on a
+`.filter(p).map(cb)` chain they render inside the filter guard, matching JS
+evaluation order. The declared names are registered as loop-bound, so a
+same-named module const can't inline over the local the loop just declared.
+
+Lowering is all-or-nothing. A preamble is an order-dependent statement
+sequence, so carrying its declarable prefix and dropping the rest would put
+the missing statement's effect nowhere — the same silent divergence in a new
+disguise. One statement that is not a value declaration (an assignment, an
+imperative loop, a destructuring binding, an initializer outside the
+expression subset) therefore refuses on a DSL target with `BF021` and the
+`/* @client */` escape, alongside the existing filter / sort / array-builder /
+flatMap gates. A JS runtime keeps running any preamble verbatim.
+
+Two behaviour changes fall out of this:
+
+- **`map-preamble-branch-body` now renders on every adapter.** Its `BF021`
+  pins are removed from all eight DSL adapters. They existed on the premise
+  that a loop-local cannot be carried into a conditional branch template; that
+  stopped being true once a value preamble lowers, because the if/else fold
+  puts the conditional *inside* the loop body, where the local is in scope in
+  both arms. The refusal now keys off whether the preamble is declarable, not
+  whether the body branches.
+- **A non-declarable preamble that used to compile is now a build error on DSL
+  targets.** It previously produced a template that read unassigned names, so
+  the change is from silently-wrong output to a diagnostic with a documented
+  escape.
+
+The `loop-preamble-attr-value` fixture's render divergences are graduated
+(deleted from all eight `render-divergences.ts` files). Both fixtures now pass
+on all nine adapters and CSR conformance.
+
+Unchanged and tracked separately: an attribute whose value comes from a
+preamble local is still not classified as reactive on the client, so it is
+interpolated into the row template and not rewritten on a same-key item
+update. That is a client-side classification question, pinned as the current
+contract in `packages/client/__tests__/runtime/lazy-row-preamble.test.ts`.

--- a/packages/adapter-blade/src/adapter/blade-adapter.ts
+++ b/packages/adapter-blade/src/adapter/blade-adapter.ts
@@ -1059,6 +1059,15 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     // Re-render children now that inLoop is set (so nested components use the
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
+
+    // Per-row locals for a `.map()` callback preamble (#2447), in source
+    // order so a later initializer sees an earlier local — same as the
+    // source block. Phase 1 refuses the loop outright when the preamble
+    // isn't fully declarable, so there is no partial-lowering case: either
+    // every statement is lowered here, or the build already failed.
+    const preambleLines = (loop.preamble?.declarations ?? []).map(
+      d => `@php(${bladeVar(d.name)} = ${this.convertExpressionToBlade(d.raw, d.valueParsed)})`,
+    )
     const childrenUnderLoop = this.renderChildren(loop.children)
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
@@ -1126,9 +1135,11 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
         )
       }
       lines.push(`@if(${filterCond})`)
+      lines.push(...preambleLines)
       lines.push(bodyChildren)
       lines.push(`@endif`)
     } else {
+      lines.push(...preambleLines)
       lines.push(bodyChildren)
     }
 

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -15,11 +15,6 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  // A `.map()` body with a `const`/`let` preamble before its branches:
-  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
-  // conditional branch template, so it refuses with BF021 + `/* @client */`.
-  // See spec/callback-fidelity.md.
-  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -19,12 +19,4 @@ export const renderDivergences: RenderDivergences = {
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
-
-  // #2447: the `.map()` callback preamble's value declarations
-  // (`const cls = row.done ? 'done' : 'open'`) are not lowered into the
-  // template at all, so the emitted row references a variable nothing ever
-  // assigns and the attribute renders empty. Pre-existing — confirmed by
-  // running the fixture with the §9.5 lazy-preamble compiler change reverted.
-  'loop-preamble-attr-value':
-    "a `.map()` callback preamble's value declarations are not lowered into the template, so the row reads an unassigned variable and the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)",
 }

--- a/packages/adapter-erb/src/adapter/erb-adapter.ts
+++ b/packages/adapter-erb/src/adapter/erb-adapter.ts
@@ -981,6 +981,14 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
         : supportableDestructure
           ? ['__bf_item', ...(loop.paramBindings ?? []).map(b => b.name), loop.index ?? '_i']
           : [param, loop.index ?? '_i']
+    // A `.map()` callback preamble lowers to one per-row Ruby local per
+    // declaration (#2447). The names must be loop-bound for the whole body,
+    // or `ErbTopLevelEmitter.identifier` renders each read as `v[:cls]` —
+    // a vars-Hash key nothing ever seeds, i.e. the empty attribute this
+    // fixes. Phase 1 guarantees `declarations` is present or the loop was
+    // already refused, so there is no partial-lowering case here.
+    const preambleDecls = loop.preamble?.declarations ?? []
+    for (const d of preambleDecls) loopBound.push(d.name)
     for (const n of loopBound) {
       this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
     }
@@ -1101,6 +1109,15 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
     }
     }
 
+    // Per-row preamble locals (#2447), in source order so a later
+    // initializer sees an earlier local — same as the source block. Emitted
+    // INSIDE the filter guard below, matching JS evaluation order: a
+    // `.filter(p).map(cb)` chain never runs `cb`'s body for a filtered-out
+    // item.
+    const preambleLines = preambleDecls.map(
+      d => `<%- ${rubyLocal(d.name)} = ${this.convertExpressionToRuby(d.raw, d.valueParsed)} -%>`,
+    )
+
     // Handle filter().map() pattern by wrapping children in if-condition
     if (loop.filterPredicate) {
       let filterCond: string
@@ -1134,9 +1151,11 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
         filterCond = 'true'
       }
       lines.push(`<%- if bf.truthy?(${filterCond}) -%>`)
+      lines.push(...preambleLines)
       lines.push(children)
       lines.push(`<%- end -%>`)
     } else {
+      lines.push(...preambleLines)
       lines.push(children)
     }
 

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -16,11 +16,6 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  // A `.map()` body with a `const`/`let` preamble before its branches:
-  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
-  // conditional branch template, so it refuses with BF021 + `/* @client */`.
-  // See spec/callback-fidelity.md.
-  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -19,12 +19,4 @@ export const renderDivergences: RenderDivergences = {
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
-
-  // #2447: the `.map()` callback preamble's value declarations
-  // (`const cls = row.done ? 'done' : 'open'`) are not lowered into the
-  // template at all, so the emitted row references a variable nothing ever
-  // assigns and the attribute renders empty. Pre-existing — confirmed by
-  // running the fixture with the §9.5 lazy-preamble compiler change reverted.
-  'loop-preamble-attr-value':
-    "a `.map()` callback preamble's value declarations are not lowered into the template, so the row reads an unassigned variable and the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)",
 }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -5859,6 +5859,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // nested loops with the same index var name from clobbering the outer entry
     // on cleanup.
     const addedLoopVars: string[] = []
+    // A `.map()` callback preamble lowers to one `{{$cls := …}}` per-row
+    // variable per declaration (#2447). Registering the names on
+    // `loopVarRefCount` is what makes `identifier()` resolve each read as
+    // `$cls`; without it the read falls through to `rootFieldRef` and emits
+    // `$.Cls` — a PARENT-struct field, never populated, which rendered the
+    // attribute empty on every row (the same hoisted-to-parent class of
+    // defect as #2445).
+    for (const d of loop.preamble?.declarations ?? []) {
+      this.loopVarRefCount.set(d.name, (this.loopVarRefCount.get(d.name) ?? 0) + 1)
+      addedLoopVars.push(d.name)
+    }
     let pushedBindingMap = false
     if (supportableDestructure) {
       // Bindings resolve against the synthetic `$__bf_item` range var; don't push
@@ -5892,6 +5903,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     )
     this.loopWrapperStack.push(!!loop.childComponent)
     this.loopKeyDepthStack.push(loop.depth)
+    // Rendered inside the pushed loop scope so each initializer resolves
+    // against the range item (`.Done`), in source order so a later
+    // initializer sees an earlier `$` variable — same as the source block.
+    const preambleAssignments = (loop.preamble?.declarations ?? [])
+      .map(d => `{{$${d.name} := ${this.renderParsedExpr(d.valueParsed)}}}`)
+      .join('')
     const children = this.renderChildren(loop.children)
     this.loopKeyDepthStack.pop()
     this.loopWrapperStack.pop()
@@ -5953,10 +5970,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         filterCond = 'true'
       }
 
-      return `{{bfComment "loop:${loop.markerId}"}}{{range $${rangeIndex}, $${rangeValue} := ${goArray}}}{{if ${filterCond}}}${itemMarker}${children}{{end}}{{end}}{{bfComment "/loop:${loop.markerId}"}}`
+      // The preamble assignments sit INSIDE the `{{if}}`, matching JS
+      // evaluation order: a `.filter(p).map(cb)` chain never runs `cb`'s
+      // body for a filtered-out item.
+      return `{{bfComment "loop:${loop.markerId}"}}{{range $${rangeIndex}, $${rangeValue} := ${goArray}}}{{if ${filterCond}}}${preambleAssignments}${itemMarker}${children}{{end}}{{end}}{{bfComment "/loop:${loop.markerId}"}}`
     }
 
-    return `{{bfComment "loop:${loop.markerId}"}}{{range $${rangeIndex}, $${rangeValue} := ${goArray}}}${itemMarker}${children}{{end}}{{bfComment "/loop:${loop.markerId}"}}`
+    return `{{bfComment "loop:${loop.markerId}"}}{{range $${rangeIndex}, $${rangeValue} := ${goArray}}}${preambleAssignments}${itemMarker}${children}{{end}}{{bfComment "/loop:${loop.markerId}"}}`
   }
 
   /**

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -15,11 +15,6 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  // A `.map()` body with a `const`/`let` preamble before its branches:
-  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
-  // conditional branch template, so it refuses with BF021 + `/* @client */`.
-  // See spec/callback-fidelity.md.
-  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -29,11 +29,4 @@ export const renderDivergences: RenderDivergences = {
   // production). `buildDynamicChildLoopSeeding` (this package's
   // `test-render.ts`) now replicates that documented contract for a
   // signal-backed dynamic child-component loop.
-
-  // #2447: same missing preamble lowering as the DSL adapters, with Go's
-  // usual twist (cf. #2445): the value is emitted as `{{$.Cls}}` — a
-  // PARENT-scope struct field, not a per-row one — and nothing populates it,
-  // so every row's attribute renders empty.
-  'loop-preamble-attr-value':
-    "a `.map()` callback preamble's value declaration is hoisted to a parent-scope field instead of being built per row, so the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)",
 }

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -902,6 +902,15 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     // Re-render children now that inLoop is set (so nested components use the
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
+
+    // Per-row locals for a `.map()` callback preamble (#2447), in source
+    // order so a later initializer sees an earlier local — same as the
+    // source block. Phase 1 refuses the loop outright when the preamble
+    // isn't fully declarable, so there is no partial-lowering case: either
+    // every statement is lowered here, or the build already failed.
+    const preambleLines = (loop.preamble?.declarations ?? []).map(
+      d => `{% set ${jinjaIdent(d.name)} = ${this.convertExpressionToJinja(d.raw, d.valueParsed)} %}`,
+    )
     const childrenUnderLoop = this.renderChildren(loop.children)
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
@@ -962,9 +971,11 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
         )
       }
       lines.push(`{% if ${filterCond} %}`)
+      lines.push(...preambleLines)
       lines.push(bodyChildren)
       lines.push(`{% endif %}`)
     } else {
+      lines.push(...preambleLines)
       lines.push(bodyChildren)
     }
 

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -15,11 +15,6 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  // A `.map()` body with a `const`/`let` preamble before its branches:
-  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
-  // conditional branch template, so it refuses with BF021 + `/* @client */`.
-  // See spec/callback-fidelity.md.
-  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -19,12 +19,4 @@ export const renderDivergences: RenderDivergences = {
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
-
-  // #2447: the `.map()` callback preamble's value declarations
-  // (`const cls = row.done ? 'done' : 'open'`) are not lowered into the
-  // template at all, so the emitted row references a variable nothing ever
-  // assigns and the attribute renders empty. Pre-existing — confirmed by
-  // running the fixture with the §9.5 lazy-preamble compiler change reverted.
-  'loop-preamble-attr-value':
-    "a `.map()` callback preamble's value declarations are not lowered into the template, so the row reads an unassigned variable and the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)",
 }

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -936,6 +936,12 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
         : supportableDestructure
           ? ['__bf_item', ...(loop.paramBindings ?? []).map(b => b.name), loop.index ?? '_i']
           : [param, loop.index ?? '_i']
+    // A `.map()` callback preamble lowers to one per-row `my` local per
+    // declaration (#2447). Loop-binding the names keeps a same-named module
+    // const from inlining over the local the loop just declared — the same
+    // hazard class `resolveModuleStringConst` already consults this map for.
+    const preambleDecls = loop.preamble?.declarations ?? []
+    for (const d of preambleDecls) loopBound.push(d.name)
     for (const n of loopBound) {
       this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
     }
@@ -1053,6 +1059,15 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     }
     }
 
+    // Per-row preamble locals (#2447), in source order so a later
+    // initializer sees an earlier local — same as the source block. Emitted
+    // INSIDE the filter guard below, matching JS evaluation order: a
+    // `.filter(p).map(cb)` chain never runs `cb`'s body for a filtered-out
+    // item.
+    const preambleLines = preambleDecls.map(
+      d => `% my $${d.name} = ${this.convertExpressionToPerl(d.raw, d.valueParsed)};`,
+    )
+
     // Handle filter().map() pattern by wrapping children in if-condition
     if (loop.filterPredicate) {
       let filterCond: string
@@ -1072,9 +1087,11 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
         )
       }
       lines.push(`% if (${filterCond}) {`)
+      lines.push(...preambleLines)
       lines.push(children)
       lines.push(`% }`)
     } else {
+      lines.push(...preambleLines)
       lines.push(children)
     }
 

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -13,11 +13,6 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  // A `.map()` body with a `const`/`let` preamble before its branches:
-  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
-  // conditional branch template, so it refuses with BF021 + `/* @client */`.
-  // See spec/callback-fidelity.md.
-  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -19,12 +19,4 @@ export const renderDivergences: RenderDivergences = {
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
-
-  // #2447: the `.map()` callback preamble's value declarations
-  // (`const cls = row.done ? 'done' : 'open'`) are not lowered into the
-  // template at all, so the emitted row references a variable nothing ever
-  // assigns and the attribute renders empty. Pre-existing — confirmed by
-  // running the fixture with the §9.5 lazy-preamble compiler change reverted.
-  'loop-preamble-attr-value':
-    "a `.map()` callback preamble's value declarations are not lowered into the template, so the row reads an unassigned variable and the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)",
 }

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -943,6 +943,15 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     // Re-render children now that inLoop is set (so nested components use the
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
+
+    // Per-row locals for a `.map()` callback preamble (#2447), in source
+    // order so a later initializer sees an earlier local — same as the
+    // source block. Phase 1 refuses the loop outright when the preamble
+    // isn't fully declarable, so there is no partial-lowering case: either
+    // every statement is lowered here, or the build already failed.
+    const preambleLines = (loop.preamble?.declarations ?? []).map(
+      d => `{% set ${minijinjaIdent(d.name)} = ${this.convertExpressionToJinja(d.raw, d.valueParsed)} %}`,
+    )
     const childrenUnderLoop = this.renderChildren(loop.children)
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
@@ -1009,9 +1018,11 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
         )
       }
       lines.push(`{% if ${filterCond} %}`)
+      lines.push(...preambleLines)
       lines.push(bodyChildren)
       lines.push(`{% endif %}`)
     } else {
+      lines.push(...preambleLines)
       lines.push(bodyChildren)
     }
 

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -16,11 +16,6 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  // A `.map()` body with a `const`/`let` preamble before its branches:
-  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
-  // conditional branch template, so it refuses with BF021 + `/* @client */`.
-  // See spec/callback-fidelity.md.
-  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -21,12 +21,4 @@ export const renderDivergences: RenderDivergences = {
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
-
-  // #2447: the `.map()` callback preamble's value declarations
-  // (`const cls = row.done ? 'done' : 'open'`) are not lowered into the
-  // template at all, so the emitted row references a variable nothing ever
-  // assigns and the attribute renders empty. Pre-existing — confirmed by
-  // running the fixture with the §9.5 lazy-preamble compiler change reverted.
-  'loop-preamble-attr-value':
-    "a `.map()` callback preamble's value declarations are not lowered into the template, so the row reads an unassigned variable and the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)",
 }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2551,10 +2551,34 @@
     "loop-preamble-attr-value": {
       "kinds": [
         "call",
+        "conditional",
         "identifier",
+        "literal",
         "member"
       ],
-      "axes": [],
+      "axes": [
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "loop-preamble-chained-filter": {
+      "kinds": [
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "unary"
+      ],
+      "axes": [
+        "binary:+",
+        "literal:string",
+        "unary:!"
+      ],
       "contexts": [
         "attribute",
         "loop",
@@ -2695,10 +2719,13 @@
     },
     "map-preamble-branch-body": {
       "kinds": [
+        "array-method",
         "identifier",
         "member"
       ],
-      "axes": [],
+      "axes": [
+        "array-method:toUpperCase"
+      ],
       "contexts": [
         "attribute",
         "condition",
@@ -4631,19 +4658,19 @@
   },
   "kindCounts": {
     "array-literal": 69,
-    "array-method": 65,
+    "array-method": 66,
     "arrow": 63,
-    "binary": 77,
-    "call": 182,
-    "conditional": 22,
-    "identifier": 268,
+    "binary": 78,
+    "call": 183,
+    "conditional": 23,
+    "identifier": 269,
     "index-access": 12,
-    "literal": 219,
+    "literal": 221,
     "logical": 43,
-    "member": 147,
+    "member": 148,
     "object-literal": 51,
     "template-literal": 29,
-    "unary": 22,
+    "unary": 23,
     "unsupported": 31
   },
   "axisCounts": {
@@ -4667,14 +4694,14 @@
     "array-method:toFixed": 2,
     "array-method:toLowerCase": 4,
     "array-method:toReversed": 1,
-    "array-method:toUpperCase": 1,
+    "array-method:toUpperCase": 2,
     "array-method:trim": 1,
     "array-method:trimEnd": 1,
     "array-method:trimStart": 1,
     "binary:!=": 2,
     "binary:!==": 9,
     "binary:*": 9,
-    "binary:+": 17,
+    "binary:+": 18,
     "binary:-": 11,
     "binary:/": 1,
     "binary:<": 1,
@@ -4684,13 +4711,13 @@
     "literal:boolean": 41,
     "literal:null": 22,
     "literal:number": 94,
-    "literal:string": 159,
+    "literal:string": 161,
     "logical:&&": 7,
     "logical:??": 38,
     "logical:||": 13,
     "member:computed": 8,
     "member:optional": 1,
-    "unary:!": 14,
+    "unary:!": 15,
     "unary:-": 11
   },
   "uncoveredKinds": [

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -388,6 +388,7 @@ import { fixture as jsxElementProp } from './jsx-element-prop'
 import { fixture as grandchildComposition } from './grandchild-composition'
 import { fixture as compositeRowChildComponent } from './composite-row-child-component'
 import { fixture as loopPreambleAttrValue } from './loop-preamble-attr-value'
+import { fixture as loopPreambleChainedFilter } from './loop-preamble-chained-filter'
 import { fixture as loopRowStaticConditional } from './loop-row-static-conditional'
 import { fixture as childPrimitiveProps } from './child-primitive-props'
 import { fixture as preWhitespace } from './pre-whitespace'
@@ -721,6 +722,7 @@ export const jsxFixtures: JSXFixture[] = [
   grandchildComposition,
   compositeRowChildComponent,
   loopPreambleAttrValue,
+  loopPreambleChainedFilter,
   loopRowStaticConditional,
   childPrimitiveProps,
   preWhitespace,

--- a/packages/adapter-tests/fixtures/loop-preamble-chained-filter.ts
+++ b/packages/adapter-tests/fixtures/loop-preamble-chained-filter.ts
@@ -1,0 +1,62 @@
+import { createFixture } from '../src/types'
+
+/**
+ * The two ORDERING claims the per-row preamble lowering makes (#2447), in one
+ * shape that would render wrong on any adapter that got either backwards:
+ *
+ *  1. **Declarations render in source order**, so a later initializer sees an
+ *     earlier local. `cls` reads `base`; an adapter that emitted them in any
+ *     other order (or hoisted them out of the row) renders `class="-open"` or
+ *     an empty class instead of `write it-open`.
+ *  2. **They render INSIDE the filter guard**, matching JS: a
+ *     `.filter(p).map(cb)` chain never runs `cb`'s body for a filtered-out
+ *     item. Not observable in the output HTML — a filtered row emits nothing
+ *     either way — but observable as a runtime error on a strict backend if a
+ *     declaration dereferenced something only the kept rows have, so the
+ *     placement is pinned by the emitted templates and this fixture keeps the
+ *     chained shape compiling and rendering on every backend.
+ *
+ * The single-declaration base case is `loop-preamble-attr-value`; the
+ * preamble-before-branches case is `map-preamble-branch-body`.
+ */
+export const fixture = createFixture({
+  id: 'loop-preamble-chained-filter',
+  description: 'Chained .map() preamble locals in a .filter().map() row',
+  componentName: 'LoopPreambleChainedFilter',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string; done: boolean }
+export function LoopPreambleChainedFilter(props: { rows: Row[] }) {
+  const [rows, setRows] = createSignal<Row[]>(props.rows)
+  return (
+    <ul>
+      {rows().filter(r => !r.done).map(row => {
+        const base = row.label
+        const cls = base + '-open'
+        return (
+          <li key={row.id} class={cls}>{row.label}</li>
+        )
+      })}
+    </ul>
+  )
+}
+`,
+  props: {
+    rows: [
+      { id: 1, label: 'write it', done: false },
+      { id: 2, label: 'ship it', done: true },
+      { id: 3, label: 'sign it', done: false },
+    ],
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li class="write it-open" data-key="1"><!--bf:s0-->write it<!--/--></li>
+      <li class="sign it-open" data-key="3"><!--bf:s0-->sign it<!--/--></li>
+    </ul>
+  `,
+  dataPoints: [
+    { name: 'empty', props: { rows: [] } },
+    { name: 'all-done', props: { rows: [{ id: 9, label: 'done', done: true }] } },
+  ],
+})

--- a/packages/adapter-tests/fixtures/map-preamble-branch-body.ts
+++ b/packages/adapter-tests/fixtures/map-preamble-branch-body.ts
@@ -3,24 +3,30 @@ import { createFixture } from '../src/types'
 /**
  * A `.map()` callback body with a leading `const` preamble before an if/else
  * branch — `{ const label = fmt(it); if (it.on) return <b/>; return <span/> }`.
- * Stage 2 of `spec/callback-fidelity.md`: a JS-runtime adapter folds this into
- * a nested `IRConditional` and emits the preamble once per iteration, so the
- * local is in scope in both branches; a DSL adapter can't carry a loop-local
- * into a conditional branch template, so it refuses (BF021) rather than render
- * the local `undefined` (a silent divergence).
+ * Stage 2 of `spec/callback-fidelity.md`: every adapter folds this into a
+ * nested `IRConditional` and emits the preamble once per iteration, so the
+ * local is in scope in both branches.
  *
- * Adapter-gated, like the off-subset filter/sort predicates:
- *   - Hono / CSR fold and run it; the reference `expectedHtml` renders the
- *     labels faithfully.
- *   - DSL adapters (Go, Perl, Ruby, PHP, Rust, Python) surface BF021 with the
- *     `/* @client *\/` escape (declared via each adapter's `conformancePins`);
- *     marking the map client-only defers the whole loop to the browser, which
- *     runs the preamble. (The `/* @client *\/` escape is exercised in the
- *     `map-multi-return-body` compiler-unit test.)
+ * **Every adapter renders it now (#2447).** It used to be adapter-gated —
+ * Hono/CSR folded and ran it, and every DSL adapter refused with BF021 on the
+ * premise that a loop-local cannot be carried into a conditional branch
+ * template. That premise stopped holding once a value preamble lowers to
+ * per-row locals: the fold puts the conditional INSIDE the loop body, so a
+ * local declared ahead of it is in scope in both arms
+ * (`{{$label := bf_upper .Kind}}{{if .On}}…{{$label}}…`). The BF021 pins are
+ * gone from all eight DSL adapters, and this fixture is now the cross-adapter
+ * proof of that: if the per-row declaration stops being emitted, the labels
+ * render empty here on whichever backend regressed.
+ *
+ * What is still refused is a preamble that is not a sequence of value
+ * declarations (an assignment, an imperative loop, a destructure) — nothing
+ * lowers, so both branches would read an unassigned name. That shape keeps
+ * BF021 + the `/* @client *\/` escape, exercised in
+ * `packages/jsx/src/__tests__/preamble-declarations.test.ts`.
  */
 export const fixture = createFixture({
   id: 'map-preamble-branch-body',
-  description: 'const preamble + if/else as a .map() body — JS-runtime folds, DSL refuses (BF021)',
+  description: 'const preamble + if/else as a .map() body — folded, with the preamble as a per-row local',
   source: `
 function MapPreambleBranch({ items }: { items: { id: string; on: boolean; kind: string }[] }) {
   return (

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -950,6 +950,15 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     // Re-render children now that inLoop is set (so nested components use the
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
+
+    // Per-row locals for a `.map()` callback preamble (#2447), in source
+    // order so a later initializer sees an earlier local — same as the
+    // source block. Phase 1 refuses the loop outright when the preamble
+    // isn't fully declarable, so there is no partial-lowering case: either
+    // every statement is lowered here, or the build already failed.
+    const preambleLines = (loop.preamble?.declarations ?? []).map(
+      d => `{% set ${twigIdent(d.name)} = ${this.convertExpressionToTwig(d.raw, d.valueParsed)} %}`,
+    )
     const childrenUnderLoop = this.renderChildren(loop.children)
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
@@ -1012,9 +1021,11 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
         )
       }
       lines.push(`{% if ${filterCond} %}`)
+      lines.push(...preambleLines)
       lines.push(bodyChildren)
       lines.push(`{% endif %}`)
     } else {
+      lines.push(...preambleLines)
       lines.push(bodyChildren)
     }
 

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -15,11 +15,6 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  // A `.map()` body with a `const`/`let` preamble before its branches:
-  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
-  // conditional branch template, so it refuses with BF021 + `/* @client */`.
-  // See spec/callback-fidelity.md.
-  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -19,12 +19,4 @@ export const renderDivergences: RenderDivergences = {
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
-
-  // #2447: the `.map()` callback preamble's value declarations
-  // (`const cls = row.done ? 'done' : 'open'`) are not lowered into the
-  // template at all, so the emitted row references a variable nothing ever
-  // assigns and the attribute renders empty. Pre-existing — confirmed by
-  // running the fixture with the §9.5 lazy-preamble compiler change reverted.
-  'loop-preamble-attr-value':
-    "a `.map()` callback preamble's value declarations are not lowered into the template, so the row reads an unassigned variable and the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)",
 }

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -880,6 +880,15 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // Re-render children now that inLoop is set (so nested components use the
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
+
+    // Per-row locals for a `.map()` callback preamble (#2447), in source
+    // order so a later initializer sees an earlier local — same as the
+    // source block. Phase 1 refuses the loop outright when the preamble
+    // isn't fully declarable, so there is no partial-lowering case: either
+    // every statement is lowered here, or the build already failed.
+    const preambleLines = (loop.preamble?.declarations ?? []).map(
+      d => `: my $${d.name} = ${this.convertExpressionToKolon(d.raw, d.valueParsed)};`,
+    )
     const childrenUnderLoop = this.renderChildren(loop.children)
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
@@ -934,9 +943,11 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
         )
       }
       lines.push(`: if (${filterCond}) {`)
+      lines.push(...preambleLines)
       lines.push(bodyChildren)
       lines.push(`: }`)
     } else {
+      lines.push(...preambleLines)
       lines.push(bodyChildren)
     }
 

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -13,11 +13,6 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  // A `.map()` body with a `const`/`let` preamble before its branches:
-  // a JS runtime folds it, a DSL adapter can't carry the loop-local into a
-  // conditional branch template, so it refuses with BF021 + `/* @client */`.
-  // See spec/callback-fidelity.md.
-  'map-preamble-branch-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -19,12 +19,4 @@ export const renderDivergences: RenderDivergences = {
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
-
-  // #2447: the `.map()` callback preamble's value declarations
-  // (`const cls = row.done ? 'done' : 'open'`) are not lowered into the
-  // template at all, so the emitted row references a variable nothing ever
-  // assigns and the attribute renders empty. Pre-existing — confirmed by
-  // running the fixture with the §9.5 lazy-preamble compiler change reverted.
-  'loop-preamble-attr-value':
-    "a `.map()` callback preamble's value declarations are not lowered into the template, so the row reads an unassigned variable and the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)",
 }

--- a/packages/jsx/src/__tests__/map-multi-return-body.test.ts
+++ b/packages/jsx/src/__tests__/map-multi-return-body.test.ts
@@ -133,11 +133,21 @@ describe('.map() multi-return body fold (Stage 2)', () => {
     })
   })
 
-  describe('leading-const preamble is adapter-gated (JS folds, DSL refuses)', () => {
+  describe('leading-const preamble — folded on JS, lowered on DSL, gated on shape', () => {
     const preambleBody = `{
       const label = it.kind.toUpperCase()
       if (it.on) return <b key={it.id}>{label}</b>
       return <span key={it.id}>{label}</span>
+    }`
+
+    // The same fold, but with a preamble no template language can declare: a
+    // destructuring binding takes several names off one initializer, and no
+    // adapter has a single per-row local form for that. Nothing lowers, so
+    // both branches would read an unassigned name.
+    const undeclarableBody = `{
+      const { kind } = it
+      if (it.on) return <b key={it.id}>{kind}</b>
+      return <span key={it.id}>{kind}</span>
     }`
 
     function compileWith(source: string, dsl: boolean) {
@@ -156,15 +166,32 @@ describe('.map() multi-return body fold (Stage 2)', () => {
       expect(cj.content).not.toMatch(/return <(b|span)/)
     })
 
-    test('a DSL adapter refuses with BF021 + the /* @client */ escape', () => {
+    test('a DSL adapter accepts it too — the preamble lowers to a per-row local (#2447)', () => {
+      // This used to be a BF021 refusal, on the premise that a loop-local
+      // can't reach a conditional branch template. The fold puts the
+      // conditional INSIDE the loop body, so once the preamble lowers to a
+      // per-row declaration the local is in scope in both arms — see the
+      // `map-preamble-branch-body` fixture, which now renders on all nine
+      // adapters.
       const r = compileWith(wrap(preambleBody), true)
+      expect(r.errors.filter(e => e.severity !== 'warning')).toHaveLength(0)
+    })
+
+    test('a preamble that is NOT declarable still refuses with BF021 + /* @client */', () => {
+      const r = compileWith(wrap(undeclarableBody), true)
       const bf021 = r.errors.filter(e => e.code === 'BF021')
       expect(bf021).toHaveLength(1)
+      expect(bf021[0].message).toMatch(/preamble is not a sequence of value declarations/)
       expect(bf021[0].suggestion?.message).toContain('@client')
     })
 
+    test('a JS runtime runs the undeclarable preamble verbatim — no refusal', () => {
+      const r = compileWith(wrap(undeclarableBody), false)
+      expect(r.errors.filter(e => e.severity !== 'warning')).toHaveLength(0)
+    })
+
     test('/* @client */ suppresses the DSL refusal', () => {
-      const clientSource = wrap(preambleBody).replace('items.map', '/* @client */ items.map')
+      const clientSource = wrap(undeclarableBody).replace('items.map', '/* @client */ items.map')
       const r = compileWith(clientSource, true)
       expect(r.errors.filter(e => e.code === 'BF021')).toHaveLength(0)
     })

--- a/packages/jsx/src/__tests__/preamble-declarations.test.ts
+++ b/packages/jsx/src/__tests__/preamble-declarations.test.ts
@@ -1,0 +1,207 @@
+/**
+ * `.map()` callback preamble → backend-neutral value declarations (#2447).
+ *
+ * ## What was broken
+ *
+ * A block-body `.map()` whose preamble computes a value used in the row
+ * (`const cls = row.done ? 'done' : 'open'`) carried that preamble only as
+ * `segments` — JS text, which a template language cannot execute. Every DSL
+ * adapter emitted the row anyway, reading a name it never assigned: ERB read
+ * `v[:cls]` (an unseeded vars-Hash key), Go read `$.Cls` (a PARENT-struct
+ * field), the rest read a bare undefined local. The class rendered empty, on
+ * eight backends, with no diagnostic — the exact silent divergence the
+ * sound-or-loud invariant forbids.
+ *
+ * ## The two halves pinned here
+ *
+ *  1. **Lowerable → carried.** `MapCallbackPreamble.declarations` holds one
+ *     `{ name, valueParsed }` per declaration, so each adapter emits it in its
+ *     own per-row local syntax through the `ParsedExpr` door it already has.
+ *  2. **Not lowerable → loud.** Anything that is not a sequence of value
+ *     declarations leaves `declarations` unset, and a DSL target refuses with
+ *     the `/* @client *\/` escape rather than emitting a row that reads
+ *     nothing. A JS runtime keeps running the preamble verbatim either way.
+ *
+ * All-or-nothing is the point of the shape assertions below: lowering the
+ * declarable prefix of a mixed preamble and dropping the rest would be a new
+ * silent divergence wearing the fix's clothes.
+ *
+ * The per-adapter emission is asserted end-to-end by the
+ * `loop-preamble-attr-value` conformance fixture (real ERB / Jinja / Twig /
+ * Blade / Kolon / Mojo / minijinja / Go renders vs. the JS reference), not
+ * here; this file pins the IR contract and the gate.
+ */
+
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import type { IRElement, IRLoop, IRNode } from '../types'
+
+const ROWS = (preamble: string, row = `<li key={r.id} class={cls}>{r.label}</li>`) => `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string; done: boolean }
+export function Rows(props: { rows: Row[] }) {
+  const [rows, setRows] = createSignal<Row[]>(props.rows)
+  return (
+    <ul>
+      {rows().map(r => {
+        ${preamble}
+        return ${row}
+      })}
+    </ul>
+  )
+}
+`
+
+function findLoop(node: IRNode | null): IRLoop | null {
+  if (!node) return null
+  if (node.type === 'loop') return node
+  const kids = (node as IRElement).children
+  if (!Array.isArray(kids)) return null
+  for (const c of kids) {
+    const hit = findLoop(c)
+    if (hit) return hit
+  }
+  return null
+}
+
+function loopOf(source: string): IRLoop {
+  const loop = findLoop(jsxToIR(analyzeComponent(source, 'Rows.tsx')))
+  if (!loop) throw new Error('no loop in IR')
+  return loop
+}
+
+/** Compile against a DSL-tier adapter (one that cannot run a callback body). */
+function dslErrors(source: string): string[] {
+  const adapter = new TestAdapter()
+  adapter.acceptsCallbackBody = () => false
+  return compileJSX(source, 'Rows.tsx', { adapter })
+    .errors.filter(e => e.severity !== 'warning')
+    .map(e => `${e.code}: ${e.message}`)
+}
+
+// The first `analyzeComponent` in a process pays the TS program setup, which
+// alone exceeds the default per-test timeout. Pay it once, outside a test.
+beforeAll(() => {
+  analyzeComponent(ROWS(`const warm = r.label`), 'Warmup.tsx')
+}, 60_000)
+
+describe('preamble value declarations — carried as neutral IR', () => {
+  test('a single ternary declaration', () => {
+    const loop = loopOf(ROWS(`const cls = r.done ? 'done' : 'open'`))
+    expect(loop.preamble?.declarations).toEqual([
+      expect.objectContaining({ name: 'cls', raw: `r.done ? 'done' : 'open'` }),
+    ])
+    expect(loop.preamble?.declarations?.[0].valueParsed.kind).toBe('conditional')
+  })
+
+  test('declarations keep SOURCE order, so a later one can read an earlier one', () => {
+    const loop = loopOf(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string; done: boolean }
+export function Rows(props: { rows: Row[] }) {
+  const [rows, setRows] = createSignal<Row[]>(props.rows)
+  return (
+    <ul>
+      {rows().map(r => {
+        const base = r.done ? 'done' : 'open'
+        const cls = base + ' row'
+        return <li key={r.id} class={cls}>{r.label}</li>
+      })}
+    </ul>
+  )
+}
+`)
+    expect(loop.preamble?.declarations?.map(d => d.name)).toEqual(['base', 'cls'])
+  })
+
+  test('several declarators in one statement each become a declaration', () => {
+    const loop = loopOf(ROWS(`const a = r.label, b = r.id`))
+    expect(loop.preamble?.declarations?.map(d => d.name)).toEqual(['a', 'b'])
+  })
+
+  test('the names are loop-bound for the body, like a loop param', async () => {
+    // `collectLoopBoundNames` is what stops a same-named module const from
+    // inlining over the local the loop just declared.
+    const { collectLoopBoundNames } = await import('../adapters/loop-bound-names.ts')
+    const ctx = analyzeComponent(ROWS(`const cls = r.done ? 'done' : 'open'`), 'Rows.tsx')
+    const root = jsxToIR(ctx)
+    expect(root).not.toBeNull()
+    const names = collectLoopBoundNames({ ...ctx.componentIR!, root: root! })
+    expect(names.has('cls')).toBe(true)
+  })
+})
+
+describe('preamble value declarations — all-or-nothing', () => {
+  // Each of these has SOMETHING declarable in it. Carrying just that part and
+  // dropping the rest would put the missing statement's effect nowhere, with
+  // no diagnostic — so the whole preamble must decline.
+  const notDeclarable: Array<[string, string]> = [
+    ['an assignment after a declaration', `let n = 0\n        n = r.id`],
+    ['an imperative loop', `const out = []\n        for (const c of r.label) out.push(c)`],
+    ['a destructuring binding', `const { label } = r`],
+    ['a declaration with no initializer', `let cls\n        const other = r.label`],
+    [
+      'an initializer the expression subset cannot model',
+      `const cls = (() => r.done)()`,
+    ],
+  ]
+
+  for (const [name, preamble] of notDeclarable) {
+    test(name, () => {
+      const loop = loopOf(ROWS(preamble, `<li key={r.id}>{r.label}</li>`))
+      expect(loop.preamble).toBeDefined()
+      expect(loop.preamble?.declarations).toBeUndefined()
+    })
+  }
+})
+
+describe('the DSL gate — loud, not an empty attribute', () => {
+  test('a declarable preamble compiles clean on a DSL target', () => {
+    expect(dslErrors(ROWS(`const cls = r.done ? 'done' : 'open'`))).toEqual([])
+  })
+
+  test('a non-declarable preamble refuses, with the /* @client */ escape', () => {
+    const errors = dslErrors(
+      ROWS(`let n = 0\n        n = r.id`, `<li key={r.id}>{r.label}</li>`),
+    )
+    expect(errors.length).toBeGreaterThan(0)
+    expect(errors[0]).toMatch(/not a sequence of value declarations/)
+  })
+
+  test('a JS runtime runs the same preamble verbatim — no refusal', () => {
+    // The whole point of the per-backend fidelity model: the price is paid by
+    // the backend that genuinely cannot express the shape.
+    const r = compileJSX(
+      ROWS(`let n = 0\n        n = r.id`, `<li key={r.id}>{r.label}</li>`),
+      'Rows.tsx',
+      { adapter: new TestAdapter() },
+    )
+    expect(r.errors.filter(e => e.severity !== 'warning')).toEqual([])
+  })
+
+  test('/* @client */ silences the DSL refusal', () => {
+    const source = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string; done: boolean }
+export function Rows(props: { rows: Row[] }) {
+  const [rows, setRows] = createSignal<Row[]>(props.rows)
+  return (
+    <ul>
+      {/* @client */ rows().map(r => {
+        let n = 0
+        n = r.id
+        return <li key={r.id}>{r.label}</li>
+      })}
+    </ul>
+  )
+}
+`
+    expect(dslErrors(source)).toEqual([])
+  })
+})

--- a/packages/jsx/src/adapters/loop-bound-names.ts
+++ b/packages/jsx/src/adapters/loop-bound-names.ts
@@ -50,6 +50,12 @@ export function collectLoopBoundNames(ir: ComponentIR): Set<string> {
         // param (which may differ from the map callback's `param`) before
         // any rename to the loop param happens.
         if (node.filterPredicate) names.add(node.filterPredicate.param)
+        // A `.map()` callback preamble's declarations lower to per-row locals
+        // in the loop body on every DSL adapter (#2447), so a preamble name is
+        // bound in body scope exactly like a param — and must get the same
+        // exclusion, or a same-named module const would inline over the local
+        // the loop just declared.
+        for (const name of node.preamble?.declaredNames ?? []) names.add(name)
         for (const child of node.children) visit(child)
         if (node.childComponent) {
           for (const child of node.childComponent.children) visit(child)

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -29,6 +29,7 @@ import {
   type MapCallbackPreamble,
   type PreambleSegment,
   type PreambleRegionSource,
+  type PreambleValueDeclaration,
   tsxSourceText,
   type SourceLocation,
   type TypeInfo,
@@ -4250,20 +4251,29 @@ function transformMapCall(
           // verbatim.
           preamble = preambleFromValueStatements(pre, ctx)
 
-          // A DSL adapter can't carry a loop-local `const` into a conditional
-          // branch template, so it would render the branches with the local
-          // undefined (silent divergence). Refuse instead — adapter-gated like
-          // the filter/sort sites: a JS-runtime target folds and runs it, a DSL
-          // target errors with the /* @client */ escape (which renders the map
-          // client-only, where the browser runs the preamble). Stage 2 of
-          // spec/callback-fidelity.md.
-          if (!isClientOnly && !(ctx.analyzer.acceptsCallbackBody?.('map') ?? false)) {
+          // Stage 2 of spec/callback-fidelity.md, narrowed by #2447. This used
+          // to refuse EVERY branch preamble on a DSL target, on the premise
+          // that a loop-local can't be carried into a conditional branch
+          // template. That premise stopped holding once `declarations` lower
+          // to a per-row local: the fold emits the conditional INSIDE the loop
+          // body, so a local declared ahead of it is in scope in both arms —
+          // `{{$label := bf_upper .Kind}}{{if .On}}…{{$label}}…{{else}}…`. What
+          // remains true is the original hazard for a preamble that CANNOT be
+          // declared: nothing lowers, both branches read an unassigned name.
+          // So the refusal now keys off the same condition as the single-return
+          // gate below, not off the presence of branches.
+          if (
+            !preamble.declarations &&
+            !isClientOnly &&
+            !(ctx.analyzer.acceptsCallbackBody?.('map') ?? false)
+          ) {
             ctx.analyzer.errors.push(
               createError(ErrorCodes.UNSUPPORTED_JSX_PATTERN, loc, {
                 message:
-                  'A .map() callback body with a `const`/`let` preamble before its ' +
-                  'branches cannot be lowered to a template: the loop-local binding ' +
-                  'cannot be carried into a conditional branch on this backend.',
+                  'A .map() callback body with a preamble before its branches cannot be ' +
+                  'lowered to a template: the preamble is not a sequence of value ' +
+                  'declarations, so this backend has no per-row local to carry into the ' +
+                  'branches.',
                 suggestion: {
                   message: 'Add /* @client */ to evaluate this expression on the client only',
                 },
@@ -4402,6 +4412,37 @@ function transformMapCall(
           }
           if (valueStmts.length > 0) {
             preamble = preambleFromValueStatements(valueStmts, ctx)
+
+            // #2447. A DSL adapter cannot execute `preamble.segments` (JS
+            // text), so it lowers `declarations` — one per-row local each —
+            // and the row markup reads them as locals. When the preamble
+            // isn't fully declarable there is nothing to lower, and the
+            // adapter used to emit the row anyway, reading names it never
+            // assigned: the class rendered empty, on every DSL backend, with
+            // no diagnostic. Refuse loudly instead, with the same
+            // `/* @client */` escape as the branch-preamble, array-builder
+            // and flatMap gates above.
+            if (
+              !preamble.declarations &&
+              !isClientOnly &&
+              !(ctx.analyzer.acceptsCallbackBody?.('map') ?? false)
+            ) {
+              ctx.analyzer.errors.push(
+                createError(
+                  ErrorCodes.UNSUPPORTED_JSX_PATTERN,
+                  getSourceLocation(body, ctx.sourceFile, ctx.filePath),
+                  {
+                    message:
+                      'A .map() callback preamble that is not a sequence of value ' +
+                      'declarations cannot be lowered to a template: this backend can ' +
+                      'declare a per-row local, but cannot run arbitrary statements per row.',
+                    suggestion: {
+                      message: 'Add /* @client */ to evaluate this expression on the client only',
+                    },
+                  },
+                )
+              )
+            }
           }
         }
       }
@@ -5148,7 +5189,48 @@ function preambleFromValueStatements(
     declaredNames: [...declared],
     // Value-only preambles accumulate no JSX, so no child needs the array join.
     builderNames: [],
+    declarations: neutralPreambleDeclarations(statements, ctx) ?? undefined,
   }
+}
+
+/**
+ * The DSL SSR half of a value preamble (#2447): every statement as a neutral
+ * {@link PreambleValueDeclaration}, or `null` if any statement is not one.
+ *
+ * All-or-nothing — see `MapCallbackPreamble.declarations`. `null` is what the
+ * Phase-1 gate turns into a loud refusal, so every rejection here must be a
+ * shape a template language genuinely cannot express per row, not a shape this
+ * function merely hasn't got round to.
+ */
+function neutralPreambleDeclarations(
+  statements: readonly ts.Statement[],
+  ctx: TransformContext,
+): PreambleValueDeclaration[] | null {
+  const out: PreambleValueDeclaration[] = []
+  for (const stmt of statements) {
+    // A non-declaration statement (assignment, `for`, a call for its side
+    // effects) has no per-row template form at all.
+    if (!ts.isVariableStatement(stmt)) return null
+    for (const decl of stmt.declarationList.declarations) {
+      // A destructuring binding declares several names from one initializer;
+      // no adapter has a single per-row local form for that.
+      if (!ts.isIdentifier(decl.name)) return null
+      if (!decl.initializer) return null
+      const valueParsed = tsNodeToParsedExpr(decl.initializer)
+      // The same subset gate every other DSL-lowered expression passes
+      // through. An adapter that additionally cannot emit a supported shape
+      // (Go has no array-literal form, say) still records its own BF101 from
+      // its own emitter — this only decides whether the shape is expressible
+      // in principle.
+      if (!isSupported(valueParsed).supported) return null
+      out.push({
+        name: decl.name.text,
+        valueParsed,
+        raw: decl.initializer.getText(ctx.sourceFile),
+      })
+    }
+  }
+  return out.length > 0 ? out : null
 }
 
 /** Drop the trailing separator space from the final js segment. */

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -855,6 +855,28 @@ export interface MapCallbackPreamble {
   /** const/let/function names the preamble declares (D5 key-derivability guard). */
   declaredNames: string[]
   /**
+   * The whole preamble as backend-neutral value declarations — set only when
+   * EVERY statement is one (#2447). This is the DSL SSR carrier: a template
+   * language cannot execute `segments` (that is JS text, for the client bundle
+   * and for JS-runtime SSR), but it CAN declare a per-row local, and each
+   * declaration's initializer is a {@link ParsedExpr} every adapter already
+   * knows how to emit in its own syntax — the same door `arrayParsed` /
+   * `filterPredicate.predicate` / `sortComparator` go through.
+   *
+   * All-or-nothing on purpose. A preamble is a statement SEQUENCE with
+   * order-dependent scope; lowering the declarable prefix and dropping the rest
+   * would leave later statements' effects missing with no diagnostic — the
+   * silent divergence #2447 was. So one non-declaration statement (an
+   * assignment, a loop, a call for side effects) or one initializer the
+   * expression subset cannot model leaves this `undefined`, and the Phase-1
+   * DSL gate refuses the whole loop with `/* @client *\/` guidance.
+   *
+   * Declarations appear in source order and may read earlier ones; adapters
+   * emit them in order, so an earlier local is in scope for a later
+   * initializer, exactly as in the source.
+   */
+  declarations?: PreambleValueDeclaration[]
+  /**
    * The subset of {@link declaredNames} that accumulate JSX leaves — the
    * `push`/`unshift` targets of a `jsx` segment and the declaration targets of
    * a leaf-bearing initializer (`const out = xs.map(x => <td/>)`). Only these
@@ -862,6 +884,25 @@ export interface MapCallbackPreamble {
    * keeps the plain interpolation it always had.
    */
   builderNames: string[]
+}
+
+/**
+ * One `const`/`let` value declaration from a `.map()` callback preamble, in
+ * backend-neutral form (#2447 — see {@link MapCallbackPreamble.declarations}).
+ * `name` is always a simple identifier: a destructuring binding declares
+ * several names from one initializer, which no adapter has a single per-row
+ * local form for, so that shape refuses instead of being carried here.
+ */
+export interface PreambleValueDeclaration {
+  /** Declared local name (simple identifier binding). */
+  name: string
+  /** Initializer, structured for per-adapter emission. */
+  valueParsed: ParsedExpr
+  /**
+   * Initializer source text, for a diagnostic that needs to quote it. Never an
+   * emission input — emission goes through `valueParsed`.
+   */
+  raw: string
 }
 
 /**

--- a/spec/callback-fidelity.md
+++ b/spec/callback-fidelity.md
@@ -10,8 +10,13 @@
 > (adapter-gate the Phase-1 `filter`/`sort` constraint), `#2374` (close the
 > `fill` gap + doc/comment cleanup), `#2375` (find/some/every off-subset
 > conformance), `#2376` (reduce/reduceRight/flatMap off-subset conformance).
-> Stage 2 has landed (if/else-if + `switch` fold, `const`-preamble fold
-> adapter-gated). Stage 3 has landed in two steps: the imperative array-builder
+> Stage 2 has landed (if/else-if + `switch` fold, `const`-preamble fold), and
+> Stage 2a with it: a value preamble is carried as backend-neutral
+> `declarations` and lowered to per-row template locals on every DSL adapter
+> (#2447 — before that it had only a JS-text carrier, so eight backends emitted
+> a row reading names they never assigned). A preamble that is NOT a sequence
+> of value declarations still refuses on a DSL target with `BF021` +
+> `/* @client */`. Stage 3 has landed in two steps: the imperative array-builder
 > body (`const out = []; for (…) out.push(<td/>); return <tr>{out}</tr>`)
 > renders verbatim on JS-runtime adapters (D4 + D5(a), keyFn hoisted; DSL
 > refuses with `BF021` + `/* @client */`), and the follow-up **root cure**
@@ -311,15 +316,42 @@ Each stage is independently shippable, tested, and PR-sized. Value/risk-ordered.
   into a nested `IRConditional` — the neutral IR a ternary map body already
   produces — instead of silently leaking the raw `if`/`switch` into the
   callback. All backends gain SSR fidelity for these shapes. A **leading
-  `const`/`let` preamble** folds on JS-runtime adapters and, since a DSL
-  backend can't carry a loop-local into a conditional branch template, is
-  adapter-gated: a DSL target refuses with `BF021` + `/* @client */` (never
-  silent divergence). Two shapes are deliberately **not** folded and bail
+  `const`/`let` preamble** folds on every backend (#2447 — see Stage 2a): the
+  fold puts the conditional inside the loop body, so a preamble lowered to
+  per-row locals is in scope in both arms. Two shapes are deliberately **not** folded and bail
   conservatively: a *branch-local* `const` (inside a branch block / case), and
   a **statement-level nested loop** (an imperative `for`-with-`push` that builds
   a JSX array) — the latter is an arbitrary imperative body handled by Stage 3's
   verbatim-JS path, not the neutral-IR fold. *Tests: compiler-unit, CSR +
   cross-adapter + hydration conformance (new fixtures), coverage.*
+- **Stage 2a — Lower a value preamble to per-row locals on DSL backends.** ✅
+  *Landed (#2447).* A `.map()` preamble had exactly one carrier —
+  `MapCallbackPreamble.segments`, JS text a template language cannot execute —
+  so eight DSL adapters emitted the row while assigning none of the names it
+  read: ERB read `v[:cls]` (an unseeded vars-Hash key), Go read `$.Cls` (a
+  PARENT-struct field, the same hoisted-to-parent defect class as #2445), the
+  rest read a bare undefined local. Every one rendered the attribute empty,
+  with no diagnostic. The fix is a **second, backend-neutral carrier**:
+  `MapCallbackPreamble.declarations`, one `{ name, valueParsed }` per
+  declaration, so each adapter emits a per-row local through the `ParsedExpr`
+  door it already has for `arrayParsed` / `filterPredicate` / `sortComparator`
+  (`{% set %}`, `@php()`, `<%- … -%>`, `: my $x = …;`, `{{$x := …}}`).
+  Declarations render in source order, so a later initializer sees an earlier
+  local; on a `.filter(p).map(cb)` chain they render inside the filter guard,
+  matching JS order. It is **all-or-nothing** — a preamble is an
+  order-dependent statement sequence, and lowering its declarable prefix while
+  dropping the rest would be the same silent divergence wearing the fix's
+  clothes — so one statement that is not a value declaration (an assignment, an
+  imperative loop, a destructure, an initializer off the expression subset)
+  leaves `declarations` unset and a DSL target refuses with `BF021` +
+  `/* @client */`, the sibling of every other Phase-1 callback gate. The
+  refusal that Stage 2 attached to *branches* is subsumed by this one: it keys
+  off "is the preamble declarable", not "does the body branch".
+  *Tests: `preamble-declarations.test.ts` (IR contract + gate + the
+  `/* @client */` escape); the `loop-preamble-attr-value` and
+  `map-preamble-branch-body` fixtures now render on all nine adapters and CSR,
+  which is what would catch a per-row declaration going missing on any one
+  backend.*
 - **Stage 3 — JS-runtime verbatim + `/* @client */` for the rest (D4 + D5).**
   Reaches the fidelity ceiling for JSX-`map`. Requires the Stage-0 `keyFn`
   decision. *Tests: runtime-unit (key contract), CSR conformance, E2E

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 287,
+    "totalFixtures": 288,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -2279,40 +2279,6 @@
           ]
         }
       },
-      "loop-preamble-attr-value": {
-        "blade": {
-          "kind": "render",
-          "reason": "a `.map()` callback preamble's value declarations are not lowered into the template, so the row reads an unassigned variable and the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "a `.map()` callback preamble's value declarations are not lowered into the template, so the row reads an unassigned variable and the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)"
-        },
-        "go-template": {
-          "kind": "render",
-          "reason": "a `.map()` callback preamble's value declaration is hoisted to a parent-scope field instead of being built per row, so the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "a `.map()` callback preamble's value declarations are not lowered into the template, so the row reads an unassigned variable and the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "a `.map()` callback preamble's value declarations are not lowered into the template, so the row reads an unassigned variable and the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "a `.map()` callback preamble's value declarations are not lowered into the template, so the row reads an unassigned variable and the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "a `.map()` callback preamble's value declarations are not lowered into the template, so the row reads an unassigned variable and the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "a `.map()` callback preamble's value declarations are not lowered into the template, so the row reads an unassigned variable and the attribute renders empty (https://github.com/piconic-ai/barefootjs/issues/2447)"
-        }
-      },
       "map-array-builder-body": {
         "blade": {
           "kind": "refusal",
@@ -2364,56 +2330,6 @@
         }
       },
       "map-array-builder-escaping": {
-        "blade": {
-          "kind": "refusal",
-          "codes": [
-            "BF021"
-          ]
-        },
-        "erb": {
-          "kind": "refusal",
-          "codes": [
-            "BF021"
-          ]
-        },
-        "go-template": {
-          "kind": "refusal",
-          "codes": [
-            "BF021"
-          ]
-        },
-        "jinja": {
-          "kind": "refusal",
-          "codes": [
-            "BF021"
-          ]
-        },
-        "minijinja": {
-          "kind": "refusal",
-          "codes": [
-            "BF021"
-          ]
-        },
-        "mojolicious": {
-          "kind": "refusal",
-          "codes": [
-            "BF021"
-          ]
-        },
-        "twig": {
-          "kind": "refusal",
-          "codes": [
-            "BF021"
-          ]
-        },
-        "xslate": {
-          "kind": "refusal",
-          "codes": [
-            "BF021"
-          ]
-        }
-      },
-      "map-preamble-branch-body": {
         "blade": {
           "kind": "refusal",
           "codes": [
@@ -2895,10 +2811,6 @@
         "description": "Off-subset `.flatMap()` projection (typeof) — JS-runtime faithful, DSL diagnostic",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/flatmap-typeof-projection.ts"
       },
-      "loop-preamble-attr-value": {
-        "description": "Loop row preamble computes an attribute value; row text reads the item",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/loop-preamble-attr-value.ts"
-      },
       "map-array-builder-body": {
         "description": "imperative array-builder .map() body — JS-runtime verbatim, DSL refuses (BF021)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/map-array-builder-body.ts"
@@ -2906,10 +2818,6 @@
       "map-array-builder-escaping": {
         "description": "special characters in array-builder leaf text escape identically at SSR and CSR",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/map-array-builder-escaping.ts"
-      },
-      "map-preamble-branch-body": {
-        "description": "const preamble + if/else as a .map() body — JS-runtime folds, DSL refuses (BF021)",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/map-preamble-branch-body.ts"
       },
       "preamble-cells": {
         "description": "keyed .map() row with a preamble-built leaf child — patched in place on same-key update, not frozen",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -486,15 +486,15 @@
       }
     },
     "array-method": {
-      "total": 65,
+      "total": 66,
       "cells": {
         "hono": {
-          "pass": 65,
-          "total": 65
+          "pass": 66,
+          "total": 66
         },
         "blade": {
-          "pass": 62,
-          "total": 65,
+          "pass": 63,
+          "total": 66,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -511,8 +511,8 @@
           ]
         },
         "erb": {
-          "pass": 62,
-          "total": 65,
+          "pass": 63,
+          "total": 66,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -529,8 +529,8 @@
           ]
         },
         "go-template": {
-          "pass": 62,
-          "total": 65,
+          "pass": 63,
+          "total": 66,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -547,8 +547,8 @@
           ]
         },
         "jinja": {
-          "pass": 62,
-          "total": 65,
+          "pass": 63,
+          "total": 66,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -565,8 +565,8 @@
           ]
         },
         "minijinja": {
-          "pass": 62,
-          "total": 65,
+          "pass": 63,
+          "total": 66,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -583,8 +583,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 62,
-          "total": 65,
+          "pass": 63,
+          "total": 66,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -601,8 +601,8 @@
           ]
         },
         "twig": {
-          "pass": 62,
-          "total": 65,
+          "pass": 63,
+          "total": 66,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -619,8 +619,8 @@
           ]
         },
         "xslate": {
-          "pass": 62,
-          "total": 65,
+          "pass": 63,
+          "total": 66,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -1026,15 +1026,15 @@
       }
     },
     "binary": {
-      "total": 77,
+      "total": 78,
       "cells": {
         "hono": {
-          "pass": 77,
-          "total": 77
+          "pass": 78,
+          "total": 78
         },
         "blade": {
-          "pass": 68,
-          "total": 77,
+          "pass": 69,
+          "total": 78,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1081,8 +1081,8 @@
           ]
         },
         "erb": {
-          "pass": 69,
-          "total": 77,
+          "pass": 70,
+          "total": 78,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1123,8 +1123,8 @@
           ]
         },
         "go-template": {
-          "pass": 68,
-          "total": 77,
+          "pass": 69,
+          "total": 78,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1171,8 +1171,8 @@
           ]
         },
         "jinja": {
-          "pass": 68,
-          "total": 77,
+          "pass": 69,
+          "total": 78,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1219,8 +1219,8 @@
           ]
         },
         "minijinja": {
-          "pass": 68,
-          "total": 77,
+          "pass": 69,
+          "total": 78,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1267,8 +1267,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 69,
-          "total": 77,
+          "pass": 70,
+          "total": 78,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1309,8 +1309,8 @@
           ]
         },
         "twig": {
-          "pass": 68,
-          "total": 77,
+          "pass": 69,
+          "total": 78,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1357,8 +1357,8 @@
           ]
         },
         "xslate": {
-          "pass": 68,
-          "total": 77,
+          "pass": 69,
+          "total": 78,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 182,
+      "total": 183,
       "cells": {
         "hono": {
-          "pass": 181,
-          "total": 182,
+          "pass": 182,
+          "total": 183,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1433,8 +1433,8 @@
           ]
         },
         "blade": {
-          "pass": 166,
-          "total": 182,
+          "pass": 168,
+          "total": 183,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1472,10 +1472,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-preamble-attr-value",
               "issues": []
             },
             {
@@ -1513,8 +1509,8 @@
           ]
         },
         "erb": {
-          "pass": 167,
-          "total": 182,
+          "pass": 169,
+          "total": 183,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1546,10 +1542,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-preamble-attr-value",
               "issues": []
             },
             {
@@ -1587,8 +1579,8 @@
           ]
         },
         "go-template": {
-          "pass": 166,
-          "total": 182,
+          "pass": 168,
+          "total": 183,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1626,10 +1618,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-preamble-attr-value",
               "issues": []
             },
             {
@@ -1667,8 +1655,8 @@
           ]
         },
         "jinja": {
-          "pass": 166,
-          "total": 182,
+          "pass": 168,
+          "total": 183,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1706,10 +1694,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-preamble-attr-value",
               "issues": []
             },
             {
@@ -1747,8 +1731,8 @@
           ]
         },
         "minijinja": {
-          "pass": 166,
-          "total": 182,
+          "pass": 168,
+          "total": 183,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1786,10 +1770,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-preamble-attr-value",
               "issues": []
             },
             {
@@ -1827,8 +1807,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 167,
-          "total": 182,
+          "pass": 169,
+          "total": 183,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1860,10 +1840,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-preamble-attr-value",
               "issues": []
             },
             {
@@ -1901,8 +1877,8 @@
           ]
         },
         "twig": {
-          "pass": 166,
-          "total": 182,
+          "pass": 168,
+          "total": 183,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1940,10 +1916,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-preamble-attr-value",
               "issues": []
             },
             {
@@ -1981,8 +1953,8 @@
           ]
         },
         "xslate": {
-          "pass": 166,
-          "total": 182,
+          "pass": 168,
+          "total": 183,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2020,10 +1992,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-preamble-attr-value",
               "issues": []
             },
             {
@@ -2074,15 +2042,15 @@
       }
     },
     "conditional": {
-      "total": 22,
+      "total": 23,
       "cells": {
         "hono": {
-          "pass": 22,
-          "total": 22
+          "pass": 23,
+          "total": 23
         },
         "blade": {
-          "pass": 20,
-          "total": 22,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2095,8 +2063,8 @@
           ]
         },
         "erb": {
-          "pass": 20,
-          "total": 22,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2109,8 +2077,8 @@
           ]
         },
         "go-template": {
-          "pass": 20,
-          "total": 22,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2123,8 +2091,8 @@
           ]
         },
         "jinja": {
-          "pass": 20,
-          "total": 22,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2137,8 +2105,8 @@
           ]
         },
         "minijinja": {
-          "pass": 20,
-          "total": 22,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2151,8 +2119,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 20,
-          "total": 22,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2165,8 +2133,8 @@
           ]
         },
         "twig": {
-          "pass": 20,
-          "total": 22,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2179,8 +2147,8 @@
           ]
         },
         "xslate": {
-          "pass": 20,
-          "total": 22,
+          "pass": 21,
+          "total": 23,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2206,11 +2174,11 @@
       }
     },
     "identifier": {
-      "total": 268,
+      "total": 269,
       "cells": {
         "hono": {
-          "pass": 267,
-          "total": 268,
+          "pass": 268,
+          "total": 269,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2221,8 +2189,8 @@
           ]
         },
         "blade": {
-          "pass": 249,
-          "total": 268,
+          "pass": 252,
+          "total": 269,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2263,19 +2231,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -2313,8 +2273,8 @@
           ]
         },
         "erb": {
-          "pass": 250,
-          "total": 268,
+          "pass": 253,
+          "total": 269,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2349,19 +2309,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -2399,8 +2351,8 @@
           ]
         },
         "go-template": {
-          "pass": 249,
-          "total": 268,
+          "pass": 252,
+          "total": 269,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2441,19 +2393,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -2491,8 +2435,8 @@
           ]
         },
         "jinja": {
-          "pass": 249,
-          "total": 268,
+          "pass": 252,
+          "total": 269,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2533,19 +2477,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -2583,8 +2519,8 @@
           ]
         },
         "minijinja": {
-          "pass": 249,
-          "total": 268,
+          "pass": 252,
+          "total": 269,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2625,19 +2561,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -2675,8 +2603,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 250,
-          "total": 268,
+          "pass": 253,
+          "total": 269,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2711,19 +2639,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -2761,8 +2681,8 @@
           ]
         },
         "twig": {
-          "pass": 249,
-          "total": 268,
+          "pass": 252,
+          "total": 269,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2803,19 +2723,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -2853,8 +2765,8 @@
           ]
         },
         "xslate": {
-          "pass": 249,
-          "total": 268,
+          "pass": 252,
+          "total": 269,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2895,19 +2807,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -3010,15 +2914,15 @@
       }
     },
     "literal": {
-      "total": 219,
+      "total": 221,
       "cells": {
         "hono": {
-          "pass": 219,
-          "total": 219
+          "pass": 221,
+          "total": 221
         },
         "blade": {
-          "pass": 208,
-          "total": 219,
+          "pass": 210,
+          "total": 221,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3069,8 +2973,8 @@
           ]
         },
         "erb": {
-          "pass": 208,
-          "total": 219,
+          "pass": 210,
+          "total": 221,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3121,8 +3025,8 @@
           ]
         },
         "go-template": {
-          "pass": 208,
-          "total": 219,
+          "pass": 210,
+          "total": 221,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3173,8 +3077,8 @@
           ]
         },
         "jinja": {
-          "pass": 208,
-          "total": 219,
+          "pass": 210,
+          "total": 221,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3225,8 +3129,8 @@
           ]
         },
         "minijinja": {
-          "pass": 208,
-          "total": 219,
+          "pass": 210,
+          "total": 221,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3277,8 +3181,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 208,
-          "total": 219,
+          "pass": 210,
+          "total": 221,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3329,8 +3233,8 @@
           ]
         },
         "twig": {
-          "pass": 208,
-          "total": 219,
+          "pass": 210,
+          "total": 221,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3381,8 +3285,8 @@
           ]
         },
         "xslate": {
-          "pass": 208,
-          "total": 219,
+          "pass": 210,
+          "total": 221,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3594,11 +3498,11 @@
       }
     },
     "member": {
-      "total": 147,
+      "total": 148,
       "cells": {
         "hono": {
-          "pass": 146,
-          "total": 147,
+          "pass": 147,
+          "total": 148,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3609,8 +3513,8 @@
           ]
         },
         "blade": {
-          "pass": 128,
-          "total": 147,
+          "pass": 131,
+          "total": 148,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3651,19 +3555,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -3701,8 +3597,8 @@
           ]
         },
         "erb": {
-          "pass": 129,
-          "total": 147,
+          "pass": 132,
+          "total": 148,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3737,19 +3633,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -3787,8 +3675,8 @@
           ]
         },
         "go-template": {
-          "pass": 128,
-          "total": 147,
+          "pass": 131,
+          "total": 148,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3829,19 +3717,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -3879,8 +3759,8 @@
           ]
         },
         "jinja": {
-          "pass": 128,
-          "total": 147,
+          "pass": 131,
+          "total": 148,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3921,19 +3801,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -3971,8 +3843,8 @@
           ]
         },
         "minijinja": {
-          "pass": 128,
-          "total": 147,
+          "pass": 131,
+          "total": 148,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4013,19 +3885,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -4063,8 +3927,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 129,
-          "total": 147,
+          "pass": 132,
+          "total": 148,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4099,19 +3963,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -4149,8 +4005,8 @@
           ]
         },
         "twig": {
-          "pass": 128,
-          "total": 147,
+          "pass": 131,
+          "total": 148,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4191,19 +4047,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -4241,8 +4089,8 @@
           ]
         },
         "xslate": {
-          "pass": 128,
-          "total": 147,
+          "pass": 131,
+          "total": 148,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4283,19 +4131,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-preamble-attr-value",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "map-preamble-branch-body",
               "issues": []
             },
             {
@@ -4640,15 +4480,15 @@
       }
     },
     "unary": {
-      "total": 22,
+      "total": 23,
       "cells": {
         "hono": {
-          "pass": 22,
-          "total": 22
+          "pass": 23,
+          "total": 23
         },
         "blade": {
-          "pass": 21,
-          "total": 22,
+          "pass": 22,
+          "total": 23,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4659,12 +4499,12 @@
           ]
         },
         "erb": {
-          "pass": 22,
-          "total": 22
+          "pass": 23,
+          "total": 23
         },
         "go-template": {
-          "pass": 21,
-          "total": 22,
+          "pass": 22,
+          "total": 23,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4675,8 +4515,8 @@
           ]
         },
         "jinja": {
-          "pass": 21,
-          "total": 22,
+          "pass": 22,
+          "total": 23,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4687,8 +4527,8 @@
           ]
         },
         "minijinja": {
-          "pass": 21,
-          "total": 22,
+          "pass": 22,
+          "total": 23,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4699,12 +4539,12 @@
           ]
         },
         "mojolicious": {
-          "pass": 22,
-          "total": 22
+          "pass": 23,
+          "total": 23
         },
         "twig": {
-          "pass": 21,
-          "total": 22,
+          "pass": 22,
+          "total": 23,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4715,8 +4555,8 @@
           ]
         },
         "xslate": {
-          "pass": 21,
-          "total": 22,
+          "pass": 22,
+          "total": 23,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -6361,43 +6201,43 @@
       }
     },
     "array-method:toUpperCase": {
-      "total": 1,
+      "total": 2,
       "cells": {
         "hono": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "blade": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "erb": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "go-template": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "jinja": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "minijinja": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "mojolicious": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "twig": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "xslate": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         }
       },
       "source": {
@@ -6724,15 +6564,15 @@
       }
     },
     "binary:+": {
-      "total": 17,
+      "total": 18,
       "cells": {
         "hono": {
-          "pass": 17,
-          "total": 17
+          "pass": 18,
+          "total": 18
         },
         "blade": {
-          "pass": 16,
-          "total": 17,
+          "pass": 17,
+          "total": 18,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6743,8 +6583,8 @@
           ]
         },
         "erb": {
-          "pass": 16,
-          "total": 17,
+          "pass": 17,
+          "total": 18,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6755,8 +6595,8 @@
           ]
         },
         "go-template": {
-          "pass": 16,
-          "total": 17,
+          "pass": 17,
+          "total": 18,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6767,8 +6607,8 @@
           ]
         },
         "jinja": {
-          "pass": 16,
-          "total": 17,
+          "pass": 17,
+          "total": 18,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6779,8 +6619,8 @@
           ]
         },
         "minijinja": {
-          "pass": 16,
-          "total": 17,
+          "pass": 17,
+          "total": 18,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6791,8 +6631,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 16,
-          "total": 17,
+          "pass": 17,
+          "total": 18,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6803,8 +6643,8 @@
           ]
         },
         "twig": {
-          "pass": 16,
-          "total": 17,
+          "pass": 17,
+          "total": 18,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6815,8 +6655,8 @@
           ]
         },
         "xslate": {
-          "pass": 16,
-          "total": 17,
+          "pass": 17,
+          "total": 18,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -7823,15 +7663,15 @@
       }
     },
     "literal:string": {
-      "total": 159,
+      "total": 161,
       "cells": {
         "hono": {
-          "pass": 159,
-          "total": 159
+          "pass": 161,
+          "total": 161
         },
         "blade": {
-          "pass": 151,
-          "total": 159,
+          "pass": 153,
+          "total": 161,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7870,8 +7710,8 @@
           ]
         },
         "erb": {
-          "pass": 151,
-          "total": 159,
+          "pass": 153,
+          "total": 161,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7910,8 +7750,8 @@
           ]
         },
         "go-template": {
-          "pass": 151,
-          "total": 159,
+          "pass": 153,
+          "total": 161,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7950,8 +7790,8 @@
           ]
         },
         "jinja": {
-          "pass": 151,
-          "total": 159,
+          "pass": 153,
+          "total": 161,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7990,8 +7830,8 @@
           ]
         },
         "minijinja": {
-          "pass": 151,
-          "total": 159,
+          "pass": 153,
+          "total": 161,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8030,8 +7870,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 151,
-          "total": 159,
+          "pass": 153,
+          "total": 161,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8070,8 +7910,8 @@
           ]
         },
         "twig": {
-          "pass": 151,
-          "total": 159,
+          "pass": 153,
+          "total": 161,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8110,8 +7950,8 @@
           ]
         },
         "xslate": {
-          "pass": 151,
-          "total": 159,
+          "pass": 153,
+          "total": 161,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8519,15 +8359,15 @@
       }
     },
     "unary:!": {
-      "total": 14,
+      "total": 15,
       "cells": {
         "hono": {
-          "pass": 14,
-          "total": 14
+          "pass": 15,
+          "total": 15
         },
         "blade": {
-          "pass": 13,
-          "total": 14,
+          "pass": 14,
+          "total": 15,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -8538,12 +8378,12 @@
           ]
         },
         "erb": {
-          "pass": 14,
-          "total": 14
+          "pass": 15,
+          "total": 15
         },
         "go-template": {
-          "pass": 13,
-          "total": 14,
+          "pass": 14,
+          "total": 15,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -8554,8 +8394,8 @@
           ]
         },
         "jinja": {
-          "pass": 13,
-          "total": 14,
+          "pass": 14,
+          "total": 15,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -8566,8 +8406,8 @@
           ]
         },
         "minijinja": {
-          "pass": 13,
-          "total": 14,
+          "pass": 14,
+          "total": 15,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -8578,12 +8418,12 @@
           ]
         },
         "mojolicious": {
-          "pass": 14,
-          "total": 14
+          "pass": 15,
+          "total": 15
         },
         "twig": {
-          "pass": 13,
-          "total": 14,
+          "pass": 14,
+          "total": 15,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -8594,8 +8434,8 @@
           ]
         },
         "xslate": {
-          "pass": 13,
-          "total": 14,
+          "pass": 14,
+          "total": 15,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",


### PR DESCRIPTION
Closes #2447.

## The hole

A `.map()` preamble had exactly one carrier — `MapCallbackPreamble.segments`, JS text. A template language cannot execute that, so every DSL adapter emitted the row *anyway*, reading names it never assigned:

| Adapter | What the row read | Why |
|---|---|---|
| erb | `v[:cls]` | vars-Hash key nothing seeds |
| go-template | `$.Cls` | a **parent-struct** field, never populated — same hoisted-to-parent class as #2445 |
| blade / twig / jinja / rust / xslate / mojolicious | a bare undefined local | nothing declares it |

All eight rendered `class=""`, with **no diagnostic**. Hono and CSR were correct throughout, which is why it only showed against a real DSL runtime.

## The fix

A second, **backend-neutral** carrier: `MapCallbackPreamble.declarations`, one `{ name, valueParsed }` per declaration. Each adapter emits a per-row local in its own syntax through the `ParsedExpr` door it already has for `arrayParsed` / `filterPredicate` / `sortComparator`:

```
erb          <%- cls = (bf.truthy?(row[:done]) ? 'done' : 'open') -%>
blade        @php($cls = ($bf->truthy(data_get($row, 'done')) ? 'done' : 'open'))
jinja        {% set cls = ('done' if bf.truthy(row['done']) else 'open') %}
twig         {% set cls = (bf.truthy(row.done) ? 'done' : 'open') %}
rust         {% set cls = ('done' if bf.truthy(row.done) else 'open') %}
xslate       : my $cls = ($row.done ? 'done' : 'open');
mojolicious  % my $cls = ($row->{done} ? 'done' : 'open');
go           {{$cls := (bf_ternary (bf_truthy .Done) "done" "open")}}
```

No new expression path, and no adapter interpreting JS text. Load-bearing details:

- **Source order** is preserved, so a later initializer sees an earlier local (`const base = …; const cls = base + '-open'`).
- **Inside the filter guard** on a `.filter(p).map(cb)` chain, matching JS: the callback body never runs for a filtered-out item.
- **The names are registered loop-bound**, so a same-named module const can't inline over the local the loop just declared. Go needed this too — `loopVarRefCount` is what makes `identifier()` resolve the read as `$cls` instead of falling through to `rootFieldRef`.

## All-or-nothing, on purpose

A preamble is an order-dependent statement *sequence*. Carrying its declarable prefix and dropping the rest would put the missing statement's effect nowhere — the same silent divergence in a new disguise. So one statement that is not a value declaration (an assignment, an imperative loop, a destructuring binding, an initializer outside the expression subset) leaves `declarations` unset, and a DSL target refuses with `BF021` + `/* @client */` — the sibling of the existing filter / sort / array-builder / flatMap gates. A JS runtime keeps running any preamble verbatim.

## Two behaviour changes

- **`map-preamble-branch-body` now renders on every adapter**; its `BF021` pins are gone from all eight. They existed on the premise that a loop-local cannot be carried into a conditional branch template. That stopped being true the moment a value preamble lowers: the if/else fold puts the conditional *inside* the loop body, so the local is in scope in both arms — `{{$label := bf_upper .Kind}}{{if .On}}…{{$label}}…{{else}}…`. The refusal now keys off whether the preamble is *declarable*, not whether the body branches. The support matrix records this as `array-method` going 62/65 → 63/66 on every DSL adapter.
- **A non-declarable preamble that used to compile is now a build error on DSL targets.** It previously produced a template reading unassigned names, so the change is silently-wrong-output → diagnostic with a documented escape.

## Coverage

- `loop-preamble-attr-value` — its render divergences are **graduated** (deleted from all eight `render-divergences.ts`).
- `loop-preamble-chained-filter` — **new**, pinning the two ordering claims above, which nothing else proved cross-adapter.
- `preamble-declarations.test.ts` — **new**: the IR contract, the all-or-nothing rule (five shapes that must decline as a whole), the gate, and that `/* @client */` silences it.
- `map-multi-return-body.test.ts` — retargeted: the branch preamble now compiles on DSL, and a *destructuring* branch preamble is the shape that still refuses.
- Regenerated: `coverage-map.json`, `ui/compat.lock.json`, `ui/support-matrix.lock.json`.

## Verification

**CI is green on all 40 checks** at `8569610` — every adapter `test` job against its real runtime, all e2e legs, plus the drift gates (`update-expected-html`, `update-doc-snapshots`, `update-meta`, `lockfile`, `dist`).

All nine adapters were also re-verified against **real runtimes locally**, which matters because #2447's original evidence for four of them was templates read by eye. The three preamble fixtures render correctly through real Text::Xslate:

```
loop-preamble-attr-value      <li data-key="1" class="open">…  <li data-key="2" class="done">…
loop-preamble-chained-filter  <li data-key="1" class="write it-open">…  <li data-key="3" class="sign it-open">…
map-preamble-branch-body      <b bf-c="s0" data-key="1">A</b>  <span bf-c="s0" data-key="2">B</span>
```

— the chained case also confirming both ordering claims at once: `cls` reads `base`, and the `done: true` row is filtered out before the declarations run.

## Out of scope, still open

An attribute whose value comes from a preamble local is not classified as reactive on the client, so it is interpolated into the row template and not rewritten on a same-key item update. That is a client-side classification question, pinned as the current contract in `packages/client/__tests__/runtime/lazy-row-preamble.test.ts`, and unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM