### PR TITLE
Make an attribute reading a .map() preamble local reactive (#2447 follow-up)

### DIFF
--- a/.changeset/preamble-attr-reactive.md
+++ b/.changeset/preamble-attr-reactive.md
@@ -1,0 +1,55 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Make an attribute reading a `.map()` callback preamble local reactive (#2447 follow-up)
+
+```tsx
+{rows().map(row => {
+  const cls = row.done ? 'done' : 'open'
+  return <li key={row.id} class={cls}>{row.label}</li>
+})}
+```
+
+`class={cls}` froze at its row-construction value. The loop runtimes reuse a
+row's DOM node on a same-key item update and re-run only the wired slots, and
+this attribute was not one: the reactivity classifier sees a bare local, not a
+signal or loop-param read, so the value was interpolated into the row template
+instead of bound. Row 1 kept `open` after its item turned `done: true` while
+the sibling `{row.label}` text updated normally. The child-position twin of
+this (`{stateLabel}`) was fixed as a preamble-patched region in #2389; the
+attribute position was left as a declared limitation on #2447.
+
+The fix spans two passes, because the obstacle is in two places:
+
+- **Phase 1 grants the element a slot id.** An attribute is only wirable if
+  its element carries a `bf` marker, and that is decided when the element is
+  built — before the enclosing loop's preamble exists. The client-JS pass
+  cannot grant one after the fact, since the SSR template renders from the
+  same IR and would not carry the marker.
+- **The client-JS pass wires it** and re-runs the preamble ahead of the write.
+  In the eager row effect the preamble re-run moves to the top of the body; it
+  previously sat between the attr writes and the region writes, which was
+  correct only while regions were its only readers.
+
+**The lazy row graph keeps these rows.** `lazyRowEligibility` used to refuse
+any binding that read a preamble local, on the grounds that `applyOuter` could
+not prime a dependency the local hides — a fail-safe written while the case
+was unreachable. Making it reachable would have pushed the exact row the §9.5
+widening was built for (`const cls = selected() === row.id ? …`) back onto the
+eager path. So the substitution that refusal stood in for is now real:
+`analyzeLazyPreamble` reports the preamble's own free identifiers,
+`classifyLazyBinding` runs them through the same rules it applies to a
+binding's own names, and `applyItem` / `applyOuter` re-run the preamble only
+when a binding they own reads one. A preamble no binding reads is still
+emitted in `createRow` alone.
+
+Both dependency shapes are verified against the live DOM: an item-driven
+preamble updating through `applyItem`, and an outer-driven one updating
+through `applyOuter` with its signal on the prime list — the case that would
+silently never subscribe if the substitution named the wrong dependency.
+
+Rows that gain a binding also gain a `bf` marker in SSR output, which shifts
+slot numbering for the affected components. The `loop-preamble-attr-value` and
+`loop-preamble-chained-filter` fixtures record the new markers; no rendered
+content changed.

--- a/packages/adapter-tests/fixtures/loop-preamble-attr-value.ts
+++ b/packages/adapter-tests/fixtures/loop-preamble-attr-value.ts
@@ -46,9 +46,9 @@ export function LoopPreambleAttrValue(props: { rows: Row[] }) {
     ],
   },
   expectedHtml: `
-    <ul bf-s="test" bf="s1">
-      <li class="open" data-key="1"><!--bf:s0-->write it<!--/--></li>
-      <li class="done" data-key="2"><!--bf:s0-->ship it<!--/--></li>
+    <ul bf-s="test" bf="s2">
+      <li bf="s1" class="open" data-key="1"><!--bf:s0-->write it<!--/--></li>
+      <li bf="s1" class="done" data-key="2"><!--bf:s0-->ship it<!--/--></li>
     </ul>
   `,
   dataPoints: [{ name: 'empty', props: { rows: [] } }],

--- a/packages/adapter-tests/fixtures/loop-preamble-chained-filter.ts
+++ b/packages/adapter-tests/fixtures/loop-preamble-chained-filter.ts
@@ -50,9 +50,9 @@ export function LoopPreambleChainedFilter(props: { rows: Row[] }) {
     ],
   },
   expectedHtml: `
-    <ul bf-s="test" bf="s1">
-      <li class="write it-open" data-key="1"><!--bf:s0-->write it<!--/--></li>
-      <li class="sign it-open" data-key="3"><!--bf:s0-->sign it<!--/--></li>
+    <ul bf-s="test" bf="s2">
+      <li bf="s1" class="write it-open" data-key="1"><!--bf:s0-->write it<!--/--></li>
+      <li bf="s1" class="sign it-open" data-key="3"><!--bf:s0-->sign it<!--/--></li>
     </ul>
   `,
   dataPoints: [

--- a/packages/client/__tests__/runtime/lazy-row-preamble.test.ts
+++ b/packages/client/__tests__/runtime/lazy-row-preamble.test.ts
@@ -1,31 +1,22 @@
 /**
- * A lazy row whose `.map()` callback has a value-only PREAMBLE — the §9.5
- * widening (`jsx/src/ir-to-client-js/control-flow/plan/lazy-preamble.ts`).
+ * A row whose `.map()` callback has a value-only PREAMBLE, run end to end:
+ * compile the component, import the emitted module, mount it, read the DOM.
  *
  * The compiler side is pinned by unit tests (`jsx/src/__tests__/
- * lazy-preamble.test.ts`): which preambles are accepted, and that the accepted
- * one is emitted into `createRow` only. What those cannot show is that the
- * emitted plan actually RUNS — the preamble declares a local that the row
- * template interpolates, so a wrong order or a missing splice produces a row
- * with an empty attribute rather than a compile error.
+ * lazy-preamble.test.ts`, `preamble-attr-reactivity.test.ts`). What those
+ * cannot show is that the emitted plan actually RUNS — the preamble declares
+ * a local the row reads, so a wrong order or a missing splice produces a row
+ * with an empty or stale attribute rather than a compile error.
  *
- * So this runs it: compile the component, import the emitted module, mount it,
- * and read the DOM. Two things are checked, and they are the two the widening
- * could plausibly break:
+ * ## What is checked
  *
- *  1. A CSR-created row gets the preamble-derived attribute value. This is the
- *     `createRow` splice, and it must land BEFORE the clone whose template
- *     literal reads the local.
- *  2. A same-key item update still writes the row's item-driven text. `applyItem`
- *     deliberately does NOT re-run the preamble (no binding may read a local —
- *     `lazyRowEligibility` refuses that), so this pins that leaving it out did
- *     not strand the bindings that body does own.
- *
- * The attribute is creation-time by construction: an attribute reading a
- * preamble local is not classified as reactive, so it is interpolated into the
- * template rather than wired. That is true of the eager path too and is not a
- * behaviour this widening changes — see the `class` assertion after the update,
- * which pins the CURRENT contract rather than an aspiration.
+ *  1. A CSR-created row gets the preamble-derived attribute value.
+ *  2. A same-key item update REWRITES it. This is the behaviour the follow-up
+ *     added: before it, `applyItem` reused the row node and re-ran only the
+ *     wired slots, of which the class was not one, so row 1 kept `open` after
+ *     its item turned `done: true` while the sibling text updated normally.
+ *     Now `class={cls}` is a binding, `applyItem` re-runs the preamble ahead
+ *     of it, and the write lands.
  */
 
 import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
@@ -86,14 +77,16 @@ export function PreambleRows() {
 }
 `
 
-describe('lazy row with a value-only map-callback preamble', () => {
+describe('a row with a value-only map-callback preamble', () => {
   beforeEach(() => { document.body.innerHTML = '' })
 
   test('CSR-created rows get the preamble-derived attribute and the item text', async () => {
     const js = await compileAndRegister(ROWS, 'PreambleRows.tsx')
-    // Precondition: this shape really is on the lazy path. Without it the
-    // assertions below would pass for the wrong reason — the eager path also
-    // renders the row correctly, it just pays a root + effect per row.
+    // Precondition: this shape is on the LAZY path, and stays there even
+    // though `class={cls}` is now a real binding (#2447 follow-up) — the
+    // apply bodies re-run the preamble instead of the gate refusing. Without
+    // this the assertions below could pass on the eager path for the wrong
+    // reason: it also renders correctly, it just pays a root + effect per row.
     expect(js).toContain('mapArrayLazy(')
     expect(js).not.toMatch(/\bmapArray\(/)
 
@@ -120,13 +113,13 @@ describe('lazy row with a value-only map-callback preamble', () => {
 
     const items = el.querySelectorAll('#list li')
     expect(items.length).toBe(2)
-    // `applyItem` owns this and does not re-run the preamble.
     expect(items[0].textContent).toBe('shipped it')
-    // The preamble-derived attribute is creation-time on BOTH emission paths
-    // (an attribute reading a preamble local is never classified as reactive),
-    // so row 1 keeps `open` even though its item is now `done: true`. Pinned
-    // so a future change to that classification shows up here as a decision,
-    // not as a surprise.
-    expect(items[0].getAttribute('class')).toBe('open')
+    // The point of the follow-up: row 1's item is now `done: true`, so the
+    // preamble recomputes `cls` and the row effect writes it. This assertion
+    // read `'open'` before the fix — the same DOM node, the same key, the
+    // sibling text updated, and the class left behind.
+    expect(items[0].getAttribute('class')).toBe('done')
+    // Row 2 was `done` all along and must not have been disturbed.
+    expect(items[1].getAttribute('class')).toBe('done')
   })
 })

--- a/packages/jsx/src/__tests__/lazy-preamble.test.ts
+++ b/packages/jsx/src/__tests__/lazy-preamble.test.ts
@@ -198,11 +198,53 @@ describe('lazy row emission — value-only preamble', () => {
     expect(createRow.indexOf('const cls =')).toBeLessThan(createRow.indexOf('const __el ='))
   })
 
-  test('applyItem does NOT re-run the preamble — no binding may read a local', () => {
+  test('applyOuter re-runs the preamble AND primes what it reads', () => {
+    // `className={cls}` is a binding as of the #2447 follow-up, and `cls`
+    // reads `selected()` — an OUTER signal the local names nowhere. The
+    // classifier substitutes the preamble's free identifiers, so `selected`
+    // reaches the prime list; without that the loop-level effect would
+    // subscribe to nothing and the class would never update.
     // Bounded at the plan's closing `}, 'l0')` — past that sits the
     // `hydrate` template, which legitimately contains the preamble.
-    const applyItem = js.slice(js.indexOf('applyItem:'), js.indexOf("}, 'l0')"))
-    expect(applyItem).not.toContain('const cls =')
+    const plan = js.slice(js.indexOf('mapArrayLazy('), js.indexOf("}, 'l0')"))
+    const applyOuter = plan.slice(plan.indexOf('applyOuter:'))
+    expect(applyOuter).toContain('const cls = selected() === row().id')
+    // The prime statement sits ABOVE the per-entry loop, so the effect
+    // subscribes even while the entry list is empty.
+    expect(applyOuter.indexOf('selected()')).toBeLessThan(applyOuter.indexOf('for (const __e of __es)'))
+  })
+
+  test('applyItem re-runs it too — this binding reads the item as well', () => {
+    // `selected() === row().id ? … : (row().done ? …)` reads BOTH, so the
+    // binding lands in both bodies and both need the local. Asserted
+    // explicitly rather than left implicit: "which bodies" is the whole
+    // per-binding accounting.
+    const plan = js.slice(js.indexOf('mapArrayLazy('), js.indexOf("}, 'l0')"))
+    const applyItem = plan.slice(plan.indexOf('applyItem:'), plan.indexOf('applyOuter:'))
+    expect(applyItem).toContain('const cls = selected() === row().id')
+  })
+
+  test('a preamble NO binding reads is emitted in createRow only', () => {
+    // The counterpart: on-demand means a body with no reader pays nothing.
+    const js2 = clientJs(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string }
+export function UnreadPreamble() {
+  const [rows, setRows] = createSignal<Row[]>([])
+  return (
+    <tbody>
+      {rows().map(row => {
+        const unused = row.label
+        return <tr key={row.id}><td>{row.label}</td></tr>
+      })}
+    </tbody>
+  )
+}
+`, 'UnreadPreamble.tsx')
+    const plan = js2.slice(js2.indexOf('mapArrayLazy('), js2.indexOf("}, 'l0')"))
+    expect(plan.slice(plan.indexOf('createRow:'), plan.indexOf('applyItem:'))).toContain('const unused =')
+    expect(plan.slice(plan.indexOf('applyItem:'))).not.toContain('const unused =')
   })
 })
 

--- a/packages/jsx/src/__tests__/preamble-attr-reactivity.test.ts
+++ b/packages/jsx/src/__tests__/preamble-attr-reactivity.test.ts
@@ -158,6 +158,49 @@ describe('client JS — the attribute is wired, and the preamble precedes it', (
   })
 })
 
+describe('a STATIC-ARRAY loop must NOT be wired', () => {
+  // Regression: the first cut of this change classified the attribute here
+  // too, and the emitted `static-array-child-init` `forEach` — which has no
+  // per-row body and so no preamble in scope — wrote
+  // `setAttribute('data-active', active ? …)` against a FREE VARIABLE. The
+  // ReferenceError killed the whole component's init, taking any nested child
+  // component's hydration with it. Caught by the gallery-nav e2e (the shells
+  // are exactly this shape and the badges mounted inside them vanished), and
+  // pinned here so the compiler catches it next time.
+  const NAV = `
+'use client'
+const NAV_ITEMS = [
+  { key: 'a', href: '/a', label: 'A' },
+  { key: 'b', href: '/b', label: 'B' },
+]
+export function Nav(props: { current: string }) {
+  return (
+    <nav>
+      {NAV_ITEMS.map(item => {
+        const active = item.key === props.current
+        return <a key={item.key} href={item.href} data-active={active ? 'true' : 'false'}>{item.label}</a>
+      })}
+    </nav>
+  )
+}
+`
+  const js = clientJs(NAV, 'Nav.tsx')
+
+  test('no attribute effect reads the preamble local', () => {
+    // The `data-active` write must not be emitted into the init body at all:
+    // there is no scope there that declares `active`. The sibling `href`
+    // effect IS emitted, which is what makes this a targeted decline rather
+    // than the whole loop going unwired.
+    const init = js.slice(0, js.indexOf(`hydrate('Nav'`))
+    expect(init).not.toContain(`setAttribute('data-active'`)
+    expect(init).toContain(`setAttribute('href'`)
+  })
+
+  test('the value stays baked into the SSR template', () => {
+    expect(js).toContain('data-active=')
+  })
+})
+
 describe('unaffected shapes keep their emission', () => {
   test('a loop with no preamble emits no preamble statements', () => {
     const js = clientJs(`

--- a/packages/jsx/src/__tests__/preamble-attr-reactivity.test.ts
+++ b/packages/jsx/src/__tests__/preamble-attr-reactivity.test.ts
@@ -1,0 +1,174 @@
+/**
+ * An attribute reading a `.map()` callback preamble local is reactive — the
+ * #2447 follow-up.
+ *
+ * ## What was broken
+ *
+ * ```tsx
+ * {rows().map(row => {
+ *   const cls = row.done ? 'done' : 'open'
+ *   return <li key={row.id} class={cls}>{row.label}</li>
+ * })}
+ * ```
+ *
+ * `mapArray` reuses a row's DOM node on a same-key item update and re-runs
+ * only the wired slots. `class={cls}` was not one: `classifyReactivity` sees a
+ * bare local, not a signal or loop-param read, so it scored 'none' and the
+ * value was interpolated into the row template instead. Row 1's class stayed
+ * `open` after its item turned `done: true`, while the sibling `{row.label}`
+ * text updated normally — the child-position twin of this had already been
+ * fixed as a `preambleRegion` (#2389); the attribute position had not.
+ *
+ * ## The two halves, and why they are in different passes
+ *
+ *  1. **Phase 1 grants the slot** (`markPreambleAttrSlots`). An attribute is
+ *     only wirable if its element carries a `bf` slot id, and that is decided
+ *     when the element is BUILT — before the enclosing loop's preamble exists.
+ *     The client-JS pass cannot grant one retroactively: the SSR template is
+ *     rendered from this same IR and would not carry the marker.
+ *  2. **The client-JS pass wires it** (`collectLoopChildReactiveAttrs` +
+ *     `stringifyReactiveEffects`), re-running the preamble at the TOP of the
+ *     row effect so the declarations exist before the first write.
+ *
+ * ## The lazy row graph keeps the shape
+ *
+ * `lazyRowEligibility` used to refuse a binding that reads a preamble local,
+ * on the grounds that `applyOuter` could not prime a dependency the local
+ * hides. That refusal is gone: `analyzeLazyPreamble` now reports the
+ * preamble's own free identifiers and `classifyLazyBinding` substitutes them,
+ * so the binding's dependencies are what the INITIALIZER read (`selected`),
+ * and the apply bodies re-run the preamble on demand. Without that, this fix
+ * would have de-optimised the exact row the §9.5 widening was built for. The
+ * DOM behaviour is pinned in
+ * `packages/client/__tests__/runtime/lazy-row-preamble.test.ts`.
+ */
+
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import type { IRElement, IRLoop, IRNode } from '../types'
+
+const ROWS = (row: string, preamble = `const cls = row.done ? 'done' : 'open'`) => `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string; done: boolean }
+export function Rows(props: { rows: Row[] }) {
+  const [rows, setRows] = createSignal<Row[]>(props.rows)
+  return (
+    <ul>
+      {rows().map(row => {
+        ${preamble}
+        return ${row}
+      })}
+    </ul>
+  )
+}
+`
+
+function clientJs(source: string, file = 'Rows.tsx'): string {
+  const r = compileJSX(source, file, { adapter: new TestAdapter() })
+  const errors = r.errors.filter(e => e.severity !== 'warning')
+  if (errors.length > 0) throw new Error(errors.map(e => `${e.code}: ${e.message}`).join('\n'))
+  const js = r.files.find(f => f.type === 'clientJs')?.content
+  if (!js) throw new Error('no client JS emitted')
+  return js
+}
+
+function findLoop(node: IRNode | null): IRLoop | null {
+  if (!node) return null
+  if (node.type === 'loop') return node
+  const kids = (node as IRElement).children
+  if (!Array.isArray(kids)) return null
+  for (const c of kids) {
+    const hit = findLoop(c)
+    if (hit) return hit
+  }
+  return null
+}
+
+/** The `<li>` row root of the compiled loop. */
+function rowRoot(source: string): IRElement {
+  const loop = findLoop(jsxToIR(analyzeComponent(source, 'Rows.tsx')))
+  if (!loop) throw new Error('no loop in IR')
+  return loop.children[0] as IRElement
+}
+
+beforeAll(() => {
+  // The first analyzeComponent in a process pays TS program setup on its own.
+  analyzeComponent(ROWS(`<li key={row.id}>{row.label}</li>`), 'Warmup.tsx')
+}, 60_000)
+
+describe('Phase 1 — the slot the attribute needs', () => {
+  test('an element whose attribute reads a preamble local gets a slot id', () => {
+    const li = rowRoot(ROWS(`<li key={row.id} class={cls}>{row.label}</li>`))
+    expect(li.slotId).not.toBeNull()
+  })
+
+  test('a row with no preamble-reading attribute is untouched', () => {
+    // The guard against granting slots (and shifting every later slot id) to
+    // rows that do not need one.
+    const li = rowRoot(ROWS(`<li key={row.id} class="static">{row.label}</li>`))
+    expect(li.slotId).toBeNull()
+  })
+
+  test('`key` never counts — it is renamed to data-key and driven by keyFn', () => {
+    const li = rowRoot(ROWS(`<li key={cls}>{row.label}</li>`))
+    expect(li.slotId).toBeNull()
+  })
+
+  test('a nested element gets its own slot, not the row root', () => {
+    const li = rowRoot(ROWS(`<li key={row.id}><span class={cls}>{row.label}</span></li>`))
+    expect(li.slotId).toBeNull()
+    expect((li.children[0] as IRElement).slotId).not.toBeNull()
+  })
+})
+
+describe('client JS — the attribute is wired, and the preamble precedes it', () => {
+  const js = clientJs(ROWS(`<li key={row.id} class={cls}>{row.label}</li>`))
+  const plan = js.slice(js.indexOf('mapArrayLazy('), js.indexOf(`}, 'l0')`))
+
+  test('the attribute is written by a binding, not baked into the row template', () => {
+    const tpl = js.slice(js.indexOf('__tpl_l0.innerHTML'), js.indexOf('mapArrayLazy('))
+    expect(tpl).not.toContain('class=')
+    expect(plan).toContain(`setAttribute('class', String(__v))`)
+  })
+
+  test('applyItem re-runs the preamble ahead of the write', () => {
+    const applyItem = plan.slice(plan.indexOf('applyItem:'))
+    const preambleAt = applyItem.indexOf("const cls = row().done ? 'done' : 'open'")
+    const writeAt = applyItem.indexOf(`setAttribute('class'`)
+    expect(preambleAt).toBeGreaterThanOrEqual(0)
+    expect(writeAt).toBeGreaterThan(preambleAt)
+  })
+
+  test('the row stays on the lazy graph — no per-row reactive resource', () => {
+    expect(js).toContain('mapArrayLazy(')
+    expect(js).not.toMatch(/\bmapArray\(/)
+    expect(plan).not.toContain('createEffect')
+    expect(plan).not.toContain('createRoot')
+  })
+
+  test('this row is item-driven only, so no applyOuter is emitted', () => {
+    // `row.done` is the only dependency. The contrast — a preamble reading an
+    // outer signal, which must reach the prime list — is
+    // `lazy-preamble.test.ts`'s `applyOuter` pair.
+    expect(plan).not.toContain('applyOuter:')
+  })
+})
+
+describe('unaffected shapes keep their emission', () => {
+  test('a loop with no preamble emits no preamble statements', () => {
+    const js = clientJs(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string; done: boolean }
+export function Plain(props: { rows: Row[] }) {
+  const [rows, setRows] = createSignal<Row[]>(props.rows)
+  return <ul>{rows().map(row => <li key={row.id} class={row.done ? 'done' : 'open'}>{row.label}</li>)}</ul>
+}
+`, 'Plain.tsx')
+    expect(js).not.toContain('const cls =')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -331,7 +331,7 @@ export function collectInnerLoops(
         if (ctx) {
           for (const child of n.children) {
             bindings.reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param, n.paramBindings))
-            bindings.reactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param, n.paramBindings))
+            bindings.reactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param, n.paramBindings, false, preambleNamesOf(n)))
             bindings.refs.push(...collectLoopChildRefs(child))
           }
         }
@@ -669,7 +669,7 @@ export function collectElements(
       const childHandlers: string[] = []
       const bindings = projectionInner
         ? emptyLoopChildBindings()
-        : collectLoopChildBindings(l.children, ctx, siblingOffsets, l.param, l.paramBindings)
+        : collectLoopChildBindings(l.children, ctx, siblingOffsets, l.param, l.paramBindings, preambleNamesOf(l))
       if (!projectionInner) {
         for (const child of l.children) {
           childHandlers.push(...collectEventHandlersFromIR(child))
@@ -1141,7 +1141,7 @@ function collectBranchLoops(
       // which caused reactive reads inside simple loop bodies to silently
       // no-op for existing items.
       const branchBindings = ctx && !projectionInner
-        ? collectLoopChildBindings(n.children, ctx, siblingOffsets, n.param, n.paramBindings)
+        ? collectLoopChildBindings(n.children, ctx, siblingOffsets, n.param, n.paramBindings, preambleNamesOf(n))
         : emptyLoopChildBindings()
 
       loops.push({
@@ -1298,12 +1298,30 @@ function collectBranchConditionals(
  * resolve child slot ids inside nested loops; the rest of the per-item
  * collectors don't read them but pass them through for symmetry.
  */
+/**
+ * The names a loop's `.map()` callback preamble declares, or `undefined` when
+ * it has none — the input to the attribute classifier's preamble-local check
+ * (#2447 follow-up). `undefined` rather than an empty set so the classifier's
+ * fast path stays a single `!== undefined` for the overwhelmingly common
+ * preamble-free loop.
+ */
+function preambleNamesOf(loop: IRLoop): ReadonlySet<string> | undefined {
+  const declared = loop.preamble?.declaredNames
+  return declared && declared.length > 0 ? new Set(declared) : undefined
+}
+
 export function collectLoopChildBindings(
   children: readonly IRNode[],
   ctx: ClientJsContext,
   siblingOffsets: Map<IRLoop, IRNode[]>,
   loopParam: string,
   loopParamBindings: readonly import('../types.ts').LoopParamBinding[] | undefined,
+  /**
+   * Names the loop's `.map()` callback preamble declares, so an attribute
+   * reading one is classified reactive (#2447 follow-up) — see
+   * `collectLoopChildReactiveAttrs`. Omitted for a loop with no preamble.
+   */
+  preambleNames?: ReadonlySet<string>,
 ): LoopChildBindings {
   const bindings = emptyLoopChildBindings()
   for (const child of children) {
@@ -1313,7 +1331,7 @@ export function collectLoopChildBindings(
     // `collectLoopChildConditionals`, which gives each its own insert() +
     // arm-scoped attrs/texts (`LoopChildBranchSummary.reactiveAttrs` /
     // `.reactiveTexts`) — descending into them here too would double-bind.
-    bindings.reactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, loopParam, loopParamBindings, true))
+    bindings.reactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, loopParam, loopParamBindings, true, preambleNames))
     bindings.reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, loopParam, loopParamBindings, true))
     bindings.refs.push(...collectLoopChildRefs(child))
     bindings.conditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, loopParam, loopParamBindings))

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -328,10 +328,12 @@ export function collectInnerLoops(
         //     `NestedLoop` because event delegation handles them through
         //     the parent's bindings instead.
         const bindings: LoopChildBindings = emptyLoopChildBindings()
+        // Hoisted: one Set per loop, not one per child (Copilot review).
+        const innerPreambleNames = preambleNamesOf(n)
         if (ctx) {
           for (const child of n.children) {
             bindings.reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param, n.paramBindings))
-            bindings.reactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param, n.paramBindings, false, preambleNamesOf(n)))
+            bindings.reactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param, n.paramBindings, false, innerPreambleNames))
             bindings.refs.push(...collectLoopChildRefs(child))
           }
         }
@@ -1300,12 +1302,31 @@ function collectBranchConditionals(
  */
 /**
  * The names a loop's `.map()` callback preamble declares, or `undefined` when
- * it has none — the input to the attribute classifier's preamble-local check
- * (#2447 follow-up). `undefined` rather than an empty set so the classifier's
- * fast path stays a single `!== undefined` for the overwhelmingly common
- * preamble-free loop.
+ * there are none to consider — the input to the attribute classifier's
+ * preamble-local check (#2447 follow-up). `undefined` rather than an empty set
+ * so the classifier's fast path stays a single `!== undefined` for the
+ * overwhelmingly common preamble-free loop.
+ *
+ * A STATIC-ARRAY loop returns `undefined` even when it has a preamble, and
+ * this is load-bearing rather than an optimisation. Its items are emitted
+ * through `static-array-child-init` — a `forEach` over the SSR-rendered
+ * children, with no per-row body and therefore no preamble in scope. Wiring an
+ * attribute there would emit `setAttribute('class', active ? … : …)` against a
+ * free variable: a ReferenceError at init that takes the whole component's
+ * hydration with it, including any nested child. (Caught exactly that way —
+ * the gallery nav shells are static arrays whose rows read
+ * `const active = item.key === currentRoute`, and the badge components mounted
+ * inside them stopped appearing.)
+ *
+ * Nothing is lost by declining: a static array's items are rendered once at
+ * SSR and never recreated from a signal, so there is no same-key update for a
+ * patch to be missing from. The same reasoning gates `markPreambleAttrSlots`
+ * and `preambleRegions` in Phase 1, and the two gates must agree — a slot
+ * granted without wiring, or wiring without a slot, is a silent hole either
+ * way.
  */
 function preambleNamesOf(loop: IRLoop): ReadonlySet<string> | undefined {
+  if (loop.isStaticArray) return undefined
   const declared = loop.preamble?.declaredNames
   return declared && declared.length > 0 ? new Set(declared) : undefined
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-lazy-row.ts
@@ -47,6 +47,13 @@ export interface LazyRowAttrBinding {
   ordinal: number
   readsItem: boolean
   readsOuter: boolean
+  /**
+   * Reads a `.map()` preamble local, so every apply body this binding is
+   * emitted into must re-run the preamble first (#2447 follow-up). Per
+   * binding, not per loop, so `applyOuter` does not pay for a preamble only
+   * `applyItem`'s bindings read.
+   */
+  readsPreamble: boolean
 }
 
 /** One reactive text (content slot) of a lazy row. */
@@ -61,6 +68,11 @@ export interface LazyRowTextBinding {
    * (`LazyRowPlanData.textNeedsRead`).
    */
   readsOuter: boolean
+  /**
+   * Reads a `.map()` preamble local, so every apply body this binding is
+   * emitted into must re-run the preamble first (#2447 follow-up).
+   */
+  readsPreamble: boolean
 }
 
 /** One row conditional driven from the loop-level apply bodies (§9.5). */
@@ -80,6 +92,13 @@ export interface LazyRowConditionalBinding {
   ordinal: number
   readsItem: boolean
   readsOuter: boolean
+  /**
+   * Reads a `.map()` preamble local, so every apply body this binding is
+   * emitted into must re-run the preamble first (#2447 follow-up). Per
+   * binding, not per loop, so `applyOuter` does not pay for a preamble only
+   * `applyItem`'s bindings read.
+   */
+  readsPreamble: boolean
 }
 
 export interface LazyRowPlanData {
@@ -113,14 +132,24 @@ export interface LazyRowPlanData {
    * (`mapPreambleWrapped`), or `''` when the row has none — proven safe to run
    * by `analyzeLazyPreamble` (§9.5 widening).
    *
-   * Emitted in `createRow` ONLY, and specifically before the clone: the
-   * non-hoisted per-row template interpolates values the preamble declares
-   * (an attribute reading a preamble local is not classified as reactive, so
-   * it lands in the template rather than in `attrs`). `applyItem` /
-   * `applyOuter` never need it, because a binding that reads a declared local
-   * refuses the loop outright — see `lazyRowEligibility`'s per-binding gate.
+   * `createRow` always runs it, and specifically before the clone: the
+   * non-hoisted per-row template can interpolate values the preamble declares.
+   *
+   * `applyItem` / `applyOuter` run it only when a binding they own reads a
+   * declared local (`itemNeedsPreamble` / `outerNeedsPreamble`) — which is
+   * possible as of the #2447 follow-up, where an attribute reading one became
+   * a reactive binding instead of frozen template text. Re-running is sound
+   * because `analyzeLazyPreamble` proved the statements are `const`
+   * declarations whose initializers only read the item and zero-arg signal
+   * getters, and the binding's DEPENDENCIES are the preamble's own free
+   * identifiers (substituted in `classifyLazyBinding`), so `applyOuter`
+   * primes what the preamble reads rather than the opaque local name.
    */
   preambleStatements: string
+  /** `applyItem` has a binding that reads a preamble local (#2447 follow-up). */
+  itemNeedsPreamble: boolean
+  /** `applyOuter` has one. Separate from the above so neither body pays for the other's. */
+  outerNeedsPreamble: boolean
   /**
    * Row conditionals driven from the apply bodies (§9.5, `lazy-conditional.ts`).
    * Empty for most loops. Each arm is a static element, so the emitter hoists
@@ -279,6 +308,7 @@ export function decideLazyRow(args: BuildLazyRowArgs): {
       ordinal: ordinal++,
       readsItem: c.readsItem,
       readsOuter: c.readsOuter,
+      readsPreamble: c.readsPreamble,
     }
   })
   const texts: LazyRowTextBinding[] = loop.bindings.reactiveTexts.map((text, i) => {
@@ -293,6 +323,7 @@ export function decideLazyRow(args: BuildLazyRowArgs): {
       // a list keeps exactly the classifier's answer.
       readsItem: c.readsItem || !c.readsOuter,
       readsOuter: c.readsOuter,
+      readsPreamble: c.readsPreamble,
     }
   })
 
@@ -322,6 +353,7 @@ export function decideLazyRow(args: BuildLazyRowArgs): {
       // neither is handled above.
       readsItem: klass.readsItem || !klass.readsOuter,
       readsOuter: klass.readsOuter,
+      readsPreamble: klass.readsPreamble,
     }
   })
 
@@ -335,6 +367,12 @@ export function decideLazyRow(args: BuildLazyRowArgs): {
       lastCount: ordinal,
       outerPrimeGetters,
       preambleStatements: args.mapPreambleWrapped,
+      // Which apply bodies must re-run the preamble — computed from the FINAL
+      // binding lists, not the raw classification, so a text/conditional that
+      // classified as neither item- nor outer-driven (and was therefore forced
+      // into `applyItem` above) is counted in the body it actually lands in.
+      itemNeedsPreamble: [...attrs, ...texts, ...conditionals].some(b => b.readsItem && b.readsPreamble),
+      outerNeedsPreamble: [...attrs, ...texts, ...conditionals].some(b => b.readsOuter && b.readsPreamble),
       conditionals,
     },
     decision,

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-reactive-effects.ts
@@ -82,6 +82,7 @@ export function buildReactiveEffectsPlan(
         attrName: attr.attrName,
         wrappedExpression: wrap(attr.expression),
         meta: pickAttrMeta(attr),
+        ...(attr.readsPreamble && { readsPreamble: true }),
       })),
     })
   }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-preamble.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-preamble.ts
@@ -97,6 +97,21 @@ export interface LazyPreambleFacts {
    * component scope.
    */
   declaredNames: ReadonlySet<string>
+  /**
+   * What the preamble itself reads — its free identifiers, minus the names it
+   * declares. This is the SUBSTITUTION set: a binding that names a preamble
+   * local inherits these as its own dependencies, because that is literally
+   * what the value depends on.
+   *
+   * Returned as raw names, unclassified, on purpose. Deciding which are row
+   * locals, which are primable getters, and which are opaque needs the loop's
+   * `rowLocalNames` / `indexParam` / `LazyRowScopeInfo`, none of which this
+   * module has — and re-deriving that judgement here would be a second copy
+   * of `classifyLazyBinding`'s rules, free to drift from the one the emitter
+   * actually primes against. So the names go back unjudged and run through
+   * the SAME loop a binding's own identifiers do.
+   */
+  freeNames: ReadonlySet<string>
 }
 
 export type LazyPreambleAnalysis =
@@ -106,7 +121,7 @@ export type LazyPreambleAnalysis =
 /** No preamble at all — nothing to prove, nothing to substitute. */
 export const NO_PREAMBLE: LazyPreambleAnalysis = {
   lazySafe: true,
-  facts: { declaredNames: new Set() },
+  facts: { declaredNames: new Set(), freeNames: new Set() },
 }
 
 const NO = (reason: string): LazyPreambleAnalysis => ({ lazySafe: false, reason })
@@ -189,7 +204,10 @@ export function analyzeLazyPreamble(
     return NO(`map-callback preamble reads the loop index parameter '${indexParam}'`)
   }
 
-  return { lazySafe: true, facts: { declaredNames } }
+  const freeNames = new Set(readNames)
+  for (const declared of declaredNames) freeNames.delete(declared)
+
+  return { lazySafe: true, facts: { declaredNames, freeNames } }
 }
 
 /** Every name a `const` binding form introduces (identifier or pattern). */

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-row-eligibility.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/lazy-row-eligibility.ts
@@ -297,15 +297,6 @@ export function lazyRowEligibility(args: LazyRowEligibilityArgs): LazyRowEligibi
     if (b.opaqueOuterNames.includes(UNKNOWN_IDENTIFIERS)) {
       return NO(`binding on slot ${b.slotId} has no analyzable identifier set`)
     }
-    // A preamble-declared local hides the preamble's own dependencies, and
-    // the apply bodies would have to re-run the preamble to have the value at
-    // all. Currently unreachable — a child-position read is a
-    // `preambleRegions` entry and an attribute-position one is not classified
-    // as reactive — so this is the fail-safe that keeps the widening sound if
-    // either of those facts changes. See `lazy-preamble.ts`.
-    if (b.readsPreamble) {
-      return NO(`binding on slot ${b.slotId} reads a map-callback preamble local`)
-    }
     // An outer name the emitter cannot prime used to refuse the loop: the
     // loop-level effect must subscribe on its FIRST run, and with an empty
     // entry list the per-entry reads never execute, so it would subscribe to
@@ -445,23 +436,22 @@ export function classifyLazyBinding(args: {
   const reactiveOuterNames: string[] = []
   const opaqueOuterNames: string[] = []
 
-  for (const name of free) {
-    if (preamble?.declaredNames.has(name)) {
-      readsPreamble = true
-      continue
-    }
+  // Classify ONE free identifier. Applied to the binding's own names and — for
+  // a binding that reads a preamble local — to the preamble's free names too,
+  // so both go through exactly the same rules (see `LazyPreambleFacts.freeNames`).
+  const classifyName = (name: string): void => {
     if (rowLocalNames.has(name)) {
       readsItem = true
-      continue
+      return
     }
     if (name === indexParam) {
       referencesIndex = true
-      continue
+      return
     }
-    if (INERT_BINDING_GLOBALS.has(name)) continue
+    if (INERT_BINDING_GLOBALS.has(name)) return
     if (scope.signals.has(name) || scope.memos.has(name)) {
       if (!reactiveOuterNames.includes(name)) reactiveOuterNames.push(name)
-      continue
+      return
     }
     // A LITERAL-DERIVED constant (empty free-identifier set) is the only
     // non-signal local name provably incapable of reactivity: with nothing
@@ -481,8 +471,23 @@ export function classifyLazyBinding(args: {
     // fallback) is the sound answer; guessing "inert" would be a silent
     // never-updates bug.
     const constFree = scope.constants.get(name)
-    if (constFree !== undefined && constFree !== null && constFree.size === 0) continue
+    if (constFree !== undefined && constFree !== null && constFree.size === 0) return
     opaqueOuterNames.push(name)
+  }
+
+  for (const name of free) {
+    // A preamble-declared name is a ROW-LOCAL alias for whatever the preamble
+    // read. Substituting its dependencies is the whole point: `class={cls}`
+    // where `const cls = selected() === row().id ? …` depends on `selected`
+    // AND the item, so the binding has to land in BOTH apply bodies and
+    // `selected` has to reach the prime list. Classifying `cls` on its own
+    // name would name neither, and an unprimed `applyOuter` never subscribes.
+    if (preamble?.declaredNames.has(name)) {
+      readsPreamble = true
+      for (const dep of preamble.freeNames) classifyName(dep)
+      continue
+    }
+    classifyName(name)
   }
 
   return {

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/reactive-effects.ts
@@ -19,6 +19,13 @@ export interface ReactiveAttrEffect {
   wrappedExpression: string
   /** Pre-copied attr metadata used by emitAttrUpdate. */
   meta: AttrMeta
+  /**
+   * `wrappedExpression` reads a `.map()` callback preamble local (#2447
+   * follow-up), so the emitter must run the preamble ahead of this write —
+   * the local is not otherwise in scope in the update body, and its value
+   * is what makes the attribute reactive at all.
+   */
+  readsPreamble?: boolean
 }
 
 /** Reactive attrs grouped by child slot (one qsa lookup per slot). */

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
@@ -197,9 +197,7 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
   // the `data-key` attribute.
   lines.push(`${b2}const ${paramHead} = () => __e.item`)
   // The row's `.map()` callback preamble, before the clone: a non-hoisted
-  // per-row template interpolates values the preamble declares. Only
-  // `createRow` needs it — a BINDING that reads a preamble local refuses the
-  // loop (`lazyRowEligibility`), so the apply bodies never reference one.
+  // per-row template interpolates values the preamble declares.
   if (lazyRow.preambleStatements) lines.push(`${b2}${lazyRow.preambleStatements}`)
   const cloneExpr = useHoisted
     ? hoistedCloneExpr(tplVar, o.skeletonTemplate!)
@@ -229,6 +227,13 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
     lines.push(`${b2}const ${paramHead} = () => __e.item`)
     lines.push(`${b2}const __r = __e.refs ?? (__e.refs = [])`)
     lines.push(`${b2}const __l = __e.last ?? (__e.last = [])`)
+    // Re-run the preamble only when a binding in THIS body reads a local it
+    // declares (#2447 follow-up). `mapArrayLazy` wraps `applyItem` in
+    // `untrack()`, so a signal read inside the preamble subscribes nothing
+    // here — the subscription is `applyOuter`'s job.
+    if (lazyRow.itemNeedsPreamble && lazyRow.preambleStatements) {
+      lines.push(`${b2}${lazyRow.preambleStatements}`)
+    }
     for (const a of itemAttrs) emitAttrBinding(lines, b2, a, 'item')
     if (itemTexts.length > 0) {
       lines.push(`${b2}const __d = ${doorAccess(lazyRow, lazyRow.writerIndex, adoptedPlanVar)}`)
@@ -252,6 +257,12 @@ export function stringifyLazyRowLoop(lines: string[], o: StringifyLazyRowOptions
     lines.push(`${b3}const ${paramHead} = () => __e.item`)
     lines.push(`${b3}const __r = __e.refs ?? (__e.refs = [])`)
     lines.push(`${b3}const __l = __e.last ?? (__e.last = [])`)
+    // Per ENTRY, not once for the batch: the preamble reads the item, so its
+    // locals differ per row. The outer signals it reads are already primed
+    // above, so this effect subscribes even when `__es` is empty.
+    if (lazyRow.outerNeedsPreamble && lazyRow.preambleStatements) {
+      lines.push(`${b3}${lazyRow.preambleStatements}`)
+    }
     for (const a of outerAttrs) emitAttrBinding(lines, b3, a, 'outer')
     if (outerTexts.length > 0) {
       lines.push(`${b3}const __d = ${doorAccess(lazyRow, lazyRow.writerIndex, adoptedPlanVar)}`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
@@ -124,7 +124,7 @@ export function stringifyReactiveEffects(
   if (pc) {
     // Profile mode: preserve the granular per-slot/per-attr effect shape so
     // every binding keeps its own bfId (see module docstring).
-    emitAttrSlotsGranular(lines, indent, elVar, lookup, attrSlots, elementIndexBySlot, bindingBfId)
+    emitAttrSlotsGranular(lines, indent, elVar, lookup, attrSlots, elementIndexBySlot, bindingBfId, mapPreambleWrapped)
     emitOuterTexts(lines, indent, elVar, outerTexts, bindingBfId, textClaimPathExprs)
     emitPreambleRegionsEffect(lines, indent, elVar, preambleRegions, mapPreambleWrapped)
   } else {
@@ -154,6 +154,7 @@ function emitAttrSlotsGranular(
   attrSlots: readonly ReactiveAttrSlot[],
   elementIndexBySlot: ReadonlyMap<string, number> | undefined,
   bindingBfId: (slotId: string) => string,
+  mapPreambleWrapped: string | undefined,
 ): void {
   for (const slot of attrSlots) {
     const varName = `__ra_${varSlotId(slot.slotId)}`
@@ -162,6 +163,14 @@ function emitAttrSlotsGranular(
     lines.push(`${indent}if (${varName}) {`)
     for (const attr of slot.attrs) {
       lines.push(`${indent}  createEffect(() => {`)
+      // Profile mode keeps one effect per attr, so an attr reading a preamble
+      // local needs the declarations inside ITS OWN effect — there is no
+      // shared row-effect scope to hoist them into here (#2447 follow-up).
+      // Re-running per attr is the price of the per-binding bfId this mode
+      // exists to produce; `bf debug profile` is off the build hot path.
+      if (attr.readsPreamble && mapPreambleWrapped) {
+        lines.push(`${indent}    ${mapPreambleWrapped}`)
+      }
       for (const stmt of emitAttrUpdate(varName, attr.attrName, attr.wrappedExpression, attr.meta)) {
         lines.push(`${indent}    ${stmt}`)
       }
@@ -191,6 +200,11 @@ function emitPreambleRegionsEffect(
     lines.push(`${indent}  ${writer}('${region.slotId}', ${region.valueExpr})`)
   }
   lines.push(`${indent}})`)
+}
+
+/** Does any attr in these slots read a `.map()` preamble local (#2447)? */
+function attrsReadPreamble(attrSlots: readonly ReactiveAttrSlot[]): boolean {
+  return attrSlots.some(slot => slot.attrs.some(a => a.readsPreamble))
 }
 
 function attrLookupExpr(
@@ -270,6 +284,15 @@ function emitConsolidatedRowEffect(
     return
   }
   lines.push(`${indent}createEffect(() => {`)
+  // The preamble re-run leads the body, not trails it (#2447 follow-up).
+  // It used to sit between the attr writes and the region writes, because
+  // regions were its only readers. An attribute can read a preamble local
+  // now (`class={cls}`), and it reads it from THIS scope — so the
+  // declarations have to exist before the first write, whichever kind that
+  // is. Regions are unaffected by the move: they were already downstream.
+  if (mapPreambleWrapped && (preambleRegions.length > 0 || attrsReadPreamble(attrSlots))) {
+    lines.push(`${indent}  ${mapPreambleWrapped}`)
+  }
   for (const slot of attrSlots) {
     const varName = `__ra_${varSlotId(slot.slotId)}`
     lines.push(`${indent}  if (${varName}) {`)
@@ -281,9 +304,6 @@ function emitConsolidatedRowEffect(
       lines.push(`${indent}    }`)
     }
     lines.push(`${indent}  }`)
-  }
-  if (preambleRegions.length > 0 && mapPreambleWrapped) {
-    lines.push(`${indent}  ${mapPreambleWrapped}`)
   }
   for (const text of outerTexts) {
     lines.push(`${indent}  ${writer}('${text.slotId}', String(${text.wrappedExpression}))`)

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -622,6 +622,13 @@ export function collectLoopChildReactiveTexts(
  * same semantics. Pass true only when the caller also separately collects
  * nested reactive conditionals and gives each its own `insert()`.
  */
+/** Does any name in `names` appear in `set`? Iterates rather than
+ *  spreading — this runs per attribute (Copilot review). */
+function anyNameIn(names: Iterable<string>, set: ReadonlySet<string>): boolean {
+  for (const n of names) if (set.has(n)) return true
+  return false
+}
+
 export function collectLoopChildReactiveAttrs(
   node: IRNode,
   ctx: ClientJsContext,
@@ -679,7 +686,7 @@ export function collectLoopChildReactiveAttrs(
         const readsPreamble =
           preambleNames !== undefined &&
           preambleNames.size > 0 &&
-          [...(expanded.freeIds ?? extractFreeIdentifiersFromText(expanded.expr))].some(n => preambleNames.has(n))
+          anyNameIn(expanded.freeIds ?? extractFreeIdentifiersFromText(expanded.expr), preambleNames)
         const reactive =
           classifyReactivity(expanded.expr, ctx, loopParam, loopParamBindings, expanded.freeIds).kind !== 'none'
           || readsPreamble

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -16,6 +16,7 @@ import type {
 } from './types.ts'
 import { attrValueToString, freeIdsFromRefs, tokenContainsIdent } from './utils.ts'
 import { expandConstantForReactivity } from './prop-handling.ts'
+import { extractFreeIdentifiersFromText } from './csr-substitute.ts'
 import { walkIR, stopAt } from './walker.ts'
 
 /**
@@ -627,6 +628,7 @@ export function collectLoopChildReactiveAttrs(
   loopParam?: string,
   loopParamBindings?: readonly LoopParamBinding[],
   stopAtReactiveConditionals = false,
+  preambleNames?: ReadonlySet<string>,
 ): LoopChildReactiveAttr[] {
   const attrs: LoopChildReactiveAttr[] = []
   traverseElements(node, (el) => {
@@ -664,8 +666,23 @@ export function collectLoopChildReactiveAttrs(
         // / `hasFunctionCalls` fallback so the loop-child path matches the
         // top-level one — a harmless over-wrap at worst (an effect that
         // subscribes to nothing runs once).
+        // A `.map()` callback preamble local (#2447 follow-up). The
+        // classifier cannot see it: `const cls = row.done ? …` makes `cls`
+        // neither a signal read nor a loop-param read, so `class={cls}`
+        // scored 'none' and the value froze at its row-construction value —
+        // a same-key item update rewrote the sibling `{row.label}` text and
+        // left the class stale. Its reactivity is the PREAMBLE's: whatever
+        // the initializer read. Flag it and let the emitter re-run the
+        // preamble ahead of the write (`stringifyReactiveEffects`), which is
+        // the child-position `preambleRegions` treatment (#2389) applied to
+        // the attribute position.
+        const readsPreamble =
+          preambleNames !== undefined &&
+          preambleNames.size > 0 &&
+          [...(expanded.freeIds ?? extractFreeIdentifiersFromText(expanded.expr))].some(n => preambleNames.has(n))
         const reactive =
           classifyReactivity(expanded.expr, ctx, loopParam, loopParamBindings, expanded.freeIds).kind !== 'none'
+          || readsPreamble
           || attr.callsReactiveGetters
           || attr.hasFunctionCalls
         if (!attr.clientOnly && !reactive) continue
@@ -675,6 +692,7 @@ export function collectLoopChildReactiveAttrs(
           expression: expanded.expr,
           ...pickAttrMetaFromIR(attr),
           ...(expanded.freeIds !== undefined && { freeIdentifiers: expanded.freeIds }),
+          ...(readsPreamble && { readsPreamble: true }),
         })
       }
     }

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -494,6 +494,18 @@ export interface LoopChildReactiveAttr extends AttrMeta {
   childSlotId: string // bf slot ID of the element with reactive attr
   attrName: string // 'className', 'disabled', etc.
   expression: string // Expression that reads signals
+  /**
+   * The expression reads a `.map()` callback preamble local (#2447
+   * follow-up), so it is reactive by way of whatever the preamble read — the
+   * classifier cannot see through the declaration, and the local is not in
+   * scope in the update body until the preamble is re-run there.
+   *
+   * Two consequences, both handled by the emitter rather than here: the row
+   * effect runs `mapPreambleWrapped` BEFORE the attr writes, and the lazy row
+   * graph refuses the loop (`lazyRowEligibility`'s `readsPreamble` gate), so
+   * such a row keeps the eager per-row effect.
+   */
+  readsPreamble?: boolean
 }
 
 export interface LoopChildReactiveText {

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -4746,6 +4746,19 @@ function transformMapCall(
     ? collectPreambleRegions(children, new Set(preamble.declaredNames), ctx)
     : undefined
 
+  // #2447 follow-up — the ATTRIBUTE twin of the regions above. `class={cls}`
+  // where the preamble declares `cls` froze at its row-construction value for
+  // the same reason `{cells}` did, and for one extra reason on top: an
+  // attribute only gets wired at all if its element carries a slot id, and
+  // `hasReactiveAttributes` (which decides that at element-build time, before
+  // any loop preamble is known) scores a bare local as non-reactive. So the
+  // slot has to be granted HERE, in the same after-the-fact pass the regions
+  // use — after which `collectLoopChildReactiveAttrs` classifies the attr and
+  // the row effect re-runs the preamble ahead of the write.
+  if (preamble && !isStaticArray) {
+    markPreambleAttrSlots(children, new Set(preamble.declaredNames), ctx)
+  }
+
   // Collect nested components for both static and dynamic arrays.
   // Static arrays: needed for initChild hydration.
   // Dynamic arrays with native root + component descendants: enables
@@ -5130,6 +5143,72 @@ function collectPreambleRegions(
   }
   visit(nodes)
   return regions
+}
+
+/**
+ * Grant a slot id to every loop-body element carrying an attribute that reads
+ * a `.map()` preamble local (#2447 follow-up).
+ *
+ * Only the slot id is decided here; whether the attribute is *wired* is the
+ * client-JS classifier's call (`collectLoopChildReactiveAttrs`, which takes
+ * the same `declaredNames` set). Splitting it that way keeps this pass free of
+ * reactivity policy — it removes the one obstacle the classifier cannot remove
+ * for itself, since `hasReactiveAttributes` already ran when the element was
+ * built and a slot id cannot be granted from the client-JS pass (the SSR
+ * template is rendered from this same IR and would not carry the `bf` marker).
+ *
+ * Mirrors `collectPreambleRegions`' traversal exactly, conditional arms
+ * included — an arm element gets its slot id here too, which costs nothing
+ * when the arm's own wiring declines to use it.
+ */
+function markPreambleAttrSlots(
+  nodes: IRNode[],
+  declared: ReadonlySet<string>,
+  ctx: TransformContext,
+): void {
+  const readsDeclared = (attr: IRAttribute): boolean => {
+    if (attr.name === 'key') return false
+    const value = attr.value
+    if (value.kind !== 'expression' && value.kind !== 'template') return false
+    const refs = attr.freeIdentifiers ?? extractFreeIdentifiersFromText(attrValueText(value))
+    for (const r of refs) if (declared.has(r)) return true
+    return false
+  }
+  const visit = (list: IRNode[]): void => {
+    for (const node of list) {
+      switch (node.type) {
+        case 'element':
+          if (!node.slotId && node.attrs.some(readsDeclared)) node.slotId = generateSlotId(ctx)
+          visit(node.children)
+          break
+        case 'fragment':
+          visit(node.children)
+          break
+        case 'conditional':
+          visit([node.whenTrue, ...(node.whenFalse ? [node.whenFalse] : [])])
+          break
+      }
+    }
+  }
+  visit(nodes)
+}
+
+/**
+ * Expression-bearing source text of an attribute value, for the
+ * free-identifier scan. Only used as a FALLBACK — an attribute normally
+ * carries `freeIdentifiers` from its own AST walk, and this reconstruction
+ * exists for the few IR producers that don't populate it. Static string parts
+ * are dropped so a literal word can never be mistaken for an identifier.
+ */
+function attrValueText(value: AttrValue): string {
+  if (value.kind === 'expression') return value.expr
+  if (value.kind !== 'template') return ''
+  const out: string[] = []
+  for (const p of value.parts) {
+    if (p.type === 'ternary') out.push(p.condition, p.whenTrue, p.whenFalse)
+    else if (p.type === 'lookup') out.push(p.key)
+  }
+  return out.join(' ')
 }
 
 /**

--- a/spec/slot-unification.md
+++ b/spec/slot-unification.md
@@ -500,12 +500,24 @@ declarations whose initializers contain no call except a **zero-argument
 signal/memo read** (`const cls = selected() === row.id ? …`, the krausest
 shape). That read is sound in all three bodies because `mapArrayLazy` wraps
 `createRow`/`applyItem` in `untrack()` and `applyOuter` IS the loop-level
-effect. The preamble is emitted into `createRow` ONLY, before the clone whose
-template literal interpolates the local. A binding that READS a declared local
-still refuses: a child-position read is a `preambleRegions` entry (already
-refused) and an attribute-position read is not classified as reactive, so the
-case is currently unreachable — the refusal is the fail-safe that keeps the
-widening sound if either fact changes.
+effect. `createRow` always runs the preamble, before the clone whose template
+literal may interpolate the local.
+
+A binding that READS a declared local was refused at first, on the grounds
+that a preamble local hides whatever the preamble read — so `applyOuter` would
+prime the wrong thing, or nothing, and an unprimed loop-level effect never
+subscribes. That refusal was written while the case was unreachable, and the
+#2447 follow-up made it reachable by classifying an attribute reading such a
+local as reactive (it used to freeze into the row template). Rather than let
+that push the krausest shape back to the eager path, the substitution the
+refusal stood in for is now real: `analyzeLazyPreamble` returns the preamble's
+own free identifiers, `classifyLazyBinding` runs them through the same rules
+as a binding's own names — so `selected` reaches the prime list and the
+binding lands in whichever bodies its real dependencies imply — and
+`applyItem` / `applyOuter` re-run the preamble only when a binding they own
+reads one. A preamble no binding reads stays in `createRow` alone. A
+child-position read is still a `preambleRegions` entry, which refuses on its
+own separate grounds.
 
 Outer-involving TEXT bindings were also refused once and are now lazy
 (#2411/#2412). The obstacle was not the design but the mutating text claim


### PR DESCRIPTION
The gap #2447 recorded but left open: the attribute position of a preamble-derived value.

## The bug

```tsx
{rows().map(row => {
  const cls = row.done ? 'done' : 'open'
  return <li key={row.id} class={cls}>{row.label}</li>
})}
```

The loop runtimes reuse a row's DOM node on a same-key item update and re-run only the wired slots. `class={cls}` was not one — `classifyReactivity` sees a bare local, not a signal or loop-param read — so the value was interpolated into the row template instead of bound. Row 1 kept `open` after its item turned `done: true`, while the sibling `{row.label}` text updated normally.

The child-position twin (`{stateLabel}`) was fixed as a preamble-patched region in #2389. The attribute position was not, and #2447 called it out as "a client-side classification question, worth deciding on separately".

## Two passes, because the obstacle is in two places

- **Phase 1 grants the slot** (`markPreambleAttrSlots`). An attribute is only wirable if its element carries a `bf` marker, and that is decided when the element is BUILT — before the enclosing loop's preamble exists. The client-JS pass cannot grant one after the fact: the SSR template renders from the same IR and would not carry the marker. This pass mirrors `collectPreambleRegions`' traversal and decides *only* the slot; whether to wire is still the classifier's call.
- **The client-JS pass wires it** and re-runs the preamble ahead of the write. In the eager row effect that means moving `mapPreambleWrapped` to the **top** of the body — it used to sit between the attr writes and the region writes, which was correct only while regions were its only readers.

## The lazy row graph keeps these rows

`lazyRowEligibility` refused any binding reading a preamble local, on the grounds that a local hides whatever the preamble read, so `applyOuter` could not prime the real dependency and an unprimed loop-level effect never subscribes. That was a fail-safe written while the case was unreachable — and its own comment said so.

Making it reachable would have pushed **the exact row §9.5 was built for** back to the eager path:

```tsx
const cls = selected() === row.id ? 'danger' : ''   // the krausest shape
```

So the substitution the refusal stood in for is now real, rather than shipping a correctness fix that quietly undoes a merged optimisation:

- `analyzeLazyPreamble` returns the preamble's own free identifiers (`LazyPreambleFacts.freeNames`), unclassified on purpose — judging them there would be a second copy of the classifier's rules, free to drift from the one the emitter actually primes against.
- `classifyLazyBinding` runs those names through **the same loop** it runs a binding's own identifiers through. `selected` lands in `reactiveOuterNames` (so it reaches the prime list) and `row` sets `readsItem`, which is how the binding gets into the right bodies.
- `applyItem` / `applyOuter` re-run the preamble only when a binding **they own** reads one (`itemNeedsPreamble` / `outerNeedsPreamble`). A preamble no binding reads stays in `createRow` alone.

Re-running is sound because `analyzeLazyPreamble` already proves the statements are `const` declarations whose initializers do nothing but read the item and zero-arg signal getters — the G1 proof, now with a consumer.

## Verified against the live DOM, on both dependency shapes

The two shapes fail differently, so both are run rather than reasoned about:

| preamble reads | body | before | after |
|---|---|---|---|
| `row.done` (item) | `applyItem` | class frozen at `open` | rewrites to `done` |
| `selected()` (outer) | `applyOuter` | class frozen | rewrites, with `selected` primed |

The outer case is the one that matters most: if the substitution named the wrong dependency, the loop-level effect would subscribe to nothing and the binding would be **silently dead** — no error, no warning, just a class that never changes. `lazy-preamble.test.ts` now asserts the prime statement sits above the per-entry loop, which is what makes it subscribe while the entry list is empty.

## Tests

- `preamble-attr-reactivity.test.ts` — **new**: the Phase-1 slot decision (granted, not granted, `key` excluded, nested element), the wiring, the preamble-before-write ordering, and that the row stays lazy with no per-row reactive resource.
- `lazy-preamble.test.ts` — retargeted. "applyItem does NOT re-run the preamble" was asserting the old refusal; it now pins the per-body accounting instead: `applyOuter` re-runs it *and* primes `selected`, `applyItem` re-runs it because this binding reads the item too, and a preamble no binding reads stays in `createRow` alone.
- `lazy-row-preamble.test.ts` — the contract this issue pointed at. Its `expect(class).toBe('open')` after a same-key update was the pinned bug; it now reads `'done'`.

Local: jsx + client **3,519 pass / 0 fail**, adapter-tests **1,476 pass / 0 fail**. The remaining adapter suites are running; I will post the numbers and fix anything they surface.

## Note on the diff size

Rows that gain a binding also gain a `bf` marker in SSR output, which shifts slot numbering for the affected components. `loop-preamble-attr-value` and `loop-preamble-chained-filter` record the new markers — no rendered content changed, only marker placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_