### PR TITLE
Refuse a per-row prop override that would leave a derived child field stale (#2448)

### DIFF
--- a/.changeset/go-derived-prop-refusal.md
+++ b/.changeset/go-derived-prop-refusal.md
@@ -7,7 +7,7 @@ Refuse loudly when a per-row prop override would leave a derived child field sta
 Follow-up to #2445. That fix re-applies a loop-dependent prop per row via the
 `bf_with_props` runtime helper, which overrides fields on the child's
 already-constructed shared instance. It cannot re-run `New<Child>Props`, which
-is where memos are computed:
+is where a memo body AND a signal's initial value are both computed:
 
 ```go
 func NewBadgeProps(in BadgeInput) BadgeProps {
@@ -30,11 +30,15 @@ register per-component constructors into the template FuncMap, a breaking
 setup change for every Go user. Both are worse than a loud refusal, and the
 behaviour being replaced is silently wrong output.
 
-Detection is a structural walk over the child's own memo `parsed` bodies,
+Detection is a structural walk over the child's own constructor-evaluated
+`parsed` initializers — both `createMemo` bodies and `createSignal` initial
+values, since `New<Child>Props` bakes each of them once and `bf_with_props`
+re-runs neither (`const [dbl] = createSignal(props.n)` emits `Dbl: in.N` and
+goes stale under a per-row `n` override exactly as the memo form does) —
 collecting which input props each reads. It is best-effort by construction — a
-memo with no resolvable parsed body is skipped — so its failure mode is a
-missed refusal (today's behaviour), never a wrong one. The walk carries an
-exhaustiveness pin so a new `ParsedExpr` kind cannot silently drop a
+declaration with no resolvable parsed initializer is skipped — so its failure
+mode is a missed refusal (today's behaviour), never a wrong one. The walk
+carries an exhaustiveness pin so a new `ParsedExpr` kind cannot silently drop a
 dependency.
 
 New fixture `composite-row-child-derived-prop` pins the shape: `BF101` on Go,

--- a/.changeset/go-derived-prop-refusal.md
+++ b/.changeset/go-derived-prop-refusal.md
@@ -41,6 +41,11 @@ mode is a missed refusal (today's behaviour), never a wrong one. The walk
 carries an exhaustiveness pin so a new `ParsedExpr` kind cannot silently drop a
 dependency.
 
+Dependencies are keyed by the prop's canonical source name
+(`ParamInfo.sourceName ?? name`), so an aliased destructure
+(`function Badge({ n: count })`, whose memo reads `count` while the parent
+writes `n=`) refuses too rather than missing the lookup.
+
 New fixture `composite-row-child-derived-prop` pins the shape: `BF101` on Go,
 rendered correctly by every other adapter and CSR, which construct the child
 fresh per row and are unaffected.

--- a/.changeset/go-derived-prop-refusal.md
+++ b/.changeset/go-derived-prop-refusal.md
@@ -1,0 +1,42 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Refuse loudly when a per-row prop override would leave a derived child field stale (#2448)
+
+Follow-up to #2445. That fix re-applies a loop-dependent prop per row via the
+`bf_with_props` runtime helper, which overrides fields on the child's
+already-constructed shared instance. It cannot re-run `New<Child>Props`, which
+is where memos are computed:
+
+```go
+func NewBadgeProps(in BadgeInput) BadgeProps {
+	return BadgeProps{ ..., N: in.N, Dbl: in.N * 2 }
+}
+```
+
+So `N` became per-row correctly while `Dbl` kept the one-shot constructor's
+value (`in.N == 0` → `0`) on every row — silently wrong output, no diagnostic.
+
+The Go adapter now detects this and refuses with `BF101` naming the child, the
+overridden prop, and the field that would go stale, suggesting either
+`/* @client */` on the loop position or lifting the derived value into the
+parent. Two alternatives were evaluated and rejected: a per-row props slice
+(the `.TodoItems` wrapper shape) is populated by the route handler rather than
+the generated constructor, so extending it here would demand handler work for
+a component the user never named at a call site; and calling `New<Child>Props`
+at template-execution time would require the generated components package to
+register per-component constructors into the template FuncMap, a breaking
+setup change for every Go user. Both are worse than a loud refusal, and the
+behaviour being replaced is silently wrong output.
+
+Detection is a structural walk over the child's own memo `parsed` bodies,
+collecting which input props each reads. It is best-effort by construction — a
+memo with no resolvable parsed body is skipped — so its failure mode is a
+missed refusal (today's behaviour), never a wrong one. The walk carries an
+exhaustiveness pin so a new `ParsedExpr` kind cannot silently drop a
+dependency.
+
+New fixture `composite-row-child-derived-prop` pins the shape: `BF101` on Go,
+rendered correctly by every other adapter and CSR, which construct the child
+fresh per row and are unaffected.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -2749,14 +2749,16 @@ func WithChildren(props interface{}, children template.HTML) (interface{}, error
 //
 // This overrides fields on the ALREADY-CONSTRUCTED instance — it does not
 // re-run New<Child>Props. A field the child derives FROM the overridden prop
-// at construction time (a memo) would keep whatever the one-shot constructor
+// at construction time (a memo body, or a signal's initial value — the
+// constructor bakes both) would keep whatever the one-shot constructor
 // computed and never update per row; only the directly-overridden field is
 // correct per row. That combination is REFUSED at compile time (BF101, #2448):
-// the TypeScript compiler tracks which memo fields derive from which input
-// props (`ChildComponentShape.derivedFieldDeps`,
-// packages/adapter-go-template/src/adapter/lib/types.ts) and never emits a
-// `bf_with_props` call whose overridden field would go stale, so a call this
-// helper actually receives at runtime never hits that combination.
+// the TypeScript compiler tracks which constructor-computed fields derive from
+// which input props (GoTemplateAdapter.childDerivedFieldDeps, built by
+// recordDerivedFieldDeps in
+// packages/adapter-go-template/src/adapter/go-template-adapter.ts) and never
+// emits a bf_with_props call whose overridden field would go stale, so a call
+// this helper actually receives at runtime never hits that combination.
 // See https://github.com/piconic-ai/barefootjs/issues/2448.
 func WithProps(props interface{}, kv ...interface{}) (interface{}, error) {
 	if len(kv)%2 != 0 {

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -2747,12 +2747,17 @@ func WithChildren(props interface{}, children template.HTML) (interface{}, error
 // instance's constructor-built value stands, mirroring WithChildren's
 // "props type without a Children field" passthrough.
 //
-// KNOWN LIMITATION (#2448): this overrides fields on the ALREADY-CONSTRUCTED
-// instance — it does not re-run New<Child>Props. A field the child derives
-// FROM the overridden prop at construction time (a memo, or a prop-shadowing
-// signal's initial value) keeps whatever the one-shot constructor computed
-// and does not update per row; only the directly-overridden field is
-// correct per row. Tracked as a follow-up, not fixed by #2445.
+// This overrides fields on the ALREADY-CONSTRUCTED instance — it does not
+// re-run New<Child>Props. A field the child derives FROM the overridden prop
+// at construction time (a memo) would keep whatever the one-shot constructor
+// computed and never update per row; only the directly-overridden field is
+// correct per row. That combination is REFUSED at compile time (BF101, #2448):
+// the TypeScript compiler tracks which memo fields derive from which input
+// props (`ChildComponentShape.derivedFieldDeps`,
+// packages/adapter-go-template/src/adapter/lib/types.ts) and never emits a
+// `bf_with_props` call whose overridden field would go stale, so a call this
+// helper actually receives at runtime never hits that combination.
+// See https://github.com/piconic-ai/barefootjs/issues/2448.
 func WithProps(props interface{}, kv ...interface{}) (interface{}, error) {
 	if len(kv)%2 != 0 {
 		return nil, fmt.Errorf("bf_with_props: odd number of key/value arguments (%d)", len(kv))

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4490,14 +4490,17 @@ export function CompositeRowChildComponent(props: { items: Item[] }) {
 // #2448: `bf_with_props` (#2445, above) overrides fields on the ALREADY-
 // CONSTRUCTED shared instance — it does not re-run `New<Child>Props`. When
 // the overridden prop feeds a child field the constructor DERIVES at
-// construction time (a `createMemo`), the override would leave that field
-// holding the shared instance's one-shot value on every row — silently
-// wrong output. Refused loudly with BF101 instead.
+// construction time (a `createMemo` body or a `createSignal` initial value —
+// `New<Child>Props` bakes both), the override would leave that field holding
+// the shared instance's one-shot value on every row — silently wrong output.
+// Refused loudly with BF101 instead.
 describe('GoTemplateAdapter - #2448 per-row override of a prop feeding a derived child field', () => {
-  // Two-phase build (mirrors the rest-bag test's pattern above): a bare
-  // `compileJSX` never calls `registerChildComponentShape` (only the CLI's
-  // cross-file pre-pass, #2131, does), so `Badge`'s `derivedFieldDeps`
-  // wouldn't exist for the parent's generate pass otherwise.
+  // Two-phase build (mirrors the rest-bag test's pattern above): the adapter
+  // instance here never compiles `Badge` itself, so without the explicit
+  // `registerChildComponentShape` its `childDerivedFieldDeps` entry wouldn't
+  // exist for the parent's generate pass. (Under `compileJSX` — the second
+  // test below — the same-file child IS generated first, and `generate()`
+  // self-registers, so both doors are exercised.)
   test('a per-row-overridden prop feeding a memo field is refused with BF101', () => {
     const source = `
 'use client'
@@ -4563,10 +4566,50 @@ export function CompositeRowChildDerivedProp(props: { rows: Row[] }) {
     expect(template).not.toContain('"N"')
   })
 
+  // A `createSignal` INITIAL VALUE is baked into `New<Child>Props` exactly
+  // like a memo body is (`const [dbl] = createSignal(props.n)` emits
+  // `Dbl: in.N`), and `bf_with_props` re-runs neither — so the signal form
+  // goes stale under a per-row override for the same reason and must refuse
+  // the same way. Compiled through `compileJSX` (not the two-phase build
+  // above) so this also pins `generate()`'s self-registration door.
+  test("a per-row-overridden prop feeding a signal's initial value is refused with BF101", () => {
+    const result = compileJSX(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string; n: number }
+function Badge(props: { text: string; n: number }) {
+  const [dbl] = createSignal(props.n)
+  return <span class="badge">{props.text}:{dbl()}</span>
+}
+export function SignalRowChildDerivedProp(props: { rows: Row[] }) {
+  const [rows] = createSignal<Row[]>(props.rows)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={row.label} n={row.n} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    const bf101s = (result.errors ?? []).filter(e => e.code === 'BF101')
+    expect(bf101s).toHaveLength(1)
+    expect(bf101s[0]!.message).toContain('Badge')
+    expect(bf101s[0]!.message).toContain("'n'")
+    expect(bf101s[0]!.message).toContain('dbl')
+    const template = result.files.find(f => f.type === 'markedTemplate')!.content
+    // Same scoping as the memo case: only `n` is refused, `text` is still
+    // reapplied per row, and no `"N"` pair reaches the template.
+    expect(template).toContain('"Text" .Label')
+    expect(template).not.toContain('"N"')
+  })
+
   // Regression pin for #2445: a nested child with NO derived field (no
-  // `createMemo` reading the overridden prop) must still compile clean and
-  // still emit `bf_with_props` — this refusal must not fire on the shape
-  // #2445 already fixed.
+  // `createMemo`/`createSignal` reading the overridden prop) must still
+  // compile clean and still emit `bf_with_props` — this refusal must not fire
+  // on the shape #2445 already fixed.
   test('a per-row-overridden prop with no derived field still emits bf_with_props', () => {
     const result = compileJSX(`
 'use client'

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4606,6 +4606,46 @@ export function SignalRowChildDerivedProp(props: { rows: Row[] }) {
     expect(template).not.toContain('"N"')
   })
 
+  // An ALIASED destructure (`{ n: count }`) reads `count` in the memo body,
+  // but the only name the parent knows is the JSX attribute `n` — which is
+  // what `loopRowChildPropOverrides` capitalizes. `recordDerivedFieldDeps`
+  // keys dependencies by `ParamInfo.sourceName ?? name` for exactly this
+  // reason; keying on the local binding would file the dependency under
+  // `Count`, the lookup would miss, and the refusal would silently not fire.
+  test('an aliased destructured prop feeding a memo is still refused with BF101', () => {
+    const result = compileJSX(`
+'use client'
+import { createSignal, createMemo } from '@barefootjs/client'
+type Row = { id: number; label: string; n: number }
+function Badge({ text, n: count }: { text: string; n: number }) {
+  const dbl = createMemo(() => count * 2)
+  return <span class="badge">{text}:{dbl()}</span>
+}
+export function AliasedRowChildDerivedProp(props: { rows: Row[] }) {
+  const [rows] = createSignal<Row[]>(props.rows)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={row.label} n={row.n} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    const bf101s = (result.errors ?? []).filter(e => e.code === 'BF101')
+    expect(bf101s).toHaveLength(1)
+    // The message names the prop as the PARENT wrote it (`n`), not the
+    // child's local binding (`count`) — that's the name the author has to act
+    // on at the call site.
+    expect(bf101s[0]!.message).toContain("'n'")
+    expect(bf101s[0]!.message).toContain('dbl')
+    const template = result.files.find(f => f.type === 'markedTemplate')!.content
+    expect(template).toContain('"Text" .Label')
+    expect(template).not.toContain('"N"')
+  })
+
   // Regression pin for #2445: a nested child with NO derived field (no
   // `createMemo`/`createSignal` reading the overridden prop) must still
   // compile clean and still emit `bf_with_props` — this refusal must not fire

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4487,6 +4487,113 @@ export function CompositeRowChildComponent(props: { items: Item[] }) {
   })
 })
 
+// #2448: `bf_with_props` (#2445, above) overrides fields on the ALREADY-
+// CONSTRUCTED shared instance — it does not re-run `New<Child>Props`. When
+// the overridden prop feeds a child field the constructor DERIVES at
+// construction time (a `createMemo`), the override would leave that field
+// holding the shared instance's one-shot value on every row — silently
+// wrong output. Refused loudly with BF101 instead.
+describe('GoTemplateAdapter - #2448 per-row override of a prop feeding a derived child field', () => {
+  // Two-phase build (mirrors the rest-bag test's pattern above): a bare
+  // `compileJSX` never calls `registerChildComponentShape` (only the CLI's
+  // cross-file pre-pass, #2131, does), so `Badge`'s `derivedFieldDeps`
+  // wouldn't exist for the parent's generate pass otherwise.
+  test('a per-row-overridden prop feeding a memo field is refused with BF101', () => {
+    const source = `
+'use client'
+import { createSignal, createMemo } from '@barefootjs/client'
+type Row = { id: number; label: string; n: number }
+function Badge(props: { text: string; n: number }) {
+  const dbl = createMemo(() => props.n * 2)
+  return <span class="badge">{props.text}:{dbl()}</span>
+}
+export function CompositeRowChildDerivedProp(props: { rows: Row[] }) {
+  const [rows] = createSignal<Row[]>(props.rows)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={row.label} n={row.n} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart()
+
+    const badgeCtx = analyzeComponent(source, 'test.tsx', 'Badge')
+    const badgeIR: ComponentIR = {
+      version: '0.1',
+      metadata: buildMetadata(badgeCtx),
+      root: jsxToIR(badgeCtx)!,
+      errors: [],
+    }
+    const rootCtx = analyzeComponent(source, 'test.tsx', 'CompositeRowChildDerivedProp')
+    const rootIR: ComponentIR = {
+      version: '0.1',
+      metadata: buildMetadata(rootCtx),
+      root: jsxToIR(rootCtx)!,
+      errors: [],
+    }
+
+    const adapter = new GoTemplateAdapter()
+    adapter.registerChildComponentShape(badgeIR)
+    adapter.generateTypes(badgeIR)
+    adapter.generateTypes(rootIR)
+    const template = adapter.generate(rootIR, { skipScriptRegistration: true }).template
+
+    const bf101s = rootIR.errors.filter(e => e.code === 'BF101')
+    expect(bf101s).toHaveLength(1)
+    // Names the child, the overridden prop, and the derived field that
+    // would go stale, so the message stands alone without cross-referencing
+    // internal task labels.
+    expect(bf101s[0]!.message).toContain('Badge')
+    expect(bf101s[0]!.message).toContain("'n'")
+    expect(bf101s[0]!.message).toContain('dbl')
+    // The other per-row prop (`text`, feeding no derived field) is NOT
+    // reported, and is still correctly reapplied per row via `bf_with_props`
+    // — the refusal is scoped to the ONE prop that actually feeds a
+    // derived field, not the whole child instance.
+    expect(bf101s[0]!.message).not.toContain("'text'")
+    expect(template).toContain('"Text" .Label')
+
+    // The refused override itself never reaches the template: `bf_with_props`
+    // is never called with an `"N"` pair (the #2445 bug this refusal exists
+    // to close would otherwise silently emit `"N" .N` and leave `Dbl` stale).
+    expect(template).not.toContain('"N"')
+  })
+
+  // Regression pin for #2445: a nested child with NO derived field (no
+  // `createMemo` reading the overridden prop) must still compile clean and
+  // still emit `bf_with_props` — this refusal must not fire on the shape
+  // #2445 already fixed.
+  test('a per-row-overridden prop with no derived field still emits bf_with_props', () => {
+    const result = compileJSX(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number; label: string }
+function Badge(props: { text: string }) {
+  return <span class="badge">{props.text}</span>
+}
+export function CompositeRowChildComponent(props: { items: Item[] }) {
+  const [rows] = createSignal<Item[]>(props.items)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={row.label} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(0)
+    const template = result.files.find(f => f.type === 'markedTemplate')!.content
+    expect(template).toContain('{{template "Badge" (bf_with_props $.BadgeSlot0 "Text" .Label)}}')
+  })
+})
+
 // #2228: a `.filter(t => …).map(todo => <Child todo={todo} .../>)` loop whose
 // body is a single child component ranges the WRAPPER slice (`.TodoItems`,
 // `.{ChildName}s` — see #2130 above), so `{{if}}`'s dot context for the

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -133,7 +133,7 @@ import { typeInfoToGo } from "./type/type-codegen.ts"
 import { isBooleanMemo, isListFilterMemo, isStringTernaryMemo } from "./memo/memo-type.ts"
 import { lowerCtorExpr } from "./memo/ctor-lowering.ts"
 import { resolveBlockBodyMemoModuleConst } from "./memo/memo-value.ts"
-import { computeMemoInitialValue, computeMemoInitialValueOrNull, filterArmEarlierSiblingRefs, collectPropsReadByMemoBody } from "./memo/memo-compute.ts"
+import { computeMemoInitialValue, computeMemoInitialValueOrNull, filterArmEarlierSiblingRefs, collectPropsReadByCtorInit } from "./memo/memo-compute.ts"
 import { collectSpreadSlots, buildSpreadInitializer } from "./spread/spread-codegen.ts"
 import { buildPropTypeOverrides, resolvePropGoType, collectNillablePropNames, collectNullishConsumedPropNames, collectOmittableAttrConsumedPropNames, collectTextConsumedPropNames, collectPresenceCheckedPropNames, NULLISH_SCALAR_GO_TYPES } from "./props/prop-types.ts"
 import { collectStringValueNames } from "./props/prop-classes.ts"
@@ -646,17 +646,24 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private childDerivedFieldDeps: Map<string, Map<string, ReadonlySet<string>>> = new Map()
 
   /**
-   * Record which of `ir`'s memo fields derive from one of its own input props
-   * (#2448). See `childDerivedFieldDeps`.
+   * Record which of `ir`'s constructor-computed fields derive from one of its
+   * own input props (#2448). See `childDerivedFieldDeps`.
    *
-   * A memo whose Go field name collides with a prop's own field name is a
-   * same-named "shadow" (`size = createMemo(() => props.size ?? 'icon')`) —
+   * BOTH constructor-evaluated declaration forms count, because
+   * `generateNewPropsFunction` bakes both into the struct once:
+   * a `createMemo` BODY (`createMemo(() => props.n * 2)` → `Dbl: in.N * 2`)
+   * and a `createSignal` INITIAL VALUE (`createSignal(props.n)` → `Dbl: in.N`).
+   * `bf_with_props` re-runs neither, so a per-row override of `n` leaves
+   * either one holding the shared instance's one-shot value.
+   *
+   * A declaration whose Go field name collides with a prop's own field name is
+   * a same-named "shadow" (`size = createMemo(() => props.size ?? 'icon')`) —
    * `generateNewPropsFunction` folds it into the PROP's passthrough field
    * rather than emitting a separate derived one, so a per-row override of
-   * that prop lands on the same field and nothing goes stale. A memo with no
-   * structurally-resolvable `parsed` body is skipped too: this map is
-   * best-effort, and its absence costs a missed refusal (today's behaviour),
-   * never a wrong one.
+   * that prop lands on the same field and nothing goes stale. A declaration
+   * with no structurally-resolvable `parsed` initializer is skipped too: this
+   * map is best-effort, and its absence costs a missed refusal (today's
+   * behaviour), never a wrong one.
    */
   private recordDerivedFieldDeps(
     ir: Pick<ComponentIR, 'metadata'>,
@@ -666,16 +673,20 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (!name) return
     const propFieldNames = new Set([...paramNames].map(p => capitalizeFieldName(p)))
     const deps = new Map<string, ReadonlySet<string>>()
-    for (const memo of ir.metadata.memos ?? []) {
-      if (propFieldNames.has(capitalizeFieldName(memo.name))) continue
-      if (!memo.parsed) continue
-      const read = collectPropsReadByMemoBody(
-        memo.parsed,
+    const ctorInits: { field: string; init: ParsedExpr | undefined }[] = [
+      ...(ir.metadata.memos ?? []).map(m => ({ field: m.name, init: m.parsed })),
+      ...(ir.metadata.signals ?? []).map(s => ({ field: s.getter, init: s.parsed })),
+    ]
+    for (const { field, init } of ctorInits) {
+      if (propFieldNames.has(capitalizeFieldName(field))) continue
+      if (!init) continue
+      const read = collectPropsReadByCtorInit(
+        init,
         ir.metadata.propsObjectName ?? null,
         paramNames,
       )
       if (read.size === 0) continue
-      deps.set(memo.name, new Set([...read].map(d => capitalizeFieldName(d))))
+      deps.set(field, new Set([...read].map(d => capitalizeFieldName(d))))
     }
     if (deps.size > 0) this.childDerivedFieldDeps.set(name, deps)
   }
@@ -5080,13 +5091,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * #2445, which this method fixes): `bf_with_props` overrides fields on the
    * ALREADY-CONSTRUCTED shared instance — it does not re-run
    * `New<Child>Props`. A field the child derives FROM the overridden prop at
-   * construction time (a memo) would keep whatever the one-shot constructor
-   * computed and never update per row — silently wrong output. Rather than
-   * emit that, this method checks the prop against the child's
-   * `derivedFieldDeps` (`ChildComponentShape`, populated by
-   * `registerChildComponentShape`) and pushes a BF101 + `continue`s when a
-   * derived field would go stale, exactly like the unsupported-expression
-   * refusal a few lines below.
+   * construction time (a memo body or a signal's initial value) would keep
+   * whatever the one-shot constructor computed and never update per row —
+   * silently wrong output. Rather than emit that, this method checks the prop
+   * against `this.childDerivedFieldDeps` (built by `recordDerivedFieldDeps`,
+   * this file) and pushes a BF101 + `continue`s when a derived field would go
+   * stale, exactly like the unsupported-expression refusal a few lines below.
    *
    * Returns the space-joined `"Field" value "Field2" value2 …` argument list
    * for `bf_with_props`, or null when nothing needs overriding (caller keeps
@@ -5119,9 +5129,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // #2448: this prop is about to be overridden per row via
       // `bf_with_props` — but that helper only sets the NAMED fields on the
       // already-constructed shared instance; it can't re-run
-      // `New<Child>Props`. If a memo field derives from this prop at
-      // construction time, the override would leave that field holding the
-      // shared instance's one-shot value on every row — silently wrong.
+      // `New<Child>Props`. If a memo body or a signal's initial value derives
+      // from this prop at construction time, the override would leave that
+      // field holding the shared instance's one-shot value on every row —
+      // silently wrong.
       // Refuse loudly instead (same push-error-then-`continue` shape as the
       // unsupported-expression refusal below).
       {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -133,7 +133,7 @@ import { typeInfoToGo } from "./type/type-codegen.ts"
 import { isBooleanMemo, isListFilterMemo, isStringTernaryMemo } from "./memo/memo-type.ts"
 import { lowerCtorExpr } from "./memo/ctor-lowering.ts"
 import { resolveBlockBodyMemoModuleConst } from "./memo/memo-value.ts"
-import { computeMemoInitialValue, computeMemoInitialValueOrNull, filterArmEarlierSiblingRefs } from "./memo/memo-compute.ts"
+import { computeMemoInitialValue, computeMemoInitialValueOrNull, filterArmEarlierSiblingRefs, collectPropsReadByMemoBody } from "./memo/memo-compute.ts"
 import { collectSpreadSlots, buildSpreadInitializer } from "./spread/spread-codegen.ts"
 import { buildPropTypeOverrides, resolvePropGoType, collectNillablePropNames, collectNullishConsumedPropNames, collectOmittableAttrConsumedPropNames, collectTextConsumedPropNames, collectPresenceCheckedPropNames, NULLISH_SCALAR_GO_TYPES } from "./props/prop-types.ts"
 import { collectStringValueNames } from "./props/prop-classes.ts"
@@ -441,6 +441,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.state.pendingChildrenDefines = []
     this.primeCompileState(ir)
     this.state.stringValueNames = collectStringValueNames(ir)
+    // #2448: self-register this component's derived-memo dependencies, so a
+    // SAME-FILE child (generated before its parent in the same run) is
+    // visible to `loopRowChildPropOverrides`. The cross-file pre-pass door is
+    // `registerChildComponentShape`; `compileJSX` only goes through here.
+    this.recordDerivedFieldDeps(ir, new Set((ir.metadata.propsParams ?? []).map(p => p.name)))
 
     // Surface loop-body usages of sibling-imported components (see
     // `checkImportedLoopChildComponents`). The barefoot CLI compiles a
@@ -618,6 +623,63 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * (the CLI's cross-file shape pre-pass, #2131) can register from a bare
    * analyzer pass — a full `ComponentIR` still satisfies it structurally.
    */
+  /**
+   * #2448: component name -> (memo field -> the INPUT prop Go field names its
+   * initializer reads). Deliberately SEPARATE from `childComponentShapes`,
+   * which only the CLI's cross-file pre-pass
+   * (`registerChildComponentShape`) populates — `compileJSX` never calls that
+   * hook, so a SAME-FILE child (the only kind a loop row may contain: a
+   * sibling-module child is BF103-refused there) would never have an entry
+   * and the #2448 refusal would never fire. That is exactly how the first cut
+   * of this fix shipped a conformance pin for a diagnostic that was never
+   * emitted.
+   *
+   * Populated from BOTH doors: `registerChildComponentShape` for the
+   * cross-file pre-pass, and `generate()` for every component compiled in
+   * this run — a same-file child is generated before its parent, so its entry
+   * is present by the time `loopRowChildPropOverrides` looks. Kept out of
+   * `ChildComponentShape` on purpose: that struct's presence/absence already
+   * drives rest-bag routing and map-typed-param baking, and widening WHEN it
+   * exists would change emission for every same-file child in the corpus.
+   * This map has exactly one reader.
+   */
+  private childDerivedFieldDeps: Map<string, Map<string, ReadonlySet<string>>> = new Map()
+
+  /**
+   * Record which of `ir`'s memo fields derive from one of its own input props
+   * (#2448). See `childDerivedFieldDeps`.
+   *
+   * A memo whose Go field name collides with a prop's own field name is a
+   * same-named "shadow" (`size = createMemo(() => props.size ?? 'icon')`) —
+   * `generateNewPropsFunction` folds it into the PROP's passthrough field
+   * rather than emitting a separate derived one, so a per-row override of
+   * that prop lands on the same field and nothing goes stale. A memo with no
+   * structurally-resolvable `parsed` body is skipped too: this map is
+   * best-effort, and its absence costs a missed refusal (today's behaviour),
+   * never a wrong one.
+   */
+  private recordDerivedFieldDeps(
+    ir: Pick<ComponentIR, 'metadata'>,
+    paramNames: ReadonlySet<string>,
+  ): void {
+    const name = ir.metadata.componentName
+    if (!name) return
+    const propFieldNames = new Set([...paramNames].map(p => capitalizeFieldName(p)))
+    const deps = new Map<string, ReadonlySet<string>>()
+    for (const memo of ir.metadata.memos ?? []) {
+      if (propFieldNames.has(capitalizeFieldName(memo.name))) continue
+      if (!memo.parsed) continue
+      const read = collectPropsReadByMemoBody(
+        memo.parsed,
+        ir.metadata.propsObjectName ?? null,
+        paramNames,
+      )
+      if (read.size === 0) continue
+      deps.set(memo.name, new Set([...read].map(d => capitalizeFieldName(d))))
+    }
+    if (deps.size > 0) this.childDerivedFieldDeps.set(name, deps)
+  }
+
   registerChildComponentShape(ir: Pick<ComponentIR, 'metadata'>): void {
     const name = ir.metadata.componentName
     if (!name) return
@@ -638,6 +700,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         .map(p => p.name),
     )
     this.childComponentShapes.set(name, { paramNames, restBagField, mapTypedParamNames })
+    this.recordDerivedFieldDeps(ir, paramNames)
     // Contexts this child consumes, so a parent `<Ctx.Provider value>` wrapping
     // it can set the matching field on the child's slot input.
     this.childContextConsumers.set(name, collectContextConsumers(ir.metadata))
@@ -5013,13 +5076,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * fixture's emitted template byte-identical (no fixture in the corpus
    * reaches this method with a loop-dependent prop today).
    *
-   * KNOWN LIMITATION (#2448, tracked separately from #2445, which this
-   * method fixes): `bf_with_props` overrides fields on the ALREADY-CONSTRUCTED
-   * shared instance — it does not re-run `New<Child>Props`. A field the
-   * child derives FROM the overridden prop at construction time (a memo,
-   * or a prop-shadowing signal's initial value) keeps whatever the
-   * one-shot constructor computed and does not update per row. Only the
-   * directly-overridden field itself is correct per row.
+   * REFUSED, not silently mis-rendered (#2448, tracked separately from
+   * #2445, which this method fixes): `bf_with_props` overrides fields on the
+   * ALREADY-CONSTRUCTED shared instance — it does not re-run
+   * `New<Child>Props`. A field the child derives FROM the overridden prop at
+   * construction time (a memo) would keep whatever the one-shot constructor
+   * computed and never update per row — silently wrong output. Rather than
+   * emit that, this method checks the prop against the child's
+   * `derivedFieldDeps` (`ChildComponentShape`, populated by
+   * `registerChildComponentShape`) and pushes a BF101 + `continue`s when a
+   * derived field would go stale, exactly like the unsupported-expression
+   * refusal a few lines below.
    *
    * Returns the space-joined `"Field" value "Field2" value2 …` argument list
    * for `bf_with_props`, or null when nothing needs overriding (caller keeps
@@ -5049,6 +5116,33 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (prop.value.kind !== 'expression') continue
       const free = prop.freeIdentifiers
       if (!free || ![...free].some(name => this.isLoopShadowedName(name))) continue
+      // #2448: this prop is about to be overridden per row via
+      // `bf_with_props` — but that helper only sets the NAMED fields on the
+      // already-constructed shared instance; it can't re-run
+      // `New<Child>Props`. If a memo field derives from this prop at
+      // construction time, the override would leave that field holding the
+      // shared instance's one-shot value on every row — silently wrong.
+      // Refuse loudly instead (same push-error-then-`continue` shape as the
+      // unsupported-expression refusal below).
+      {
+        const derived = this.childDerivedFieldDeps.get(comp.name)
+        const overriddenField = capitalizeFieldName(prop.name)
+        const staleField = derived
+          ? [...derived].find(([, deps]) => deps.has(overriddenField))?.[0]
+          : undefined
+        if (staleField) {
+          this.state.errors.push({
+            code: 'BF101',
+            severity: 'error',
+            message: `Prop '${prop.name}' on <${comp.name}> nested inside a dynamic loop row is overridden per row, but <${comp.name}>'s '${staleField}' field is computed from '${prop.name}' when the shared instance is first constructed and won't recompute per row — it would keep the first row's value on every row.`,
+            loc: prop.loc,
+            suggestion: {
+              message: `Mark this loop position '@client' to render <${comp.name}> client-side, or compute '${staleField}' in the parent and pass it to <${comp.name}> as a plain prop instead of deriving it inside <${comp.name}>.`,
+            },
+          })
+          continue
+        }
+      }
       const exprOut: { parsed?: ParsedExpr } = {}
       const errorCountBefore = this.state.errors.length
       let go = this.convertExpressionToGo(prop.value.expr, exprOut, prop.value.parsed)

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -664,6 +664,20 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * with no structurally-resolvable `parsed` initializer is skipped too: this
    * map is best-effort, and its absence costs a missed refusal (today's
    * behaviour), never a wrong one.
+   *
+   * Dependencies are keyed by the prop's CANONICAL source name
+   * (`ParamInfo.sourceName ?? name`), not the child's local binding. An
+   * ALIASED destructure (`function Badge({ n: count }: { n: number })`) reads
+   * `count` in the memo body, but the only name the parent knows is the JSX
+   * attribute `n` — `loopRowChildPropOverrides` capitalizes THAT. Keying on
+   * the local name would file the dependency under `Count`, the lookup would
+   * miss, and the refusal would silently not fire on exactly the shape it
+   * exists for.
+   *
+   * Note this canonicalization covers the DERIVED case only. An aliased prop
+   * with no derived field still has the parent emitting `"N" .N` against a
+   * child whose field is `Count`, which `bf.WithProps` silently passes over —
+   * tracked separately as #2457, a residual of #2445 rather than of #2448.
    */
   private recordDerivedFieldDeps(
     ir: Pick<ComponentIR, 'metadata'>,
@@ -671,7 +685,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   ): void {
     const name = ir.metadata.componentName
     if (!name) return
-    const propFieldNames = new Set([...paramNames].map(p => capitalizeFieldName(p)))
+    // Local binding → the prop name the PARENT writes at the call site.
+    // Identity for every un-aliased param (`sourceName` is set only on a
+    // renaming destructure).
+    const sourceOf = new Map(
+      (ir.metadata.propsParams ?? []).map(p => [p.name, p.sourceName ?? p.name]),
+    )
+    const canonical = (local: string): string => capitalizeFieldName(sourceOf.get(local) ?? local)
+    const propFieldNames = new Set([...paramNames].map(canonical))
     const deps = new Map<string, ReadonlySet<string>>()
     const ctorInits: { field: string; init: ParsedExpr | undefined }[] = [
       ...(ir.metadata.memos ?? []).map(m => ({ field: m.name, init: m.parsed })),
@@ -686,7 +707,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         paramNames,
       )
       if (read.size === 0) continue
-      deps.set(field, new Set([...read].map(d => capitalizeFieldName(d))))
+      deps.set(field, new Set([...read].map(canonical)))
     }
     if (deps.size > 0) this.childDerivedFieldDeps.set(name, deps)
   }

--- a/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
@@ -801,3 +801,119 @@ function propsAccessNameFromParsed(ctx: GoEmitContext, node: ParsedExpr): string
   if (!ctx.state.propsObjectName || node.object.name !== ctx.state.propsObjectName) return null
   return node.property
 }
+
+/**
+ * #2448: every INPUT prop name a memo's `parsed` BODY reads, either via a
+ * `<propsObjectName>.<name>` member access (object-props signature, e.g.
+ * `props.n`) or a bare identifier bound to a destructured prop (no
+ * `propsObjectName`). Feeds `ChildComponentShape.derivedFieldDeps`
+ * (`registerChildComponentShape`, `go-template-adapter.ts`) so a parent
+ * overriding one of THESE props per row (`bf_with_props`, #2445) can be
+ * refused loudly instead of silently leaving the derived field stale — see
+ * that map's docstring.
+ *
+ * Structural counterpart of {@link freeVarsInBody}: that walk reports a
+ * member's OBJECT identifier only (`props`), treating the property name as
+ * non-referential (fine for its own free-var-substitution purpose). Here the
+ * PROPERTY name is exactly what's wanted, so a `member` node contributes it
+ * once its object resolves to the props binding — walking stops at that
+ * first `propsObjectName.<name>` hop, so a deeper chain (`props.a.b`) still
+ * contributes only its BASE prop `a` (mirrors `collectPropRefs` in
+ * `ssr-defaults.ts`, the same first-level-only rule, for the same reason: an
+ * adapter that later re-derives a nested field still needs the base field
+ * seeded).
+ *
+ * This is a best-effort STRUCTURAL walk over the child's OWN analysis-time
+ * `parsed` tree — not a re-derivation of the Go initializer text, which
+ * isn't available yet at registration time (the cross-file shape pre-pass,
+ * #2131, runs before any component's codegen).
+ */
+export function collectPropsReadByMemoBody(
+  body: ParsedExpr,
+  propsObjectName: string | null,
+  propNames: ReadonlySet<string>,
+): Set<string> {
+  const found = new Set<string>()
+  const visit = (e: ParsedExpr, bound: ReadonlySet<string>): void => {
+    switch (e.kind) {
+      case 'identifier':
+        // Destructured signature only: a bare identifier bound to a
+        // destructured prop param IS the reference (`(props) => props.n`
+        // has no bare `n` — that shape is the `member` branch below).
+        if (!propsObjectName && propNames.has(e.name) && !bound.has(e.name)) found.add(e.name)
+        return
+      case 'member':
+        if (
+          propsObjectName &&
+          !e.computed &&
+          e.object.kind === 'identifier' &&
+          e.object.name === propsObjectName
+        ) {
+          found.add(e.property)
+          return
+        }
+        visit(e.object, bound)
+        return
+      case 'index-access':
+        visit(e.object, bound)
+        visit(e.index, bound)
+        return
+      case 'binary':
+      case 'logical':
+        visit(e.left, bound)
+        visit(e.right, bound)
+        return
+      case 'unary':
+        visit(e.argument, bound)
+        return
+      case 'conditional':
+        visit(e.test, bound)
+        visit(e.consequent, bound)
+        visit(e.alternate, bound)
+        return
+      case 'call':
+        visit(e.callee, bound)
+        e.args.forEach(a => visit(a, bound))
+        return
+      case 'template-literal':
+        for (const p of e.parts) if (p.type === 'expression') visit(p.expr, bound)
+        return
+      case 'array-literal':
+        e.elements.forEach(el => visit(el, bound))
+        return
+      case 'object-literal':
+        for (const p of e.properties) visit(p.value, bound)
+        return
+      case 'array-method':
+        visit(e.object, bound)
+        e.args.forEach(a => visit(a, bound))
+        if (e.method === 'flat' && e.depthExpr) visit(e.depthExpr, bound)
+        return
+      case 'arrow': {
+        const inner = e.params.length === 0 ? bound : new Set([...bound, ...e.params])
+        visit(e.body, inner)
+        return
+      }
+      // Non-referential leaves — nothing to collect.
+      case 'literal':
+      case 'regex':
+      case 'unsupported':
+        return
+      default: {
+        // Exhaustiveness pin. A NEW `ParsedExpr` kind that lands without a
+        // case here would silently contribute no dependencies, and this
+        // walk's whole job is to answer "does this memo read that prop?" —
+        // a missed dependency is a MISSED REFUSAL, i.e. the silently-stale
+        // derived field #2448 exists to prevent. Fail the build instead:
+        // `never` makes the omission a compile error at the point the kind
+        // is added, the same drift defence `PARSED_EXPR_KINDS` gives the
+        // registry (`expression-parser.ts`).
+        const _exhaustive: never = e
+        void _exhaustive
+        return
+      }
+    }
+  }
+  visit(body, new Set())
+  return found
+}

--- a/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
@@ -803,14 +803,23 @@ function propsAccessNameFromParsed(ctx: GoEmitContext, node: ParsedExpr): string
 }
 
 /**
- * #2448: every INPUT prop name a memo's `parsed` BODY reads, either via a
- * `<propsObjectName>.<name>` member access (object-props signature, e.g.
- * `props.n`) or a bare identifier bound to a destructured prop (no
- * `propsObjectName`). Feeds `ChildComponentShape.derivedFieldDeps`
- * (`registerChildComponentShape`, `go-template-adapter.ts`) so a parent
- * overriding one of THESE props per row (`bf_with_props`, #2445) can be
- * refused loudly instead of silently leaving the derived field stale — see
- * that map's docstring.
+ * #2448: every INPUT prop name a constructor-evaluated `parsed` expression
+ * reads, either via a `<propsObjectName>.<name>` member access (object-props
+ * signature, e.g. `props.n`) or a bare identifier bound to a destructured
+ * prop (no `propsObjectName`).
+ *
+ * Two kinds of expression reach here, because `New<Comp>Props` bakes BOTH
+ * into the struct at construction time: a `createMemo` body and a
+ * `createSignal` INITIAL VALUE (`const [dbl] = createSignal(props.n)` emits
+ * `Dbl: in.N`, exactly as `createMemo(() => props.n * 2)` emits
+ * `Dbl: in.N * 2`). Either one goes stale under a per-row override, so both
+ * feed the dependency map.
+ *
+ * Feeds `GoTemplateAdapter.childDerivedFieldDeps` (built by
+ * `recordDerivedFieldDeps`, `go-template-adapter.ts`) so a parent overriding
+ * one of THESE props per row (`bf_with_props`, #2445) can be refused loudly
+ * instead of silently leaving the derived field stale — see that map's
+ * docstring.
  *
  * Structural counterpart of {@link freeVarsInBody}: that walk reports a
  * member's OBJECT identifier only (`props`), treating the property name as
@@ -828,7 +837,7 @@ function propsAccessNameFromParsed(ctx: GoEmitContext, node: ParsedExpr): string
  * isn't available yet at registration time (the cross-file shape pre-pass,
  * #2131, runs before any component's codegen).
  */
-export function collectPropsReadByMemoBody(
+export function collectPropsReadByCtorInit(
   body: ParsedExpr,
   propsObjectName: string | null,
   propNames: ReadonlySet<string>,

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -186,4 +186,14 @@ export const conformancePins: ConformancePins = {
   // `adapter.generate()`), not an adapter-specific gap, so it is pinned
   // identically across every adapter package including Hono.
   'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2356' }],
+  // #2448: `Badge`'s `dbl` memo is computed once from `in.N` when the
+  // shared `$.BadgeSlot0` instance is constructed outside `{{range}}`;
+  // `bf_with_props` (#2445) only overrides the NAMED fields on that
+  // instance per row — it can't re-run `NewBadgeProps` — so overriding `N`
+  // per row would leave `Dbl` stale on every row after the first. Refused
+  // loudly with BF101 (`loopRowChildPropOverrides`) instead of silently
+  // rendering the first row's derived value everywhere. Every other
+  // adapter constructs the child fresh per row and is unaffected.
+  // See https://github.com/piconic-ai/barefootjs/issues/2448.
+  'composite-row-child-derived-prop': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2448' }],
 }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1201,6 +1201,24 @@
         "text"
       ]
     },
+    "composite-row-child-derived-prop": {
+      "kinds": [
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "member"
+      ],
+      "axes": [
+        "binary:*",
+        "literal:number"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "condition-position-ternary": {
       "kinds": [
         "call",
@@ -4660,14 +4678,14 @@
     "array-literal": 69,
     "array-method": 66,
     "arrow": 63,
-    "binary": 78,
-    "call": 183,
+    "binary": 79,
+    "call": 184,
     "conditional": 23,
-    "identifier": 269,
+    "identifier": 270,
     "index-access": 12,
-    "literal": 221,
+    "literal": 222,
     "logical": 43,
-    "member": 148,
+    "member": 149,
     "object-literal": 51,
     "template-literal": 29,
     "unary": 23,
@@ -4700,7 +4718,7 @@
     "array-method:trimStart": 1,
     "binary:!=": 2,
     "binary:!==": 9,
-    "binary:*": 9,
+    "binary:*": 10,
     "binary:+": 18,
     "binary:-": 11,
     "binary:/": 1,
@@ -4710,7 +4728,7 @@
     "binary:>=": 1,
     "literal:boolean": 41,
     "literal:null": 22,
-    "literal:number": 94,
+    "literal:number": 95,
     "literal:string": 161,
     "logical:&&": 7,
     "logical:??": 38,

--- a/packages/adapter-tests/fixtures/composite-row-child-derived-prop.ts
+++ b/packages/adapter-tests/fixtures/composite-row-child-derived-prop.ts
@@ -1,0 +1,54 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Composite loop row (`useElementReconciliation` + `nestedComponents`) whose
+ * nested child has a `createMemo` DERIVED from the per-row-overridden prop
+ * (#2448, the narrower gap the `composite-row-child-component` fixture's
+ * docstring calls out as NOT covered there).
+ *
+ * `Badge`'s `dbl` memo is computed once, at `NewBadgeProps` construction
+ * time, from `in.N`. The Go template adapter builds the shared
+ * `$.BadgeSlot0` instance ONCE outside `{{range}}` and re-applies only the
+ * NAMED fields per row via `bf_with_props` (#2445) — it does not re-run
+ * `NewBadgeProps`. So overriding `N` per row would leave `Dbl` holding
+ * row 0's value (`0 * 2 = 0`) on every row: silently wrong output.
+ *
+ * The Go adapter refuses this loudly with BF101 instead — see
+ * `conformance-pins.ts`'s entry for this fixture. Every other adapter (and
+ * CSR) constructs the child fresh per row and is unaffected; this fixture's
+ * `expectedHtml` is generated from the reference Hono adapter and must show
+ * `Dbl` computed CORRECTLY per row (6 and 10, not 0 and 0) on those adapters.
+ */
+export const fixture = createFixture({
+  id: 'composite-row-child-derived-prop',
+  description: 'Nested child in a dynamic loop row has a memo derived from the per-row-overridden prop',
+  componentName: 'CompositeRowChildDerivedProp',
+  source: `
+'use client'
+import { createSignal, createMemo } from '@barefootjs/client'
+type Row = { id: number; label: string; n: number }
+function Badge(props: { text: string; n: number }) {
+  const dbl = createMemo(() => props.n * 2)
+  return <span class="badge">{props.text}:{dbl()}</span>
+}
+export function CompositeRowChildDerivedProp(props: { rows: Row[] }) {
+  const [rows] = createSignal<Row[]>(props.rows)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={row.label} n={row.n} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  props: { rows: [{ id: 1, label: 'one', n: 3 }, { id: 2, label: 'two', n: 5 }] },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li data-key="1"><span bf-s="test_s0" bf="s2" class="badge"><!--bf:s0-->one<!--/-->:<!--bf:s1-->6<!--/--></span></li>
+      <li data-key="2"><span bf-s="test_s0" bf="s2" class="badge"><!--bf:s0-->two<!--/-->:<!--bf:s1-->10<!--/--></span></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -387,6 +387,7 @@ import { fixture as conditionalReturnNull } from './conditional-return-null'
 import { fixture as jsxElementProp } from './jsx-element-prop'
 import { fixture as grandchildComposition } from './grandchild-composition'
 import { fixture as compositeRowChildComponent } from './composite-row-child-component'
+import { fixture as compositeRowChildDerivedProp } from './composite-row-child-derived-prop'
 import { fixture as loopPreambleAttrValue } from './loop-preamble-attr-value'
 import { fixture as loopPreambleChainedFilter } from './loop-preamble-chained-filter'
 import { fixture as loopRowStaticConditional } from './loop-row-static-conditional'
@@ -721,6 +722,7 @@ export const jsxFixtures: JSXFixture[] = [
   jsxElementProp,
   grandchildComposition,
   compositeRowChildComponent,
+  compositeRowChildDerivedProp,
   loopPreambleAttrValue,
   loopPreambleChainedFilter,
   loopRowStaticConditional,

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -368,6 +368,14 @@
       }
     }
   ],
+  "composite-row-child-derived-prop": [
+    {
+      "name": "gen:rows:empty",
+      "props": {
+        "rows": []
+      }
+    }
+  ],
   "conditional-return-button": [
     {
       "name": "gen:variant:empty",

--- a/packages/compat/src/__tests__/compat-engine.test.ts
+++ b/packages/compat/src/__tests__/compat-engine.test.ts
@@ -46,8 +46,9 @@ describe('compileForCompat', () => {
     // `issues` is the UNION of every issue URL any BF101 pin carries on
     // this adapter (buildCompatCell attributes by code, not by fixture —
     // see its docstring) — #2320 (this shape, nested filter callback,
-    // successor to #2038) and #2321 (static-array-from-props computed loop
-    // source) surface here even though this test only exercises the nested-
+    // successor to #2038), #2321 (static-array-from-props computed loop
+    // source) and #2448 (loop-row child prop override reading a derived
+    // field) surface here even though this test only exercises the nested-
     // filter-callback shape. #2319 (dangerous-inner-html-dynamic) is no
     // longer among them — it graduated to a faithful raw-output lowering on
     // every template adapter, so its BF101 pin was removed. #2208's
@@ -61,6 +62,7 @@ describe('compileForCompat', () => {
         issues: [
           'https://github.com/piconic-ai/barefootjs/issues/2320',
           'https://github.com/piconic-ai/barefootjs/issues/2321',
+          'https://github.com/piconic-ai/barefootjs/issues/2448',
         ],
       },
     ])

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,8 +1814,19 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 288,
+    "totalFixtures": 289,
     "fixtures": {
+      "composite-row-child-derived-prop": {
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2448"
+          ]
+        }
+      },
       "date-method-uncatalogued": {
         "blade": {
           "kind": "refusal",
@@ -2779,6 +2790,10 @@
       }
     },
     "docs": {
+      "composite-row-child-derived-prop": {
+        "description": "Nested child in a dynamic loop row has a memo derived from the per-row-overridden prop",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/composite-row-child-derived-prop.ts"
+      },
       "date-method-uncatalogued": {
         "description": "Method call on a Date-typed prop refuses with BF021 (no catalogued lowering)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/date-method-uncatalogued.ts"

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1026,15 +1026,15 @@
       }
     },
     "binary": {
-      "total": 78,
+      "total": 79,
       "cells": {
         "hono": {
-          "pass": 78,
-          "total": 78
+          "pass": 79,
+          "total": 79
         },
         "blade": {
-          "pass": 69,
-          "total": 78,
+          "pass": 70,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1081,8 +1081,8 @@
           ]
         },
         "erb": {
-          "pass": 70,
-          "total": 78,
+          "pass": 71,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1124,8 +1124,14 @@
         },
         "go-template": {
           "pass": 69,
-          "total": 78,
+          "total": 79,
           "gaps": [
+            {
+              "fixture": "composite-row-child-derived-prop",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2448"
+              ]
+            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1171,8 +1177,8 @@
           ]
         },
         "jinja": {
-          "pass": 69,
-          "total": 78,
+          "pass": 70,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1219,8 +1225,8 @@
           ]
         },
         "minijinja": {
-          "pass": 69,
-          "total": 78,
+          "pass": 70,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1267,8 +1273,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 70,
-          "total": 78,
+          "pass": 71,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1309,8 +1315,8 @@
           ]
         },
         "twig": {
-          "pass": 69,
-          "total": 78,
+          "pass": 70,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1357,8 +1363,8 @@
           ]
         },
         "xslate": {
-          "pass": 69,
-          "total": 78,
+          "pass": 70,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1424,11 @@
       }
     },
     "call": {
-      "total": 183,
+      "total": 184,
       "cells": {
         "hono": {
-          "pass": 182,
-          "total": 183,
+          "pass": 183,
+          "total": 184,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1433,8 +1439,8 @@
           ]
         },
         "blade": {
-          "pass": 168,
-          "total": 183,
+          "pass": 169,
+          "total": 184,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1509,8 +1515,8 @@
           ]
         },
         "erb": {
-          "pass": 169,
-          "total": 183,
+          "pass": 170,
+          "total": 184,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1580,8 +1586,14 @@
         },
         "go-template": {
           "pass": 168,
-          "total": 183,
+          "total": 184,
           "gaps": [
+            {
+              "fixture": "composite-row-child-derived-prop",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2448"
+              ]
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1655,8 +1667,8 @@
           ]
         },
         "jinja": {
-          "pass": 168,
-          "total": 183,
+          "pass": 169,
+          "total": 184,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1731,8 +1743,8 @@
           ]
         },
         "minijinja": {
-          "pass": 168,
-          "total": 183,
+          "pass": 169,
+          "total": 184,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1807,8 +1819,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 169,
-          "total": 183,
+          "pass": 170,
+          "total": 184,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1877,8 +1889,8 @@
           ]
         },
         "twig": {
-          "pass": 168,
-          "total": 183,
+          "pass": 169,
+          "total": 184,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1953,8 +1965,8 @@
           ]
         },
         "xslate": {
-          "pass": 168,
-          "total": 183,
+          "pass": 169,
+          "total": 184,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2174,11 +2186,11 @@
       }
     },
     "identifier": {
-      "total": 269,
+      "total": 270,
       "cells": {
         "hono": {
-          "pass": 268,
-          "total": 269,
+          "pass": 269,
+          "total": 270,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2189,8 +2201,8 @@
           ]
         },
         "blade": {
-          "pass": 252,
-          "total": 269,
+          "pass": 253,
+          "total": 270,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2273,8 +2285,8 @@
           ]
         },
         "erb": {
-          "pass": 253,
-          "total": 269,
+          "pass": 254,
+          "total": 270,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2352,8 +2364,14 @@
         },
         "go-template": {
           "pass": 252,
-          "total": 269,
+          "total": 270,
           "gaps": [
+            {
+              "fixture": "composite-row-child-derived-prop",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2448"
+              ]
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2435,8 +2453,8 @@
           ]
         },
         "jinja": {
-          "pass": 252,
-          "total": 269,
+          "pass": 253,
+          "total": 270,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2519,8 +2537,8 @@
           ]
         },
         "minijinja": {
-          "pass": 252,
-          "total": 269,
+          "pass": 253,
+          "total": 270,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2603,8 +2621,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 253,
-          "total": 269,
+          "pass": 254,
+          "total": 270,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2681,8 +2699,8 @@
           ]
         },
         "twig": {
-          "pass": 252,
-          "total": 269,
+          "pass": 253,
+          "total": 270,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2765,8 +2783,8 @@
           ]
         },
         "xslate": {
-          "pass": 252,
-          "total": 269,
+          "pass": 253,
+          "total": 270,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2914,15 +2932,15 @@
       }
     },
     "literal": {
-      "total": 221,
+      "total": 222,
       "cells": {
         "hono": {
-          "pass": 221,
-          "total": 221
+          "pass": 222,
+          "total": 222
         },
         "blade": {
-          "pass": 210,
-          "total": 221,
+          "pass": 211,
+          "total": 222,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2973,8 +2991,8 @@
           ]
         },
         "erb": {
-          "pass": 210,
-          "total": 221,
+          "pass": 211,
+          "total": 222,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3026,8 +3044,14 @@
         },
         "go-template": {
           "pass": 210,
-          "total": 221,
+          "total": 222,
           "gaps": [
+            {
+              "fixture": "composite-row-child-derived-prop",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2448"
+              ]
+            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3077,8 +3101,8 @@
           ]
         },
         "jinja": {
-          "pass": 210,
-          "total": 221,
+          "pass": 211,
+          "total": 222,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3129,8 +3153,8 @@
           ]
         },
         "minijinja": {
-          "pass": 210,
-          "total": 221,
+          "pass": 211,
+          "total": 222,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3181,8 +3205,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 210,
-          "total": 221,
+          "pass": 211,
+          "total": 222,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3233,8 +3257,8 @@
           ]
         },
         "twig": {
-          "pass": 210,
-          "total": 221,
+          "pass": 211,
+          "total": 222,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3285,8 +3309,8 @@
           ]
         },
         "xslate": {
-          "pass": 210,
-          "total": 221,
+          "pass": 211,
+          "total": 222,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3498,11 +3522,11 @@
       }
     },
     "member": {
-      "total": 148,
+      "total": 149,
       "cells": {
         "hono": {
-          "pass": 147,
-          "total": 148,
+          "pass": 148,
+          "total": 149,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3513,8 +3537,8 @@
           ]
         },
         "blade": {
-          "pass": 131,
-          "total": 148,
+          "pass": 132,
+          "total": 149,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3597,8 +3621,8 @@
           ]
         },
         "erb": {
-          "pass": 132,
-          "total": 148,
+          "pass": 133,
+          "total": 149,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3676,8 +3700,14 @@
         },
         "go-template": {
           "pass": 131,
-          "total": 148,
+          "total": 149,
           "gaps": [
+            {
+              "fixture": "composite-row-child-derived-prop",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2448"
+              ]
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3759,8 +3789,8 @@
           ]
         },
         "jinja": {
-          "pass": 131,
-          "total": 148,
+          "pass": 132,
+          "total": 149,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3843,8 +3873,8 @@
           ]
         },
         "minijinja": {
-          "pass": 131,
-          "total": 148,
+          "pass": 132,
+          "total": 149,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3927,8 +3957,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 132,
-          "total": 148,
+          "pass": 133,
+          "total": 149,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4005,8 +4035,8 @@
           ]
         },
         "twig": {
-          "pass": 131,
-          "total": 148,
+          "pass": 132,
+          "total": 149,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4089,8 +4119,8 @@
           ]
         },
         "xslate": {
-          "pass": 131,
-          "total": 148,
+          "pass": 132,
+          "total": 149,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -6512,43 +6542,51 @@
       }
     },
     "binary:*": {
-      "total": 9,
+      "total": 10,
       "cells": {
         "hono": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "blade": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "erb": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "go-template": {
           "pass": 9,
-          "total": 9
+          "total": 10,
+          "gaps": [
+            {
+              "fixture": "composite-row-child-derived-prop",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2448"
+              ]
+            }
+          ]
         },
         "jinja": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "minijinja": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "mojolicious": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "twig": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "xslate": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         }
       },
       "source": {
@@ -7435,15 +7473,15 @@
       }
     },
     "literal:number": {
-      "total": 94,
+      "total": 95,
       "cells": {
         "hono": {
-          "pass": 94,
-          "total": 94
+          "pass": 95,
+          "total": 95
         },
         "blade": {
-          "pass": 89,
-          "total": 94,
+          "pass": 90,
+          "total": 95,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7468,8 +7506,8 @@
           ]
         },
         "erb": {
-          "pass": 89,
-          "total": 94,
+          "pass": 90,
+          "total": 95,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7495,8 +7533,14 @@
         },
         "go-template": {
           "pass": 89,
-          "total": 94,
+          "total": 95,
           "gaps": [
+            {
+              "fixture": "composite-row-child-derived-prop",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2448"
+              ]
+            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -7520,8 +7564,8 @@
           ]
         },
         "jinja": {
-          "pass": 89,
-          "total": 94,
+          "pass": 90,
+          "total": 95,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7546,8 +7590,8 @@
           ]
         },
         "minijinja": {
-          "pass": 89,
-          "total": 94,
+          "pass": 90,
+          "total": 95,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7572,8 +7616,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 89,
-          "total": 94,
+          "pass": 90,
+          "total": 95,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7598,8 +7642,8 @@
           ]
         },
         "twig": {
-          "pass": 89,
-          "total": 94,
+          "pass": 90,
+          "total": 95,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7624,8 +7668,8 @@
           ]
         },
         "xslate": {
-          "pass": 89,
-          "total": 94,
+          "pass": 90,
+          "total": 95,
           "gaps": [
             {
               "fixture": "fill-unsupported",


### PR DESCRIPTION
Closes #2448 — the residual #2445 left behind.

## The bug

`bf_with_props` (#2445) re-applies a loop-dependent prop per row by overriding fields on the child's **already-constructed** shared instance. It cannot re-run `NewProps`, which is where memos are computed:

```go
func NewBadgeProps(in BadgeInput) BadgeProps {
	return BadgeProps{ ..., Text: in.Text, N: in.N, Dbl: in.N * 2 }
}
```
```gotemplate
{{template "Badge" (bf_with_props $.BadgeSlot0 "Text" .Label "N" .N)}}
```

`Text` and `N` become per-row correctly. `Dbl` keeps whatever the one-shot constructor computed — `in.N == 0` → `0` — on every row, forever. Silently wrong output, no diagnostic.

## Why refusal, and not a fix

Both directions the issue floated were evaluated against the code before choosing:

| Direction | Why not |
|---|---|
| Per-row props slice, like the `.TodoItems` wrapper shape | That slice is populated by the **route handler**, not the generated constructor — `NewWrapperLoopProps`' own generated docstring instructs the caller to build it. Extending that here would demand handler work for a component the user never named at a call site, for a case that today needs none. |
| Call `NewProps` at template-execution time | Go templates cannot construct the `Input` struct. It would require the generated components package to register per-component constructors into the template FuncMap — `t.Funcs(bf.FuncMap())` would stop being sufficient. A breaking setup change for every Go user. |

Both are worse than a loud refusal, and what they'd be replacing is **silently wrong output**. So: BF101 naming the child, the overridden prop, and the field that would go stale, with the `/* @client */` escape or lifting the derived value into the parent as the way out.

## Detection

A structural walk over the child's own **constructor-evaluated** `parsed` initializers, collecting which input props each reads. Two declaration forms qualify, because `NewProps` bakes each of them once and `bf_with_props` re-runs neither:

| Form | Constructor emits |
|---|---|
| `const dbl = createMemo(() => props.n * 2)` | `Dbl: in.N * 2` |
| `const [dbl] = createSignal(props.n)` | `Dbl: in.N` |

Dependencies are keyed by the prop's **canonical source name** (`ParamInfo.sourceName ?? name`), not the child's local binding — for an aliased destructure (`function Badge({ n: count })`) the memo body reads `count`, but the only name the parent knows is the JSX attribute `n`, and that is what the override check capitalizes.

Both the signal form and the aliased form were missed by the first cut and caught in review; each was reproduced against this branch before being fixed, and each goes stale under a per-row override for the same reason the memo form does.

Best-effort by construction — a declaration with no resolvable parsed initializer is skipped — so a gap costs a **missed refusal** (today's behaviour), never a wrong one. That asymmetry is the reason the walk carries an exhaustiveness pin: a new `ParsedExpr` kind landing without a case would silently contribute no dependencies, and a dropped dependency here *is* a missed refusal, so it's a compile error instead.

A same-named "shadow" declaration (`size = createMemo(() => props.size ?? 'icon')`) is excluded — `generateNewPropsFunction` folds it into the prop's own passthrough field, so a per-row override lands on the same field and nothing goes stale.

## The bug the fixture caught in review

The first cut keyed the refusal off `ChildComponentShape`. That struct is populated **only** by the CLI's cross-file pre-pass, which `compileJSX` never calls — so a same-file child (the only kind a loop row may contain; a sibling-module child is BF103-refused there) never had an entry and the diagnostic never fired. It shipped a conformance pin for an error that was never emitted, and the fixture is what surfaced it:

```
[composite-row-child-derived-prop] expected diagnostic error/BF101 was not emitted.
Diagnostics seen:
  (none)
```

The dependency map is now separate from `ChildComponentShape` and self-registered from `generate()`. Keeping it separate is deliberate: that struct's presence/absence already drives rest-bag routing and map-typed-param baking, so widening *when it exists* would change emission for every same-file child in the corpus. This map has exactly one reader.

## Found while verifying, filed not fixed

#2457 — the **same** aliased-destructure shape with **no** derived field. The child's Go field is `Count` while the parent still emits `"N" .N`, and `bf.WithProps`' documented unknown-field passthrough discards the pair, so every row keeps the constructor's value with no diagnostic. That's a residual of #2445, not of #2448: nothing is derived, so this PR's dependency map has nothing to refuse on. The docstring points at the issue.

## Coverage

- `composite-row-child-derived-prop` — **new**. BF101-pinned on Go; rendered correctly by every other adapter and CSR, which construct the child fresh per row and are unaffected.
- Compiler tests: the memo shape refuses; the signal shape refuses; the aliased-destructure shape refuses (the latter two compiled through `compileJSX`, which also exercises the `generate()` self-registration door the two-phase memo test bypasses); a nested child with **no** derived field still compiles clean and still emits `bf_with_props` (#2445 must not regress — verified directly, `bf_with_props $.BadgeSlot0 "Text" .Label` still emitted).
- Both KNOWN LIMITATION docstrings (`WithProps` in `runtime/bf.go`, `loopRowChildPropOverrides`) now describe the refusal instead of the silent staleness.
- Regenerated: `coverage-map.json`, `generated-data-points.json`, `ui/compat.lock.json`, `ui/support-matrix.lock.json`. A new BF101 pin also widens the `issues` union in `compat-engine.test.ts` — `buildCompatCell` attributes a diagnostic by **code**, not by fixture.

## Tests

Local, run serially: `packages/adapter-go-template` **1487 pass / 0 fail** with real Go renders (`GOTOOLCHAIN=go1.25.6`; system Go is 1.24.7, under the harness' 1.25 floor), `packages/adapter-tests` **1481 pass / 0 fail**, `packages/compat` **184 pass / 0 fail**, `packages/jsx` **2894 pass / 0 fail**. Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_