### PR TITLE
Rebuild a loop-row child's props per row instead of refusing (#2448)

### DIFF
--- a/.changeset/go-reprops-rebuild.md
+++ b/.changeset/go-reprops-rebuild.md
@@ -1,0 +1,74 @@
+---
+"@barefootjs/go-template": minor
+---
+
+Rebuild a loop-row child's props per row instead of refusing (#2448)
+
+#2456 made the Go adapter refuse with `BF101` when a per-row prop override
+would leave a child's constructor-derived field stale. This replaces the
+refusal with a fix: the child rebuilds itself per row.
+
+`bf_with_props` (#2445) patches fields on the child's already-constructed
+shared instance. It cannot re-run `New<Child>Props`, which is where a
+`createMemo` body and a `createSignal` initial value are both baked — so
+overriding `n` left `Dbl` at the one-shot value on every row. The blocker was
+that `html/template` has no expression language and can only call FuncMap
+entries, and `New<Child>Props` is not one.
+
+The compiler now emits a props **rebuilder** per affected component and
+registers it from the generated package's `init()`:
+
+```go
+func init() {
+	bf.RegisterReprops("Badge", func(base interface{}, kv ...interface{}) (interface{}, error) {
+		b := base.(BadgeProps)
+		in := BadgeInput{ScopeID: b.ScopeID, BfParent: b.BfParent, BfMount: b.BfMount,
+			Text: b.Text, N: b.N}
+		// … apply the row's overrides …
+		p := NewBadgeProps(in)   // every derived field recomputes
+		p.Scripts = b.Scripts
+		return p, nil
+	})
+}
+```
+
+and the row calls it through one new fixed FuncMap entry:
+
+```gotemplate
+{{template "Badge" (bf_reprops "Badge" $.BadgeSlot0 "Text" .Label "N" .N)}}
+```
+
+**No setup change.** `t.Funcs(bf.FuncMap())` is unchanged; `bf_reprops` is a
+fixed entry that looks the rebuilder up at template EXECUTE time. That
+deferral is load-bearing: Go initializes a package's variables before its
+`init()` functions, so an app that builds its template set in a package-level
+var calls `FuncMap()` while the registry is still empty. Merging the
+constructors into `FuncMap()`'s return value would fail such an app at parse
+time with `function "bf_new_Badge" not defined`; one fixed entry resolved at
+execute time cannot. Pinned by `TestRepropsResolvesAtExecuteTimeNotFuncsTime`.
+
+Identity is carried from the base instance, never re-derived — `New<Child>Props`
+mints a random `ScopeID` when handed an empty one, and a per-row scope would
+break hydration. `bf_with_children` still composes on the outside, so per-row
+children are applied to the rebuilt value.
+
+Blast radius is deliberately zero for everything else: only a child with a
+constructor-derived field gets a rebuilder, and only an override that actually
+feeds one of those fields switches helpers. A plain passthrough override stays
+on `bf_with_props`, byte-identical.
+
+`BF101` remains for shapes the rebuilder declines — a `...rest` bag, a spread
+slot, context consumers, or nested child Inputs add Input fields with no Props
+counterpart, so the Input can't be reconstructed. Refusing still beats emitting
+silently-stale output.
+
+`bf_with_props` stays exported and registered: templates generated before this
+call it, and it remains the cheaper path when nothing is derived. Measured at
+100 rows, the two are within noise of each other (`bf_reprops` is ~3–5% slower
+per execution and allocates slightly less).
+
+Aliased destructures are handled correctly on the rebuild path. The generated
+override switch is keyed by the name the PARENT writes (`"N"`) and assigns to
+the child's own Input field (`in.Count`), which is where those two naming sides
+are reconciled. The `bf_with_props` path still has that mismatch when nothing
+is derived — tracked as #2457.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -183,6 +183,16 @@ func FuncMap() template.FuncMap {
 		// bf_with_children.
 		"bf_with_props": WithProps,
 
+		// Per-row props for a child whose CONSTRUCTOR derives a field from
+		// the overridden prop (#2448). bf_with_props patches fields on the
+		// shared instance and cannot re-run New<Child>Props, so a memo body
+		// or a signal initial value computed there would stay at the shared
+		// instance's one-shot value on every row. This entry looks up the
+		// component's generated rebuilder and re-runs the real constructor
+		// instead. See reprops.go for why the lookup is deferred to execute
+		// time rather than merged into this map.
+		"bf_reprops": Reprops,
+
 		// Scope comment for fragment roots
 		"bfScopeComment":    ScopeComment,
 		"bfScopeCommentEnd": ScopeCommentEnd,
@@ -2752,14 +2762,14 @@ func WithChildren(props interface{}, children template.HTML) (interface{}, error
 // at construction time (a memo body, or a signal's initial value — the
 // constructor bakes both) would keep whatever the one-shot constructor
 // computed and never update per row; only the directly-overridden field is
-// correct per row. That combination is REFUSED at compile time (BF101, #2448):
-// the TypeScript compiler tracks which constructor-computed fields derive from
-// which input props (GoTemplateAdapter.childDerivedFieldDeps, built by
-// recordDerivedFieldDeps in
-// packages/adapter-go-template/src/adapter/go-template-adapter.ts) and never
-// emits a bf_with_props call whose overridden field would go stale, so a call
-// this helper actually receives at runtime never hits that combination.
-// See https://github.com/piconic-ai/barefootjs/issues/2448.
+// correct per row. The compiler therefore does not route that case here: a
+// child with any constructor-derived field gets a generated props rebuilder
+// and the call site emits bf_reprops instead, which re-runs the real
+// constructor per row (#2448, see reprops.go). What reaches this helper is
+// the plain-passthrough case, where patching the field IS the whole update.
+//
+// Still exported and still registered: templates generated before #2448 call
+// it, and it remains the cheaper path when nothing is derived.
 func WithProps(props interface{}, kv ...interface{}) (interface{}, error) {
 	if len(kv)%2 != 0 {
 		return nil, fmt.Errorf("bf_with_props: odd number of key/value arguments (%d)", len(kv))

--- a/packages/adapter-go-template/runtime/reprops.go
+++ b/packages/adapter-go-template/runtime/reprops.go
@@ -1,0 +1,133 @@
+// Per-row child props reconstruction (#2448).
+//
+// `bf_with_props` (#2445) overrides fields on a child's already-constructed
+// shared instance by reflection. That is correct for a plain passthrough prop
+// and WRONG for anything the child's constructor DERIVES from it: a
+// `createMemo` body and a `createSignal` initial value are both baked into the
+// struct once by `New<Child>Props`, and reflection cannot re-run that.
+//
+// This file is the fix. Instead of patching fields, the parent asks the child
+// to REBUILD its props: reconstruct the constructor Input from the base
+// instance, apply the row's overrides, re-run the real constructor. Every
+// derived field recomputes because the real Go code runs again.
+//
+// The constructor cannot be called from a template directly — `html/template`
+// has no expression language and can only call FuncMap entries. So the
+// compiler emits, per component, a closure that does the rebuild in generated
+// Go (typed field assignments, no reflection), and registers it here from the
+// generated package's `init()`. `FuncMap()` gains exactly ONE fixed entry,
+// `bf_reprops`, so `t.Funcs(bf.FuncMap())` keeps working unchanged.
+//
+// The registry is consulted at template EXECUTE time, never at `Funcs()` time.
+// That is load-bearing, not incidental: Go initializes a package's variables
+// BEFORE its `init()` functions, so an app that builds its template set in a
+// package-level var —
+//
+//	var tmpl = template.Must(template.New("").Funcs(bf.FuncMap()).ParseGlob(...))
+//
+// — calls `FuncMap()` while the registry is still empty. Merging the
+// constructors into `FuncMap()`'s return value would fail that app at parse
+// time with `function "bf_new_Badge" not defined`. Looking them up behind one
+// fixed entry, at execute time, makes the ordering irrelevant.
+package bf
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+// RepropsFunc rebuilds a child component's props from a base instance plus a
+// flat name/value override list (`"Text", .Label, "N", .N, …`), by re-running
+// the component's generated constructor.
+//
+// Names in `kv` are the Go FIELD names the PARENT computed from the JSX
+// attribute (`n=` → `"N"`). A generated implementation maps those onto its own
+// constructor Input, which is what makes an aliased destructure
+// (`{ n: count }`, whose field is `Count`) land correctly — the mapping lives
+// in generated code that knows both sides.
+//
+// Identity fields (ScopeID / BfParent / BfMount) MUST be carried over from the
+// base rather than re-derived: `New<Child>Props` mints a random ScopeID when
+// given an empty one, so a naive re-run would give every row its own scope and
+// break hydration. Fields that live only on Props and never on Input (Scripts,
+// BfIsChild, BfDataKey) must be carried over for the same reason.
+type RepropsFunc func(base interface{}, kv ...interface{}) (interface{}, error)
+
+var (
+	repropsMu       sync.RWMutex
+	repropsRegistry = map[string]RepropsFunc{}
+)
+
+// RegisterReprops registers a component's props rebuilder under its component
+// name. Called from the generated package's `init()`; re-registering the same
+// name replaces the previous entry, so a rebuilt components file in a
+// long-lived dev process wins.
+func RegisterReprops(name string, fn RepropsFunc) {
+	repropsMu.Lock()
+	defer repropsMu.Unlock()
+	repropsRegistry[name] = fn
+}
+
+// Reprops is the `bf_reprops` FuncMap entry: rebuild `base` with the row's
+// overrides applied, by re-running the named component's constructor.
+//
+//	{{template "Badge" (bf_reprops "Badge" $.BadgeSlot0 "Text" .Label "N" .N)}}
+//
+// An unregistered name is an error rather than a silent passthrough: the
+// compiler only emits this call for a component whose rebuilder it also
+// emitted, so a missing entry means the generated package was not linked in,
+// and falling back to the stale shared instance would reintroduce exactly the
+// silently-wrong output this exists to prevent.
+func Reprops(name string, base interface{}, kv ...interface{}) (interface{}, error) {
+	if len(kv)%2 != 0 {
+		return nil, fmt.Errorf("bf_reprops: odd number of key/value arguments (%d) for %q", len(kv), name)
+	}
+	repropsMu.RLock()
+	fn, ok := repropsRegistry[name]
+	repropsMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf(
+			"bf_reprops: no props rebuilder registered for %q — is the generated components package linked into this binary?",
+			name,
+		)
+	}
+	return fn(base, kv...)
+}
+
+// RepropsTypeError is the error a generated rebuilder returns when handed a
+// value that is not its own props struct. Kept here so the generated code
+// stays a fixed shape instead of formatting its own message.
+func RepropsTypeError(name string, base interface{}) error {
+	return fmt.Errorf("bf_reprops: the %s rebuilder got %T, not its own props struct", name, base)
+}
+
+// RepropsAssign writes `val` into `*target`, which a generated rebuilder passes
+// as a pointer to one field of its constructor Input (`&in.N`).
+//
+// This is the one place the rebuild uses reflection, and it does so on purpose:
+// it delegates to the SAME `setStructFieldValue` that `bf_with_props` uses, so
+// a prop that already assigned correctly under the old helper assigns
+// identically under this one. Re-deriving the conversion rules per Go type in
+// the generator would be more code and would drift from that behaviour.
+//
+// `field` names the field for the error message; `component` names the owner.
+func RepropsAssign(component, field string, target interface{}, val interface{}) error {
+	p := reflect.ValueOf(target)
+	if p.Kind() != reflect.Ptr || p.IsNil() {
+		return fmt.Errorf("bf_reprops: %s.%s: target must be a non-nil pointer, got %T", component, field, target)
+	}
+	if err := setStructFieldValue(p.Elem(), val); err != nil {
+		return fmt.Errorf("bf_reprops: %s.%s: %w", component, field, err)
+	}
+	return nil
+}
+
+// RepropsRegistered reports whether a rebuilder is registered for `name`.
+// For tests and diagnostics.
+func RepropsRegistered(name string) bool {
+	repropsMu.RLock()
+	defer repropsMu.RUnlock()
+	_, ok := repropsRegistry[name]
+	return ok
+}

--- a/packages/adapter-go-template/runtime/reprops.go
+++ b/packages/adapter-go-template/runtime/reprops.go
@@ -83,6 +83,17 @@ func Reprops(name string, base interface{}, kv ...interface{}) (interface{}, err
 	if len(kv)%2 != 0 {
 		return nil, fmt.Errorf("bf_reprops: odd number of key/value arguments (%d) for %q", len(kv), name)
 	}
+	// Field names are validated HERE, not in each generated rebuilder, so the
+	// generated `name, _ := kv[i].(string)` is safe by construction. Rejecting
+	// them matches `bf_with_props`: a non-string name would otherwise degrade
+	// to `""`, match no case, and silently drop the override — the same class
+	// of silent misrender this whole path exists to remove.
+	for i := 0; i < len(kv); i += 2 {
+		if _, ok := kv[i].(string); !ok {
+			return nil, fmt.Errorf(
+				"bf_reprops: %s field name at position %d must be a string, got %T", name, i, kv[i])
+		}
+	}
 	repropsMu.RLock()
 	fn, ok := repropsRegistry[name]
 	repropsMu.RUnlock()
@@ -100,6 +111,19 @@ func Reprops(name string, base interface{}, kv ...interface{}) (interface{}, err
 // stays a fixed shape instead of formatting its own message.
 func RepropsTypeError(name string, base interface{}) error {
 	return fmt.Errorf("bf_reprops: the %s rebuilder got %T, not its own props struct", name, base)
+}
+
+// RepropsUnknownFieldError is what a generated rebuilder returns for a field
+// name it has no case for.
+//
+// Unlike `bf_with_props`, whose unknown-field passthrough is load-bearing (a
+// prop routed into a rest bag has no named field to set), a rebuilder is only
+// emitted for components with NO rest bag and no spread slot, and the compiler
+// emits a case for every prop the parent can override. So an unknown name here
+// is a compiler gap, and dropping it silently would leave the override
+// unapplied — the failure mode this path replaced.
+func RepropsUnknownFieldError(component, field string) error {
+	return fmt.Errorf("bf_reprops: %s has no overridable field %q", component, field)
 }
 
 // RepropsAssign writes `val` into `*target`, which a generated rebuilder passes

--- a/packages/adapter-go-template/runtime/reprops_test.go
+++ b/packages/adapter-go-template/runtime/reprops_test.go
@@ -1,0 +1,201 @@
+package bf
+
+import (
+	"html/template"
+	"strings"
+	"testing"
+)
+
+// Stand-ins for what the compiler generates: an Input, a Props whose Dbl is
+// DERIVED at construction time, and the constructor that derives it.
+type badgeInput struct {
+	ScopeID, BfParent, BfMount string
+	Text                       string
+	N                          int
+}
+
+type badgeProps struct {
+	ScopeID   string
+	BfParent  string
+	BfMount   string
+	BfDataKey string
+	Scripts   *ScriptCollector
+	Children  template.HTML
+	Text      string
+	N         int
+	Dbl       int
+}
+
+func newBadgeProps(in badgeInput) badgeProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		// The real generated constructor mints a random id here. A fixed
+		// sentinel makes "identity was re-derived instead of carried" visible.
+		scopeID = "MINTED"
+	}
+	return badgeProps{
+		ScopeID: scopeID, BfParent: in.BfParent, BfMount: in.BfMount,
+		Text: in.Text, N: in.N, Dbl: in.N * 2,
+	}
+}
+
+// The generated rebuilder, verbatim in shape.
+func registerBadge() {
+	RegisterReprops("Badge", func(base interface{}, kv ...interface{}) (interface{}, error) {
+		b, ok := base.(badgeProps)
+		if !ok {
+			return nil, RepropsTypeError("Badge", base)
+		}
+		in := badgeInput{
+			ScopeID: b.ScopeID, BfParent: b.BfParent, BfMount: b.BfMount,
+			Text: b.Text, N: b.N,
+		}
+		for i := 0; i < len(kv); i += 2 {
+			name, _ := kv[i].(string)
+			var err error
+			switch name {
+			case "Text":
+				err = RepropsAssign("Badge", "Text", &in.Text, kv[i+1])
+			case "N":
+				err = RepropsAssign("Badge", "N", &in.N, kv[i+1])
+			}
+			if err != nil {
+				return nil, err
+			}
+		}
+		p := newBadgeProps(in)
+		p.Scripts = b.Scripts
+		p.BfDataKey = b.BfDataKey
+		return p, nil
+	})
+}
+
+func baseBadge() badgeProps {
+	return newBadgeProps(badgeInput{ScopeID: "parent_s0", BfParent: "parent", BfMount: "s0"})
+}
+
+// A rebuild recomputes the DERIVED field, which is the whole point: patching
+// fields (bf_with_props) cannot, because the derivation lives in Go code the
+// template can't call.
+func TestRepropsRecomputesDerivedField(t *testing.T) {
+	registerBadge()
+	out, err := Reprops("Badge", baseBadge(), "Text", "one", "N", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := out.(badgeProps)
+	if got.Text != "one" || got.N != 3 || got.Dbl != 6 {
+		t.Errorf("got Text=%q N=%d Dbl=%d, want one/3/6", got.Text, got.N, got.Dbl)
+	}
+	// Contrast: the same override through WithProps leaves Dbl at the base
+	// instance's value. This is the bug the rebuild path exists to close.
+	patched, err := WithProps(baseBadge(), "Text", "one", "N", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p := patched.(badgeProps); p.Dbl != 0 {
+		t.Errorf("WithProps Dbl = %d, want 0 (the stale value it cannot recompute)", p.Dbl)
+	}
+}
+
+// Identity must be carried from the base, never re-derived: the constructor
+// mints a fresh ScopeID when handed an empty one, and a per-row scope would
+// break hydration.
+func TestRepropsCarriesIdentity(t *testing.T) {
+	registerBadge()
+	out, err := Reprops("Badge", baseBadge(), "N", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := out.(badgeProps)
+	if got.ScopeID != "parent_s0" || got.BfParent != "parent" || got.BfMount != "s0" {
+		t.Errorf("identity not carried: %+v", got)
+	}
+}
+
+// The base value is untouched — every row rebuilds from the same shared
+// instance, so a mutation would leak across rows.
+func TestRepropsDoesNotMutateBase(t *testing.T) {
+	registerBadge()
+	base := baseBadge()
+	if _, err := Reprops("Badge", base, "N", 7); err != nil {
+		t.Fatal(err)
+	}
+	if base.N != 0 || base.Dbl != 0 {
+		t.Errorf("base mutated: %+v", base)
+	}
+}
+
+func TestRepropsErrors(t *testing.T) {
+	registerBadge()
+	if _, err := Reprops("Badge", baseBadge(), "N"); err == nil {
+		t.Error("odd kv count should error")
+	}
+	// An unregistered name must NOT fall back to the stale shared instance —
+	// that would reintroduce silently-wrong output.
+	if _, err := Reprops("NotRegistered", baseBadge()); err == nil {
+		t.Error("unregistered component should error")
+	}
+	if _, err := Reprops("Badge", "not a props struct"); err == nil {
+		t.Error("wrong base type should error")
+	}
+}
+
+// Composition order: the compiler emits `bf_with_children (bf_reprops …) …`,
+// so children are applied to the REBUILT value and must survive.
+func TestWithChildrenComposesOverReprops(t *testing.T) {
+	registerBadge()
+	rebuilt, err := Reprops("Badge", baseBadge(), "Text", "one", "N", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := WithChildren(rebuilt, template.HTML("<em>kid</em>"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := out.(badgeProps)
+	if got.Children != "<em>kid</em>" || got.Dbl != 6 {
+		t.Errorf("got Children=%q Dbl=%d", got.Children, got.Dbl)
+	}
+}
+
+// The registry is read at template EXECUTE time, never at Funcs() time. Go
+// initializes a package's variables BEFORE its init() functions, so an app
+// that builds its template set in a package-level var calls FuncMap() while
+// the registry is still empty. Merging constructors into FuncMap()'s return
+// would fail such an app at PARSE time; one fixed entry resolved at execute
+// time cannot.
+func TestRepropsResolvesAtExecuteTimeNotFuncsTime(t *testing.T) {
+	const name = "LateRegistered"
+	// Parse against a FuncMap captured while nothing is registered for `name`.
+	if RepropsRegistered(name) {
+		t.Fatalf("%s registered before the test ran", name)
+	}
+	tmpl, err := template.New("t").Funcs(FuncMap()).
+		Parse(`{{with (bf_reprops "LateRegistered" .Base "N" 4)}}{{.Dbl}}{{end}}`)
+	if err != nil {
+		t.Fatalf("parse must succeed against an empty registry: %v", err)
+	}
+
+	// Registration happens afterwards, as a generated init() would.
+	RegisterReprops(name, func(base interface{}, kv ...interface{}) (interface{}, error) {
+		b := base.(badgeProps)
+		in := badgeInput{ScopeID: b.ScopeID, Text: b.Text, N: b.N}
+		for i := 0; i < len(kv); i += 2 {
+			if kv[i] == "N" {
+				if err := RepropsAssign(name, "N", &in.N, kv[i+1]); err != nil {
+					return nil, err
+				}
+			}
+		}
+		return newBadgeProps(in), nil
+	})
+
+	var sb strings.Builder
+	if err := tmpl.Execute(&sb, struct{ Base badgeProps }{baseBadge()}); err != nil {
+		t.Fatal(err)
+	}
+	if sb.String() != "8" {
+		t.Errorf("got %q, want %q", sb.String(), "8")
+	}
+}

--- a/packages/adapter-go-template/runtime/reprops_test.go
+++ b/packages/adapter-go-template/runtime/reprops_test.go
@@ -58,6 +58,8 @@ func registerBadge() {
 				err = RepropsAssign("Badge", "Text", &in.Text, kv[i+1])
 			case "N":
 				err = RepropsAssign("Badge", "N", &in.N, kv[i+1])
+			default:
+				err = RepropsUnknownFieldError("Badge", name)
 			}
 			if err != nil {
 				return nil, err
@@ -138,6 +140,21 @@ func TestRepropsErrors(t *testing.T) {
 	}
 	if _, err := Reprops("Badge", "not a props struct"); err == nil {
 		t.Error("wrong base type should error")
+	}
+	// A non-string field name would degrade to "" in the generated
+	// `name, _ := kv[i].(string)`, match no case, and silently drop the
+	// override. Rejected up front, matching bf_with_props.
+	if _, err := Reprops("Badge", baseBadge(), 42, "x"); err == nil {
+		t.Error("non-string field name should error")
+	}
+	if _, err := WithProps(baseBadge(), 42, "x"); err == nil {
+		t.Error("bf_with_props rejects it too — the two must agree")
+	}
+	// An unknown field name means the override would go unapplied. A
+	// rebuilder is only emitted for components with no rest bag, so unlike
+	// bf_with_props there is no legitimate passthrough here.
+	if _, err := Reprops("Badge", baseBadge(), "Nope", 1); err == nil {
+		t.Error("unknown field name should error")
 	}
 }
 

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4544,24 +4544,29 @@ describe('GoTemplateAdapter - #2448 per-row override of a prop feeding a derived
 
     const adapter = new GoTemplateAdapter()
     adapter.registerChildComponentShape(badgeIR)
+    // Generating `Badge`'s types RECORDS that a rebuilder is possible; it does
+    // not emit one. Only a parent knows whether the child is actually
+    // overridden per row, so the registration rides the PARENT's type block.
     const badgeTypes = adapter.generateTypes(badgeIR)
-    adapter.generateTypes(rootIR)
-    const template = adapter.generate(rootIR, { skipScriptRegistration: true }).template
+    expect(badgeTypes).not.toContain('RegisterReprops')
+
+    const { template, types } = adapter.generate(rootIR, { skipScriptRegistration: true })
 
     expect(rootIR.errors.filter(e => e.code === 'BF101')).toHaveLength(0)
     // BOTH per-row props ride the rebuild — `n` is no longer dropped.
     expect(template).toContain('{{template "Badge" (bf_reprops "Badge" $.BadgeSlot0 "Text" .Label "N" .N)}}')
 
     // The rebuilder reconstructs the Input from the base Props, applies the
-    // row's overrides, and re-runs the real constructor.
-    expect(badgeTypes).toContain('bf.RegisterReprops("Badge"')
-    expect(badgeTypes).toContain('p := NewBadgeProps(in)')
-    expect(badgeTypes).toContain('err = bf.RepropsAssign("Badge", "N", &in.N, kv[i+1])')
+    // row's overrides, and re-runs the real constructor. `Badge`'s own types
+    // are in the same Go package (`combineGoTypes`), so they're in scope here.
+    expect(types).toContain('bf.RegisterReprops("Badge"')
+    expect(types).toContain('p := NewBadgeProps(in)')
+    expect(types).toContain('err = bf.RepropsAssign("Badge", "N", &in.N, kv[i+1])')
     // Identity is carried over, never re-derived: NewBadgeProps mints a random
     // ScopeID when handed an empty one, so re-running it without this would
     // give every row its own scope and break hydration.
-    expect(badgeTypes).toContain('ScopeID: b.ScopeID,')
-    expect(badgeTypes).toContain('p.Scripts = b.Scripts')
+    expect(types).toContain('ScopeID: b.ScopeID,')
+    expect(types).toContain('p.Scripts = b.Scripts')
   })
 
   // A `createSignal` INITIAL VALUE is baked into `New<Child>Props` exactly

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4491,18 +4491,14 @@ export function CompositeRowChildComponent(props: { items: Item[] }) {
 // CONSTRUCTED shared instance — it does not re-run `New<Child>Props`. When
 // the overridden prop feeds a child field the constructor DERIVES at
 // construction time (a `createMemo` body or a `createSignal` initial value —
-// `New<Child>Props` bakes both), the override would leave that field holding
-// the shared instance's one-shot value on every row — silently wrong output.
-// Refused loudly with BF101 instead.
-describe('GoTemplateAdapter - #2448 per-row override of a prop feeding a derived child field', () => {
-  // Two-phase build (mirrors the rest-bag test's pattern above): the adapter
-  // instance here never compiles `Badge` itself, so without the explicit
-  // `registerChildComponentShape` its `childDerivedFieldDeps` entry wouldn't
-  // exist for the parent's generate pass. (Under `compileJSX` — the second
-  // test below — the same-file child IS generated first, and `generate()`
-  // self-registers, so both doors are exercised.)
-  test('a per-row-overridden prop feeding a memo field is refused with BF101', () => {
-    const source = `
+// `New<Child>Props` bakes both), patching fields would leave that field
+// holding the shared instance's one-shot value on every row.
+//
+// The child therefore gets a generated props REBUILDER, registered from the
+// generated package's `init()`, and the call site emits `bf_reprops` — which
+// re-runs the real constructor per row so every derived field recomputes.
+// BF101 remains only for shapes the rebuilder declines.
+const DERIVED_PROP_SOURCE = `
 'use client'
 import { createSignal, createMemo } from '@barefootjs/client'
 type Row = { id: number; label: string; n: number }
@@ -4524,14 +4520,21 @@ export function CompositeRowChildDerivedProp(props: { rows: Row[] }) {
 }
 `.trimStart()
 
-    const badgeCtx = analyzeComponent(source, 'test.tsx', 'Badge')
+describe('GoTemplateAdapter - #2448 per-row override of a prop feeding a derived child field', () => {
+  // Two-phase build (mirrors the rest-bag test's pattern above): the adapter
+  // instance here never compiles `Badge` through `generate()`, so the explicit
+  // `generateTypes(badgeIR)` is what emits its rebuilder and marks it ready.
+  // (Under `compileJSX` — the tests below — the same-file child is generated
+  // first and self-registers, so both doors are exercised.)
+  test('a per-row-overridden prop feeding a memo field rebuilds the child per row', () => {
+    const badgeCtx = analyzeComponent(DERIVED_PROP_SOURCE, 'test.tsx', 'Badge')
     const badgeIR: ComponentIR = {
       version: '0.1',
       metadata: buildMetadata(badgeCtx),
       root: jsxToIR(badgeCtx)!,
       errors: [],
     }
-    const rootCtx = analyzeComponent(source, 'test.tsx', 'CompositeRowChildDerivedProp')
+    const rootCtx = analyzeComponent(DERIVED_PROP_SOURCE, 'test.tsx', 'CompositeRowChildDerivedProp')
     const rootIR: ComponentIR = {
       version: '0.1',
       metadata: buildMetadata(rootCtx),
@@ -4541,38 +4544,31 @@ export function CompositeRowChildDerivedProp(props: { rows: Row[] }) {
 
     const adapter = new GoTemplateAdapter()
     adapter.registerChildComponentShape(badgeIR)
-    adapter.generateTypes(badgeIR)
+    const badgeTypes = adapter.generateTypes(badgeIR)
     adapter.generateTypes(rootIR)
     const template = adapter.generate(rootIR, { skipScriptRegistration: true }).template
 
-    const bf101s = rootIR.errors.filter(e => e.code === 'BF101')
-    expect(bf101s).toHaveLength(1)
-    // Names the child, the overridden prop, and the derived field that
-    // would go stale, so the message stands alone without cross-referencing
-    // internal task labels.
-    expect(bf101s[0]!.message).toContain('Badge')
-    expect(bf101s[0]!.message).toContain("'n'")
-    expect(bf101s[0]!.message).toContain('dbl')
-    // The other per-row prop (`text`, feeding no derived field) is NOT
-    // reported, and is still correctly reapplied per row via `bf_with_props`
-    // — the refusal is scoped to the ONE prop that actually feeds a
-    // derived field, not the whole child instance.
-    expect(bf101s[0]!.message).not.toContain("'text'")
-    expect(template).toContain('"Text" .Label')
+    expect(rootIR.errors.filter(e => e.code === 'BF101')).toHaveLength(0)
+    // BOTH per-row props ride the rebuild — `n` is no longer dropped.
+    expect(template).toContain('{{template "Badge" (bf_reprops "Badge" $.BadgeSlot0 "Text" .Label "N" .N)}}')
 
-    // The refused override itself never reaches the template: `bf_with_props`
-    // is never called with an `"N"` pair (the #2445 bug this refusal exists
-    // to close would otherwise silently emit `"N" .N` and leave `Dbl` stale).
-    expect(template).not.toContain('"N"')
+    // The rebuilder reconstructs the Input from the base Props, applies the
+    // row's overrides, and re-runs the real constructor.
+    expect(badgeTypes).toContain('bf.RegisterReprops("Badge"')
+    expect(badgeTypes).toContain('p := NewBadgeProps(in)')
+    expect(badgeTypes).toContain('err = bf.RepropsAssign("Badge", "N", &in.N, kv[i+1])')
+    // Identity is carried over, never re-derived: NewBadgeProps mints a random
+    // ScopeID when handed an empty one, so re-running it without this would
+    // give every row its own scope and break hydration.
+    expect(badgeTypes).toContain('ScopeID: b.ScopeID,')
+    expect(badgeTypes).toContain('p.Scripts = b.Scripts')
   })
 
   // A `createSignal` INITIAL VALUE is baked into `New<Child>Props` exactly
   // like a memo body is (`const [dbl] = createSignal(props.n)` emits
-  // `Dbl: in.N`), and `bf_with_props` re-runs neither — so the signal form
-  // goes stale under a per-row override for the same reason and must refuse
-  // the same way. Compiled through `compileJSX` (not the two-phase build
-  // above) so this also pins `generate()`'s self-registration door.
-  test("a per-row-overridden prop feeding a signal's initial value is refused with BF101", () => {
+  // `Dbl: in.N`), so it takes the same rebuild path. Compiled through
+  // `compileJSX` so this also pins `generate()`'s self-registration door.
+  test("a per-row-overridden prop feeding a signal's initial value rebuilds too", () => {
     const result = compileJSX(`
 'use client'
 import { createSignal } from '@barefootjs/client'
@@ -4594,25 +4590,18 @@ export function SignalRowChildDerivedProp(props: { rows: Row[] }) {
   )
 }
 `.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
-    const bf101s = (result.errors ?? []).filter(e => e.code === 'BF101')
-    expect(bf101s).toHaveLength(1)
-    expect(bf101s[0]!.message).toContain('Badge')
-    expect(bf101s[0]!.message).toContain("'n'")
-    expect(bf101s[0]!.message).toContain('dbl')
+    expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(0)
     const template = result.files.find(f => f.type === 'markedTemplate')!.content
-    // Same scoping as the memo case: only `n` is refused, `text` is still
-    // reapplied per row, and no `"N"` pair reaches the template.
-    expect(template).toContain('"Text" .Label')
-    expect(template).not.toContain('"N"')
+    expect(template).toContain('(bf_reprops "Badge" $.BadgeSlot0 "Text" .Label "N" .N)')
   })
 
-  // An ALIASED destructure (`{ n: count }`) reads `count` in the memo body,
-  // but the only name the parent knows is the JSX attribute `n` — which is
-  // what `loopRowChildPropOverrides` capitalizes. `recordDerivedFieldDeps`
-  // keys dependencies by `ParamInfo.sourceName ?? name` for exactly this
-  // reason; keying on the local binding would file the dependency under
-  // `Count`, the lookup would miss, and the refusal would silently not fire.
-  test('an aliased destructured prop feeding a memo is still refused with BF101', () => {
+  // An ALIASED destructure (`{ n: count }`) is where the two naming sides
+  // diverge: the memo reads `count` and the child's Go field is `Count`, but
+  // the parent only knows the JSX attribute `n` → `"N"`. `bf_with_props` would
+  // silently no-op that pair (its unknown-field passthrough). The rebuilder's
+  // generated switch is where the two sides are reconciled, so the case label
+  // is the PARENT's name and the assignment target is the CHILD's field.
+  test('an aliased destructured prop maps the parent name onto the child field', () => {
     const result = compileJSX(`
 'use client'
 import { createSignal, createMemo } from '@barefootjs/client'
@@ -4634,16 +4623,54 @@ export function AliasedRowChildDerivedProp(props: { rows: Row[] }) {
   )
 }
 `.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(0)
+    const template = result.files.find(f => f.type === 'markedTemplate')!.content
+    expect(template).toContain('(bf_reprops "Badge" $.BadgeSlot0 "Text" .Label "N" .N)')
+    const types = result.files.find(f => f.type === 'types')!.content
+    expect(types).toContain('case "N":')
+    expect(types).toContain('&in.Count,')
+    // The child's own field is `Count`; `"Count"` is never a case label,
+    // because the parent never writes that name.
+    expect(types).not.toContain('case "Count":')
+  })
+
+  // Sound-or-loud fallback: a shape whose Input can NOT be reconstructed from
+  // Props gets no rebuilder, and the refusal has to stay. A `...rest` bag adds
+  // an Input field with no Props counterpart, so it is declined — and because
+  // `Badge` still derives `dbl` from `n`, emitting `bf_with_props` here would
+  // be the silently-stale output all of this exists to prevent.
+  test('a child whose Input cannot be rebuilt still refuses with BF101', () => {
+    const result = compileJSX(`
+'use client'
+import { createSignal, createMemo } from '@barefootjs/client'
+type Row = { id: number; label: string; n: number }
+function Badge({ text, n, ...rest }: { text: string; n: number; [k: string]: unknown }) {
+  const dbl = createMemo(() => n * 2)
+  return <span class="badge" {...rest}>{text}:{dbl()}</span>
+}
+export function RestBagRowChildDerivedProp(props: { rows: Row[] }) {
+  const [rows] = createSignal<Row[]>(props.rows)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={row.label} n={row.n} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
     const bf101s = (result.errors ?? []).filter(e => e.code === 'BF101')
     expect(bf101s).toHaveLength(1)
-    // The message names the prop as the PARENT wrote it (`n`), not the
-    // child's local binding (`count`) — that's the name the author has to act
-    // on at the call site.
     expect(bf101s[0]!.message).toContain("'n'")
     expect(bf101s[0]!.message).toContain('dbl')
     const template = result.files.find(f => f.type === 'markedTemplate')!.content
-    expect(template).toContain('"Text" .Label')
+    expect(template).not.toContain('bf_reprops')
     expect(template).not.toContain('"N"')
+    // No rebuilder was emitted, so nothing registers a "Badge" entry that
+    // `bf_reprops` could have resolved at runtime.
+    expect(result.files.find(f => f.type === 'types')!.content).not.toContain('RegisterReprops')
   })
 
   // Regression pin for #2445: a nested child with NO derived field (no

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -646,6 +646,21 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private childDerivedFieldDeps: Map<string, Map<string, ReadonlySet<string>>> = new Map()
 
   /**
+   * Components this run emitted a `bf.RegisterReprops` rebuilder for
+   * (`generateRepropsRegistration`, #2448). A parent overriding a prop that
+   * feeds one of the child's derived fields emits `bf_reprops` when the child
+   * is in here, and falls back to the BF101 refusal when it is not — the
+   * rebuilder is declined for shapes whose Input can't be reconstructed from
+   * Props, and emitting the call anyway would fail at template execute time
+   * with "no props rebuilder registered".
+   *
+   * Populated from the same two doors as `childDerivedFieldDeps`: a same-file
+   * child is generated before its parent, and the CLI's cross-file pre-pass
+   * generates types for every component up front.
+   */
+  private childRepropsReady: Set<string> = new Set()
+
+  /**
    * Record which of `ir`'s constructor-computed fields derive from one of its
    * own input props (#2448). See `childDerivedFieldDeps`.
    *
@@ -856,7 +871,122 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     this.generateNewPropsFunction(lines, ir, componentName, nestedComponents, spreadSlots, propTypeOverrides)
 
+    this.generateRepropsRegistration(lines, ir, componentName, nestedComponents, spreadSlots)
+
     return this.composeFileHeader(lines)
+  }
+
+  /**
+   * #2448: emit a props REBUILDER for a component whose constructor derives a
+   * field from one of its own input props, and register it from `init()`.
+   *
+   * `bf_with_props` patches fields on the child's already-constructed shared
+   * instance; it cannot re-run `New<Child>Props`, where a `createMemo` body and
+   * a `createSignal` initial value are both baked. This closure reconstructs
+   * the Input from the base Props, folds the row's overrides in, and re-runs
+   * the real constructor — so every derived field recomputes per row. The
+   * parent's call site then emits `bf_reprops` instead of `bf_with_props`
+   * (`loopRowChildPropOverrides`).
+   *
+   * Two invariants the emitted code depends on:
+   *
+   * - **Input is recoverable from Props.** `emitPropsDataFields` and
+   *   `generateInputStruct` emit each props param with the SAME field name and
+   *   the SAME `resolvePropGoType`, so `in.<F> = b.<F>` is exact. A prop read
+   *   only by a memo still gets its passthrough field, so nothing is lost.
+   *   Shapes that add Input fields with no Props counterpart (a rest bag, a
+   *   spread slot, context consumers, nested child Inputs) are declined —
+   *   `eligible` below — and the parent falls back to today's BF101.
+   * - **Identity is carried, never re-derived.** `New<Child>Props` mints a
+   *   random ScopeID when handed an empty one, so re-running it naively would
+   *   give every row its own scope and break hydration. ScopeID/BfParent/
+   *   BfMount come from the base, and the Props-only fields (Scripts,
+   *   BfIsRoot/BfIsChild/BfDataKey) are reapplied after the constructor.
+   *
+   * The override switch is keyed by the name the PARENT writes — the JSX
+   * attribute, `ParamInfo.sourceName ?? name` — while the assignment targets
+   * the child's own Input field (`ParamInfo.name`). For an aliased destructure
+   * (`{ n: count }`) those differ (`"N"` vs `in.Count`), and this generated
+   * switch is where the two sides are reconciled.
+   */
+  private generateRepropsRegistration(
+    lines: string[],
+    ir: ComponentIR,
+    componentName: string,
+    nestedComponents: NestedComponentInfo[],
+    spreadSlots: SpreadSlotInfo[],
+  ): void {
+    if (!this.childDerivedFieldDeps.has(componentName)) return
+
+    const nestedArrayFields = new Set(nestedComponents.map(n => `${n.name}s`))
+    const params = (ir.metadata.propsParams ?? []).filter(
+      p => !nestedArrayFields.has(capitalizeFieldName(p.name)),
+    )
+    const takenInput = new Set((ir.metadata.propsParams ?? []).map(p => capitalizeFieldName(p.name)))
+    const eligible =
+      nestedComponents.every(n => n.isDynamic && !n.isPropDerived) &&
+      spreadSlots.length === 0 &&
+      !ir.metadata.restPropsName &&
+      this.nonCollidingContextConsumers(takenInput).length === 0
+    if (!eligible) return
+
+    const inputTypeName = `${componentName}Input`
+    const q = JSON.stringify(componentName)
+
+    lines.push(`// ${componentName} computes at least one field from an input prop when its`)
+    lines.push('// props are constructed, so a per-row override inside a composite loop row')
+    lines.push('// cannot be applied by patching fields — the derived field would keep the')
+    lines.push('// shared instance\'s one-shot value on every row (#2448). This rebuilder')
+    lines.push(`// re-runs New${componentName}Props with the row's overrides folded into the`)
+    lines.push('// Input; the parent calls it through bf_reprops.')
+    lines.push('func init() {')
+    lines.push(`\tbf.RegisterReprops(${q}, func(base interface{}, kv ...interface{}) (interface{}, error) {`)
+    lines.push(`\t\tb, ok := base.(${componentName}Props)`)
+    lines.push('\t\tif !ok {')
+    lines.push(`\t\t\treturn nil, bf.RepropsTypeError(${q}, base)`)
+    lines.push('\t\t}')
+    lines.push(`\t\tin := ${inputTypeName}{`)
+    // Identity comes from the base instance — re-deriving it would re-mint the
+    // ScopeID and break hydration.
+    lines.push('\t\t\tScopeID: b.ScopeID,')
+    lines.push('\t\t\tBfParent: b.BfParent,')
+    lines.push('\t\t\tBfMount: b.BfMount,')
+    if (this.usesSearchParams(ir)) lines.push('\t\t\tSearchParams: b.SearchParams,')
+    for (const p of params) {
+      const field = capitalizeFieldName(p.name)
+      lines.push(`\t\t\t${field}: b.${field},`)
+    }
+    lines.push('\t\t}')
+    lines.push('\t\tfor i := 0; i < len(kv); i += 2 {')
+    lines.push('\t\t\tname, _ := kv[i].(string)')
+    lines.push('\t\t\tvar err error')
+    lines.push('\t\t\tswitch name {')
+    for (const p of params) {
+      // Case label: the name the PARENT computed from the JSX attribute.
+      // Target: this component's own Input field. They differ under an
+      // aliased destructure.
+      const wire = capitalizeFieldName(p.sourceName ?? p.name)
+      const field = capitalizeFieldName(p.name)
+      lines.push(`\t\t\tcase ${JSON.stringify(wire)}:`)
+      lines.push(`\t\t\t\terr = bf.RepropsAssign(${q}, ${JSON.stringify(wire)}, &in.${field}, kv[i+1])`)
+    }
+    lines.push('\t\t\t}')
+    lines.push('\t\t\tif err != nil {')
+    lines.push('\t\t\t\treturn nil, err')
+    lines.push('\t\t\t}')
+    lines.push('\t\t}')
+    lines.push(`\t\tp := New${componentName}Props(in)`)
+    lines.push('\t\t// Props-only state, absent from Input and therefore not rebuilt.')
+    lines.push('\t\tp.Scripts = b.Scripts')
+    lines.push('\t\tp.BfIsRoot = b.BfIsRoot')
+    lines.push('\t\tp.BfIsChild = b.BfIsChild')
+    lines.push('\t\tp.BfDataKey = b.BfDataKey')
+    lines.push('\t\treturn p, nil')
+    lines.push('\t})')
+    lines.push('}')
+    lines.push('')
+
+    this.childRepropsReady.add(componentName)
   }
 
   /** Convert a TS type definition to Go: object types → structs, string-literal unions → a `string` alias. */
@@ -5108,24 +5238,32 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * fixture's emitted template byte-identical (no fixture in the corpus
    * reaches this method with a loop-dependent prop today).
    *
-   * REFUSED, not silently mis-rendered (#2448, tracked separately from
-   * #2445, which this method fixes): `bf_with_props` overrides fields on the
-   * ALREADY-CONSTRUCTED shared instance — it does not re-run
-   * `New<Child>Props`. A field the child derives FROM the overridden prop at
-   * construction time (a memo body or a signal's initial value) would keep
-   * whatever the one-shot constructor computed and never update per row —
-   * silently wrong output. Rather than emit that, this method checks the prop
-   * against `this.childDerivedFieldDeps` (built by `recordDerivedFieldDeps`,
-   * this file) and pushes a BF101 + `continue`s when a derived field would go
-   * stale, exactly like the unsupported-expression refusal a few lines below.
+   * #2448 — `bf_with_props` overrides fields on the ALREADY-CONSTRUCTED
+   * shared instance; it does not re-run `New<Child>Props`. A field the child
+   * derives FROM the overridden prop at construction time (a memo body or a
+   * signal's initial value) would keep whatever the one-shot constructor
+   * computed and never update per row. Two outcomes, decided per child:
    *
-   * Returns the space-joined `"Field" value "Field2" value2 …` argument list
-   * for `bf_with_props`, or null when nothing needs overriding (caller keeps
-   * the bare `$.<Name>SlotN` reference).
+   * - The child has a generated props rebuilder (`childRepropsReady`): the
+   *   caller emits `bf_reprops` instead, which re-runs the real constructor
+   *   per row so every derived field recomputes. Nothing is refused.
+   * - It does not (its Input can't be reconstructed from Props — see
+   *   `generateRepropsRegistration`'s eligibility gate): BF101 + `continue`,
+   *   exactly like the unsupported-expression refusal a few lines below.
+   *   Refusing beats emitting silently-stale output.
+   *
+   * Returns the space-joined `"Field" value …` argument list plus the helper
+   * the caller must wrap it in, or null when nothing needs overriding (caller
+   * keeps the bare `$.<Name>SlotN` reference).
    */
-  private loopRowChildPropOverrides(comp: IRComponent): string | null {
+  private loopRowChildPropOverrides(
+    comp: IRComponent,
+  ): { args: string; helper: 'bf_with_props' | 'bf_reprops' } | null {
     const childShape = this.childComponentShapes.get(comp.name)
     const args: string[] = []
+    // Set by the derived-field check below when at least one overridden prop
+    // feeds a constructor-derived field AND the child can rebuild itself.
+    let needsRebuild = false
     for (const prop of comp.props) {
       // Client-only props never reach SSR output; `key`/`children` aren't
       // Props-struct fields; event handlers have no Go field (same
@@ -5147,22 +5285,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (prop.value.kind !== 'expression') continue
       const free = prop.freeIdentifiers
       if (!free || ![...free].some(name => this.isLoopShadowedName(name))) continue
-      // #2448: this prop is about to be overridden per row via
-      // `bf_with_props` — but that helper only sets the NAMED fields on the
-      // already-constructed shared instance; it can't re-run
-      // `New<Child>Props`. If a memo body or a signal's initial value derives
-      // from this prop at construction time, the override would leave that
-      // field holding the shared instance's one-shot value on every row —
-      // silently wrong.
-      // Refuse loudly instead (same push-error-then-`continue` shape as the
-      // unsupported-expression refusal below).
+      // #2448: does this prop feed a field the child's CONSTRUCTOR derives?
+      // If so, patching fields on the shared instance leaves that field at the
+      // one-shot value on every row. Re-run the constructor per row when the
+      // child has a rebuilder; refuse when it doesn't.
       {
         const derived = this.childDerivedFieldDeps.get(comp.name)
         const overriddenField = capitalizeFieldName(prop.name)
         const staleField = derived
           ? [...derived].find(([, deps]) => deps.has(overriddenField))?.[0]
           : undefined
-        if (staleField) {
+        if (staleField && !this.childRepropsReady.has(comp.name)) {
           this.state.errors.push({
             code: 'BF101',
             severity: 'error',
@@ -5174,6 +5307,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           })
           continue
         }
+        if (staleField) needsRebuild = true
       }
       const exprOut: { parsed?: ParsedExpr } = {}
       const errorCountBefore = this.state.errors.length
@@ -5231,7 +5365,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
       args.push(`${JSON.stringify(capitalizeFieldName(prop.name))} ${wrapIfMultiToken(go)}`)
     }
-    return args.length > 0 ? args.join(' ') : null
+    if (args.length === 0) return null
+    return { args: args.join(' '), helper: needsRebuild ? 'bf_reprops' : 'bf_with_props' }
   }
 
   /**
@@ -6289,8 +6424,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       const suffix = slotIdToFieldSuffix(comp.slotId)
       const overrides = this.loopRowChildPropOverrides(comp)
       const loopBodyDefine = this.queueLoopBodyChildrenDefine(comp)
+      // `bf_reprops` re-runs the child's constructor and so takes the
+      // component name; `bf_with_props` patches fields and doesn't (#2448).
+      // Either way the props helper stays INNER — `bf_with_children` applies
+      // the row's children last, on the rebuilt value.
       const base = overrides
-        ? `(bf_with_props $.${comp.name}${suffix} ${overrides})`
+        ? overrides.helper === 'bf_reprops'
+          ? `(bf_reprops ${JSON.stringify(comp.name)} $.${comp.name}${suffix} ${overrides.args})`
+          : `(bf_with_props $.${comp.name}${suffix} ${overrides.args})`
         : `$.${comp.name}${suffix}`
       templateCall = loopBodyDefine
         ? `{{template "${comp.name}" (bf_with_children ${base} (bf_tmpl "${loopBodyDefine}" .))}}`

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -156,6 +156,19 @@ type HigherOrderShape = {
 }
 
 /**
+ * Everything needed to emit a component's #2448 props rebuilder, captured when
+ * its own types are generated so a PARENT can emit the registration into its
+ * own type block (`emitPendingReprops`). `wire` is the field name the parent
+ * computes from the JSX attribute; `field` is this component's own Input
+ * field. They differ under an aliased destructure (`{ n: count }` → `"N"` vs
+ * `Count`).
+ */
+type RepropsSpec = {
+  params: { field: string; wire: string }[]
+  usesSearchParams: boolean
+}
+
+/**
  * String-returning array/string methods. `.get(...)` stays a generic `call`;
  * the rest fold into `array-method`. Module-level so `isStringExpr` (which
  * recurses over expression trees) reuses one set instead of allocating per call.
@@ -646,19 +659,31 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private childDerivedFieldDeps: Map<string, Map<string, ReadonlySet<string>>> = new Map()
 
   /**
-   * Components this run emitted a `bf.RegisterReprops` rebuilder for
-   * (`generateRepropsRegistration`, #2448). A parent overriding a prop that
-   * feeds one of the child's derived fields emits `bf_reprops` when the child
-   * is in here, and falls back to the BF101 refusal when it is not — the
-   * rebuilder is declined for shapes whose Input can't be reconstructed from
-   * Props, and emitting the call anyway would fail at template execute time
-   * with "no props rebuilder registered".
+   * Components a `bf.RegisterReprops` rebuilder CAN be emitted for
+   * (`recordRepropsSpec`, #2448), with everything needed to emit it. A parent
+   * overriding a prop that feeds one of the child's derived fields emits
+   * `bf_reprops` when the child is in here, and falls back to the BF101
+   * refusal when it is not — the rebuilder is declined for shapes whose Input
+   * can't be reconstructed from Props, and emitting the call anyway would fail
+   * at template execute time with "no props rebuilder registered".
    *
-   * Populated from the same two doors as `childDerivedFieldDeps`: a same-file
-   * child is generated before its parent, and the CLI's cross-file pre-pass
-   * generates types for every component up front.
+   * Populated from `generateTypes`, so a same-file child (the only kind a loop
+   * row may contain) is recorded before its parent renders.
    */
-  private childRepropsReady: Set<string> = new Set()
+  private childRepropsReady: Map<string, RepropsSpec> = new Map()
+
+  /**
+   * child component name -> the component whose type block carries its
+   * rebuilder registration. First parent to need the child wins, so two
+   * parents overriding the same child don't both emit an `init()` for it.
+   *
+   * An assignment, not a queue: `generateTypes` is called more than once for
+   * the same component (the conformance harness re-generates the entry's types
+   * after `compileJSX` already did), and a queue drained by the first call
+   * would leave the second call's output — the one that actually gets used —
+   * missing the registration.
+   */
+  private repropsOwner: Map<string, string> = new Map()
 
   /**
    * Record which of `ir`'s constructor-computed fields derive from one of its
@@ -871,7 +896,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     this.generateNewPropsFunction(lines, ir, componentName, nestedComponents, spreadSlots, propTypeOverrides)
 
-    this.generateRepropsRegistration(lines, ir, componentName, nestedComponents, spreadSlots)
+    this.recordRepropsSpec(ir, componentName, nestedComponents, spreadSlots)
+    this.emitOwnedReprops(lines, componentName)
 
     return this.composeFileHeader(lines)
   }
@@ -909,8 +935,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * (`{ n: count }`) those differ (`"N"` vs `in.Count`), and this generated
    * switch is where the two sides are reconciled.
    */
-  private generateRepropsRegistration(
-    lines: string[],
+  private recordRepropsSpec(
     ir: ComponentIR,
     componentName: string,
     nestedComponents: NestedComponentInfo[],
@@ -930,6 +955,47 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       this.nonCollidingContextConsumers(takenInput).length === 0
     if (!eligible) return
 
+    this.childRepropsReady.set(componentName, {
+      params: params.map(p => ({
+        field: capitalizeFieldName(p.name),
+        wire: capitalizeFieldName(p.sourceName ?? p.name),
+      })),
+      usesSearchParams: this.usesSearchParams(ir),
+    })
+  }
+
+  /**
+   * Emit the rebuilders assigned to `owner` — the children its own render
+   * asked for (`loopRowChildPropOverrides` → `repropsOwner`).
+   *
+   * Emitted from the PARENT rather than the child on purpose. The prop-seeded
+   * signal (`createSignal(props.initial)`) is one of the most common shapes in
+   * the corpus, so emitting a rebuilder for every component that merely HAS a
+   * derived field added ~250 lines of never-called Go to each integration's
+   * generated file. Only a parent knows whether a child is actually overridden
+   * per row inside a composite loop row, and it knows before its own type block
+   * is built — `generate()` renders the template first. Every component's type
+   * block lands in the same package (`combineGoTypes`, `build.ts`), so the
+   * child's Input/Props types are in scope from here.
+   *
+   * Idempotent: driven by the recorded assignment, so re-generating the same
+   * component's types produces the same block.
+   */
+  private emitOwnedReprops(lines: string[], owner: string): void {
+    for (const [childName, ownerName] of this.repropsOwner) {
+      if (ownerName !== owner) continue
+      const spec = this.childRepropsReady.get(childName)
+      if (!spec) continue
+      this.emitRepropsRegistration(lines, childName, spec)
+    }
+  }
+
+  private emitRepropsRegistration(
+    lines: string[],
+    componentName: string,
+    spec: RepropsSpec,
+  ): void {
+    const { params, usesSearchParams } = spec
     const inputTypeName = `${componentName}Input`
     const q = JSON.stringify(componentName)
 
@@ -951,9 +1017,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     lines.push('\t\t\tScopeID: b.ScopeID,')
     lines.push('\t\t\tBfParent: b.BfParent,')
     lines.push('\t\t\tBfMount: b.BfMount,')
-    if (this.usesSearchParams(ir)) lines.push('\t\t\tSearchParams: b.SearchParams,')
-    for (const p of params) {
-      const field = capitalizeFieldName(p.name)
+    if (usesSearchParams) lines.push('\t\t\tSearchParams: b.SearchParams,')
+    for (const { field } of params) {
       lines.push(`\t\t\t${field}: b.${field},`)
     }
     lines.push('\t\t}')
@@ -961,12 +1026,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     lines.push('\t\t\tname, _ := kv[i].(string)')
     lines.push('\t\t\tvar err error')
     lines.push('\t\t\tswitch name {')
-    for (const p of params) {
+    for (const { field, wire } of params) {
       // Case label: the name the PARENT computed from the JSX attribute.
       // Target: this component's own Input field. They differ under an
       // aliased destructure.
-      const wire = capitalizeFieldName(p.sourceName ?? p.name)
-      const field = capitalizeFieldName(p.name)
       lines.push(`\t\t\tcase ${JSON.stringify(wire)}:`)
       lines.push(`\t\t\t\terr = bf.RepropsAssign(${q}, ${JSON.stringify(wire)}, &in.${field}, kv[i+1])`)
     }
@@ -992,8 +1055,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     lines.push('\t})')
     lines.push('}')
     lines.push('')
-
-    this.childRepropsReady.add(componentName)
   }
 
   /** Convert a TS type definition to Go: object types → structs, string-literal unions → a `string` alias. */
@@ -5314,7 +5375,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           })
           continue
         }
-        if (staleField) needsRebuild = true
+        if (staleField) {
+          needsRebuild = true
+          // The rebuilder is emitted into THIS component's type block, not the
+          // child's — only here do we know it is actually needed. First parent
+          // to claim a child owns the registration, so two parents overriding
+          // the same child don't both emit an `init()` for it.
+          if (!this.repropsOwner.has(comp.name)) {
+            this.repropsOwner.set(comp.name, this.state.componentName)
+          }
+        }
       }
       const exprOut: { parsed?: ParsedExpr } = {}
       const errorCountBefore = this.state.errors.length

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -970,6 +970,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       lines.push(`\t\t\tcase ${JSON.stringify(wire)}:`)
       lines.push(`\t\t\t\terr = bf.RepropsAssign(${q}, ${JSON.stringify(wire)}, &in.${field}, kv[i+1])`)
     }
+    // No silent drop. `bf_with_props` passes an unknown field through because
+    // a rest-bag prop legitimately has no named field — but a rebuilder is
+    // only emitted for components with no rest bag, and there is a case for
+    // every prop the parent can override, so an unknown name here means the
+    // override would go unapplied.
+    lines.push('\t\t\tdefault:')
+    lines.push(`\t\t\t\terr = bf.RepropsUnknownFieldError(${q}, name)`)
     lines.push('\t\t\t}')
     lines.push('\t\t\tif err != nil {')
     lines.push('\t\t\t\treturn nil, err')

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -186,14 +186,4 @@ export const conformancePins: ConformancePins = {
   // `adapter.generate()`), not an adapter-specific gap, so it is pinned
   // identically across every adapter package including Hono.
   'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2356' }],
-  // #2448: `Badge`'s `dbl` memo is computed once from `in.N` when the
-  // shared `$.BadgeSlot0` instance is constructed outside `{{range}}`;
-  // `bf_with_props` (#2445) only overrides the NAMED fields on that
-  // instance per row — it can't re-run `NewBadgeProps` — so overriding `N`
-  // per row would leave `Dbl` stale on every row after the first. Refused
-  // loudly with BF101 (`loopRowChildPropOverrides`) instead of silently
-  // rendering the first row's derived value everywhere. Every other
-  // adapter constructs the child fresh per row and is unaffected.
-  // See https://github.com/piconic-ai/barefootjs/issues/2448.
-  'composite-row-child-derived-prop': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2448' }],
 }

--- a/packages/adapter-tests/fixtures/composite-row-child-component.ts
+++ b/packages/adapter-tests/fixtures/composite-row-child-component.ts
@@ -23,10 +23,12 @@ import { createFixture } from '../src/types'
  *   - #2445 — Go template: the shared `BadgeSlot0` props instance built
  *     outside `{{range}}` is now overridden per row, at
  *     template-execution time, via the `bf_with_props` runtime helper —
- *     see `packages/adapter-go-template/runtime/bf.go`. A NARROWER residual
- *     gap (a child field DERIVED from the overridden prop, e.g. a memo,
- *     doesn't update per row — this fixture's `Badge` has no such field) is
- *     tracked separately as #2448, not by a divergence entry here.
+ *     see `packages/adapter-go-template/runtime/bf.go`. A child field
+ *     DERIVED from the overridden prop (a memo, a signal initial value) needs
+ *     more than a field patch and takes the `bf_reprops` rebuild path instead
+ *     (#2448); this fixture's `Badge` has no such field, so it stays on
+ *     `bf_with_props`. `composite-row-child-derived-prop` covers the other
+ *     side.
  */
 export const fixture = createFixture({
   id: 'composite-row-child-component',

--- a/packages/adapter-tests/fixtures/composite-row-child-derived-prop.ts
+++ b/packages/adapter-tests/fixtures/composite-row-child-derived-prop.ts
@@ -8,16 +8,18 @@ import { createFixture } from '../src/types'
  *
  * `Badge`'s `dbl` memo is computed once, at `NewBadgeProps` construction
  * time, from `in.N`. The Go template adapter builds the shared
- * `$.BadgeSlot0` instance ONCE outside `{{range}}` and re-applies only the
- * NAMED fields per row via `bf_with_props` (#2445) — it does not re-run
- * `NewBadgeProps`. So overriding `N` per row would leave `Dbl` holding
- * row 0's value (`0 * 2 = 0`) on every row: silently wrong output.
+ * `$.BadgeSlot0` instance ONCE outside `{{range}}`, and `bf_with_props`
+ * (#2445) re-applies only the NAMED fields on it — it cannot re-run
+ * `NewBadgeProps`. Overriding `N` that way would leave `Dbl` holding row 0's
+ * value (`0 * 2 = 0`) on every row: silently wrong output.
  *
- * The Go adapter refuses this loudly with BF101 instead — see
- * `conformance-pins.ts`'s entry for this fixture. Every other adapter (and
- * CSR) constructs the child fresh per row and is unaffected; this fixture's
- * `expectedHtml` is generated from the reference Hono adapter and must show
- * `Dbl` computed CORRECTLY per row (6 and 10, not 0 and 0) on those adapters.
+ * Go therefore takes the rebuild path for this shape: the compiler emits a
+ * props rebuilder for `Badge` and the row calls `bf_reprops`, which re-runs
+ * the real constructor per row so `Dbl` recomputes (#2448). Every other
+ * adapter (and CSR) constructs the child fresh per row and never had the
+ * problem. `expectedHtml` is generated from the reference Hono adapter and
+ * every adapter, Go included, must now show `Dbl` computed per row — 6 and
+ * 10, not 0 and 0.
  */
 export const fixture = createFixture({
   id: 'composite-row-child-derived-prop',

--- a/packages/cli/scripts/embed-runtimes.mjs
+++ b/packages/cli/scripts/embed-runtimes.mjs
@@ -30,6 +30,7 @@ const repoRoot = resolve(cliPkg, '../..')
 const sources = {
   bfGoSource: 'packages/adapter-go-template/runtime/bf.go',
   evalGoSource: 'packages/adapter-go-template/runtime/eval.go',
+  repropsGoSource: 'packages/adapter-go-template/runtime/reprops.go',
   streamingGoSource: 'packages/adapter-go-template/runtime/streaming.go',
   bfdevGoSource: 'packages/adapter-go-template/runtime/bfdev/bfdev.go',
 }

--- a/packages/cli/src/__tests__/templates.test.ts
+++ b/packages/cli/src/__tests__/templates.test.ts
@@ -33,6 +33,10 @@ describe('adapter registry', () => {
       // auto-reload handler lives in and eval.go (ParsedExpr evaluator).
       expect(adapter.files['bf-runtime/bf.go']).toContain('package bf')
       expect(adapter.files['bf-runtime/eval.go']).toContain('package bf')
+      // reprops.go carries RegisterReprops, which every generated
+      // components file with a constructor-derived field calls from init()
+      // — a scaffold missing it fails to compile (#2448).
+      expect(adapter.files['bf-runtime/reprops.go']).toContain('func RegisterReprops(')
       expect(adapter.files['bf-runtime/bfdev/bfdev.go']).toContain('package bfdev')
       expect(adapter.files['go.mod']).toContain(
         'replace github.com/barefootjs/runtime/bf => ./bf-runtime',
@@ -301,6 +305,7 @@ describe('adapter registry', () => {
     expect(echo.files['bf-runtime/bf.go']).toMatch(/package bf/)
     expect(echo.files['bf-runtime/eval.go']).toMatch(/package bf/)
     expect(echo.files['bf-runtime/streaming.go']).toBeTruthy()
+    expect(echo.files['bf-runtime/reprops.go']).toContain('func RegisterReprops(')
     expect(echo.files['bf-runtime/go.mod']).toMatch(/^module github\.com\/barefootjs\/runtime\/bf/m)
     expect(echo.files['go.mod']).toMatch(/replace github\.com\/barefootjs\/runtime\/bf => \.\/bf-runtime/)
     expect(echo.files['bf_render.go']).toContain('bf.TemplateFuncMap(root)')

--- a/packages/cli/src/lib/adapters/echo.ts
+++ b/packages/cli/src/lib/adapters/echo.ts
@@ -33,6 +33,7 @@ import {
 import {
   bfGoSource,
   evalGoSource,
+  repropsGoSource,
   streamingGoSource,
 } from './runtimes.generated'
 
@@ -531,6 +532,7 @@ export const ECHO_ADAPTER: AdapterTemplate = {
     'go.mod': ECHO_GO_MOD,
     'bf-runtime/bf.go': bfGoSource,
     'bf-runtime/eval.go': evalGoSource,
+    'bf-runtime/reprops.go': repropsGoSource,
     'bf-runtime/streaming.go': streamingGoSource,
     'bf-runtime/go.mod': ECHO_BF_RUNTIME_GO_MOD,
     'barefoot.config.ts': ECHO_BAREFOOT_CONFIG_TS,

--- a/packages/cli/src/lib/adapters/go-shared.ts
+++ b/packages/cli/src/lib/adapters/go-shared.ts
@@ -44,6 +44,7 @@ import {
   bfdevGoSource,
   bfGoSource,
   evalGoSource,
+  repropsGoSource,
   streamingGoSource,
 } from './runtimes.generated'
 import type { AdapterTemplate, AdapterScriptValue } from '../templates'
@@ -272,6 +273,7 @@ export function goCommonFiles(): Record<string, string> {
     'env.go': GO_ENV_GO,
     'bf-runtime/bf.go': bfGoSource,
     'bf-runtime/eval.go': evalGoSource,
+    'bf-runtime/reprops.go': repropsGoSource,
     'bf-runtime/streaming.go': streamingGoSource,
     'bf-runtime/bfdev/bfdev.go': bfdevGoSource,
     'bf-runtime/go.mod': GO_BF_RUNTIME_GO_MOD,

--- a/packages/compat/src/__tests__/compat-engine.test.ts
+++ b/packages/compat/src/__tests__/compat-engine.test.ts
@@ -46,15 +46,15 @@ describe('compileForCompat', () => {
     // `issues` is the UNION of every issue URL any BF101 pin carries on
     // this adapter (buildCompatCell attributes by code, not by fixture —
     // see its docstring) — #2320 (this shape, nested filter callback,
-    // successor to #2038), #2321 (static-array-from-props computed loop
-    // source) and #2448 (loop-row child prop override reading a derived
-    // field) surface here even though this test only exercises the nested-
-    // filter-callback shape. #2319 (dangerous-inner-html-dynamic) is no
-    // longer among them — it graduated to a faithful raw-output lowering on
-    // every template adapter, so its BF101 pin was removed. #2208's
-    // `static-array-children` BF101 pin was likewise removed (its loop-source
-    // gate now bakes a fully-static array-of-objects const directly) — see
-    // `go-template`'s `conformance-pins.ts`.
+    // successor to #2038) and #2321 (static-array-from-props computed loop
+    // source) surface here even though this test only exercises the nested-
+    // filter-callback shape. Three pins are no longer among them, each
+    // because the shape got a real lowering rather than a narrower refusal:
+    // #2319 (dangerous-inner-html-dynamic → a faithful raw-output lowering),
+    // #2208 (static-array-children → the loop-source gate bakes a fully-static
+    // array-of-objects const), and #2448 (loop-row child prop override feeding
+    // a derived field → the child rebuilds itself per row through
+    // `bf_reprops`). See `go-template`'s `conformance-pins.ts`.
     expect(cell.diagnostics).toEqual([
       {
         code: 'BF101',
@@ -62,7 +62,6 @@ describe('compileForCompat', () => {
         issues: [
           'https://github.com/piconic-ai/barefootjs/issues/2320',
           'https://github.com/piconic-ai/barefootjs/issues/2321',
-          'https://github.com/piconic-ai/barefootjs/issues/2448',
         ],
       },
     ])

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1816,17 +1816,6 @@
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
     "totalFixtures": 289,
     "fixtures": {
-      "composite-row-child-derived-prop": {
-        "go-template": {
-          "kind": "refusal",
-          "codes": [
-            "BF101"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2448"
-          ]
-        }
-      },
       "date-method-uncatalogued": {
         "blade": {
           "kind": "refusal",
@@ -2790,10 +2779,6 @@
       }
     },
     "docs": {
-      "composite-row-child-derived-prop": {
-        "description": "Nested child in a dynamic loop row has a memo derived from the per-row-overridden prop",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/composite-row-child-derived-prop.ts"
-      },
       "date-method-uncatalogued": {
         "description": "Method call on a Date-typed prop refuses with BF021 (no catalogued lowering)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/date-method-uncatalogued.ts"

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1123,15 +1123,9 @@
           ]
         },
         "go-template": {
-          "pass": 69,
+          "pass": 70,
           "total": 79,
           "gaps": [
-            {
-              "fixture": "composite-row-child-derived-prop",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2448"
-              ]
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1585,15 +1579,9 @@
           ]
         },
         "go-template": {
-          "pass": 168,
+          "pass": 169,
           "total": 184,
           "gaps": [
-            {
-              "fixture": "composite-row-child-derived-prop",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2448"
-              ]
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2363,15 +2351,9 @@
           ]
         },
         "go-template": {
-          "pass": 252,
+          "pass": 253,
           "total": 270,
           "gaps": [
-            {
-              "fixture": "composite-row-child-derived-prop",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2448"
-              ]
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3043,15 +3025,9 @@
           ]
         },
         "go-template": {
-          "pass": 210,
+          "pass": 211,
           "total": 222,
           "gaps": [
-            {
-              "fixture": "composite-row-child-derived-prop",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2448"
-              ]
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3699,15 +3675,9 @@
           ]
         },
         "go-template": {
-          "pass": 131,
+          "pass": 132,
           "total": 149,
           "gaps": [
-            {
-              "fixture": "composite-row-child-derived-prop",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2448"
-              ]
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -6557,16 +6527,8 @@
           "total": 10
         },
         "go-template": {
-          "pass": 9,
-          "total": 10,
-          "gaps": [
-            {
-              "fixture": "composite-row-child-derived-prop",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2448"
-              ]
-            }
-          ]
+          "pass": 10,
+          "total": 10
         },
         "jinja": {
           "pass": 10,
@@ -7532,15 +7494,9 @@
           ]
         },
         "go-template": {
-          "pass": 89,
+          "pass": 90,
           "total": 95,
           "gaps": [
-            {
-              "fixture": "composite-row-child-derived-prop",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2448"
-              ]
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []


### PR DESCRIPTION
Replaces #2456's `BF101` refusal with the actual fix. Also closes the derived half of #2457.

## What was blocking a fix

`bf_with_props` (#2445) patches fields on the child's already-constructed shared instance. It cannot re-run `New<Child>Props`, which is where a `createMemo` body **and** a `createSignal` initial value are both baked — so overriding `n` per row left `Dbl` at the one-shot value on every row.

The blocker was never arithmetic. `html/template` has no expression language and can only call FuncMap entries, and `New<Child>Props` is not one. #2456 concluded that registering it would be a breaking setup change for every Go user. That conclusion was too strong — it holds for the naive form, not for a registry.

## The fix

The compiler emits a props **rebuilder** for the child, registered from the generated package's `init()`:

```go
func init() {
	bf.RegisterReprops("Badge", func(base interface{}, kv ...interface{}) (interface{}, error) {
		b, ok := base.(BadgeProps)
		if !ok {
			return nil, bf.RepropsTypeError("Badge", base)
		}
		in := BadgeInput{ScopeID: b.ScopeID, BfParent: b.BfParent, BfMount: b.BfMount,
			Text: b.Text, N: b.N}
		for i := 0; i < len(kv); i += 2 {
			name, _ := kv[i].(string)
			var err error
			switch name {
			case "Text":
				err = bf.RepropsAssign("Badge", "Text", &in.Text, kv[i+1])
			case "N":
				err = bf.RepropsAssign("Badge", "N", &in.N, kv[i+1])
			default:
				err = bf.RepropsUnknownFieldError("Badge", name)
			}
			if err != nil {
				return nil, err
			}
		}
		p := NewBadgeProps(in) // every derived field recomputes
		p.Scripts = b.Scripts
		p.BfIsRoot, p.BfIsChild, p.BfDataKey = b.BfIsRoot, b.BfIsChild, b.BfDataKey
		return p, nil
	})
}
```

and the row calls it through one new fixed FuncMap entry:

```gotemplate
{{template "Badge" (bf_reprops "Badge" $.BadgeSlot0 "Text" .Label "N" .N)}}
```

**`t.Funcs(bf.FuncMap())` is unchanged.** No setup change for any existing Go app.

## Why the lookup is deferred to execute time

This is load-bearing, not incidental. Go initializes a package's variables **before** its `init()` functions, so an app that builds its template set in a package-level var —

```go
var tmpl = template.Must(template.New("").Funcs(bf.FuncMap()).ParseGlob(...))
```

— calls `FuncMap()` while the registry is still empty. A prototype confirmed both halves from exactly that position:

```
registry populated at package-var init time? true    ← it was empty
reprops:  → renders correctly
naive:    → PARSE FAILED: function "bf_new_Badge" not defined
```

Merging constructors into `FuncMap()`'s return value breaks such an app at parse time. One fixed entry resolved at execute time cannot. Pinned by `TestRepropsResolvesAtExecuteTimeNotFuncsTime`.

## Why the registration is emitted by the PARENT

The first cut emitted a rebuilder for every component that merely *has* a constructor-derived field. `createSignal(props.initial)` — prop-seeded local state — is one of the most common shapes in the corpus, so that added **~255 lines of never-called Go to each of the four Go integrations**. The `integrations/*/components.go` drift gate caught it.

Only a parent knows whether a child is actually overridden per row, and it knows in time: `generate()` renders the template before building its own type block, and every component's block lands in the same Go package (`combineGoTypes`), so the child's Input/Props types are in scope. `generateTypes` now *records* what a rebuilder would need and emits only the ones its own render claimed; the first parent to claim a child owns the registration.

The assignment is a map, not a drained queue — that distinction is load-bearing too. The conformance harness calls `generateTypes(ir)` a second time after `compileJSX` already ran `generate()`, and a queue left that second block (the one the harness compiles) without the registration; real Go then failed at execute time with `no props rebuilder registered for "Badge"`.

All four integrations regenerate byte-identical.

## Identity

`New<Child>Props` mints a random `ScopeID` when handed an empty one, so a naive re-run would give every row its own scope and break hydration. `ScopeID` / `BfParent` / `BfMount` come from the base, and the Props-only fields (`Scripts`, `BfIsRoot`/`BfIsChild`/`BfDataKey`) are reapplied after the constructor.

Verified against real Go — the hydration attributes are byte-identical to the old path on every row, and only the derived value changes:

```
before:  one:0   two:0
after:   one:6   two:10
```
```html
<span class="badge" bf-s="test_s0" bf-h="test" bf-m="s0" bf-r="" bf="s2">…one…:…6…</span>
<span class="badge" bf-s="test_s0" bf-h="test" bf-m="s0" bf-r="" bf="s2">…two…:…10…</span>
```

## Blast radius

Zero for everything else, and now verified rather than asserted. Only an override that actually feeds a constructor-derived field switches helpers — a plain passthrough override stays on `bf_with_props` and emits byte-identical output — and no rebuilder is emitted for a component nobody rebuilds. `bf_with_children` still composes on the outside (the props helper was already the inner one), so per-row children apply to the rebuilt value.

`bf_with_props` stays exported and registered: templates generated before this call it, and it remains the cheaper path when nothing is derived. Measured at 100 rows × 3 runs, the two are within noise — `bf_reprops` is ~3–5% slower per execution and allocates slightly less (9,131 vs 9,136 allocs/op; 227.7 KB vs 232.5 KB).

## No silent drops

`bf_reprops` rejects a non-string field name up front, matching `bf_with_props` (a non-string name would degrade to `""`, match no case, and silently drop the override). The generated switch also ends in a `default:` that errors: unlike `bf_with_props`, whose unknown-field passthrough is load-bearing for rest-bag props, a rebuilder is only emitted for components with no rest bag and there is a case for every prop the parent can override, so an unknown name there is a compiler gap whose only silent outcome is an unapplied override.

## BF101 survives where the rebuilder declines

A `...rest` bag, a spread slot, context consumers, or nested child Inputs add Input fields with no Props counterpart, so the Input cannot be reconstructed. Those get no rebuilder and the refusal stands. Pinned by its own test, which also asserts no `RegisterReprops` is emitted for that shape.

## The aliased destructure, as a consequence

For `function Badge({ text, n: count })` the child's Go field is `Count` while the parent writes `n=` → `"N"`. The generated switch is keyed by the **parent's** name and assigns to the **child's** field (`case "N": … &in.Count`), which is exactly where those two sides have to be reconciled. The `bf_with_props` path still carries the mismatch when nothing is derived — that half stays open as #2457.

## Coverage

- `composite-row-child-derived-prop` — the pin is removed; Go now renders it correctly alongside every other adapter. `expectedHtml` is unchanged.
- Compiler tests: memo shape rebuilds; signal shape rebuilds; aliased destructure maps parent name → child field; rest-bag shape still refuses; the #2445 no-derived-field shape still emits `bf_with_props`. The memo test also pins that the child's own type block carries *no* registration.
- Go runtime tests (`reprops_test.go`): derived field recomputes (with the `WithProps` contrast asserted directly), identity carried, base not mutated, error paths incl. non-string and unknown field names, `WithChildren` composition, execute-time resolution.
- `reprops.go` added to the CLI's embedded runtime set and both scaffold file lists — without it a scaffolded app fails to compile the moment a component derives a field. The scaffold tests pin its presence.
- Regenerated `ui/compat.lock.json` and `ui/support-matrix.lock.json` (go-template's `binary` pass goes 69 → 70); the `compat-engine` BF101 `issues` union drops #2448.

## Tests

Local, run serially: `packages/adapter-go-template` **1490 pass / 0 fail** with real Go renders (`GOTOOLCHAIN=go1.25.6`), `packages/adapter-tests` **1481 pass / 0 fail**, `packages/compat` **183 pass / 0 fail**, `packages/jsx` **2923 run / 0 fail**, `packages/cli` **1554 pass / 0 fail**, `go test ./...` in the runtime green, all four Go integrations rebuilt from a cleared cache with no drift. Biome clean, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_