### PR TITLE
fix(perl): resolve CPANTS Kwalitee issues on published dists

### DIFF
--- a/.changeset/perl-cpants-kwalitee.md
+++ b/.changeset/perl-cpants-kwalitee.md
@@ -1,0 +1,24 @@
+---
+"@barefootjs/perl": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Fix CPANTS Kwalitee issues flagged on the published CPAN dists (cpants.cpanauthors.org):
+
+- `no_pod_errors` — `BarefootJS::DevReload`'s POD used an em dash before
+  declaring `=encoding utf8`, which `Test::Pod`/CPANTS parse as a raw
+  non-ASCII byte in POD. Added the missing `=encoding utf8`.
+- `consistent_version` — `BarefootJS::Evaluator` and `BarefootJS::SearchParams`
+  were stuck at `0.14.0` because `scripts/sync-perl-versions.ts` only listed
+  `BarefootJS.pm` and `DevReload.pm` for the `packages/adapter-perl` dist, so
+  releases never bumped their `$VERSION`. Both are now synced with the rest of
+  the distribution, and the script tracks them going forward.
+- `meta_yml_has_provides` — plain `ExtUtils::MakeMaker` (unlike Module::Build
+  or Dist::Zilla) does not auto-populate META's `provides`. Each `Makefile.PL`
+  now builds it via `Module::Metadata->provides`.
+- `has_security_doc` / `security_doc_contains_contact` / `has_contributing_doc`
+  — the repository's root `SECURITY.md`/`CONTRIBUTING.md` were never part of
+  the packaged CPAN tarballs (only files listed in each dist's `MANIFEST` are
+  shipped). Copied both into each Perl dist directory, same as the existing
+  `LICENSE` copies, and added them to `MANIFEST`.

--- a/packages/adapter-mojolicious/CONTRIBUTING.md
+++ b/packages/adapter-mojolicious/CONTRIBUTING.md
@@ -1,0 +1,158 @@
+# Contributing to BarefootJS
+
+Thanks for your interest in BarefootJS! This project has a deliberately
+unusual contribution model — please read this first.
+
+> [!WARNING]
+> **Alpha software.** APIs may change without notice. The contribution
+> process below may also evolve as the project matures.
+
+## Contribution policy: issues, not external PRs
+
+**We do not accept unsolicited pull requests from outside the core team.**
+
+This is a conscious decision, not unfriendliness. As a compiler that other
+people's apps build on, BarefootJS treats its supply chain seriously, and we
+want to keep the codebase free of unreviewed, machine-generated "AI slop."
+Accepting arbitrary external PRs works against both goals.
+
+Instead, **design discussions in issues are very welcome**, and they are how
+real change happens here:
+
+- Found a bug? **Open an issue.**
+- Want a feature, an API change, or a new adapter? **Open an issue** and let's
+  discuss the design first.
+- Have a fix in mind? Describe it in the issue — code snippets, a diff, a
+  reproduction, or a full patch in the issue body are all great.
+
+**Contributions made through issues are credited as co-authors on the
+resulting commits.** When a maintainer lands the change, your name goes in the
+`Co-authored-by:` trailers. You get credit; the project keeps a reviewed,
+trusted history.
+
+If you are a core maintainer (or have been explicitly invited to send a PR for
+a specific issue), the rest of this guide is for you.
+
+## Where to start
+
+- **Bug reports** → use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml).
+- **Feature / design proposals** → use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.yml).
+- **Known limitations** are tracked under the
+  [`known-limitation`](https://github.com/piconic-ai/barefootjs/labels/known-limitation)
+  label. Each issue documents the shape, affected fixtures, available
+  workaround, and fix direction — a good place to understand current edges.
+
+## Project overview
+
+BarefootJS compiles signal-based TSX into a marked template plus client JS for
+any backend, using a 2-phase pipeline: **JSX → IR → Marked Template + Client JS**.
+
+- `packages/jsx/` — Core compiler (`jsx-to-ir.ts`, `ir-to-client-js.ts`, `analyzer.ts`).
+- `packages/client/` — Client runtime (`createSignal`, `createEffect`, DOM runtime).
+- `packages/cli/` — The `bf` CLI.
+- Adapters — `packages/adapter-hono/`, `packages/adapter-go-template/`,
+  `packages/adapter-mojolicious/`, and others.
+
+See [`spec/compiler.md`](spec/compiler.md) for the full pipeline, IR schema,
+transformation rules, adapter interface, and error codes.
+
+## Development setup
+
+Requires **Node 22+** and [Bun](https://bun.sh) (this repo uses `bun`, not `npm`,
+for package management).
+
+```sh
+git clone https://github.com/piconic-ai/barefootjs.git
+cd barefootjs
+bun install
+bun run build
+```
+
+Useful scripts:
+
+| Command | What it does |
+|---------|--------------|
+| `bun run build` | Build all packages (ordered) |
+| `bun test` | Run the root test suite |
+| `bun run lint` | Lint / format check with Biome |
+| `bun run bf --help` | The `bf` CLI — component APIs, docs, signal graphs |
+| `bun run dev:all` | Run the site + example apps locally |
+
+The `bf` CLI is the fastest way to understand a component before touching it —
+`bf docs <component>` for the API surface, `bf debug graph <component>` for the
+reactive structure of a `"use client"` component.
+
+## Testing
+
+BarefootJS has layered tests; pick the layer that matches your change. Full
+details live in [`spec/testing.md`](spec/testing.md).
+
+| Layer | Verifies | Location |
+|-------|----------|----------|
+| Compiler unit | Transformation rules, error codes, analysis | `packages/jsx/src/__tests__/` |
+| Component IR | Structure, a11y, signals, classes, event wiring | `ui/components/ui/*/index.test.tsx` |
+| Adapter conformance | IR → HTML output per adapter | `packages/adapter-tests/fixtures/` |
+| CSR conformance | Client JS → correct DOM output | `packages/adapter-tests/src/__tests__/csr-conformance.test.ts` |
+| Runtime unit | Signals, DOM ops, hydration primitives | `packages/client/__tests__/` |
+| E2E | User interactions, hydration, visual | `site/ui/e2e/` |
+
+Quick guide:
+
+- **New UI component** → Component IR test using `renderToTest()`.
+- **Compiler internals** (analysis, error codes, codegen) → Compiler unit test.
+- **Template HTML output** → Adapter conformance fixture.
+- **Client JS behavior** → CSR conformance fixture.
+- **Click / keyboard behavior** → E2E test.
+
+Run the relevant suite before submitting, and `bun run lint` to keep formatting
+consistent.
+
+## Coding conventions
+
+A few rules the codebase enforces (see [`CLAUDE.md`](CLAUDE.md) for the full set):
+
+- **Never parse imports or any JS/TS syntax with regex or string matching.**
+  Use the established AST-based patterns — the IR's parsed metadata for source
+  files, a TS AST walk for compiled client JS. `typescript` is already a
+  direct dependency; do not add a second parser.
+- **Do not add compiler options/hooks for tool-specific output rewriting.**
+  Tools that need to adjust emitted client JS post-process it themselves.
+- The codebase is TypeScript. Adapters target a range of backends (Hono,
+  Go `html/template`, Mojolicious, and more), so keep core compiler and
+  runtime code adapter-agnostic. CSS uses UnoCSS.
+
+## Changesets
+
+This repo uses [Changesets](https://github.com/changesets/changesets) for
+versioning. If your change affects a published package, add a changeset:
+
+```sh
+bun changeset
+```
+
+Describe the change and pick the appropriate semver bump. Internal-only
+packages are ignored (see `.changeset/config.json`).
+
+## Commit conventions
+
+Every commit ends with `Co-authored-by:` trailers for **all** participants
+other than the git author — including issue contributors whose design or patch
+landed in the commit. Place them as the final lines of the message, with no
+blank line or trailing content after them, or GitHub will not recognize them:
+
+```
+Fix signal dependency tracking in nested effects
+
+Co-authored-by: Some Contributor <contributor@example.com>
+```
+
+## Code of Conduct & Security
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md). To
+report a security vulnerability, follow the [Security Policy](SECURITY.md) —
+**please do not open a public issue for security reports.**
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[MIT License](LICENSE) that covers the project.

--- a/packages/adapter-mojolicious/MANIFEST
+++ b/packages/adapter-mojolicious/MANIFEST
@@ -4,6 +4,8 @@ lib/BarefootJS/Backend/Mojo.pm
 lib/Mojolicious/Plugin/BarefootJS.pm
 lib/Mojolicious/Plugin/BarefootJS/DevReload.pm
 LICENSE
+CONTRIBUTING.md
+SECURITY.md
 MANIFEST
 Makefile.PL
 t/dev_reload.t

--- a/packages/adapter-mojolicious/Makefile.PL
+++ b/packages/adapter-mojolicious/Makefile.PL
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use ExtUtils::MakeMaker;
 use Module::CPANfile;
+use Module::Metadata;
 
 my $file    = Module::CPANfile->load;
 my $runtime = $file->prereqs->requirements_for('runtime', 'requires')->as_string_hash;
@@ -20,6 +21,7 @@ WriteMakefile(
     TEST_REQUIRES     => $test,
     META_MERGE       => {
         'meta-spec' => { version => 2 },
+        provides    => Module::Metadata->provides(version => 2, dir => 'lib'),
         resources   => {
             homepage   => 'https://barefootjs.dev',
             repository => {

--- a/packages/adapter-mojolicious/SECURITY.md
+++ b/packages/adapter-mojolicious/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported versions
+
+BarefootJS is in **early alpha** (`0.x`). APIs may change without notice, and
+only the latest published release receives security fixes. There are no
+long-term support branches at this stage.
+
+| Version | Supported |
+|---------|-----------|
+| Latest `0.x` release | ✅ |
+| Older `0.x` releases | ❌ |
+
+If you are running BarefootJS in production despite the alpha status, please
+stay on the most recent release so that fixes reach you.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Report privately using GitHub's
+[private vulnerability reporting](https://github.com/piconic-ai/barefootjs/security/advisories/new)
+(the **Report a vulnerability** button under the repository's **Security** tab).
+This opens a confidential channel visible only to you and the maintainers.
+
+Please include as much of the following as you can:
+
+- A description of the vulnerability and its impact.
+- The affected package(s) and version(s) (e.g. `@barefootjs/jsx`,
+  `@barefootjs/client`, the `bf` CLI, or an adapter).
+- Steps to reproduce, ideally a minimal reproduction or proof of concept.
+- Any known mitigations or workarounds.
+
+Because BarefootJS is a compiler that other projects build on, we take
+supply-chain and generated-output safety seriously. Reports about the compiler
+emitting unsafe client JS or templates, or about the build/release pipeline,
+are in scope and welcome.
+
+## What to expect
+
+- **Acknowledgement** — we aim to acknowledge a valid report within a few
+  business days.
+- **Assessment** — we will investigate, confirm the issue, and determine the
+  affected versions.
+- **Fix & disclosure** — we will prepare a fix and coordinate a release. With
+  your permission, we will credit you in the advisory and release notes.
+
+Please give us a reasonable opportunity to address the issue before any public
+disclosure. We appreciate responsible disclosure and the effort it takes to
+report security issues carefully.

--- a/packages/adapter-perl/CONTRIBUTING.md
+++ b/packages/adapter-perl/CONTRIBUTING.md
@@ -1,0 +1,158 @@
+# Contributing to BarefootJS
+
+Thanks for your interest in BarefootJS! This project has a deliberately
+unusual contribution model — please read this first.
+
+> [!WARNING]
+> **Alpha software.** APIs may change without notice. The contribution
+> process below may also evolve as the project matures.
+
+## Contribution policy: issues, not external PRs
+
+**We do not accept unsolicited pull requests from outside the core team.**
+
+This is a conscious decision, not unfriendliness. As a compiler that other
+people's apps build on, BarefootJS treats its supply chain seriously, and we
+want to keep the codebase free of unreviewed, machine-generated "AI slop."
+Accepting arbitrary external PRs works against both goals.
+
+Instead, **design discussions in issues are very welcome**, and they are how
+real change happens here:
+
+- Found a bug? **Open an issue.**
+- Want a feature, an API change, or a new adapter? **Open an issue** and let's
+  discuss the design first.
+- Have a fix in mind? Describe it in the issue — code snippets, a diff, a
+  reproduction, or a full patch in the issue body are all great.
+
+**Contributions made through issues are credited as co-authors on the
+resulting commits.** When a maintainer lands the change, your name goes in the
+`Co-authored-by:` trailers. You get credit; the project keeps a reviewed,
+trusted history.
+
+If you are a core maintainer (or have been explicitly invited to send a PR for
+a specific issue), the rest of this guide is for you.
+
+## Where to start
+
+- **Bug reports** → use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml).
+- **Feature / design proposals** → use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.yml).
+- **Known limitations** are tracked under the
+  [`known-limitation`](https://github.com/piconic-ai/barefootjs/labels/known-limitation)
+  label. Each issue documents the shape, affected fixtures, available
+  workaround, and fix direction — a good place to understand current edges.
+
+## Project overview
+
+BarefootJS compiles signal-based TSX into a marked template plus client JS for
+any backend, using a 2-phase pipeline: **JSX → IR → Marked Template + Client JS**.
+
+- `packages/jsx/` — Core compiler (`jsx-to-ir.ts`, `ir-to-client-js.ts`, `analyzer.ts`).
+- `packages/client/` — Client runtime (`createSignal`, `createEffect`, DOM runtime).
+- `packages/cli/` — The `bf` CLI.
+- Adapters — `packages/adapter-hono/`, `packages/adapter-go-template/`,
+  `packages/adapter-mojolicious/`, and others.
+
+See [`spec/compiler.md`](spec/compiler.md) for the full pipeline, IR schema,
+transformation rules, adapter interface, and error codes.
+
+## Development setup
+
+Requires **Node 22+** and [Bun](https://bun.sh) (this repo uses `bun`, not `npm`,
+for package management).
+
+```sh
+git clone https://github.com/piconic-ai/barefootjs.git
+cd barefootjs
+bun install
+bun run build
+```
+
+Useful scripts:
+
+| Command | What it does |
+|---------|--------------|
+| `bun run build` | Build all packages (ordered) |
+| `bun test` | Run the root test suite |
+| `bun run lint` | Lint / format check with Biome |
+| `bun run bf --help` | The `bf` CLI — component APIs, docs, signal graphs |
+| `bun run dev:all` | Run the site + example apps locally |
+
+The `bf` CLI is the fastest way to understand a component before touching it —
+`bf docs <component>` for the API surface, `bf debug graph <component>` for the
+reactive structure of a `"use client"` component.
+
+## Testing
+
+BarefootJS has layered tests; pick the layer that matches your change. Full
+details live in [`spec/testing.md`](spec/testing.md).
+
+| Layer | Verifies | Location |
+|-------|----------|----------|
+| Compiler unit | Transformation rules, error codes, analysis | `packages/jsx/src/__tests__/` |
+| Component IR | Structure, a11y, signals, classes, event wiring | `ui/components/ui/*/index.test.tsx` |
+| Adapter conformance | IR → HTML output per adapter | `packages/adapter-tests/fixtures/` |
+| CSR conformance | Client JS → correct DOM output | `packages/adapter-tests/src/__tests__/csr-conformance.test.ts` |
+| Runtime unit | Signals, DOM ops, hydration primitives | `packages/client/__tests__/` |
+| E2E | User interactions, hydration, visual | `site/ui/e2e/` |
+
+Quick guide:
+
+- **New UI component** → Component IR test using `renderToTest()`.
+- **Compiler internals** (analysis, error codes, codegen) → Compiler unit test.
+- **Template HTML output** → Adapter conformance fixture.
+- **Client JS behavior** → CSR conformance fixture.
+- **Click / keyboard behavior** → E2E test.
+
+Run the relevant suite before submitting, and `bun run lint` to keep formatting
+consistent.
+
+## Coding conventions
+
+A few rules the codebase enforces (see [`CLAUDE.md`](CLAUDE.md) for the full set):
+
+- **Never parse imports or any JS/TS syntax with regex or string matching.**
+  Use the established AST-based patterns — the IR's parsed metadata for source
+  files, a TS AST walk for compiled client JS. `typescript` is already a
+  direct dependency; do not add a second parser.
+- **Do not add compiler options/hooks for tool-specific output rewriting.**
+  Tools that need to adjust emitted client JS post-process it themselves.
+- The codebase is TypeScript. Adapters target a range of backends (Hono,
+  Go `html/template`, Mojolicious, and more), so keep core compiler and
+  runtime code adapter-agnostic. CSS uses UnoCSS.
+
+## Changesets
+
+This repo uses [Changesets](https://github.com/changesets/changesets) for
+versioning. If your change affects a published package, add a changeset:
+
+```sh
+bun changeset
+```
+
+Describe the change and pick the appropriate semver bump. Internal-only
+packages are ignored (see `.changeset/config.json`).
+
+## Commit conventions
+
+Every commit ends with `Co-authored-by:` trailers for **all** participants
+other than the git author — including issue contributors whose design or patch
+landed in the commit. Place them as the final lines of the message, with no
+blank line or trailing content after them, or GitHub will not recognize them:
+
+```
+Fix signal dependency tracking in nested effects
+
+Co-authored-by: Some Contributor <contributor@example.com>
+```
+
+## Code of Conduct & Security
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md). To
+report a security vulnerability, follow the [Security Policy](SECURITY.md) —
+**please do not open a public issue for security reports.**
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[MIT License](LICENSE) that covers the project.

--- a/packages/adapter-perl/MANIFEST
+++ b/packages/adapter-perl/MANIFEST
@@ -5,6 +5,8 @@ lib/BarefootJS/DevReload.pm
 lib/BarefootJS/Evaluator.pm
 lib/BarefootJS/SearchParams.pm
 LICENSE
+CONTRIBUTING.md
+SECURITY.md
 MANIFEST
 Makefile.PL
 README.md

--- a/packages/adapter-perl/Makefile.PL
+++ b/packages/adapter-perl/Makefile.PL
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use ExtUtils::MakeMaker;
 use Module::CPANfile;
+use Module::Metadata;
 
 my $file    = Module::CPANfile->load;
 my $runtime = $file->prereqs->requirements_for('runtime', 'requires')->as_string_hash;
@@ -20,6 +21,7 @@ WriteMakefile(
     TEST_REQUIRES     => $test,
     META_MERGE       => {
         'meta-spec' => { version => 2 },
+        provides    => Module::Metadata->provides(version => 2, dir => 'lib'),
         resources   => {
             homepage   => 'https://barefootjs.dev',
             repository => {

--- a/packages/adapter-perl/SECURITY.md
+++ b/packages/adapter-perl/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported versions
+
+BarefootJS is in **early alpha** (`0.x`). APIs may change without notice, and
+only the latest published release receives security fixes. There are no
+long-term support branches at this stage.
+
+| Version | Supported |
+|---------|-----------|
+| Latest `0.x` release | ✅ |
+| Older `0.x` releases | ❌ |
+
+If you are running BarefootJS in production despite the alpha status, please
+stay on the most recent release so that fixes reach you.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Report privately using GitHub's
+[private vulnerability reporting](https://github.com/piconic-ai/barefootjs/security/advisories/new)
+(the **Report a vulnerability** button under the repository's **Security** tab).
+This opens a confidential channel visible only to you and the maintainers.
+
+Please include as much of the following as you can:
+
+- A description of the vulnerability and its impact.
+- The affected package(s) and version(s) (e.g. `@barefootjs/jsx`,
+  `@barefootjs/client`, the `bf` CLI, or an adapter).
+- Steps to reproduce, ideally a minimal reproduction or proof of concept.
+- Any known mitigations or workarounds.
+
+Because BarefootJS is a compiler that other projects build on, we take
+supply-chain and generated-output safety seriously. Reports about the compiler
+emitting unsafe client JS or templates, or about the build/release pipeline,
+are in scope and welcome.
+
+## What to expect
+
+- **Acknowledgement** — we aim to acknowledge a valid report within a few
+  business days.
+- **Assessment** — we will investigate, confirm the issue, and determine the
+  affected versions.
+- **Fix & disclosure** — we will prepare a fix and coordinate a release. With
+  your permission, we will credit you in the advisory and release notes.
+
+Please give us a reasonable opportunity to address the issue before any public
+disclosure. We appreciate responsible disclosure and the effort it takes to
+report security issues carefully.

--- a/packages/adapter-perl/lib/BarefootJS/DevReload.pm
+++ b/packages/adapter-perl/lib/BarefootJS/DevReload.pm
@@ -7,6 +7,8 @@ no warnings 'experimental::signatures';
 
 use File::Spec;
 
+=encoding utf8
+
 =head1 NAME
 
 BarefootJS::DevReload - Framework-agnostic dev-only browser auto-reload for BarefootJS apps

--- a/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
+++ b/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
@@ -1,5 +1,5 @@
 package BarefootJS::Evaluator;
-our $VERSION = "0.14.0";
+our $VERSION = "0.29.0";
 use strict;
 use warnings;
 use utf8;

--- a/packages/adapter-perl/lib/BarefootJS/SearchParams.pm
+++ b/packages/adapter-perl/lib/BarefootJS/SearchParams.pm
@@ -1,5 +1,5 @@
 package BarefootJS::SearchParams;
-our $VERSION = "0.14.0";
+our $VERSION = "0.29.0";
 use strict;
 use warnings;
 use utf8;

--- a/packages/adapter-xslate/CONTRIBUTING.md
+++ b/packages/adapter-xslate/CONTRIBUTING.md
@@ -1,0 +1,158 @@
+# Contributing to BarefootJS
+
+Thanks for your interest in BarefootJS! This project has a deliberately
+unusual contribution model — please read this first.
+
+> [!WARNING]
+> **Alpha software.** APIs may change without notice. The contribution
+> process below may also evolve as the project matures.
+
+## Contribution policy: issues, not external PRs
+
+**We do not accept unsolicited pull requests from outside the core team.**
+
+This is a conscious decision, not unfriendliness. As a compiler that other
+people's apps build on, BarefootJS treats its supply chain seriously, and we
+want to keep the codebase free of unreviewed, machine-generated "AI slop."
+Accepting arbitrary external PRs works against both goals.
+
+Instead, **design discussions in issues are very welcome**, and they are how
+real change happens here:
+
+- Found a bug? **Open an issue.**
+- Want a feature, an API change, or a new adapter? **Open an issue** and let's
+  discuss the design first.
+- Have a fix in mind? Describe it in the issue — code snippets, a diff, a
+  reproduction, or a full patch in the issue body are all great.
+
+**Contributions made through issues are credited as co-authors on the
+resulting commits.** When a maintainer lands the change, your name goes in the
+`Co-authored-by:` trailers. You get credit; the project keeps a reviewed,
+trusted history.
+
+If you are a core maintainer (or have been explicitly invited to send a PR for
+a specific issue), the rest of this guide is for you.
+
+## Where to start
+
+- **Bug reports** → use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml).
+- **Feature / design proposals** → use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.yml).
+- **Known limitations** are tracked under the
+  [`known-limitation`](https://github.com/piconic-ai/barefootjs/labels/known-limitation)
+  label. Each issue documents the shape, affected fixtures, available
+  workaround, and fix direction — a good place to understand current edges.
+
+## Project overview
+
+BarefootJS compiles signal-based TSX into a marked template plus client JS for
+any backend, using a 2-phase pipeline: **JSX → IR → Marked Template + Client JS**.
+
+- `packages/jsx/` — Core compiler (`jsx-to-ir.ts`, `ir-to-client-js.ts`, `analyzer.ts`).
+- `packages/client/` — Client runtime (`createSignal`, `createEffect`, DOM runtime).
+- `packages/cli/` — The `bf` CLI.
+- Adapters — `packages/adapter-hono/`, `packages/adapter-go-template/`,
+  `packages/adapter-mojolicious/`, and others.
+
+See [`spec/compiler.md`](spec/compiler.md) for the full pipeline, IR schema,
+transformation rules, adapter interface, and error codes.
+
+## Development setup
+
+Requires **Node 22+** and [Bun](https://bun.sh) (this repo uses `bun`, not `npm`,
+for package management).
+
+```sh
+git clone https://github.com/piconic-ai/barefootjs.git
+cd barefootjs
+bun install
+bun run build
+```
+
+Useful scripts:
+
+| Command | What it does |
+|---------|--------------|
+| `bun run build` | Build all packages (ordered) |
+| `bun test` | Run the root test suite |
+| `bun run lint` | Lint / format check with Biome |
+| `bun run bf --help` | The `bf` CLI — component APIs, docs, signal graphs |
+| `bun run dev:all` | Run the site + example apps locally |
+
+The `bf` CLI is the fastest way to understand a component before touching it —
+`bf docs <component>` for the API surface, `bf debug graph <component>` for the
+reactive structure of a `"use client"` component.
+
+## Testing
+
+BarefootJS has layered tests; pick the layer that matches your change. Full
+details live in [`spec/testing.md`](spec/testing.md).
+
+| Layer | Verifies | Location |
+|-------|----------|----------|
+| Compiler unit | Transformation rules, error codes, analysis | `packages/jsx/src/__tests__/` |
+| Component IR | Structure, a11y, signals, classes, event wiring | `ui/components/ui/*/index.test.tsx` |
+| Adapter conformance | IR → HTML output per adapter | `packages/adapter-tests/fixtures/` |
+| CSR conformance | Client JS → correct DOM output | `packages/adapter-tests/src/__tests__/csr-conformance.test.ts` |
+| Runtime unit | Signals, DOM ops, hydration primitives | `packages/client/__tests__/` |
+| E2E | User interactions, hydration, visual | `site/ui/e2e/` |
+
+Quick guide:
+
+- **New UI component** → Component IR test using `renderToTest()`.
+- **Compiler internals** (analysis, error codes, codegen) → Compiler unit test.
+- **Template HTML output** → Adapter conformance fixture.
+- **Client JS behavior** → CSR conformance fixture.
+- **Click / keyboard behavior** → E2E test.
+
+Run the relevant suite before submitting, and `bun run lint` to keep formatting
+consistent.
+
+## Coding conventions
+
+A few rules the codebase enforces (see [`CLAUDE.md`](CLAUDE.md) for the full set):
+
+- **Never parse imports or any JS/TS syntax with regex or string matching.**
+  Use the established AST-based patterns — the IR's parsed metadata for source
+  files, a TS AST walk for compiled client JS. `typescript` is already a
+  direct dependency; do not add a second parser.
+- **Do not add compiler options/hooks for tool-specific output rewriting.**
+  Tools that need to adjust emitted client JS post-process it themselves.
+- The codebase is TypeScript. Adapters target a range of backends (Hono,
+  Go `html/template`, Mojolicious, and more), so keep core compiler and
+  runtime code adapter-agnostic. CSS uses UnoCSS.
+
+## Changesets
+
+This repo uses [Changesets](https://github.com/changesets/changesets) for
+versioning. If your change affects a published package, add a changeset:
+
+```sh
+bun changeset
+```
+
+Describe the change and pick the appropriate semver bump. Internal-only
+packages are ignored (see `.changeset/config.json`).
+
+## Commit conventions
+
+Every commit ends with `Co-authored-by:` trailers for **all** participants
+other than the git author — including issue contributors whose design or patch
+landed in the commit. Place them as the final lines of the message, with no
+blank line or trailing content after them, or GitHub will not recognize them:
+
+```
+Fix signal dependency tracking in nested effects
+
+Co-authored-by: Some Contributor <contributor@example.com>
+```
+
+## Code of Conduct & Security
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md). To
+report a security vulnerability, follow the [Security Policy](SECURITY.md) —
+**please do not open a public issue for security reports.**
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[MIT License](LICENSE) that covers the project.

--- a/packages/adapter-xslate/MANIFEST
+++ b/packages/adapter-xslate/MANIFEST
@@ -2,6 +2,8 @@ Changes
 cpanfile
 lib/BarefootJS/Backend/Xslate.pm
 LICENSE
+CONTRIBUTING.md
+SECURITY.md
 MANIFEST
 Makefile.PL
 t/render.t

--- a/packages/adapter-xslate/Makefile.PL
+++ b/packages/adapter-xslate/Makefile.PL
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use ExtUtils::MakeMaker;
 use Module::CPANfile;
+use Module::Metadata;
 
 my $file    = Module::CPANfile->load;
 my $runtime = $file->prereqs->requirements_for('runtime', 'requires')->as_string_hash;
@@ -20,6 +21,7 @@ WriteMakefile(
     TEST_REQUIRES     => $test,
     META_MERGE       => {
         'meta-spec' => { version => 2 },
+        provides    => Module::Metadata->provides(version => 2, dir => 'lib'),
         resources   => {
             homepage   => 'https://barefootjs.dev',
             repository => {

--- a/packages/adapter-xslate/SECURITY.md
+++ b/packages/adapter-xslate/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported versions
+
+BarefootJS is in **early alpha** (`0.x`). APIs may change without notice, and
+only the latest published release receives security fixes. There are no
+long-term support branches at this stage.
+
+| Version | Supported |
+|---------|-----------|
+| Latest `0.x` release | ✅ |
+| Older `0.x` releases | ❌ |
+
+If you are running BarefootJS in production despite the alpha status, please
+stay on the most recent release so that fixes reach you.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Report privately using GitHub's
+[private vulnerability reporting](https://github.com/piconic-ai/barefootjs/security/advisories/new)
+(the **Report a vulnerability** button under the repository's **Security** tab).
+This opens a confidential channel visible only to you and the maintainers.
+
+Please include as much of the following as you can:
+
+- A description of the vulnerability and its impact.
+- The affected package(s) and version(s) (e.g. `@barefootjs/jsx`,
+  `@barefootjs/client`, the `bf` CLI, or an adapter).
+- Steps to reproduce, ideally a minimal reproduction or proof of concept.
+- Any known mitigations or workarounds.
+
+Because BarefootJS is a compiler that other projects build on, we take
+supply-chain and generated-output safety seriously. Reports about the compiler
+emitting unsafe client JS or templates, or about the build/release pipeline,
+are in scope and welcome.
+
+## What to expect
+
+- **Acknowledgement** — we aim to acknowledge a valid report within a few
+  business days.
+- **Assessment** — we will investigate, confirm the issue, and determine the
+  affected versions.
+- **Fix & disclosure** — we will prepare a fix and coordinate a release. With
+  your permission, we will credit you in the advisory and release notes.
+
+Please give us a reasonable opportunity to address the issue before any public
+disclosure. We appreciate responsible disclosure and the effort it takes to
+report security issues carefully.

--- a/scripts/sync-perl-versions.ts
+++ b/scripts/sync-perl-versions.ts
@@ -34,6 +34,8 @@ const PACKAGES: PerlPackage[] = [
     modules: [
       'lib/BarefootJS.pm',
       'lib/BarefootJS/DevReload.pm',
+      'lib/BarefootJS/Evaluator.pm',
+      'lib/BarefootJS/SearchParams.pm',
     ],
   },
   {


### PR DESCRIPTION
## Summary

Fixes the Kwalitee issues flagged at [cpants.cpanauthors.org for BarefootJS-0.28.1](https://cpants.cpanauthors.org/release/KFLY/BarefootJS-0.28.1):

- **`no_pod_errors`** — `BarefootJS::DevReload`'s POD used an em dash (`—`) before declaring `=encoding utf8`, which `Test::Pod`/CPANTS parse as a raw non-ASCII byte in POD (`Non-ASCII character seen before =encoding in 'â'`). Added the missing `=encoding utf8` (line 33 matched the report exactly). Verified the other Perl dists' POD-bearing modules already declare `=encoding utf8` where needed.
- **`consistent_version`** — `BarefootJS::Evaluator` and `BarefootJS::SearchParams` were stuck at `0.14.0` (report showed `0.014000,0.028001`) while the rest of the distribution had moved to `0.29.0`. Root cause: `scripts/sync-perl-versions.ts` — the release-time version sync script — only listed `BarefootJS.pm` and `DevReload.pm` for the `packages/adapter-perl` dist, so releases never bumped those two modules' `$VERSION`. Bumped both to `0.29.0` and added them to the sync script's module list so future releases keep them in lockstep.
- **`meta_yml_has_provides`** — plain `ExtUtils::MakeMaker` (unlike `Module::Build`/`Dist::Zilla::Plugin::MetaProvides`) does not auto-populate META's `provides` field. Each `Makefile.PL` now builds it via `Module::Metadata->provides(version => 2, dir => 'lib')` in `META_MERGE`.
- **`has_security_doc`** / **`security_doc_contains_contact`** / **`has_contributing_doc`** — the repo's root `SECURITY.md`/`CONTRIBUTING.md` were never part of the packaged CPAN tarballs, since `make dist` only ships files listed in each dist's `MANIFEST`. Copied both into each Perl dist directory (same pattern already used for `LICENSE`) and added them to `MANIFEST`.

Applied the `provides`/doc-file fixes to all three Perl CPAN dists (`adapter-perl`, `adapter-mojolicious`, `adapter-xslate`) for consistency, since they share the same `Makefile.PL`/`MANIFEST` structure and would otherwise fail the same Kwalitee checks on their own CPANTS pages. The POD-encoding and version-sync fixes are specific to `adapter-perl`, where the actual bugs were.

## Test plan

- [x] `perl Makefile.PL && make test` passes for all three dists (`adapter-perl`: 599 tests, `adapter-mojolicious`: 20 tests, `adapter-xslate`: 9 tests)
- [x] `make dist` tarball for each dist verified to contain `SECURITY.md`/`CONTRIBUTING.md` and a populated `provides` map in both `META.json` and `META.yml`
- [x] `Test::Pod` (installed locally) passes on `BarefootJS::DevReload` from the built tarball
- [x] Added a changeset (`.changeset/perl-cpants-kwalitee.md`) covering `@barefootjs/perl`, `@barefootjs/mojolicious`, `@barefootjs/xslate`


---
_Generated by [Claude Code](https://claude.ai/code/session_019mRHVFuzePi1iw7tNackc8)_