### PR TITLE
Emit the child's own Go field name for a per-row prop override (#2457)

### DIFF
--- a/.changeset/go-alias-prop-field-name.md
+++ b/.changeset/go-alias-prop-field-name.md
@@ -1,0 +1,71 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix a per-row prop override silently dropped for an aliased destructured child prop (#2457)
+
+A child nested inside a COMPOSITE dynamic loop row (`<li><Badge .../></li>`)
+whose props use an ALIASED destructure had its per-row override discarded
+with no diagnostic:
+
+```tsx
+function Badge({ text, n: count }: { text: string; n: number }) {
+  return <span class="badge">{text}:{count}</span>
+}
+// <li key={row.id}><Badge text={row.label} n={row.n} /></li>
+```
+
+`generateInputStruct` / `emitPropsDataFields` name a child's Go field from
+its LOCAL binding — `n: count` becomes the struct field `Count`, not `N`.
+`loopRowChildPropOverrides` (the per-row override emitter) capitalized the
+JSX attribute name instead:
+
+```gotemplate
+{{template "Badge" (bf_with_props $.BadgeSlot0 "Text" .Label "N" .N)}}
+```
+
+`bf.WithProps` documents an unknown-field pair as a deliberate passthrough
+(`bf_with_props` patches named fields on an already-constructed instance),
+so `"N" .N` was silently dropped and `Count` kept the shared instance's
+constructor-time value (row 0's `n`) on every row.
+
+The fix resolves the child's own Go field name ONCE, at the parent's
+emission site — the only place that has both the JSX attribute name and the
+child's shape — instead of leaving the mismatch for the runtime helper to
+paper over:
+
+```gotemplate
+{{template "Badge" (bf_with_props $.BadgeSlot0 "Text" .Label "Count" .N)}}
+```
+
+A new `childPropFieldNames` map (JSX attribute name → child's own Go field
+name) is populated from the same two doors `childDerivedFieldDeps` already
+uses — `registerChildComponentShape` (the CLI's cross-file pre-pass) and
+`generate()`'s self-registration — so a same-file loop-row child (the only
+kind this bug reaches) always has an entry by the time
+`loopRowChildPropOverrides` looks.
+
+This also simplifies the `#2448` props-rebuilder (`bf_reprops`): its
+generated `switch` used to be keyed by the PARENT's name on the case label
+and the CHILD's field on the assignment target, reconciling the two sides
+right there. Now that the parent already emits the child's own field name,
+the switch is keyed by that one name on both sides — one place to get the
+naming right instead of two.
+
+For an un-aliased prop the JSX attribute name and the child's field name are
+the same string, so `childPropFieldNames` is an identity map and every
+currently-passing fixture's emitted template stays byte-identical.
+
+Verified end-to-end against the real Go runtime (`renderGoTemplateComponent`)
+for both an aliased child with no derived field and one with a `createMemo`
+depending on the aliased prop (the `#2448` rebuild path) — both now show the
+correct value on every row.
+
+No conformance fixture yet, and the reason is worth recording: building one
+surfaced the mirror-image bug in the REFERENCE adapter. Hono emits an aliased
+destructure as `{ text, count }` — the local binding used as the property key —
+against a props type that has `n`, so any aliased destructured prop reads as
+`undefined` there, independent of loops, `'use client'`, or this bug. Fixtures
+generate their `expectedHtml` from Hono, so a fixture for this shape would bake
+in the wrong reference value and measure every other adapter against it. Filed
+as #2460; the fixture lands with that fix.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4600,12 +4600,13 @@ export function SignalRowChildDerivedProp(props: { rows: Row[] }) {
     expect(template).toContain('(bf_reprops "Badge" $.BadgeSlot0 "Text" .Label "N" .N)')
   })
 
-  // An ALIASED destructure (`{ n: count }`) is where the two naming sides
-  // diverge: the memo reads `count` and the child's Go field is `Count`, but
-  // the parent only knows the JSX attribute `n` → `"N"`. `bf_with_props` would
-  // silently no-op that pair (its unknown-field passthrough). The rebuilder's
-  // generated switch is where the two sides are reconciled, so the case label
-  // is the PARENT's name and the assignment target is the CHILD's field.
+  // An ALIASED destructure (`{ n: count }`) is where the JSX attribute name
+  // (`n` → `"N"`) and the child's own Go field (`Count`) diverge. #2457: the
+  // reconciliation now happens ONCE, at the PARENT's emission site
+  // (`loopRowChildPropOverrides`, via `childPropFieldNames`) — the parent
+  // emits the child's own field name directly, so the rebuilder's switch
+  // (`recordRepropsSpec` / `emitRepropsRegistration`) needs no separate
+  // "wire" name and is keyed uniformly by that one field on both sides.
   test('an aliased destructured prop maps the parent name onto the child field', () => {
     const result = compileJSX(`
 'use client'
@@ -4630,13 +4631,54 @@ export function AliasedRowChildDerivedProp(props: { rows: Row[] }) {
 `.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
     expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(0)
     const template = result.files.find(f => f.type === 'markedTemplate')!.content
-    expect(template).toContain('(bf_reprops "Badge" $.BadgeSlot0 "Text" .Label "N" .N)')
+    // The parent now writes the child's OWN field name ("Count"), not the
+    // JSX attribute ("N").
+    expect(template).toContain('(bf_reprops "Badge" $.BadgeSlot0 "Text" .Label "Count" .N)')
     const types = result.files.find(f => f.type === 'types')!.content
-    expect(types).toContain('case "N":')
+    expect(types).toContain('case "Count":')
     expect(types).toContain('&in.Count,')
-    // The child's own field is `Count`; `"Count"` is never a case label,
-    // because the parent never writes that name.
-    expect(types).not.toContain('case "Count":')
+    // "N" — the JSX attribute name — is never a case label: the switch is
+    // keyed by the child's field on both sides, and the parent already
+    // resolved the name before emitting the call.
+    expect(types).not.toContain('case "N":')
+  })
+
+  // #2457: the SAME aliased destructure, but with NO derived field — the
+  // shape `bf_with_props` mishandled even before #2448's rebuilder existed.
+  // `bf.WithProps` documents an unknown-field pair as a silent passthrough,
+  // so emitting the JSX attribute name ("N") against a child whose field is
+  // "Count" used to drop the override with no diagnostic on every row. No
+  // rebuilder is needed here — resolving the field name at the parent's
+  // emission site is enough on its own.
+  test('an aliased destructured prop with no derived field still lands on the child field', () => {
+    const result = compileJSX(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string; n: number }
+function Badge({ text, n: count }: { text: string; n: number }) {
+  return <span class="badge">{text}:{count}</span>
+}
+export function AliasedRowChildNoDerivedProp(props: { rows: Row[] }) {
+  const [rows] = createSignal<Row[]>(props.rows)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={row.label} n={row.n} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(0)
+    const template = result.files.find(f => f.type === 'markedTemplate')!.content
+    // Still bf_with_props (no derived field, so no rebuilder needed) — but
+    // the pair now names a field the child actually has.
+    expect(template).toContain('(bf_with_props $.BadgeSlot0 "Text" .Label "Count" .N)')
+    expect(template).not.toContain('bf_reprops')
+    const types = result.files.find(f => f.type === 'types')!.content
+    expect(types).not.toContain('RegisterReprops')
   })
 
   // Sound-or-loud fallback: a shape whose Input can NOT be reconstructed from

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4681,6 +4681,41 @@ export function AliasedRowChildNoDerivedProp(props: { rows: Row[] }) {
     expect(types).not.toContain('RegisterReprops')
   })
 
+  // Copilot review on #2462: `ChildComponentShape.paramNames` is looked up by
+  // the PARENT against the name it wrote at the JSX call site, so it has to be
+  // keyed the same way `childPropFieldNames` is. Keyed by the local binding,
+  // an aliased prop on a child that ALSO has a rest bag looked undeclared —
+  // `loopRowChildPropOverrides`' rest-bag guard skipped it outright, so the
+  // override never reached the template at all. Same wrong-name-at-a-
+  // parent-side-lookup bug as #2457, one guard earlier.
+  test('an aliased prop on a rest-bag child is not mistaken for a rest-bag prop', () => {
+    const result = compileJSX(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string; n: number }
+function Badge({ text, n: count, ...rest }: { text: string; n: number; [k: string]: unknown }) {
+  return <span class="badge" {...rest}>{text}:{count}</span>
+}
+export function AliasedRestBagRowChild(props: { rows: Row[] }) {
+  const [rows] = createSignal<Row[]>(props.rows)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={row.label} n={row.n} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(0)
+    const template = result.files.find(f => f.type === 'markedTemplate')!.content
+    // `n` is a DECLARED prop, so it rides the override under the child's own
+    // field name — not silently routed into the rest bag and not dropped.
+    expect(template).toContain('(bf_with_props $.BadgeSlot0 "Text" .Label "Count" .N)')
+  })
+
   // Sound-or-loud fallback: a shape whose Input can NOT be reconstructed from
   // Props gets no rebuilder, and the refusal has to stay. A `...rest` bag adds
   // an Input field with no Props counterpart, so it is declined — and because

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -803,7 +803,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   registerChildComponentShape(ir: Pick<ComponentIR, 'metadata'>): void {
     const name = ir.metadata.componentName
     if (!name) return
-    const paramNames = new Set((ir.metadata.propsParams ?? []).map(p => p.name))
+    // Both sets on `ChildComponentShape` are looked up by a PARENT against the
+    // name it wrote at the JSX call site, so they are keyed by
+    // `sourceName ?? name` — identity for an un-aliased param, the original
+    // property name for an aliased destructure (`{ n: count }` → `n`). Keying
+    // them by the local binding meant an aliased prop looked undeclared to
+    // `emitChildField` (misrouted into the rest bag) and to
+    // `loopRowChildPropOverrides` (skipped as rest-bag-only) — the same
+    // wrong-name-at-a-parent-side-lookup bug as #2457, one function over.
+    const paramNames = new Set((ir.metadata.propsParams ?? []).map(p => p.sourceName ?? p.name))
     const restPropsName = ir.metadata.restPropsName ?? null
     const restBagField = restPropsName ? capitalizeFieldName(restPropsName) : null
     // Optional object/named-interface params lower to `map[string]interface{}`
@@ -817,10 +825,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
             (p.type.kind === 'object' ||
               (p.type.kind === 'interface' && !!p.type.raw)),
         )
-        .map(p => p.name),
+        .map(p => p.sourceName ?? p.name),
     )
     this.childComponentShapes.set(name, { paramNames, restBagField, mapTypedParamNames })
-    this.recordDerivedFieldDeps(ir, paramNames)
+    // NOT `paramNames`: `recordDerivedFieldDeps` forwards this set to
+    // `collectPropsReadByCtorInit`, which in destructured mode matches BARE
+    // IDENTIFIERS in the memo/signal body — those are the LOCAL bindings
+    // (`count`), not the call-site names. Handing it the canonical set would
+    // make an aliased child's derived field look dependency-free and silently
+    // un-refuse / un-rebuild it.
+    this.recordDerivedFieldDeps(ir, new Set((ir.metadata.propsParams ?? []).map(p => p.name)))
     // Contexts this child consumes, so a parent `<Ctx.Provider value>` wrapping
     // it can set the matching field on the child's slot input.
     this.childContextConsumers.set(name, collectContextConsumers(ir.metadata))
@@ -1852,7 +1866,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // A hyphenated attr (`aria-label`) can't be a Go field and, with no rest
         // bag to route it into, has nowhere to go — skip over emitting invalid Go.
         if (jsxName.includes('-')) return
-        lines.push(`\t\t\t${capitalizeFieldName(jsxName)}: ${goValue},`)
+        // Same resolution as `loopRowChildPropOverrides` (#2457): the child's
+        // own Go field, which differs from the JSX attribute under an aliased
+        // destructure (`{ n: count }` → field `Count`). Emitting the attribute
+        // name here put an unknown field in a Go struct literal — a build
+        // error rather than a silent drop, but wrong either way. Falls back to
+        // the capitalized attribute for a child this run never registered.
+        const fieldName =
+          this.childPropFieldNames.get(child.name)?.get(jsxName) ?? capitalizeFieldName(jsxName)
+        lines.push(`\t\t\t${fieldName}: ${goValue},`)
       }
       for (const prop of child.props) {
         switch (prop.value.kind) {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -158,13 +158,17 @@ type HigherOrderShape = {
 /**
  * Everything needed to emit a component's #2448 props rebuilder, captured when
  * its own types are generated so a PARENT can emit the registration into its
- * own type block (`emitPendingReprops`). `wire` is the field name the parent
- * computes from the JSX attribute; `field` is this component's own Input
- * field. They differ under an aliased destructure (`{ n: count }` → `"N"` vs
- * `Count`).
+ * own type block (`emitOwnedReprops`). `params` are this component's own
+ * Input fields — since #2457, the PARENT (`loopRowChildPropOverrides`, via
+ * `childPropFieldNames`) already resolves the JSX attribute name to the
+ * child's own field name before emitting the call, so the switch this spec
+ * drives is keyed by that one name on both sides; there is no longer a
+ * separate "wire" name to carry (an aliased destructure used to make the
+ * parent's JSX-attribute name and the child's field name differ — `"N"` vs
+ * `Count` — and this spec used to carry both).
  */
 type RepropsSpec = {
-  params: { field: string; wire: string }[]
+  params: string[]
   usesSearchParams: boolean
 }
 
@@ -659,6 +663,39 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private childDerivedFieldDeps: Map<string, Map<string, ReadonlySet<string>>> = new Map()
 
   /**
+   * component name -> (the prop name as WRITTEN AT THE JSX CALL SITE -> that
+   * component's own Go field name). #2457.
+   *
+   * `generateInputStruct` / `emitPropsDataFields` name a child's Go field from
+   * its LOCAL binding (`capitalizeFieldName(param.name)`), but a parent
+   * emitting a per-row override
+   * (`loopRowChildPropOverrides`) only knows the JSX attribute it wrote. For
+   * an un-aliased prop those are the same string, so this map is an identity
+   * for every existing shape and every currently-passing fixture stays
+   * byte-identical. For an ALIASED destructure (`{ n: count }`) they differ
+   * (`"N"` vs `Count`) — `bf.WithProps` documents unknown-field pairs as a
+   * silent passthrough, so emitting the JSX name against a struct that has no
+   * such field drops the override with no diagnostic. Resolving through this
+   * map once, at the parent's emission site (the only place that has both
+   * the JSX name and the child's shape), replaces that silent drop with the
+   * correct field.
+   *
+   * Key = `p.sourceName ?? p.name` (identity for an un-aliased param, the JSX
+   * attribute name for an aliased one). Value = `capitalizeFieldName(p.name)`
+   * — the child's own field, from its LOCAL binding, same as
+   * `generateInputStruct` uses.
+   *
+   * Populated from the same two doors as `childDerivedFieldDeps` — inside
+   * `recordDerivedFieldDeps`, unconditionally (before that method's own
+   * `deps.size > 0` gate), so every component gets an entry here regardless
+   * of whether it has a derived field. `recordRepropsSpec` (the other nearby
+   * populator) returns early for components with no derived field or an
+   * ineligible shape — this map must NOT inherit either gate, since an
+   * aliased child with no derived field at all is exactly the #2457 shape.
+   */
+  private childPropFieldNames: Map<string, Map<string, string>> = new Map()
+
+  /**
    * Components a `bf.RegisterReprops` rebuilder CAN be emitted for
    * (`recordRepropsSpec`, #2448), with everything needed to emit it. A parent
    * overriding a prop that feeds one of the child's derived fields emits
@@ -709,15 +746,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * (`ParamInfo.sourceName ?? name`), not the child's local binding. An
    * ALIASED destructure (`function Badge({ n: count }: { n: number })`) reads
    * `count` in the memo body, but the only name the parent knows is the JSX
-   * attribute `n` — `loopRowChildPropOverrides` capitalizes THAT. Keying on
-   * the local name would file the dependency under `Count`, the lookup would
-   * miss, and the refusal would silently not fire on exactly the shape it
-   * exists for.
+   * attribute `n` — `loopRowChildPropOverrides` looks THAT up in
+   * `childPropFieldNames` before checking this map. Keying on the local name
+   * would file the dependency under `Count`, the lookup would miss, and the
+   * refusal would silently not fire on exactly the shape it exists for.
    *
-   * Note this canonicalization covers the DERIVED case only. An aliased prop
-   * with no derived field still has the parent emitting `"N" .N` against a
-   * child whose field is `Count`, which `bf.WithProps` silently passes over —
-   * tracked separately as #2457, a residual of #2445 rather than of #2448.
+   * This canonicalization used to cover the DERIVED case only — an aliased
+   * prop with no derived field still had the parent emitting `"N" .N`
+   * against a child whose field is `Count`, silently passed over by
+   * `bf.WithProps` (#2457). `childPropFieldNames`, populated a few lines
+   * below in this same method, closes that residual gap by resolving every
+   * prop's field name at the parent's emission site, not just the ones a
+   * derived field depends on.
    */
   private recordDerivedFieldDeps(
     ir: Pick<ComponentIR, 'metadata'>,
@@ -733,6 +773,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     )
     const canonical = (local: string): string => capitalizeFieldName(sourceOf.get(local) ?? local)
     const propFieldNames = new Set([...paramNames].map(canonical))
+    // #2457: record the JSX-attribute-name -> child's-own-field-name map for
+    // EVERY component, unconditionally — see `childPropFieldNames`'s
+    // docstring for why this can't share `recordRepropsSpec`'s gates.
+    const fieldNames = new Map<string, string>()
+    for (const p of ir.metadata.propsParams ?? []) {
+      fieldNames.set(p.sourceName ?? p.name, capitalizeFieldName(p.name))
+    }
+    this.childPropFieldNames.set(name, fieldNames)
     const deps = new Map<string, ReadonlySet<string>>()
     const ctorInits: { field: string; init: ParsedExpr | undefined }[] = [
       ...(ir.metadata.memos ?? []).map(m => ({ field: m.name, init: m.parsed })),
@@ -929,11 +977,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    *   BfMount come from the base, and the Props-only fields (Scripts,
    *   BfIsRoot/BfIsChild/BfDataKey) are reapplied after the constructor.
    *
-   * The override switch is keyed by the name the PARENT writes — the JSX
-   * attribute, `ParamInfo.sourceName ?? name` — while the assignment targets
-   * the child's own Input field (`ParamInfo.name`). For an aliased destructure
-   * (`{ n: count }`) those differ (`"N"` vs `in.Count`), and this generated
-   * switch is where the two sides are reconciled.
+   * The override switch is keyed by the child's own Input field
+   * (`ParamInfo.name`) on both the case label and the assignment target. That
+   * used to differ under an aliased destructure — the case label carried the
+   * name the PARENT wrote (the JSX attribute, `ParamInfo.sourceName ?? name`)
+   * while the assignment targeted the child's own field, so this switch was
+   * where those two sides were reconciled. #2457 moved that reconciliation to
+   * the PARENT (`loopRowChildPropOverrides`, via `childPropFieldNames`): the
+   * parent now emits the child's own field name at the call site, so by the
+   * time a `bf_reprops` pipeline reaches this switch both sides already agree
+   * and there's exactly one place — the parent's emission — where the naming
+   * gets reconciled, instead of two.
    */
   private recordRepropsSpec(
     ir: ComponentIR,
@@ -956,10 +1010,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (!eligible) return
 
     this.childRepropsReady.set(componentName, {
-      params: params.map(p => ({
-        field: capitalizeFieldName(p.name),
-        wire: capitalizeFieldName(p.sourceName ?? p.name),
-      })),
+      params: params.map(p => capitalizeFieldName(p.name)),
       usesSearchParams: this.usesSearchParams(ir),
     })
   }
@@ -1018,7 +1069,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     lines.push('\t\t\tBfParent: b.BfParent,')
     lines.push('\t\t\tBfMount: b.BfMount,')
     if (usesSearchParams) lines.push('\t\t\tSearchParams: b.SearchParams,')
-    for (const { field } of params) {
+    for (const field of params) {
       lines.push(`\t\t\t${field}: b.${field},`)
     }
     lines.push('\t\t}')
@@ -1026,12 +1077,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     lines.push('\t\t\tname, _ := kv[i].(string)')
     lines.push('\t\t\tvar err error')
     lines.push('\t\t\tswitch name {')
-    for (const { field, wire } of params) {
-      // Case label: the name the PARENT computed from the JSX attribute.
-      // Target: this component's own Input field. They differ under an
-      // aliased destructure.
-      lines.push(`\t\t\tcase ${JSON.stringify(wire)}:`)
-      lines.push(`\t\t\t\terr = bf.RepropsAssign(${q}, ${JSON.stringify(wire)}, &in.${field}, kv[i+1])`)
+    for (const field of params) {
+      // Case label and assignment target are the same name: the child's own
+      // Input field. The parent (`loopRowChildPropOverrides`, via
+      // `childPropFieldNames`, #2457) already resolved the JSX attribute to
+      // this field before emitting the call, so there is nothing left to
+      // reconcile here.
+      lines.push(`\t\t\tcase ${JSON.stringify(field)}:`)
+      lines.push(`\t\t\t\terr = bf.RepropsAssign(${q}, ${JSON.stringify(field)}, &in.${field}, kv[i+1])`)
     }
     // No silent drop. `bf_with_props` passes an unknown field through because
     // a rest-bag prop legitimately has no named field — but a rebuilder is
@@ -5320,6 +5373,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    *   exactly like the unsupported-expression refusal a few lines below.
    *   Refusing beats emitting silently-stale output.
    *
+   * #2457 — the `"Field"` half of each argument pair is the child's OWN Go
+   * field name (resolved through `childPropFieldNames`), not the JSX
+   * attribute name. For an un-aliased prop those are the same string; for an
+   * aliased destructure (`{ n: count }`) the child's field is `Count` while
+   * the JSX attribute is `n`, and emitting the attribute name left
+   * `bf.WithProps`/`bf.RepropsAssign` with a name the struct has no field
+   * for — silently dropped by the former, an unknown-field error from the
+   * latter. Resolving it here, once, means both helpers only ever see a name
+   * the struct actually has.
+   *
    * Returns the space-joined `"Field" value …` argument list plus the helper
    * the caller must wrap it in, or null when nothing needs overriding (caller
    * keeps the bare `$.<Name>SlotN` reference).
@@ -5440,7 +5503,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         })
         continue
       }
-      args.push(`${JSON.stringify(capitalizeFieldName(prop.name))} ${wrapIfMultiToken(go)}`)
+      // #2457: emit the CHILD's own Go field name, not the JSX attribute name.
+      // They differ under an aliased destructure (`{ n: count }` → attribute
+      // `n`, field `Count`); resolving through `childPropFieldNames` here —
+      // the parent's emission site, the only place that has both the JSX
+      // name and the child's shape — means `bf.WithProps`/`bf.RepropsAssign`
+      // never see a name the struct doesn't have. Falls back to today's
+      // capitalized-attribute behaviour for a cross-file child this run's
+      // pre-pass never registered (`childPropFieldNames` has no entry).
+      const fieldName =
+        this.childPropFieldNames.get(comp.name)?.get(prop.name) ?? capitalizeFieldName(prop.name)
+      args.push(`${JSON.stringify(fieldName)} ${wrapIfMultiToken(go)}`)
     }
     if (args.length === 0) return null
     return { args: args.join(' '), helper: needsRebuild ? 'bf_reprops' : 'bf_with_props' }


### PR DESCRIPTION
Closes #2457 — the last silent drop left over from #2445, and the one #2448's dependency map didn't reach.

## The bug

`generateInputStruct` / `emitPropsDataFields` name a child's Go field from its **local binding**, so an aliased destructure produces the field `Count`:

```tsx
function Badge({ text, n: count }: { text: string; n: number }) {
  return <span class="badge">{text}:{count}</span>
}
```
```go
type BadgeProps struct { Text string; Count int }
```

But `loopRowChildPropOverrides` capitalized the **JSX attribute** instead:

```gotemplate
{{template "Badge" (bf_with_props $.BadgeSlot0 "Text" .Label "N" .N)}}
```

`bf.WithProps` documents an unknown-field pair as a deliberate passthrough — it patches *named* fields on an already-constructed instance, and a rest-bag prop legitimately has no named field — so `"N" .N` was silently discarded and `Count` kept the shared instance's constructor value on every row. No diagnostic. Exactly the failure mode #2448 spent two PRs removing, surviving in the one case that PR's dependency map didn't cover.

## The fix

Resolve the name **once, at the parent's emission site** — the only place that has both the JSX attribute and the child's shape:

```gotemplate
{{template "Badge" (bf_with_props $.BadgeSlot0 "Text" .Label "Count" .N)}}
```

A new `childPropFieldNames` map (JSX attribute name → the child's own Go field name) is populated from the same two doors `childDerivedFieldDeps` uses: `registerChildComponentShape` for the CLI's cross-file pre-pass, and `generate()`'s self-registration — `compileJSX` never calls the pre-pass, which is precisely why #2448's first cut never fired.

Keyed by `ParamInfo.sourceName ?? name`, whose docstring already states the rule (*"Consumers keying into `propsType.properties` must use `sourceName ?? name`"*). `sourceName` is set only on a renaming destructure, so for every un-aliased prop the map is an identity and every currently-passing fixture's template stays byte-identical.

## It simplifies #2448 rather than adding to it

`bf_reprops`'s generated switch used to carry the **parent's** name on the case label and the **child's** field on the assignment target, reconciling the two right there. Now that the parent hands it a name the struct already has, the switch is keyed uniformly by that one name and `RepropsSpec` drops its `wire` half:

```go
case "Count":
    err = bf.RepropsAssign("Badge", "Count", &in.Count, kv[i+1])
```

One place to get the naming right instead of two.

## Verified against real Go

Both halves, via `renderGoTemplateComponent`:

| shape | before | after |
|---|---|---|
| aliased, no derived field (this bug) | `one:0` `two:0` | `one:3` `two:5` |
| aliased + `createMemo(() => count * 2)` (#2448's rebuild path) | — | `one:6` `two:10` |

## No conformance fixture, and why

Building one surfaced the mirror-image bug in the **reference** adapter. Hono emits the aliased destructure as `{ text, count }` — the local binding used as the property key — against a props type that has `n`, so the value is `undefined` there regardless of this fix. Independent of loops, `'use client'`, or this bug; reproduces on a plain stateless component. Filed as #2460.

Fixtures take their `expectedHtml` from Hono, so a fixture written now would bake in the wrong reference value and measure all nine adapters against it. The fixture lands with #2460.

Covered here by two compiler tests instead: the aliased shape **with** a derived field (asserting the template writes `"Count"` and the rebuilder's switch is keyed by `Count`, with `"N"` never a case label), and the aliased shape **without** one (asserting `bf_with_props` now names a field the child actually has, and that no rebuilder is emitted).

## Tests

Local, one suite per run (parallel runs trip bun's 5s per-test limit): `packages/adapter-go-template` **1491 pass / 0 fail** with real Go renders (`GOTOOLCHAIN=go1.25.6`), `packages/adapter-tests` **1481 pass / 0 fail**, `packages/compat` **183 pass / 0 fail**, `packages/jsx` **2923 run / 0 fail**, `packages/cli` **1554 pass / 0 fail**, `go test ./...` in the runtime green. All four Go integrations rebuilt from cleared caches with no `components.go` drift; `ui/compat.lock.json` and `ui/support-matrix.lock.json` regenerate unchanged. Biome and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_