### PR TITLE
Keep the rename on an aliased destructured prop (#2460)

### DIFF
--- a/.changeset/hono-alias-prop-destructure.md
+++ b/.changeset/hono-alias-prop-destructure.md
@@ -1,0 +1,62 @@
+---
+"@barefootjs/hono": patch
+"@barefootjs/jsx": patch
+---
+
+Fix the Hono adapter dropping a renamed destructured prop's caller-facing key (#2460)
+
+`function Badge({ text, n: count }: { text: string; n: number })` — the
+caller passes `n`, the body reads the local binding `count`. The Hono
+adapter built its SSR props destructure keyed by `ParamInfo.name` (the
+LOCAL binding) instead of `sourceName ?? name` (the CALLER-facing key —
+`ParamInfo.sourceName`'s own documented rule), so the emitted function
+read a `count` property the caller never passed:
+
+```tsx
+// before (wrong): reads a `count` prop that doesn't exist on the caller's object
+export function Badge({ text, count, __instanceId, ... }: BadgePropsWithHydration) { ... }
+// after: keeps the rename
+export function Badge({ text, n: count, __instanceId, ... }: BadgePropsWithHydration) { ... }
+```
+
+`count` was therefore always `undefined`, with zero diagnostics. The fix
+emits the plain shorthand when the caller-facing key matches the local
+binding (byte-identical output for every existing, un-aliased component)
+and a `key: local` rename otherwise — including a destructuring default
+(`{ n: count = 7 }` → `n: count = 7`) and a non-identifier caller key
+(quoted, e.g. `"data-key": local`). This also fixes the dead `class` →
+`className` special case: the only way a `class`-named caller prop can
+reach a destructured component is via an explicit alias
+(`{ class: className }`, since `class` can never be an un-aliased
+binding identifier), which now correctly emits the rename `class:
+className` instead of a bare `className`.
+
+`@barefootjs/jsx`'s `extractSsrDefaults` (the template-stash adapters'
+SSR-seed extractor) had the mirror-image bug: `propName` — the field the
+Perl/PHP/etc. manifest consumer reads the CALLER's props by
+(`$props->{propName}`) — was set to the local binding instead of
+`sourceName ?? name`, so a renamed prop's SSR seed silently fell back to
+`null` instead of the caller's value.
+
+The sibling keyings audited in the same pass (props-to-serialize
+filtering, the `__hydrateProps` hydration-blob assembly) were already
+consistent — both sides key by the LOCAL binding, matching what the
+generated client init function reads (`_p.<localName>`) — so they needed
+no change.
+
+Verified end-to-end through Hono (`renderHonoComponent`): aliased with no
+default, aliased with a default (both caller-omitted and
+caller-overridden), the un-aliased case (byte-identical destructure
+text), the `class` rename, and the hydration-serialization path (the
+`bf-p` blob carries the correct value under the local key that
+`initBadge`'s `const count = _p.count` extraction reads).
+
+Adds the composite-loop-row fixture #2457 (fixed on the Go side, #2462)
+was blocked on: an aliased destructured prop on a child component inside
+a keyed `.map()` row, with distinct per-row values. Verified passing on
+Hono and ERB; expected to pass on Go per #2462's fix (not run here per
+this change's scope — Go/CI will confirm). Skipped with a pointer back
+to #2460 on Blade, Jinja, Mojolicious, Twig, Xslate, and minijinja/Rust,
+which still key the caller-facing lookup by the local binding for a
+standalone aliased prop — verified failing on all six before adding the
+skip.

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -30,6 +30,8 @@ export const renderDivergences: RenderDivergences = {
   // `skipJsx` entries).
   'aliased-destructured-prop':
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
+  'composite-row-child-aliased-prop':
+    'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'select-value-ssr':
     'controlled <select> SSRs an invalid `value` attribute instead of `selected` on the matching option (https://github.com/piconic-ai/barefootjs/issues/2464)',
   'textarea-value-ssr':

--- a/packages/adapter-hono/__tests__/hono-adapter.test.ts
+++ b/packages/adapter-hono/__tests__/hono-adapter.test.ts
@@ -27,10 +27,6 @@ runAdapterConformanceTests({
   // the line here (plus the matching render-divergences entries in the
   // other adapter packages).
   skipJsx: [
-    // Aliased destructured prop `{ n: count }` loses its rename in the
-    // emitted destructure, so the aliased prop is always `undefined`.
-    // https://github.com/piconic-ai/barefootjs/issues/2460
-    'aliased-destructured-prop',
     // `<select value={sig()}>` SSRs an invalid `value` attribute instead
     // of `selected` on the matching option.
     // https://github.com/piconic-ai/barefootjs/issues/2464

--- a/packages/adapter-hono/src/__tests__/aliased-destructured-prop.test.ts
+++ b/packages/adapter-hono/src/__tests__/aliased-destructured-prop.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Aliased (renaming) destructured props (#2460).
+ *
+ * The Hono adapter used to build its SSR props destructure keyed by
+ * `ParamInfo.name` (the LOCAL binding) instead of `sourceName ?? name`
+ * (the CALLER-facing key — see `ParamInfo.sourceName`'s docstring in
+ * `packages/jsx/src/types.ts`). For a renaming destructure
+ * (`{ n: count }`) the emitted SSR function read a `count` property the
+ * caller never passed (the caller passes `n`), so the local binding was
+ * always `undefined`.
+ *
+ * These tests render through Hono end-to-end (`renderHonoComponent`) and
+ * assert the actual rendered VALUE, not just the emitted destructure
+ * text — a byte-identical destructure with the wrong runtime binding
+ * would still pass a text-only assertion.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '@barefootjs/jsx'
+import { renderHonoComponent } from '../test-render'
+import { HonoAdapter } from '../adapter/hono-adapter'
+
+describe('aliased destructured props (#2460)', () => {
+  test('{ text, n: count } — aliased, no default: the caller-supplied `n` reaches the `count` binding', async () => {
+    const html = await renderHonoComponent({
+      adapter: new HonoAdapter(),
+      source: `
+        export function Badge({ text, n: count }: { text: string; n: number }) {
+          return <span>{text}:{count}</span>
+        }
+      `,
+      props: { text: 'hello', n: 7 },
+    })
+
+    expect(html).toContain('hello')
+    expect(html).toContain(':<!--bf:s1-->7<!--/-->')
+  })
+
+  test('{ text, n: count = 7 } — aliased with a destructuring default, caller omits `n`', async () => {
+    const html = await renderHonoComponent({
+      adapter: new HonoAdapter(),
+      source: `
+        export function Badge({ text, n: count = 7 }: { text: string; n?: number }) {
+          return <span>{text}:{count}</span>
+        }
+      `,
+      props: { text: 'hello' },
+    })
+
+    expect(html).toContain(':<!--bf:s1-->7<!--/-->')
+  })
+
+  test('{ text, n: count = 7 } — aliased with a default, caller-supplied `n` overrides it', async () => {
+    const html = await renderHonoComponent({
+      adapter: new HonoAdapter(),
+      source: `
+        export function Badge({ text, n: count = 7 }: { text: string; n?: number }) {
+          return <span>{text}:{count}</span>
+        }
+      `,
+      props: { text: 'hello', n: 42 },
+    })
+
+    expect(html).toContain(':<!--bf:s1-->42<!--/-->')
+  })
+
+  test('{ text, n } — un-aliased: emitted destructure text is byte-identical to the pre-fix shorthand', () => {
+    const source = `
+      export function Badge({ text, n }: { text: string; n: number }) {
+        return <span>{text}:{n}</span>
+      }
+    `
+    const result = compileJSX(source, 'Badge.tsx', { adapter: new HonoAdapter() })
+    const errors = result.errors.filter((e) => e.severity === 'error')
+    expect(errors).toEqual([])
+    const tmpl = result.files.find((f) => f.type === 'markedTemplate')
+    expect(tmpl).toBeDefined()
+    // Plain shorthand destructure — no `sourceKey: localName` rename text
+    // for an un-aliased prop.
+    expect(tmpl!.content).toContain('export function Badge({ text, n, __instanceId,')
+  })
+
+  test('a renamed `class` prop emits the rename `class: className`, not a bare `className`', () => {
+    // `class` is a reserved word and can never be an un-aliased binding
+    // identifier (`{ class }` is a syntax error), so the only way a
+    // `class`-named caller prop reaches `propsParams` through a
+    // destructured component is via an explicit alias.
+    const source = `
+      export function Chip({ class: className }: { class: string }) {
+        return <span class={className}>x</span>
+      }
+    `
+    const result = compileJSX(source, 'Chip.tsx', { adapter: new HonoAdapter() })
+    const errors = result.errors.filter((e) => e.severity === 'error')
+    expect(errors).toEqual([])
+    const tmpl = result.files.find((f) => f.type === 'markedTemplate')
+    expect(tmpl).toBeDefined()
+    expect(tmpl!.content).toContain('class: className')
+  })
+
+  test('aliased prop reaches client-side hydration serialization with the correct value', async () => {
+    // The client init function reads `_p.<localName>` (props-extraction
+    // phase), so the SSR-serialized `bf-p` blob must carry the correct
+    // value under the LOCAL key (`count`) — the rename only affects the
+    // caller-facing key, not the local binding the hydration bridge uses.
+    const html = await renderHonoComponent({
+      adapter: new HonoAdapter(),
+      source: `
+        'use client'
+        import { createEffect } from '@barefootjs/client'
+        export function Badge({ text, n: count }: { text: string; n: number }) {
+          createEffect(() => {
+            console.log(count)
+          })
+          return <span>{text}:{count}</span>
+        }
+      `,
+      props: { text: 'hello', n: 7 },
+    })
+
+    // The rendered value is correct...
+    expect(html).toContain(':<!--bf:s1-->7<!--/-->')
+    // ...and the serialized hydration payload carries it under the LOCAL
+    // binding name, which is what the generated client JS's
+    // `const count = _p.count` extraction reads.
+    expect(html).toMatch(/bf-p="[^"]*count[^"]*7/)
+  })
+})

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -35,6 +35,7 @@ import {
   emitAttrValue,
   buildLoopChainExpr,
 } from '@barefootjs/jsx'
+import ts from 'typescript'
 
 /**
  * Hono adapter's IRNode render context: which surrounding render
@@ -96,6 +97,28 @@ function applyHonoLoopChain(loop: IRLoop): string {
     filterPredicate: loop.filterPredicate,
     chainOrder: loop.chainOrder,
   })
+}
+
+/**
+ * Authoritative IdentifierName classification for a destructure-pattern
+ * property key, built on TS's own `isIdentifierStart` / `isIdentifierPart`
+ * primitives (Unicode-aware, stays aligned with what TS itself accepts as
+ * a bare property key). Mirrors the `isIdent` precedent in
+ * `jsx-to-ir.ts` (#1244) — a source key like `data-key` or `aria-label`
+ * can't be emitted as a bare `key: local` destructure and must be quoted
+ * (`"data-key": local`).
+ */
+function isIdentifierName(key: string): boolean {
+  if (key.length === 0) return false
+  for (let i = 0; i < key.length; ) {
+    const cp = key.codePointAt(i)!
+    const ok = i === 0
+      ? ts.isIdentifierStart(cp, ts.ScriptTarget.Latest)
+      : ts.isIdentifierPart(cp, ts.ScriptTarget.Latest)
+    if (!ok) return false
+    i += cp > 0xFFFF ? 2 : 1
+  }
+  return true
 }
 
 export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderCtx> {
@@ -505,8 +528,22 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
       const parts: string[] = []
       const propsParams = ir.metadata.propsParams
         .map((p: ParamInfo) => {
-          const paramName = p.name === 'class' ? 'className' : p.name
-          return p.defaultValue ? `${paramName} = ${p.defaultValue}` : paramName
+          // The caller-facing key is `sourceName ?? name` (ParamInfo's own
+          // rule) — `name` is only ever the LOCAL binding. Emit the plain
+          // shorthand when they match (byte-identical to before this was
+          // rename-aware); emit a `key: local` rename otherwise. This also
+          // covers the `class` → `className` rename correctly: a source
+          // prop literally named `class` can only reach `propsParams` via
+          // an aliased destructure (`{ class: className }` — `class` is a
+          // reserved word, so it can never be an un-aliased binding), which
+          // already sets `sourceName: 'class'` and is handled by the rename
+          // branch below (`class: className`), not a bare `className`.
+          const callerKey = p.sourceName ?? p.name
+          const localName = p.name
+          const binding = callerKey === localName
+            ? localName
+            : `${isIdentifierName(callerKey) ? callerKey : JSON.stringify(callerKey)}: ${localName}`
+          return p.defaultValue ? `${binding} = ${p.defaultValue}` : binding
         })
         .join(', ')
       if (propsParams) {

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -30,6 +30,8 @@ export const renderDivergences: RenderDivergences = {
   // `skipJsx` entries).
   'aliased-destructured-prop':
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
+  'composite-row-child-aliased-prop':
+    'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'select-value-ssr':
     'controlled <select> SSRs an invalid `value` attribute instead of `selected` on the matching option (https://github.com/piconic-ai/barefootjs/issues/2464)',
   'textarea-value-ssr':

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -30,6 +30,8 @@ export const renderDivergences: RenderDivergences = {
   // `skipJsx` entries).
   'aliased-destructured-prop':
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
+  'composite-row-child-aliased-prop':
+    'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'select-value-ssr':
     'controlled <select> SSRs an invalid `value` attribute instead of `selected` on the matching option (https://github.com/piconic-ai/barefootjs/issues/2464)',
   'textarea-value-ssr':

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -32,6 +32,8 @@ export const renderDivergences: RenderDivergences = {
   // `skipJsx` entries).
   'aliased-destructured-prop':
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
+  'composite-row-child-aliased-prop':
+    'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'select-value-ssr':
     'controlled <select> SSRs an invalid `value` attribute instead of `selected` on the matching option (https://github.com/piconic-ai/barefootjs/issues/2464)',
   'textarea-value-ssr':

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1197,6 +1197,19 @@
         "text"
       ]
     },
+    "composite-row-child-aliased-prop": {
+      "kinds": [
+        "call",
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "composite-row-child-component": {
       "kinds": [
         "call",
@@ -4740,13 +4753,13 @@
     "array-method": 66,
     "arrow": 63,
     "binary": 79,
-    "call": 187,
+    "call": 188,
     "conditional": 23,
-    "identifier": 275,
+    "identifier": 276,
     "index-access": 12,
     "literal": 226,
     "logical": 43,
-    "member": 149,
+    "member": 150,
     "object-literal": 51,
     "template-literal": 29,
     "unary": 23,

--- a/packages/adapter-tests/fixtures/aliased-destructured-prop.ts
+++ b/packages/adapter-tests/fixtures/aliased-destructured-prop.ts
@@ -6,26 +6,26 @@ import { createFixture } from '../src/types'
  *
  * Pins #2460, which is NOT Hono-only: every consumer that keys off
  * `ParamInfo.name` instead of `sourceName ?? name` drops the rename.
- * Verified per adapter: Hono emits `{ text, count }` (reads a `count`
- * property off a props object shaped `{ text, n }` → always
- * `undefined`, `s1` renders empty); the template-string adapters key
- * `ssrDefaults` / template vars as `count` so props seeding misses;
- * Go's Input struct field is `Count` `json:"count"`, so the
- * caller-side struct literal keyed by the real prop name fails
- * `go run` outright (unknown field N); the shared client JS reads
- * `_p.count` too. All silent except Go's exit 1.
+ * Verified per adapter: Hono used to emit `{ text, count }` (reading a
+ * `count` property off a props object shaped `{ text, n }` → always
+ * `undefined`, `s1` rendered empty) — FIXED, Hono now emits
+ * `{ text, n: count }` and this fixture is no longer skipped for it. The
+ * template-string adapters still key `ssrDefaults` / template vars as
+ * `count` so props seeding misses; Go's Input struct field is `Count`
+ * `json:"count"`, so the caller-side struct literal keyed by the real
+ * prop name fails `go run` outright (unknown field N); the shared client
+ * JS reads `_p.count` too. All silent except Go's exit 1.
  * `ParamInfo.sourceName` carries the original property name precisely
  * for this; its docstring rule is "consumers keying into
  * `propsType.properties` must use `sourceName ?? name`".
  *
- * `expectedHtml` below is hand-authored to the CORRECT output (the `s1`
- * slot carries `7`) because Hono — the reference adapter that normally
- * generates `expectedHtml` — is itself the broken party here, which is
- * exactly why #2460 notes no aliased-prop fixture could exist before.
- * Adapters that still drop the rename skip this fixture with a pointer
- * to https://github.com/piconic-ai/barefootjs/issues/2460; graduating
- * means fixing the emission, regenerating `expectedHtml` from the fixed
- * reference, and deleting the skip entry.
+ * `expectedHtml` below is the CORRECT output (the `s1` slot carries `7`)
+ * and is now generated from Hono like any other fixture (Hono was the
+ * broken party before, which is exactly why #2460 notes no aliased-prop
+ * fixture could exist until it was fixed). Adapters that still drop the
+ * rename skip this fixture with a pointer to
+ * https://github.com/piconic-ai/barefootjs/issues/2460; graduating
+ * means fixing the emission and deleting the skip entry.
  */
 export const fixture = createFixture({
   id: 'aliased-destructured-prop',

--- a/packages/adapter-tests/fixtures/composite-row-child-aliased-prop.ts
+++ b/packages/adapter-tests/fixtures/composite-row-child-aliased-prop.ts
@@ -1,0 +1,49 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Composite loop row (`useElementReconciliation` + `nestedComponents`)
+ * whose nested child destructures its props with a RENAME (`{ n: count }`,
+ * #2460) instead of a bare bind. This is the composite-row fixture #2457
+ * (fixed on the Go side, merged as #2462) was blocked on — it could not
+ * land without a fixture because Hono, the reference adapter that
+ * generates `expectedHtml`, was itself the broken party for any aliased
+ * prop (#2460's general defect, not composite-row-specific). With Hono
+ * fixed, this exercises the aliased rename specifically INSIDE a keyed
+ * `.map()` row, where a shared-instance or per-row-override bug would
+ * show up as every row displaying the SAME `count` instead of its own —
+ * hence per-row distinct `n` values (3 and 5, not identical).
+ *
+ * `expectedHtml` is generated from the reference Hono adapter.
+ */
+export const fixture = createFixture({
+  id: 'composite-row-child-aliased-prop',
+  description: 'Nested child in a dynamic loop row destructures a renamed prop ({ n: count })',
+  componentName: 'CompositeRowChildAliasedProp',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string; n: number }
+function Badge({ text, n: count }: { text: string; n: number }) {
+  return <span class="badge">{text}:{count}</span>
+}
+export function CompositeRowChildAliasedProp(props: { rows: Row[] }) {
+  const [rows] = createSignal<Row[]>(props.rows)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          <Badge text={row.label} n={row.n} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  props: { rows: [{ id: 1, label: 'one', n: 3 }, { id: 2, label: 'two', n: 5 }] },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li data-key="1"><span bf-s="test_s0" bf="s2" class="badge"><!--bf:s0-->one<!--/-->:<!--bf:s1-->3<!--/--></span></li>
+      <li data-key="2"><span bf-s="test_s0" bf="s2" class="badge"><!--bf:s0-->two<!--/-->:<!--bf:s1-->5<!--/--></span></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -388,6 +388,7 @@ import { fixture as jsxElementProp } from './jsx-element-prop'
 import { fixture as grandchildComposition } from './grandchild-composition'
 import { fixture as compositeRowChildComponent } from './composite-row-child-component'
 import { fixture as compositeRowChildDerivedProp } from './composite-row-child-derived-prop'
+import { fixture as compositeRowChildAliasedProp } from './composite-row-child-aliased-prop'
 import { fixture as loopPreambleAttrValue } from './loop-preamble-attr-value'
 import { fixture as loopPreambleChainedFilter } from './loop-preamble-chained-filter'
 import { fixture as loopRowStaticConditional } from './loop-row-static-conditional'
@@ -730,6 +731,7 @@ export const jsxFixtures: JSXFixture[] = [
   grandchildComposition,
   compositeRowChildComponent,
   compositeRowChildDerivedProp,
+  compositeRowChildAliasedProp,
   loopPreambleAttrValue,
   loopPreambleChainedFilter,
   loopRowStaticConditional,

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -407,6 +407,14 @@
       }
     }
   ],
+  "composite-row-child-aliased-prop": [
+    {
+      "name": "gen:rows:empty",
+      "props": {
+        "rows": []
+      }
+    }
+  ],
   "composite-row-child-component": [
     {
       "name": "gen:items:empty",

--- a/packages/adapter-tests/scripts/generate-expected-html.ts
+++ b/packages/adapter-tests/scripts/generate-expected-html.ts
@@ -51,8 +51,6 @@ const SKIP_AUTO_UPDATE = new Set<string>([
   // Onboarding TSX-fidelity pins (PR #2461): expectedHtml is hand-authored
   // to the CORRECT output because the Hono reference itself emits the
   // broken form. Regenerate + remove from this set when the issue is fixed.
-  // https://github.com/piconic-ai/barefootjs/issues/2460
-  'aliased-destructured-prop',
   // https://github.com/piconic-ai/barefootjs/issues/2464
   'select-value-ssr',
   // https://github.com/piconic-ai/barefootjs/issues/2465

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -256,6 +256,12 @@ describe('CSR Conformance Tests', () => {
     // renders empty instead of the fixture's corrected expectedHtml.
     // https://github.com/piconic-ai/barefootjs/issues/2460
     'aliased-destructured-prop',
+    // Same #2460 CSR-template gap as `aliased-destructured-prop`, inside
+    // a keyed `.map()` loop row: the nested child's renamed prop reads
+    // `_p.count` off a row object shaped `{ text, n }`, so both rows'
+    // `s1` slot renders empty instead of the fixture's expectedHtml.
+    // https://github.com/piconic-ai/barefootjs/issues/2460
+    'composite-row-child-aliased-prop',
     // #2464 / #2465: the CSR template emits the same invalid
     // `value="..."` attribute as SSR, diverging from the fixtures'
     // corrected expectedHtml (`selected` on the matching option /

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -30,6 +30,8 @@ export const renderDivergences: RenderDivergences = {
   // `skipJsx` entries).
   'aliased-destructured-prop':
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
+  'composite-row-child-aliased-prop':
+    'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'select-value-ssr':
     'controlled <select> SSRs an invalid `value` attribute instead of `selected` on the matching option (https://github.com/piconic-ai/barefootjs/issues/2464)',
   'textarea-value-ssr':

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -30,6 +30,8 @@ export const renderDivergences: RenderDivergences = {
   // `skipJsx` entries).
   'aliased-destructured-prop':
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
+  'composite-row-child-aliased-prop':
+    'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'select-value-ssr':
     'controlled <select> SSRs an invalid `value` attribute instead of `selected` on the matching option (https://github.com/piconic-ai/barefootjs/issues/2464)',
   'textarea-value-ssr':

--- a/packages/jsx/src/__tests__/ssr-defaults.test.ts
+++ b/packages/jsx/src/__tests__/ssr-defaults.test.ts
@@ -102,6 +102,50 @@ describe('extractSsrDefaults', () => {
     expect(defaults?.n).toEqual({ value: 0 })
   })
 
+  test('aliased destructured prop (#2460): `propName` is the CALLER-facing key, not the local binding', () => {
+    // `{ n: count }` — the caller passes `n`, the template variable (and
+    // stash entry key) is the local binding `count`. The manifest
+    // consumer (`_derive_stash_from_defaults` in the Perl runtime) reads
+    // the caller's props by `propName`, so `propName` must be `n`, not
+    // `count` — using the local name here silently drops the caller's
+    // value (the stash entry falls back to the static `value`, `null`).
+    const metadata = metadataFor(`
+      function Badge({ text, n: count }: { text: string; n: number }) {
+        return <span>{text}:{count}</span>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults).toBeDefined()
+    // Keyed by the LOCAL binding (the template variable name)...
+    expect(defaults?.count).toEqual({ propName: 'n', value: null })
+    // ...but `propName` is the CALLER-facing key.
+    expect(defaults?.text).toEqual({ propName: 'text', value: null })
+  })
+
+  test('aliased destructured prop with a default (#2460): `propName` still resolves to the source key', () => {
+    const metadata = metadataFor(`
+      function Badge({ n: count = 7 }: { n?: number }) {
+        return <span>{count}</span>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.count).toEqual({ propName: 'n', value: 7 })
+  })
+
+  test('un-aliased destructured prop (regression): `propName` equals the local name', () => {
+    const metadata = metadataFor(`
+      function Badge({ text, n }: { text: string; n: number }) {
+        return <span>{text}:{n}</span>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.n).toEqual({ propName: 'n', value: null })
+    expect(defaults?.text).toEqual({ propName: 'text', value: null })
+  })
+
   test('memo derived from a signal evaluates through the chain', () => {
     const metadata = metadataFor(`
       'use client'

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -107,15 +107,20 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
   //     wins via `propName`).
   for (const p of metadata.propsParams) {
     if (p.isRest) continue
+    // `propName` is the CALLER-facing key (`$props->{propName}` in the Perl
+    // consumer above) — for a renaming destructure (`{ n: count }`) that's
+    // `n`, not the local binding `count` the template variable is keyed by.
+    // `sourceName ?? name` is an identity for every un-aliased prop.
+    const callerPropName = p.sourceName ?? p.name
     if (metadata.propsObjectName === null && p.defaultValue !== undefined) {
       const value = tryStaticEval(p.defaultValue, { bindings: {}, propsLike })
-      out[p.name] = { propName: p.name, value: resultToJsonable(value) }
+      out[p.name] = { propName: callerPropName, value: resultToJsonable(value) }
     } else {
       // No destructure default — the template reads the prop as-is;
       // Perl's `//` operator decides what `undef` becomes. The entry
       // still matters so the template variable exists and consumers
       // can supply the propName even with no static fallback.
-      out[p.name] = { propName: p.name, value: null }
+      out[p.name] = { propName: callerPropName, value: null }
     }
   }
   // Rest-props bag (`...props`) — tracked separately from `propsParams`

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1850,6 +1850,32 @@
           "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)"
         }
       },
+      "composite-row-child-aliased-prop": {
+        "blade": {
+          "kind": "render",
+          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+        }
+      },
       "date-method-uncatalogued": {
         "blade": {
           "kind": "refusal",
@@ -2884,6 +2910,10 @@
       "aliased-destructured-prop": {
         "description": "Aliased destructured prop ({ n: count }) keeps the rename (#2460)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/aliased-destructured-prop.ts"
+      },
+      "composite-row-child-aliased-prop": {
+        "description": "Nested child in a dynamic loop row destructures a renamed prop ({ n: count })",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/composite-row-child-aliased-prop.ts"
       },
       "date-method-uncatalogued": {
         "description": "Method call on a Date-typed prop refuses with BF021 (no catalogued lowering)",

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 294,
+    "totalFixtures": 295,
     "fixtures": {
       "aliased-destructured-prop": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 187,
+      "total": 188,
       "cells": {
         "hono": {
-          "pass": 186,
-          "total": 187,
+          "pass": 187,
+          "total": 188,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1433,8 +1433,8 @@
           ]
         },
         "blade": {
-          "pass": 170,
-          "total": 187,
+          "pass": 171,
+          "total": 188,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1517,8 +1517,8 @@
           ]
         },
         "erb": {
-          "pass": 171,
-          "total": 187,
+          "pass": 172,
+          "total": 188,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1595,8 +1595,8 @@
           ]
         },
         "go-template": {
-          "pass": 170,
-          "total": 187,
+          "pass": 171,
+          "total": 188,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1679,8 +1679,8 @@
           ]
         },
         "jinja": {
-          "pass": 170,
-          "total": 187,
+          "pass": 171,
+          "total": 188,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1763,8 +1763,8 @@
           ]
         },
         "minijinja": {
-          "pass": 170,
-          "total": 187,
+          "pass": 171,
+          "total": 188,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1847,8 +1847,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 171,
-          "total": 187,
+          "pass": 172,
+          "total": 188,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1925,8 +1925,8 @@
           ]
         },
         "twig": {
-          "pass": 170,
-          "total": 187,
+          "pass": 171,
+          "total": 188,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2009,8 +2009,8 @@
           ]
         },
         "xslate": {
-          "pass": 170,
-          "total": 187,
+          "pass": 171,
+          "total": 188,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2238,11 +2238,11 @@
       }
     },
     "identifier": {
-      "total": 275,
+      "total": 276,
       "cells": {
         "hono": {
-          "pass": 274,
-          "total": 275,
+          "pass": 275,
+          "total": 276,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2253,8 +2253,8 @@
           ]
         },
         "blade": {
-          "pass": 255,
-          "total": 275,
+          "pass": 256,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2349,8 +2349,8 @@
           ]
         },
         "erb": {
-          "pass": 256,
-          "total": 275,
+          "pass": 257,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2439,8 +2439,8 @@
           ]
         },
         "go-template": {
-          "pass": 255,
-          "total": 275,
+          "pass": 256,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2535,8 +2535,8 @@
           ]
         },
         "jinja": {
-          "pass": 255,
-          "total": 275,
+          "pass": 256,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2631,8 +2631,8 @@
           ]
         },
         "minijinja": {
-          "pass": 255,
-          "total": 275,
+          "pass": 256,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2727,8 +2727,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 256,
-          "total": 275,
+          "pass": 257,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2817,8 +2817,8 @@
           ]
         },
         "twig": {
-          "pass": 255,
-          "total": 275,
+          "pass": 256,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2913,8 +2913,8 @@
           ]
         },
         "xslate": {
-          "pass": 255,
-          "total": 275,
+          "pass": 256,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -3722,11 +3722,11 @@
       }
     },
     "member": {
-      "total": 149,
+      "total": 150,
       "cells": {
         "hono": {
-          "pass": 148,
-          "total": 149,
+          "pass": 149,
+          "total": 150,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3737,8 +3737,8 @@
           ]
         },
         "blade": {
-          "pass": 132,
-          "total": 149,
+          "pass": 133,
+          "total": 150,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3821,8 +3821,8 @@
           ]
         },
         "erb": {
-          "pass": 133,
-          "total": 149,
+          "pass": 134,
+          "total": 150,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3899,8 +3899,8 @@
           ]
         },
         "go-template": {
-          "pass": 132,
-          "total": 149,
+          "pass": 133,
+          "total": 150,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3983,8 +3983,8 @@
           ]
         },
         "jinja": {
-          "pass": 132,
-          "total": 149,
+          "pass": 133,
+          "total": 150,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4067,8 +4067,8 @@
           ]
         },
         "minijinja": {
-          "pass": 132,
-          "total": 149,
+          "pass": 133,
+          "total": 150,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4151,8 +4151,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 133,
-          "total": 149,
+          "pass": 134,
+          "total": 150,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4229,8 +4229,8 @@
           ]
         },
         "twig": {
-          "pass": 132,
-          "total": 149,
+          "pass": 133,
+          "total": 150,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4313,8 +4313,8 @@
           ]
         },
         "xslate": {
-          "pass": 132,
-          "total": 149,
+          "pass": 133,
+          "total": 150,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1433,9 +1433,13 @@
           ]
         },
         "blade": {
-          "pass": 171,
+          "pass": 170,
           "total": 188,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1679,9 +1683,13 @@
           ]
         },
         "jinja": {
-          "pass": 171,
+          "pass": 170,
           "total": 188,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1763,9 +1771,13 @@
           ]
         },
         "minijinja": {
-          "pass": 171,
+          "pass": 170,
           "total": 188,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1847,9 +1859,13 @@
           ]
         },
         "mojolicious": {
-          "pass": 172,
+          "pass": 171,
           "total": 188,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1925,9 +1941,13 @@
           ]
         },
         "twig": {
-          "pass": 171,
+          "pass": 170,
           "total": 188,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2009,9 +2029,13 @@
           ]
         },
         "xslate": {
-          "pass": 171,
+          "pass": 170,
           "total": 188,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2253,11 +2277,15 @@
           ]
         },
         "blade": {
-          "pass": 256,
+          "pass": 255,
           "total": 276,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
+              "issues": []
+            },
+            {
+              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2535,11 +2563,15 @@
           ]
         },
         "jinja": {
-          "pass": 256,
+          "pass": 255,
           "total": 276,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
+              "issues": []
+            },
+            {
+              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2631,11 +2663,15 @@
           ]
         },
         "minijinja": {
-          "pass": 256,
+          "pass": 255,
           "total": 276,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
+              "issues": []
+            },
+            {
+              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2727,11 +2763,15 @@
           ]
         },
         "mojolicious": {
-          "pass": 257,
+          "pass": 256,
           "total": 276,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
+              "issues": []
+            },
+            {
+              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2817,11 +2857,15 @@
           ]
         },
         "twig": {
-          "pass": 256,
+          "pass": 255,
           "total": 276,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
+              "issues": []
+            },
+            {
+              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2913,11 +2957,15 @@
           ]
         },
         "xslate": {
-          "pass": 256,
+          "pass": 255,
           "total": 276,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
+              "issues": []
+            },
+            {
+              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -3737,9 +3785,13 @@
           ]
         },
         "blade": {
-          "pass": 133,
+          "pass": 132,
           "total": 150,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3983,9 +4035,13 @@
           ]
         },
         "jinja": {
-          "pass": 133,
+          "pass": 132,
           "total": 150,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4067,9 +4123,13 @@
           ]
         },
         "minijinja": {
-          "pass": 133,
+          "pass": 132,
           "total": 150,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4151,9 +4211,13 @@
           ]
         },
         "mojolicious": {
-          "pass": 134,
+          "pass": 133,
           "total": 150,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4229,9 +4293,13 @@
           ]
         },
         "twig": {
-          "pass": 133,
+          "pass": 132,
           "total": 150,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4313,9 +4381,13 @@
           ]
         },
         "xslate": {
-          "pass": 133,
+          "pass": 132,
           "total": 150,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [


### PR DESCRIPTION
Closes #2460 for the reference adapter, and unblocks the conformance fixture #2457 could not have.

## The bug

`ParamInfo.name` is the LOCAL binding; `sourceName ?? name` is the key the caller writes. The Hono adapter built its destructure from `name` alone:

```tsx
function Badge({ text, n: count }: { text: string; n: number })
```
```ts
// emitted — reads a property the caller never passes
export function Badge({ text, count, __instanceId, … }: BadgePropsWithHydration)
```

`count` is therefore always `undefined`, with zero diagnostics. `ParamInfo`'s own docstring already states the rule: *"Consumers keying into `propsType.properties` must use `sourceName ?? name`."*

It now emits the shorthand when the two names match — byte-identical output for every un-aliased prop, since `sourceName` is only set on a rename — and `key: local` when they differ, including defaults (`n: count = 7`) and quoted non-identifier keys. Identifier classification uses TS's own `isIdentifierStart`/`isIdentifierPart`, not a regex, per the repo rule.

## A mirror-image bug in the shared layer

`extractSsrDefaults` (`packages/jsx/src/ssr-defaults.ts:108-120`) had the same defect: `propName` — the key template-stash adapters read the caller's props by — was the local name, so a renamed prop's SSR seed silently fell back to `null`. That one is shared, so fixing Hono alone would have left the value dropping in from the other side.

## The `class` → `className` branch was dead code

`p.name === 'class' ? 'className' : p.name` could never fire: `class` is a reserved word, so `{ class }` is a syntax error, and the only way a `class`-named caller prop reaches a component is `{ class: className }` — which sets `sourceName: 'class'` and leaves `name` as `className`. The general rename path now emits `class: className` correctly, and the special case is gone.

## What was already correct

`clientAnalysis.usedProps`, the `propsToSerialize` filter, and the `__hydrateProps` block all key by the LOCAL binding — which matches the generated client init's `const count = _p.count`. Verified end-to-end rather than assumed, and left alone.

## Verified by value, not by codegen

Rendered through `renderHonoComponent`:

| shape | before | after |
|---|---|---|
| `{ text, n: count }`, caller passes `n=7` | `undefined` | `7` |
| `{ text, n: count = 7 }`, caller omits `n` | `undefined` | `7` |
| `{ text, n: count = 7 }`, caller passes `n=42` | `undefined` | `42` |
| `{ text, n }` un-aliased | — | destructure text byte-identical |
| aliased prop read by a client `createEffect` | — | `bf-p` carries `{"text":"hello","count":7}` |

## The fixture #2457 was blocked on

`composite-row-child-aliased-prop` — an aliased prop on a child inside a keyed `.map()` row, with distinct per-row values so a shared-instance bug is visible. This is the shape PR #2462 fixed on the Go side but could not cover, because `expectedHtml` is generated from Hono and Hono was wrong.

Passes on Hono, ERB, and **Go**. Still diverges on Blade, Jinja, Mojolicious, Twig, Xslate, and minijinja — each verified failing before its `render-divergences.ts` entry was added, alongside the `aliased-destructured-prop` entries those adapters already carry for #2460 (which has always been the cross-adapter umbrella for this defect, not a Hono-only issue).

`aliased-destructured-prop` also graduates off Hono's `skipJsx` and off `generate-expected-html.ts`'s `SKIP_AUTO_UPDATE`, since Hono now matches its hand-authored `expectedHtml` exactly.

## Also found, not fixed here

`packages/adapter-erb/src/adapter/erb-adapter.ts:295` and `packages/adapter-blade/src/adapter/blade-adapter.ts:464` both do `propsParams.map(p => ({ name: p.name }))`, dropping `sourceName` the same way. ERB renders a standalone aliased prop empty but happens to survive the composite-loop-row case (there the JSX call-site attribute name drives the child hash keys, not `propsParams`); Blade fails both. Left for follow-ups — the divergence entries above track them.

## Tests

`packages/adapter-hono/src/__tests__/aliased-destructured-prop.test.ts` (6 cases) and 3 `propName` cases in `packages/jsx/src/__tests__/ssr-defaults.test.ts`.

Local, one suite per run: `packages/jsx` **2926 run / 0 fail**, `packages/adapter-hono` **1336 run / 0 fail**, `packages/adapter-tests` **1505 pass** (one unrelated CSR test tripped bun's 5s limit under load at 11.5s and passes alone), Go conformance green on the new fixture with real `go run`. All four Go integrations rebuilt from cleared caches with no `components.go` drift. Lockfiles regenerated with every adapter dist built (as the `lockfile` CI job does) — the only delta is the new fixture, committed separately.

Biome could not be run locally: a concurrent agent worktree under `.claude/worktrees/` carries a nested `biome.jsonc`, which makes Biome exit on configuration discovery regardless of the path argument. Leaving that to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_