### PR TITLE
test: HTML element/attribute semantics checklist fixtures

### DIFF
--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1370,6 +1370,34 @@
         "text"
       ]
     },
+    "controlled-checkbox-checked": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal"
+      ],
+      "axes": [
+        "literal:boolean"
+      ],
+      "contexts": [
+        "attribute"
+      ]
+    },
+    "controlled-radio-checked": {
+      "kinds": [
+        "binary",
+        "call",
+        "identifier",
+        "literal"
+      ],
+      "axes": [
+        "binary:===",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute"
+      ]
+    },
     "controlled-signal": {
       "kinds": [
         "call",
@@ -1672,6 +1700,19 @@
         "text"
       ]
     },
+    "details-open": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal"
+      ],
+      "axes": [
+        "literal:boolean"
+      ],
+      "contexts": [
+        "attribute"
+      ]
+    },
     "dialog": {
       "kinds": [
         "arrow",
@@ -1699,6 +1740,19 @@
         "attribute",
         "condition",
         "text"
+      ]
+    },
+    "dialog-open": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal"
+      ],
+      "axes": [
+        "literal:boolean"
+      ],
+      "contexts": [
+        "attribute"
       ]
     },
     "dropdown-menu": {
@@ -3224,6 +3278,19 @@
         "attribute",
         "loop",
         "text"
+      ]
+    },
+    "progress-meter-value": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal"
+      ],
+      "axes": [
+        "literal:number"
+      ],
+      "contexts": [
+        "attribute"
       ]
     },
     "props-reactive": {
@@ -4752,12 +4819,12 @@
     "array-literal": 69,
     "array-method": 66,
     "arrow": 63,
-    "binary": 79,
-    "call": 188,
+    "binary": 80,
+    "call": 193,
     "conditional": 23,
-    "identifier": 276,
+    "identifier": 281,
     "index-access": 12,
-    "literal": 226,
+    "literal": 231,
     "logical": 43,
     "member": 150,
     "object-literal": 51,
@@ -4797,13 +4864,13 @@
     "binary:-": 11,
     "binary:/": 1,
     "binary:<": 1,
-    "binary:===": 40,
+    "binary:===": 41,
     "binary:>": 11,
     "binary:>=": 1,
-    "literal:boolean": 42,
+    "literal:boolean": 45,
     "literal:null": 23,
-    "literal:number": 95,
-    "literal:string": 163,
+    "literal:number": 96,
+    "literal:string": 164,
     "logical:&&": 7,
     "logical:??": 38,
     "logical:||": 13,

--- a/packages/adapter-tests/fixtures/controlled-checkbox-checked.ts
+++ b/packages/adapter-tests/fixtures/controlled-checkbox-checked.ts
@@ -1,0 +1,36 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Controlled checkbox: `checked={sig()}` on `<input type="checkbox">`.
+ * `checked` is an HTML boolean attribute — the true control must carry
+ * bare `checked`, the false control must OMIT it entirely (an emitted
+ * `checked="false"` string would still check the box). Part of the
+ * HTML element/attribute semantics checklist (state-carrying
+ * attributes; sibling of `select-value-ssr` / `textarea-value-ssr`,
+ * which pin the two members of this family that are broken today).
+ */
+export const fixture = createFixture({
+  id: 'controlled-checkbox-checked',
+  description: 'Controlled checkbox SSRs boolean checked (true bare, false omitted)',
+  source: `
+"use client"
+import { createSignal } from '@barefootjs/client'
+
+export function Prefs() {
+  const [news, setNews] = createSignal(true)
+  const [spam, setSpam] = createSignal(false)
+  return (
+    <fieldset>
+      <input type="checkbox" checked={news()} onChange={(e) => setNews(e.target.checked)} />
+      <input type="checkbox" checked={spam()} onChange={(e) => setSpam(e.target.checked)} />
+    </fieldset>
+  )
+}
+`,
+  expectedHtml: `
+    <fieldset bf-s="test">
+      <input type="checkbox" checked bf="s0">
+      <input type="checkbox" bf="s1">
+    </fieldset>
+  `,
+})

--- a/packages/adapter-tests/fixtures/controlled-radio-checked.ts
+++ b/packages/adapter-tests/fixtures/controlled-radio-checked.ts
@@ -1,0 +1,32 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Controlled radio group: `checked={sig() === value}` per radio.
+ * Same boolean-attribute contract as `controlled-checkbox-checked`,
+ * plus the comparison-derived form that real radio groups use (the
+ * per-option shape `select-option-selected` pins for `<option>`).
+ */
+export const fixture = createFixture({
+  id: 'controlled-radio-checked',
+  description: 'Controlled radio group SSRs checked on the matching radio only',
+  source: `
+"use client"
+import { createSignal } from '@barefootjs/client'
+
+export function SizePicker() {
+  const [size, setSize] = createSignal('md')
+  return (
+    <fieldset>
+      <input type="radio" name="size" value="sm" checked={size() === 'sm'} onChange={() => setSize('sm')} />
+      <input type="radio" name="size" value="md" checked={size() === 'md'} onChange={() => setSize('md')} />
+    </fieldset>
+  )
+}
+`,
+  expectedHtml: `
+    <fieldset bf-s="test">
+      <input type="radio" name="size" value="sm" bf="s0">
+      <input type="radio" name="size" value="md" checked bf="s1">
+    </fieldset>
+  `,
+})

--- a/packages/adapter-tests/fixtures/details-open.ts
+++ b/packages/adapter-tests/fixtures/details-open.ts
@@ -1,0 +1,30 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `<details open={sig()}>` — `open` is the state-carrying boolean
+ * attribute of `<details>` (and `<dialog>`, see `dialog-open`). The
+ * true case must SSR bare `open`; a stringified `open="false"` would
+ * render the details expanded. HTML element/attribute semantics
+ * checklist member.
+ */
+export const fixture = createFixture({
+  id: 'details-open',
+  description: 'Signal-driven details SSRs boolean open from the initial value',
+  source: `
+"use client"
+import { createSignal } from '@barefootjs/client'
+
+export function Faq() {
+  const [open, setOpen] = createSignal(true)
+  return (
+    <details open={open()}>
+      <summary onClick={(e) => { e.preventDefault(); setOpen(!open()) }}>What is it?</summary>
+      <p>A compiler.</p>
+    </details>
+  )
+}
+`,
+  expectedHtml: `
+    <details open bf-s="test" bf="s1"><summary bf="s0">What is it?</summary><p>A compiler.</p></details>
+  `,
+})

--- a/packages/adapter-tests/fixtures/dialog-open.ts
+++ b/packages/adapter-tests/fixtures/dialog-open.ts
@@ -1,0 +1,29 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `<dialog open={sig()}>` — same boolean `open` contract as
+ * `details-open`, on the element where a wrongly-stringified value is
+ * most user-visible (a `open="false"` dialog renders on screen).
+ * The false-initial case, so this pins the OMIT side of the contract.
+ */
+export const fixture = createFixture({
+  id: 'dialog-open',
+  description: 'Signal-driven dialog omits open entirely for a false initial value',
+  source: `
+"use client"
+import { createSignal } from '@barefootjs/client'
+
+export function Confirm() {
+  const [open, setOpen] = createSignal(false)
+  return (
+    <div>
+      <button onClick={() => setOpen(true)}>Show</button>
+      <dialog open={open()}><p>Sure?</p></dialog>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test"><button bf="s0">Show</button><dialog bf="s1"><p>Sure?</p></dialog></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -447,6 +447,12 @@ import { fixture as selectValueSsr } from './select-value-ssr'
 import { fixture as textareaValueSsr } from './textarea-value-ssr'
 import { fixture as signalEarlyReturn } from './signal-early-return'
 import { fixture as logicalAndZero } from './logical-and-zero'
+// HTML element/attribute semantics checklist (state-carrying attributes)
+import { fixture as controlledCheckboxChecked } from './controlled-checkbox-checked'
+import { fixture as controlledRadioChecked } from './controlled-radio-checked'
+import { fixture as detailsOpen } from './details-open'
+import { fixture as dialogOpen } from './dialog-open'
+import { fixture as progressMeterValue } from './progress-meter-value'
 
 import type { JSXFixture } from '../src/types'
 
@@ -770,4 +776,9 @@ export const jsxFixtures: JSXFixture[] = [
   textareaValueSsr,
   signalEarlyReturn,
   logicalAndZero,
+  controlledCheckboxChecked,
+  controlledRadioChecked,
+  detailsOpen,
+  dialogOpen,
+  progressMeterValue,
 ]

--- a/packages/adapter-tests/fixtures/progress-meter-value.ts
+++ b/packages/adapter-tests/fixtures/progress-meter-value.ts
@@ -1,0 +1,31 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `<progress value>` / `<meter value>` — the two elements where
+ * `value` IS the legitimate state attribute. This is the armor twin
+ * of `select-value-ssr` / `textarea-value-ssr` (#2464/#2465): the fix
+ * for those must lower `value` per element, not strip it globally —
+ * this fixture fails if a fix overcorrects and drops `value` here.
+ */
+export const fixture = createFixture({
+  id: 'progress-meter-value',
+  description: 'progress/meter keep their value attribute (armor for the #2464/#2465 fix)',
+  source: `
+"use client"
+import { createSignal } from '@barefootjs/client'
+
+export function Usage() {
+  const [used, setUsed] = createSignal(30)
+  return (
+    <div>
+      <progress value={used()} max="100" />
+      <meter value={used()} min="0" max="100" />
+      <button onClick={() => setUsed(used() + 10)}>Add</button>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test"><progress value="30" max="100" bf="s0"></progress><meter value="30" min="0" max="100" bf="s1"></meter><button bf="s2">Add</button></div>
+  `,
+})

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1850,6 +1850,32 @@
           "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)"
         }
       },
+      "composite-row-child-aliased-prop": {
+        "blade": {
+          "kind": "render",
+          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+        }
+      },
       "date-method-uncatalogued": {
         "blade": {
           "kind": "refusal",
@@ -2884,6 +2910,10 @@
       "aliased-destructured-prop": {
         "description": "Aliased destructured prop ({ n: count }) keeps the rename (#2460)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/aliased-destructured-prop.ts"
+      },
+      "composite-row-child-aliased-prop": {
+        "description": "Nested child in a dynamic loop row destructures a renamed prop ({ n: count })",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/composite-row-child-aliased-prop.ts"
       },
       "date-method-uncatalogued": {
         "description": "Method call on a Date-typed prop refuses with BF021 (no catalogued lowering)",

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 295,
+    "totalFixtures": 300,
     "fixtures": {
       "aliased-destructured-prop": {
         "blade": {
@@ -1848,32 +1848,6 @@
         "xslate": {
           "kind": "render",
           "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)"
-        }
-      },
-      "composite-row-child-aliased-prop": {
-        "blade": {
-          "kind": "render",
-          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
         }
       },
       "date-method-uncatalogued": {
@@ -2910,10 +2884,6 @@
       "aliased-destructured-prop": {
         "description": "Aliased destructured prop ({ n: count }) keeps the rename (#2460)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/aliased-destructured-prop.ts"
-      },
-      "composite-row-child-aliased-prop": {
-        "description": "Nested child in a dynamic loop row destructures a renamed prop ({ n: count })",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/composite-row-child-aliased-prop.ts"
       },
       "date-method-uncatalogued": {
         "description": "Method call on a Date-typed prop refuses with BF021 (no catalogued lowering)",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1026,15 +1026,15 @@
       }
     },
     "binary": {
-      "total": 79,
+      "total": 80,
       "cells": {
         "hono": {
-          "pass": 79,
-          "total": 79
+          "pass": 80,
+          "total": 80
         },
         "blade": {
-          "pass": 70,
-          "total": 79,
+          "pass": 71,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1081,8 +1081,8 @@
           ]
         },
         "erb": {
-          "pass": 71,
-          "total": 79,
+          "pass": 72,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1123,8 +1123,8 @@
           ]
         },
         "go-template": {
-          "pass": 70,
-          "total": 79,
+          "pass": 71,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1171,8 +1171,8 @@
           ]
         },
         "jinja": {
-          "pass": 70,
-          "total": 79,
+          "pass": 71,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1219,8 +1219,8 @@
           ]
         },
         "minijinja": {
-          "pass": 70,
-          "total": 79,
+          "pass": 71,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1267,8 +1267,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 71,
-          "total": 79,
+          "pass": 72,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1309,8 +1309,8 @@
           ]
         },
         "twig": {
-          "pass": 70,
-          "total": 79,
+          "pass": 71,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1357,8 +1357,8 @@
           ]
         },
         "xslate": {
-          "pass": 70,
-          "total": 79,
+          "pass": 71,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 188,
+      "total": 193,
       "cells": {
         "hono": {
-          "pass": 187,
-          "total": 188,
+          "pass": 192,
+          "total": 193,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1433,13 +1433,9 @@
           ]
         },
         "blade": {
-          "pass": 170,
-          "total": 188,
+          "pass": 176,
+          "total": 193,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1521,8 +1517,8 @@
           ]
         },
         "erb": {
-          "pass": 172,
-          "total": 188,
+          "pass": 177,
+          "total": 193,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1599,8 +1595,8 @@
           ]
         },
         "go-template": {
-          "pass": 171,
-          "total": 188,
+          "pass": 176,
+          "total": 193,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1683,13 +1679,9 @@
           ]
         },
         "jinja": {
-          "pass": 170,
-          "total": 188,
+          "pass": 176,
+          "total": 193,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1771,13 +1763,9 @@
           ]
         },
         "minijinja": {
-          "pass": 170,
-          "total": 188,
+          "pass": 176,
+          "total": 193,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1859,13 +1847,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 171,
-          "total": 188,
+          "pass": 177,
+          "total": 193,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1941,13 +1925,9 @@
           ]
         },
         "twig": {
-          "pass": 170,
-          "total": 188,
+          "pass": 176,
+          "total": 193,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2029,13 +2009,9 @@
           ]
         },
         "xslate": {
-          "pass": 170,
-          "total": 188,
+          "pass": 176,
+          "total": 193,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2262,11 +2238,11 @@
       }
     },
     "identifier": {
-      "total": 276,
+      "total": 281,
       "cells": {
         "hono": {
-          "pass": 275,
-          "total": 276,
+          "pass": 280,
+          "total": 281,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2277,15 +2253,11 @@
           ]
         },
         "blade": {
-          "pass": 255,
-          "total": 276,
+          "pass": 261,
+          "total": 281,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
-            {
-              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2377,8 +2349,8 @@
           ]
         },
         "erb": {
-          "pass": 257,
-          "total": 276,
+          "pass": 262,
+          "total": 281,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2467,8 +2439,8 @@
           ]
         },
         "go-template": {
-          "pass": 256,
-          "total": 276,
+          "pass": 261,
+          "total": 281,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2563,15 +2535,11 @@
           ]
         },
         "jinja": {
-          "pass": 255,
-          "total": 276,
+          "pass": 261,
+          "total": 281,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
-            {
-              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2663,15 +2631,11 @@
           ]
         },
         "minijinja": {
-          "pass": 255,
-          "total": 276,
+          "pass": 261,
+          "total": 281,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
-            {
-              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2763,15 +2727,11 @@
           ]
         },
         "mojolicious": {
-          "pass": 256,
-          "total": 276,
+          "pass": 262,
+          "total": 281,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
-            {
-              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2857,15 +2817,11 @@
           ]
         },
         "twig": {
-          "pass": 255,
-          "total": 276,
+          "pass": 261,
+          "total": 281,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
-            {
-              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2957,15 +2913,11 @@
           ]
         },
         "xslate": {
-          "pass": 255,
-          "total": 276,
+          "pass": 261,
+          "total": 281,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
-            {
-              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -3122,15 +3074,15 @@
       }
     },
     "literal": {
-      "total": 226,
+      "total": 231,
       "cells": {
         "hono": {
-          "pass": 226,
-          "total": 226
+          "pass": 231,
+          "total": 231
         },
         "blade": {
-          "pass": 213,
-          "total": 226,
+          "pass": 218,
+          "total": 231,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3189,8 +3141,8 @@
           ]
         },
         "erb": {
-          "pass": 213,
-          "total": 226,
+          "pass": 218,
+          "total": 231,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3249,8 +3201,8 @@
           ]
         },
         "go-template": {
-          "pass": 213,
-          "total": 226,
+          "pass": 218,
+          "total": 231,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3309,8 +3261,8 @@
           ]
         },
         "jinja": {
-          "pass": 213,
-          "total": 226,
+          "pass": 218,
+          "total": 231,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3369,8 +3321,8 @@
           ]
         },
         "minijinja": {
-          "pass": 213,
-          "total": 226,
+          "pass": 218,
+          "total": 231,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3429,8 +3381,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 213,
-          "total": 226,
+          "pass": 218,
+          "total": 231,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3489,8 +3441,8 @@
           ]
         },
         "twig": {
-          "pass": 213,
-          "total": 226,
+          "pass": 218,
+          "total": 231,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3549,8 +3501,8 @@
           ]
         },
         "xslate": {
-          "pass": 213,
-          "total": 226,
+          "pass": 218,
+          "total": 231,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3785,13 +3737,9 @@
           ]
         },
         "blade": {
-          "pass": 132,
+          "pass": 133,
           "total": 150,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4035,13 +3983,9 @@
           ]
         },
         "jinja": {
-          "pass": 132,
+          "pass": 133,
           "total": 150,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4123,13 +4067,9 @@
           ]
         },
         "minijinja": {
-          "pass": 132,
+          "pass": 133,
           "total": 150,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4211,13 +4151,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 133,
+          "pass": 134,
           "total": 150,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4293,13 +4229,9 @@
           ]
         },
         "twig": {
-          "pass": 132,
+          "pass": 133,
           "total": 150,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4381,13 +4313,9 @@
           ]
         },
         "xslate": {
-          "pass": 132,
+          "pass": 133,
           "total": 150,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -7132,15 +7060,15 @@
       }
     },
     "binary:===": {
-      "total": 40,
+      "total": 41,
       "cells": {
         "hono": {
-          "pass": 40,
-          "total": 40
+          "pass": 41,
+          "total": 41
         },
         "blade": {
-          "pass": 32,
-          "total": 40,
+          "pass": 33,
+          "total": 41,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7181,8 +7109,8 @@
           ]
         },
         "erb": {
-          "pass": 33,
-          "total": 40,
+          "pass": 34,
+          "total": 41,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7217,8 +7145,8 @@
           ]
         },
         "go-template": {
-          "pass": 32,
-          "total": 40,
+          "pass": 33,
+          "total": 41,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7259,8 +7187,8 @@
           ]
         },
         "jinja": {
-          "pass": 32,
-          "total": 40,
+          "pass": 33,
+          "total": 41,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7301,8 +7229,8 @@
           ]
         },
         "minijinja": {
-          "pass": 32,
-          "total": 40,
+          "pass": 33,
+          "total": 41,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7343,8 +7271,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 33,
-          "total": 40,
+          "pass": 34,
+          "total": 41,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7379,8 +7307,8 @@
           ]
         },
         "twig": {
-          "pass": 32,
-          "total": 40,
+          "pass": 33,
+          "total": 41,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7421,8 +7349,8 @@
           ]
         },
         "xslate": {
-          "pass": 32,
-          "total": 40,
+          "pass": 33,
+          "total": 41,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7469,10 +7397,10 @@
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
       },
       "example": {
-        "fixture": "map-if-chain-body",
-        "description": "if/else-if chain as a .map() callback body folds to nested IRConditional",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/map-if-chain-body.ts",
-        "code": "it.kind === 'a'"
+        "fixture": "controlled-radio-checked",
+        "description": "Controlled radio group SSRs checked on the matching radio only",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/controlled-radio-checked.ts",
+        "code": "size() === 'sm'"
       }
     },
     "binary:>": {
@@ -7580,15 +7508,15 @@
       }
     },
     "literal:boolean": {
-      "total": 42,
+      "total": 45,
       "cells": {
         "hono": {
-          "pass": 42,
-          "total": 42
+          "pass": 45,
+          "total": 45
         },
         "blade": {
-          "pass": 41,
-          "total": 42,
+          "pass": 44,
+          "total": 45,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7597,8 +7525,8 @@
           ]
         },
         "erb": {
-          "pass": 41,
-          "total": 42,
+          "pass": 44,
+          "total": 45,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7607,8 +7535,8 @@
           ]
         },
         "go-template": {
-          "pass": 41,
-          "total": 42,
+          "pass": 44,
+          "total": 45,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7617,8 +7545,8 @@
           ]
         },
         "jinja": {
-          "pass": 41,
-          "total": 42,
+          "pass": 44,
+          "total": 45,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7627,8 +7555,8 @@
           ]
         },
         "minijinja": {
-          "pass": 41,
-          "total": 42,
+          "pass": 44,
+          "total": 45,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7637,8 +7565,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 41,
-          "total": 42,
+          "pass": 44,
+          "total": 45,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7647,8 +7575,8 @@
           ]
         },
         "twig": {
-          "pass": 41,
-          "total": 42,
+          "pass": 44,
+          "total": 45,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7657,8 +7585,8 @@
           ]
         },
         "xslate": {
-          "pass": 41,
-          "total": 42,
+          "pass": 44,
+          "total": 45,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7731,15 +7659,15 @@
       }
     },
     "literal:number": {
-      "total": 95,
+      "total": 96,
       "cells": {
         "hono": {
-          "pass": 95,
-          "total": 95
+          "pass": 96,
+          "total": 96
         },
         "blade": {
-          "pass": 90,
-          "total": 95,
+          "pass": 91,
+          "total": 96,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7764,8 +7692,8 @@
           ]
         },
         "erb": {
-          "pass": 90,
-          "total": 95,
+          "pass": 91,
+          "total": 96,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7790,8 +7718,8 @@
           ]
         },
         "go-template": {
-          "pass": 90,
-          "total": 95,
+          "pass": 91,
+          "total": 96,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7816,8 +7744,8 @@
           ]
         },
         "jinja": {
-          "pass": 90,
-          "total": 95,
+          "pass": 91,
+          "total": 96,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7842,8 +7770,8 @@
           ]
         },
         "minijinja": {
-          "pass": 90,
-          "total": 95,
+          "pass": 91,
+          "total": 96,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7868,8 +7796,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 90,
-          "total": 95,
+          "pass": 91,
+          "total": 96,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7894,8 +7822,8 @@
           ]
         },
         "twig": {
-          "pass": 90,
-          "total": 95,
+          "pass": 91,
+          "total": 96,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7920,8 +7848,8 @@
           ]
         },
         "xslate": {
-          "pass": 90,
-          "total": 95,
+          "pass": 91,
+          "total": 96,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7959,15 +7887,15 @@
       }
     },
     "literal:string": {
-      "total": 163,
+      "total": 164,
       "cells": {
         "hono": {
-          "pass": 163,
-          "total": 163
+          "pass": 164,
+          "total": 164
         },
         "blade": {
-          "pass": 153,
-          "total": 163,
+          "pass": 154,
+          "total": 164,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8014,8 +7942,8 @@
           ]
         },
         "erb": {
-          "pass": 153,
-          "total": 163,
+          "pass": 154,
+          "total": 164,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8062,8 +7990,8 @@
           ]
         },
         "go-template": {
-          "pass": 153,
-          "total": 163,
+          "pass": 154,
+          "total": 164,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8110,8 +8038,8 @@
           ]
         },
         "jinja": {
-          "pass": 153,
-          "total": 163,
+          "pass": 154,
+          "total": 164,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8158,8 +8086,8 @@
           ]
         },
         "minijinja": {
-          "pass": 153,
-          "total": 163,
+          "pass": 154,
+          "total": 164,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8206,8 +8134,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 153,
-          "total": 163,
+          "pass": 154,
+          "total": 164,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8254,8 +8182,8 @@
           ]
         },
         "twig": {
-          "pass": 153,
-          "total": 163,
+          "pass": 154,
+          "total": 164,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8302,8 +8230,8 @@
           ]
         },
         "xslate": {
-          "pass": 153,
-          "total": 163,
+          "pass": 154,
+          "total": 164,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1433,9 +1433,13 @@
           ]
         },
         "blade": {
-          "pass": 176,
+          "pass": 175,
           "total": 193,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1679,9 +1683,13 @@
           ]
         },
         "jinja": {
-          "pass": 176,
+          "pass": 175,
           "total": 193,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1763,9 +1771,13 @@
           ]
         },
         "minijinja": {
-          "pass": 176,
+          "pass": 175,
           "total": 193,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1847,9 +1859,13 @@
           ]
         },
         "mojolicious": {
-          "pass": 177,
+          "pass": 176,
           "total": 193,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1925,9 +1941,13 @@
           ]
         },
         "twig": {
-          "pass": 176,
+          "pass": 175,
           "total": 193,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2009,9 +2029,13 @@
           ]
         },
         "xslate": {
-          "pass": 176,
+          "pass": 175,
           "total": 193,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2253,11 +2277,15 @@
           ]
         },
         "blade": {
-          "pass": 261,
+          "pass": 260,
           "total": 281,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
+              "issues": []
+            },
+            {
+              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2535,11 +2563,15 @@
           ]
         },
         "jinja": {
-          "pass": 261,
+          "pass": 260,
           "total": 281,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
+              "issues": []
+            },
+            {
+              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2631,11 +2663,15 @@
           ]
         },
         "minijinja": {
-          "pass": 261,
+          "pass": 260,
           "total": 281,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
+              "issues": []
+            },
+            {
+              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2727,11 +2763,15 @@
           ]
         },
         "mojolicious": {
-          "pass": 262,
+          "pass": 261,
           "total": 281,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
+              "issues": []
+            },
+            {
+              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2817,11 +2857,15 @@
           ]
         },
         "twig": {
-          "pass": 261,
+          "pass": 260,
           "total": 281,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
+              "issues": []
+            },
+            {
+              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -2913,11 +2957,15 @@
           ]
         },
         "xslate": {
-          "pass": 261,
+          "pass": 260,
           "total": 281,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
+              "issues": []
+            },
+            {
+              "fixture": "composite-row-child-aliased-prop",
               "issues": []
             },
             {
@@ -3737,9 +3785,13 @@
           ]
         },
         "blade": {
-          "pass": 133,
+          "pass": 132,
           "total": 150,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3983,9 +4035,13 @@
           ]
         },
         "jinja": {
-          "pass": 133,
+          "pass": 132,
           "total": 150,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4067,9 +4123,13 @@
           ]
         },
         "minijinja": {
-          "pass": 133,
+          "pass": 132,
           "total": 150,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4151,9 +4211,13 @@
           ]
         },
         "mojolicious": {
-          "pass": 134,
+          "pass": 133,
           "total": 150,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4229,9 +4293,13 @@
           ]
         },
         "twig": {
-          "pass": 133,
+          "pass": 132,
           "total": 150,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4313,9 +4381,13 @@
           ]
         },
         "xslate": {
-          "pass": 133,
+          "pass": 132,
           "total": 150,
           "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [


### PR DESCRIPTION
## Summary

Second PR of the test-reinforcement stack — **stacked on #2469** (client-JS scope gate); merge that first, then retarget this to `main`.

The HTML spec's element-specific state-carrying attributes are a **finite, enumerable surface** — exactly the class #2464/#2465 (`select`/`textarea` `value`) fell into silently, because nobody had written the row of the table down. This PR adds the five uncovered members of that table as executable contracts:

| Fixture | Contract |
|---|---|
| `controlled-checkbox-checked` | Boolean `checked`: true SSRs bare `checked`, false **omits** it (a stringified `checked="false"` would still check the box) |
| `controlled-radio-checked` | Same, in the comparison-derived per-option form real radio groups use (`checked={sig() === value}`) |
| `details-open` | Boolean `open`, emit-when-true side |
| `dialog-open` | Boolean `open`, omit-when-false side (an `open="false"` dialog renders on screen) |
| `progress-meter-value` | **Armor twin of #2464/#2465**: `progress`/`meter` are where `value` IS the legitimate state attribute — this fixture fails if the select/textarea fix overcorrects and strips `value` globally |

`select-option-selected` already covers `option`/`selected`; `select`/`textarea` `value` stay pinned by their #2464/#2465 fixtures. Together these complete the state-carrying rows of the checklist.

## Verification

All five pass today on every locally-runnable backend — hono, erb, jinja, minijinja, go (`GOTOOLCHAIN=go1.25.6`) — and at the CSR-conformance and scope-gate layers. They land as pure regression armor: **no pins, no new issues, no changesets** (only the private `packages/adapter-tests` plus regenerated corpus artifacts: coverage-map, generated-data-points, compat.lock, support-matrix.lock).

## Stack

1. #2469 — client-JS scope gate (base: `main`)
2. **This PR** — HTML semantics checklist (base: #2469's branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpPtSg6rTe158671pknoD2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpPtSg6rTe158671pknoD2)_