### PR TITLE
Regenerate expectedHtml for the five HTML-semantics fixtures (unblocks update-expected-html)

### DIFF
--- a/packages/adapter-tests/fixtures/controlled-checkbox-checked.ts
+++ b/packages/adapter-tests/fixtures/controlled-checkbox-checked.ts
@@ -29,8 +29,8 @@ export function Prefs() {
 `,
   expectedHtml: `
     <fieldset bf-s="test">
-      <input type="checkbox" checked bf="s0">
-      <input type="checkbox" bf="s1">
+      <input bf="s0" checked type="checkbox">
+      <input bf="s1" type="checkbox">
     </fieldset>
   `,
 })

--- a/packages/adapter-tests/fixtures/controlled-radio-checked.ts
+++ b/packages/adapter-tests/fixtures/controlled-radio-checked.ts
@@ -25,8 +25,8 @@ export function SizePicker() {
 `,
   expectedHtml: `
     <fieldset bf-s="test">
-      <input type="radio" name="size" value="sm" bf="s0">
-      <input type="radio" name="size" value="md" checked bf="s1">
+      <input bf="s0" name="size" type="radio" value="sm">
+      <input bf="s1" checked name="size" type="radio" value="md">
     </fieldset>
   `,
 })

--- a/packages/adapter-tests/fixtures/details-open.ts
+++ b/packages/adapter-tests/fixtures/details-open.ts
@@ -25,6 +25,9 @@ export function Faq() {
 }
 `,
   expectedHtml: `
-    <details open bf-s="test" bf="s1"><summary bf="s0">What is it?</summary><p>A compiler.</p></details>
+    <details bf-s="test" bf="s1" open>
+      <summary bf="s0">What is it?</summary>
+      <p>A compiler.</p>
+    </details>
   `,
 })

--- a/packages/adapter-tests/fixtures/dialog-open.ts
+++ b/packages/adapter-tests/fixtures/dialog-open.ts
@@ -24,6 +24,9 @@ export function Confirm() {
 }
 `,
   expectedHtml: `
-    <div bf-s="test"><button bf="s0">Show</button><dialog bf="s1"><p>Sure?</p></dialog></div>
+    <div bf-s="test">
+      <button bf="s0">Show</button>
+      <dialog bf="s1"><p>Sure?</p></dialog>
+    </div>
   `,
 })

--- a/packages/adapter-tests/fixtures/progress-meter-value.ts
+++ b/packages/adapter-tests/fixtures/progress-meter-value.ts
@@ -26,6 +26,10 @@ export function Usage() {
 }
 `,
   expectedHtml: `
-    <div bf-s="test"><progress value="30" max="100" bf="s0"></progress><meter value="30" min="0" max="100" bf="s1"></meter><button bf="s2">Add</button></div>
+    <div bf-s="test">
+      <progress bf="s0" max="100" value="30"></progress>
+      <meter bf="s1" max="100" min="0" value="30"></meter>
+      <button bf="s2">Add</button>
+    </div>
   `,
 })


### PR DESCRIPTION
`update-expected-html` is red on `main` and has been since #2471 landed, so the gate currently fails every PR regardless of its contents.

## What's wrong

The five fixtures #2471 added carry hand-written `expectedHtml` that `generate-expected-html.ts` does not reproduce byte-for-byte. Two differences, both purely formatting:

```diff
-    <details open bf-s="test" bf="s1"><summary bf="s0">What is it?</summary><p>A compiler.</p></details>
+    <details bf-s="test" bf="s1" open>
+      <summary bf="s0">What is it?</summary>
+      <p>A compiler.</p>
+    </details>
```

The generator puts children on their own lines and sorts attributes; the hand-written expectations are single-line with source attribute order.

## Verified pre-existing

Not inherited from any open branch: checked out `origin/main`, rebuilt all eleven package dists (as the CI job does), ran the generator — exactly these five diffs and nothing else. Confirmed twice, once while isolating a failure on #2472 and once on this branch.

## Scope

Generated output only. No fixture source, no expectation semantics, no adapter behaviour. The point is to get the gate meaningful again — right now a red `update-expected-html` carries no information, so real drift would be indistinguishable from this noise.

Worth a follow-up either way: a hand-authored `expectedHtml` that the generator immediately overwrites means the two are free to disagree until someone runs the gate. Either the fixtures should be generated from the start, or the generator's formatting should be what authors write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM

---
_Generated by [Claude Code](https://claude.ai/code/session_015sYXhjpzoVYA5J6GbWvxqM)_