### PR TITLE
fix(jsx): scope-aware prop rewrite + loop guard on template-span const folds (#2482 falsification round)

### DIFF
--- a/.changeset/declare-loop-scope-audit-divergences.md
+++ b/.changeset/declare-loop-scope-audit-divergences.md
@@ -1,0 +1,12 @@
+---
+"@barefootjs/twig": patch
+"@barefootjs/jinja": patch
+"@barefootjs/blade": patch
+"@barefootjs/xslate": patch
+"@barefootjs/rust": patch
+"@barefootjs/erb": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/go-template": patch
+---
+
+Declare the render divergences found by probing the #2482 loop-scope audit's unguarded name-resolution sites: the Twig-family boolean-prop misroute for loop params (#2488) and the `emitSpread` local-const shadow (#2489); ERB's symbol-vs-string dynamic row-key lookup (#2491); and Go's condition-position destructured bindings (#2486), nested-loop `inLoop` clobber (#2487), row-spread attribute-name mangling (#2490), dynamic row-key lookup (#2491), and JS-computed initializer seeding (#2492). Each entry carries its issue URL and graduates when the fix lands.

--- a/.changeset/scope-aware-prop-rewrite.md
+++ b/.changeset/scope-aware-prop-rewrite.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Close two loop/callback scope holes found by the #2482 name-resolution audit: `rewriteBarePropRefs` is now scope-aware (a nested callback parameter sharing a prop's name no longer produces the syntactically invalid `.map((_p.x) => …)` in the client bundle — discovery and application both carry a binding stack, so mixed expressions rewrite exactly the genuine outer references), and `tryResolveTemplateSpanFromConst` no longer folds a module/component const into a `${IDENT}` / `${IDENT[KEY]}` template span when the identifier is bound by an enclosing `.map()` callback (every row used to render from the frozen outer const).

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -32,4 +32,12 @@ export const renderDivergences: RenderDivergences = {
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'composite-row-child-aliased-prop':
     'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
+
+  // #2482 audit follow-ups: loop-scope holes in per-adapter name
+  // classification. Graduate by applying the loop-bound-name guards
+  // described in each issue and deleting the line.
+  'loop-param-shadows-bool-prop':
+    'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
+  'loop-param-shadows-spread-const':
+    'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -30,4 +30,14 @@ export const renderDivergences: RenderDivergences = {
   // `skipJsx` entries).
   'aliased-destructured-prop':
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
+
+  // #2482 audit follow-ups: loop-scope holes in per-adapter name
+  // classification. Graduate by applying the loop-bound-name guards
+  // described in each issue and deleting the line.
+  'loop-param-shadows-bool-prop':
+    'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the loop-bound-name subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
+  'loop-param-shadows-spread-const':
+    'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check (the live `loopBoundNames` map exists but is not consulted on this path), so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
+  'loop-param-shadows-record-template-span':
+    'a dynamic-key element access on a loop row (`tone[k]`) renders empty: row hashes deserialize with SYMBOL keys while the dynamic key is a STRING, so `tone["a"]` is nil (https://github.com/piconic-ai/barefootjs/issues/2491)',
 }

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -40,4 +40,18 @@ export const renderDivergences: RenderDivergences = {
   // `skipJsx` entries).
   'aliased-destructured-prop':
     'aliased destructured prop `{ n: count }` loses its rename — the Input struct field is Count `json:"count"`, so the caller-side struct literal keyed by the real prop name fails `go run` outright (unknown field N, exit 1) (https://github.com/piconic-ai/barefootjs/issues/2460)',
+
+  // #2482 audit follow-ups: loop-scope holes specific to this adapter's
+  // four-stack scope tracking and its SSR seeding. Graduate by applying
+  // the fix described in each issue and deleting the line.
+  'loop-destructured-param-condition':
+    'a destructured .map() param binding used as a row ternary CONDITION emits the root-scope `{{if $.Active}}` — `renderConditionExpr` omits `loopBindingStack`, unlike `identifierToGoRef` (text positions resolve the same binding correctly) (https://github.com/piconic-ai/barefootjs/issues/2486)',
+  'nested-loop-tail-content':
+    'outer-row content AFTER a nested inner loop renders through non-loop arms (spread lowers to the component-root `.Spread_0`) — `inLoop` is cleared, not restored, by the inner loop\'s exit; the same content BEFORE the inner loop emits correctly (https://github.com/piconic-ai/barefootjs/issues/2487)',
+  'loop-param-shadows-spread-const':
+    'spreading a loop row object mangles attribute names (`id` → `-i-d`, `title` → `-title`); the spread VALUE is correctly row-scoped, distinguishing this from the template-adapter const-shadow hole #2489 (https://github.com/piconic-ai/barefootjs/issues/2490)',
+  'loop-param-shadows-record-template-span':
+    'a dynamic-key element access on a loop row (`tone[k]`) renders empty at execute time — the emitted template contains no baked const (correct post-fix), but the row lookup resolves to nothing (https://github.com/piconic-ai/barefootjs/issues/2491)',
+  'callback-param-shadows-prop':
+    'JS-computed signal/memo initializers (`[…].map(…).join(…)`, memo over signal + prop) don\'t seed Go SSR — renders `[]` / empty where every other adapter renders the computed value; hydration snaps to correct (https://github.com/piconic-ai/barefootjs/issues/2492)',
 }

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -32,4 +32,12 @@ export const renderDivergences: RenderDivergences = {
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'composite-row-child-aliased-prop':
     'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
+
+  // #2482 audit follow-ups: loop-scope holes in per-adapter name
+  // classification. Graduate by applying the loop-bound-name guards
+  // described in each issue and deleting the line.
+  'loop-param-shadows-bool-prop':
+    'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
+  'loop-param-shadows-spread-const':
+    'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -39,4 +39,6 @@ export const renderDivergences: RenderDivergences = {
   // consults the live `loopBoundNames` map on that path.)
   'loop-param-shadows-bool-prop':
     'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the loop-bound-name subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
+  'loop-param-shadows-record-template-span':
+    'a dynamic-key element access on a loop row (`tone[k]`) diverges on real Mojolicious at render time (same silent-empty family as ERB/Go/Twig; the Perl-side mechanism needs a dig) (https://github.com/piconic-ai/barefootjs/issues/2491)',
 }

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -32,4 +32,11 @@ export const renderDivergences: RenderDivergences = {
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'composite-row-child-aliased-prop':
     'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
+
+  // #2482 audit follow-up. Graduate by applying the loop-bound-name
+  // guard described in the issue and deleting the line. (The emitSpread
+  // sibling hole #2489 does NOT affect this adapter — its emitter
+  // consults the live `loopBoundNames` map on that path.)
+  'loop-param-shadows-bool-prop':
+    'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the loop-bound-name subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
 }

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -34,4 +34,12 @@ export const renderDivergences: RenderDivergences = {
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'composite-row-child-aliased-prop':
     'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
+
+  // #2482 audit follow-ups: loop-scope holes in per-adapter name
+  // classification. Graduate by applying the loop-bound-name guards
+  // described in each issue and deleting the line.
+  'loop-param-shadows-bool-prop':
+    'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
+  'loop-param-shadows-spread-const':
+    'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -945,6 +945,27 @@
         "text"
       ]
     },
+    "callback-param-shadows-prop": {
+      "kinds": [
+        "array-literal",
+        "array-method",
+        "arrow",
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "array-method:join",
+        "binary:+",
+        "literal:string"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "camelcase-attributes": {
       "kinds": [
         "literal"
@@ -2576,6 +2597,22 @@
         "text"
       ]
     },
+    "loop-destructured-param-condition": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal"
+      ],
+      "axes": [
+        "literal:number"
+      ],
+      "contexts": [
+        "attribute",
+        "condition",
+        "loop",
+        "text"
+      ]
+    },
     "loop-item-conditional": {
       "kinds": [
         "array-literal",
@@ -2614,6 +2651,21 @@
       "contexts": [
         "attribute",
         "condition",
+        "loop",
+        "text"
+      ]
+    },
+    "loop-param-shadows-bool-prop": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal"
+      ],
+      "axes": [
+        "literal:number"
+      ],
+      "contexts": [
+        "attribute",
         "loop",
         "text"
       ]
@@ -2668,6 +2720,44 @@
         "attribute",
         "loop",
         "text"
+      ]
+    },
+    "loop-param-shadows-record-template-span": {
+      "kinds": [
+        "call",
+        "identifier",
+        "index-access",
+        "literal",
+        "member",
+        "object-literal",
+        "template-literal"
+      ],
+      "axes": [
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "loop-param-shadows-spread-const": {
+      "kinds": [
+        "call",
+        "conditional",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop"
       ]
     },
     "loop-preamble-attr-value": {
@@ -3035,6 +3125,22 @@
         "member"
       ],
       "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "nested-loop-tail-content": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal",
+        "member"
+      ],
+      "axes": [
+        "literal:number"
+      ],
       "contexts": [
         "attribute",
         "loop",
@@ -4835,19 +4941,19 @@
     }
   },
   "kindCounts": {
-    "array-literal": 69,
-    "array-method": 66,
-    "arrow": 63,
-    "binary": 81,
-    "call": 194,
-    "conditional": 23,
-    "identifier": 282,
-    "index-access": 13,
-    "literal": 232,
+    "array-literal": 70,
+    "array-method": 67,
+    "arrow": 64,
+    "binary": 82,
+    "call": 200,
+    "conditional": 24,
+    "identifier": 288,
+    "index-access": 14,
+    "literal": 238,
     "logical": 43,
-    "member": 150,
-    "object-literal": 52,
-    "template-literal": 29,
+    "member": 154,
+    "object-literal": 55,
+    "template-literal": 30,
     "unary": 23,
     "unsupported": 31
   },
@@ -4858,7 +4964,7 @@
     "array-method:flat": 4,
     "array-method:includes": 12,
     "array-method:indexOf": 1,
-    "array-method:join": 38,
+    "array-method:join": 39,
     "array-method:lastIndexOf": 1,
     "array-method:padEnd": 1,
     "array-method:padStart": 1,
@@ -4879,7 +4985,7 @@
     "binary:!=": 2,
     "binary:!==": 9,
     "binary:*": 10,
-    "binary:+": 18,
+    "binary:+": 19,
     "binary:-": 11,
     "binary:/": 1,
     "binary:<": 1,
@@ -4888,8 +4994,8 @@
     "binary:>=": 1,
     "literal:boolean": 45,
     "literal:null": 23,
-    "literal:number": 96,
-    "literal:string": 165,
+    "literal:number": 101,
+    "literal:string": 168,
     "logical:&&": 7,
     "logical:??": 38,
     "logical:||": 13,

--- a/packages/adapter-tests/fixtures/callback-param-shadows-prop.ts
+++ b/packages/adapter-tests/fixtures/callback-param-shadows-prop.ts
@@ -1,0 +1,49 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A nested callback parameter (`.map((title) => …)`) sharing a
+ * destructured PROP's name, inside a signal initializer and a memo
+ * computation.
+ *
+ * `rewriteBarePropRefs` (the `_p.`-prefixing pass that makes signal /
+ * memo expressions scope-sound in the module-level CSR template lambda)
+ * used to collect prop references with no notion of binding scope and
+ * apply them via a global word-boundary regex — so the callback's own
+ * parameter got rewritten too, emitting the syntactically INVALID
+ * `.map((_p.title) => _p.title.a)` into the client bundle: a parse
+ * error that killed hydration for every component in the file. Fixed by
+ * making both the discovery walk and the rewrite application carry a
+ * binding stack (nested function-like params, block declarations, catch
+ * variables), so only genuine prop references are prefixed — a mixed
+ * expression like `title + items().map((title) => …)` rewrites exactly
+ * the outer occurrence.
+ */
+export const fixture = createFixture({
+  id: 'callback-param-shadows-prop',
+  description: 'Nested callback param sharing a prop name stays a param in the CSR template (no invalid `_p.` rewrite)',
+  source: `
+'use client'
+import { createSignal, createMemo } from '@barefootjs/client'
+
+export function CallbackParamShadowsProp({ title }: { title: string }) {
+  const [items, setItems] = createSignal([{ a: 'x' }, { a: 'y' }])
+  const [first] = createSignal([{ a: 'p' }].map((title) => title.a).join(','))
+  const joined = createMemo(() => title + ':' + items().map((title) => title.a).join(','))
+  return (
+    <div>
+      <span>{first()}</span>
+      <output>{joined()}</output>
+      <button onClick={() => setItems([...items(), { a: 'z' }])}>add</button>
+    </div>
+  )
+}
+`,
+  props: { title: 'T' },
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><!--bf:s0-->p<!--/--></span>
+      <output bf="s3"><!--bf:s2-->T:x,y<!--/--></output>
+      <button bf="s4">add</button>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -428,6 +428,21 @@ import { fixture as filterParamNameDiffers } from './filter-param-name-differs'
 // object const; every Twig-family adapter used to bake the const's
 // literal into each iteration instead of reading the loop's own item.
 import { fixture as loopParamShadowsRecordConst } from './loop-param-shadows-record-const'
+// #2482 audit follow-ups: two compiler-side loop/callback scope holes
+// found by probing the unguarded name-resolution sites. The first pins
+// the scope-aware `rewriteBarePropRefs` (a nested callback param sharing
+// a prop name used to emit invalid `.map((_p.x) => …)` client JS); the
+// second pins the `${IDENT[KEY]}` template-span fold's loop-param guard.
+import { fixture as callbackParamShadowsProp } from './callback-param-shadows-prop'
+import { fixture as loopParamShadowsRecordTemplateSpan } from './loop-param-shadows-record-template-span'
+// #2482 audit follow-ups, adapter-side (pinned known limitations):
+// Go condition-position destructured bindings, Go nested-loop `inLoop`
+// state clobber, Twig-family boolean-prop-set misrouting, and the
+// emitSpread local-const shadow hole.
+import { fixture as loopDestructuredParamCondition } from './loop-destructured-param-condition'
+import { fixture as nestedLoopTailContent } from './nested-loop-tail-content'
+import { fixture as loopParamShadowsBoolProp } from './loop-param-shadows-bool-prop'
+import { fixture as loopParamShadowsSpreadConst } from './loop-param-shadows-spread-const'
 import { fixture as dateMethodUncatalogued } from './date-method-uncatalogued'
 import { fixture as dateCatalogued } from './date-catalogued'
 import { fixture as formatDate } from './format-date'
@@ -767,6 +782,12 @@ export const jsxFixtures: JSXFixture[] = [
   filterWrapperPropsReachable,
   filterParamNameDiffers,
   loopParamShadowsRecordConst,
+  callbackParamShadowsProp,
+  loopParamShadowsRecordTemplateSpan,
+  loopDestructuredParamCondition,
+  nestedLoopTailContent,
+  loopParamShadowsBoolProp,
+  loopParamShadowsSpreadConst,
   dateMethodUncatalogued,
   dateCatalogued,
   formatDate,

--- a/packages/adapter-tests/fixtures/loop-destructured-param-condition.ts
+++ b/packages/adapter-tests/fixtures/loop-destructured-param-condition.ts
@@ -1,0 +1,41 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A destructured `.map()` callback param whose binding drives a ternary
+ * CONDITION inside the row (`({ label, active }) => active ? … : …`).
+ *
+ * Text positions resolve the destructured bindings correctly on every
+ * adapter, but the Go adapter's `renderConditionExpr` consults a
+ * narrower set of its loop-scope stacks than `identifierToGoRef`
+ * (it omits `loopBindingStack`, which is exactly the stack destructured
+ * bindings live on) — so the condition emits the parent-scope
+ * `{{if $.Active}}` instead of the row's binding, and every row renders
+ * the same branch (or errors at execute time when the root has no such
+ * field). See the audit trail in #2482.
+ */
+export const fixture = createFixture({
+  id: 'loop-destructured-param-condition',
+  description: 'Destructured .map() param binding used as a row ternary condition stays row-scoped',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function DestructuredCondRows({ rows }: { rows: { id: number; label: string; active: boolean }[] }) {
+  const [n, setN] = createSignal(0)
+  return (
+    <ul data-n={n()} onClick={() => setN(n() + 1)}>
+      {rows.map(({ id, label, active }) => (
+        <li key={id}>{active ? <b>{label}</b> : <i>{label}</i>}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  props: { rows: [{ id: 1, label: 'one', active: true }, { id: 2, label: 'two', active: false }] },
+  expectedHtml: `
+    <ul bf-s="test" bf="s3" data-n="0">
+      <li data-key="1"><b bf-c="s0"><!--bf:s1-->one<!--/--></b></li>
+      <li data-key="2"><i bf-c="s0"><!--bf:s2-->two<!--/--></i></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/loop-param-shadows-bool-prop.ts
+++ b/packages/adapter-tests/fixtures/loop-param-shadows-bool-prop.ts
@@ -1,0 +1,43 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A `.map()` callback param sharing a BOOLEAN-typed prop's name
+ * (`active`), used in a row attribute and row text.
+ *
+ * The Twig-family adapters classify attribute identifiers against
+ * per-component prop-name sets built in `props/prop-classes.ts`. The
+ * string-valued set (`collectStringValueNames`) got the
+ * `collectLoopBoundNames` subtraction in #2212/#2236 — but its two
+ * siblings in the SAME file, `collectBooleanTypedProps` and
+ * `collectNullableOptionalProps`, did not (the fix was applied
+ * per-function, not per-file — see the audit trail in #2482). A row
+ * value whose name matches a boolean prop is therefore routed through
+ * the boolean lowering (`bf.bool_str(...)`), rendering `"true"`/
+ * `"false"` instead of the row's string value.
+ */
+export const fixture = createFixture({
+  id: 'loop-param-shadows-bool-prop',
+  description: '.map() param sharing a boolean prop name renders the row value, not a bool lowering',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function BoolPropShadow({ active, flags }: { active: boolean; flags: string[] }) {
+  const [n, setN] = createSignal(0)
+  return (
+    <ul data-n={n()} onClick={() => setN(n() + 1)}>
+      {flags.map((active, i) => (
+        <li key={i} data-x={active}>{active}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  props: { active: true, flags: ['on', 'off'] },
+  expectedHtml: `
+    <ul bf-s="test" bf="s2" data-n="0">
+      <li bf="s1" data-key="0" data-x="on"><!--bf:s0-->on<!--/--></li>
+      <li bf="s1" data-key="1" data-x="off"><!--bf:s0-->off<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/loop-param-shadows-record-template-span.ts
+++ b/packages/adapter-tests/fixtures/loop-param-shadows-record-template-span.ts
@@ -1,0 +1,48 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A `.map()` callback param shadowing a module-scope RECORD const,
+ * read via a dynamic-key element access INSIDE a template-literal span
+ * (`` `t ${tone[k]}` ``) in the loop body.
+ *
+ * The template-span structurer (`tryResolveTemplateSpanFromConst`'s
+ * `\${IDENT[KEY]}` arm, #2000/#2300 lineage) resolved the base
+ * identifier against `localConstants` with no loop-scope check, folding
+ * the OUTER record literal into a compile-time `lookup` part — every
+ * row rendered from the frozen module const instead of its own item, on
+ * every adapter including the Hono reference and the CSR bundle. Fixed
+ * with the same `ctx.loopParams` guard the `\${IDENT}` arm family got
+ * in #2222/#2235: inside the shadowing callback the span falls back to
+ * the bare-expression path, which sees the row binding.
+ *
+ * The sibling of `loop-param-shadows-record-const` (#2237, adapter-side
+ * property-access lookups) — this one pins the COMPILER-side fold that
+ * happens before adapters ever see the IR.
+ */
+export const fixture = createFixture({
+  id: 'loop-param-shadows-record-template-span',
+  description: '.map() param shadowing a record const stays row-scoped inside a `${base[key]}` template span',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+const tone = { a: 'outer-a', b: 'outer-b' }
+
+export function LoopParamShadowsRecordTemplateSpan({ items, k }: { items: { id: number; a: string; b: string }[]; k: 'a' | 'b' }) {
+  const [n, setN] = createSignal(0)
+  return (
+    <div data-n={n()} onClick={() => setN(n() + 1)}>
+      <ul>
+        {items.map((tone) => (
+          <li key={tone.id} data-t={\`t \${tone[k]}\`}>{tone.a}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+`,
+  props: { items: [{ id: 1, a: 'row1-a', b: 'row1-b' }, { id: 2, a: 'row2-a', b: 'row2-b' }], k: 'a' },
+  expectedHtml: `
+    <div bf-s="test" bf="s3" data-n="0"><ul bf="s2"><li bf="s1" data-key="1" data-t="t row1-a"><!--bf:s0-->row1-a<!--/--></li><li bf="s1" data-key="2" data-t="t row2-a"><!--bf:s0-->row2-a<!--/--></li></ul></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/loop-param-shadows-spread-const.ts
+++ b/packages/adapter-tests/fixtures/loop-param-shadows-spread-const.ts
@@ -1,0 +1,44 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A `.map()` callback param shadowing a component-scope object const,
+ * SPREAD onto a row element (`{items.map((attrs) => <p {...attrs}/>)}`
+ * with an outer `const attrs = big ? {…} : {}`).
+ *
+ * The template adapters' `emitSpread` resolves a spread identifier
+ * against `localConstants` before falling back to the runtime value.
+ * That lookup checks the const's INITIALIZER shape but never checks
+ * whether the name is loop-bound at the emission site (the same class
+ * of hole #2221/#2237 closed for literal/record consts — `emitSpread`
+ * was not covered). Every row therefore spreads the OUTER conditional
+ * object instead of the row's own fields. The scope-precise ERB/Mojo
+ * `loopBoundNames` map exists in those adapters but is not consulted
+ * here either. See the audit trail in #2482.
+ */
+export const fixture = createFixture({
+  id: 'loop-param-shadows-spread-const',
+  description: '.map() param shadowing an object const spreads the row value, not the outer const',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function SpreadConstShadow({ items, big }: { items: { id: number; title: string }[]; big: boolean }) {
+  const attrs = big ? { role: 'note' } : {}
+  const [n, setN] = createSignal(0)
+  return (
+    <div {...attrs} data-n={n()} onClick={() => setN(n() + 1)}>
+      {items.map((attrs) => (
+        <p key={attrs.id} {...attrs}>x</p>
+      ))}
+    </div>
+  )
+}
+`,
+  props: { items: [{ id: 1, title: 'first' }, { id: 2, title: 'second' }], big: true },
+  expectedHtml: `
+    <div bf-s="test" bf="s1" data-n="0" role="note">
+      <p bf="s0" data-key="1" id="1" title="first">x</p>
+      <p bf="s0" data-key="2" id="2" title="second">x</p>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/nested-loop-tail-content.ts
+++ b/packages/adapter-tests/fixtures/nested-loop-tail-content.ts
@@ -1,0 +1,55 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Outer-loop row content that comes AFTER a nested inner loop — here a
+ * spread over a row field (`<footer {...g.extra}>`) following the inner
+ * `<ul>{g.tags.map(…)}</ul>`.
+ *
+ * The Go adapter tracks "am I inside a loop" in a single boolean
+ * (`inLoop`) that the inner loop's exit path resets to `false` with no
+ * save/restore (its Twig-family analogue does save/restore
+ * `prevInLoop`). Everything in the outer row body after the inner loop
+ * therefore renders through the NON-loop emission arms — the spread
+ * lowers to the component-root slot mechanism (`.Spread_0`) instead of
+ * the row-scoped field. The same content placed BEFORE the inner loop
+ * emits correctly, which pins the state-clobber mechanism. See the
+ * audit trail in #2482.
+ */
+export const fixture = createFixture({
+  id: 'nested-loop-tail-content',
+  description: 'Outer-row content after a nested inner loop still renders row-scoped (spread over a row field)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function NestedLoopTail({ groups }: { groups: { id: number; name: string; tags: string[]; extra: Record<string, string> }[] }) {
+  const [n, setN] = createSignal(0)
+  return (
+    <div data-n={n()} onClick={() => setN(n() + 1)}>
+      {groups.map((g) => (
+        <section key={g.id}>
+          <ul>{g.tags.map((t, j) => <li key={j}>{t}</li>)}</ul>
+          <footer {...g.extra}>{g.name}</footer>
+        </section>
+      ))}
+    </div>
+  )
+}
+`,
+  props: { groups: [{ id: 1, name: 'alpha', tags: ['x', 'y'], extra: { 'data-kind': 'a' } }, { id: 2, name: 'beta', tags: ['z'], extra: { 'data-kind': 'b' } }] },
+  expectedHtml: `
+    <div bf-s="test" bf="s4" data-n="0">
+      <section data-key="1">
+        <ul bf="s1">
+          <li data-key-1="0"><!--bf:s0-->x<!--/--></li>
+          <li data-key-1="1"><!--bf:s0-->y<!--/--></li>
+        </ul>
+        <footer bf="s3" data-kind="a"><!--bf:s2-->alpha<!--/--></footer>
+      </section>
+      <section data-key="2">
+        <ul bf="s1"><li data-key-1="0"><!--bf:s0-->z<!--/--></li></ul>
+        <footer bf="s3" data-kind="b"><!--bf:s2-->beta<!--/--></footer>
+      </section>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -337,6 +337,26 @@
       }
     }
   ],
+  "callback-param-shadows-prop": [
+    {
+      "name": "gen:title:empty",
+      "props": {
+        "title": ""
+      }
+    },
+    {
+      "name": "gen:title:markup",
+      "props": {
+        "title": "<b>&\"'</b>"
+      }
+    },
+    {
+      "name": "gen:title:multibyte",
+      "props": {
+        "title": "日本語"
+      }
+    }
+  ],
   "checkbox": [
     {
       "name": "gen:defaultChecked:true",
@@ -1014,6 +1034,18 @@
       }
     }
   ],
+  "loop-param-shadows-bool-prop": [
+    {
+      "name": "gen:active:false",
+      "props": {
+        "active": false,
+        "flags": [
+          "on",
+          "off"
+        ]
+      }
+    }
+  ],
   "loop-param-shadows-outer-name": [
     {
       "name": "gen:label:empty",
@@ -1046,6 +1078,24 @@
           2,
           3
         ]
+      }
+    }
+  ],
+  "loop-param-shadows-spread-const": [
+    {
+      "name": "gen:big:false",
+      "props": {
+        "items": [
+          {
+            "id": 1,
+            "title": "first"
+          },
+          {
+            "id": 2,
+            "title": "second"
+          }
+        ],
+        "big": false
       }
     }
   ],

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -32,4 +32,12 @@ export const renderDivergences: RenderDivergences = {
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'composite-row-child-aliased-prop':
     'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
+
+  // #2482 audit follow-ups: loop-scope holes in per-adapter name
+  // classification. Graduate by applying the loop-bound-name guards
+  // described in each issue and deleting the line.
+  'loop-param-shadows-bool-prop':
+    'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (`bf.bool_str` renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
+  'loop-param-shadows-spread-const':
+    'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -40,4 +40,6 @@ export const renderDivergences: RenderDivergences = {
     'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (`bf.bool_str` renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
   'loop-param-shadows-spread-const':
     'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
+  'loop-param-shadows-record-template-span':
+    'a dynamic-key element access on a loop row (`tone[k]`) renders empty on real PHP Twig — the row lookup resolves to nothing at render time (Jinja/minijinja render it correctly, so this is the PHP-side data-shape/access path, not the emission) (https://github.com/piconic-ai/barefootjs/issues/2491)',
 }

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -32,4 +32,12 @@ export const renderDivergences: RenderDivergences = {
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'composite-row-child-aliased-prop':
     'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
+
+  // #2482 audit follow-ups: loop-scope holes in per-adapter name
+  // classification. Graduate by applying the loop-bound-name guards
+  // described in each issue and deleting the line.
+  'loop-param-shadows-bool-prop':
+    'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
+  'loop-param-shadows-spread-const':
+    'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/packages/jsx/src/__tests__/csr-template-scope-soundness.test.ts
+++ b/packages/jsx/src/__tests__/csr-template-scope-soundness.test.ts
@@ -94,3 +94,74 @@ export function Fire() {
     expect(clientJs).toMatch(/setFlag\s*\]\s*=\s*createSignal\(0\)/)
   })
 })
+
+/**
+ * Scope-aware prop rewrite (#2482 audit): `rewriteBarePropRefs` must
+ * not touch a name where a binding INSIDE the expression shadows the
+ * prop — a nested callback's parameter above all. The pre-fix global
+ * word-boundary regex rewrote the parameter declaration itself,
+ * emitting `.map((_p.title) => _p.title.a)`: a parse error that killed
+ * the whole client bundle.
+ */
+describe('scope-aware prop rewrite (nested callback param sharing a prop name)', () => {
+  test('memo computation keeps the callback param bare', () => {
+    const clientJs = clientJsOf(`
+"use client"
+import { createSignal, createMemo } from '@barefootjs/client'
+
+export function Titles({ title }: { title: string }) {
+  const [items, setItems] = createSignal([{ a: 'x' }])
+  const joined = createMemo(() => items().map((title) => title.a).join(','))
+  return <div><span>{joined()}</span><button onClick={() => setItems([])}>x</button></div>
+}
+`)
+    expect(clientJs).not.toMatch(/\(\s*_p\.title\s*\)\s*=>/)
+    expect(clientJs).not.toMatch(/_p\.title\.a/)
+  })
+
+  test('signal initializer keeps the callback param bare', () => {
+    const clientJs = clientJsOf(`
+"use client"
+import { createSignal } from '@barefootjs/client'
+
+export function Titles({ title }: { title: string }) {
+  const [joined, setJoined] = createSignal([{ a: 'x' }].map((title) => title.a).join(','))
+  return <div><span>{joined()}</span><button onClick={() => setJoined('')}>x</button></div>
+}
+`)
+    expect(clientJs).not.toMatch(/\(\s*_p\.title\s*\)\s*=>/)
+  })
+
+  test('mixed usage rewrites exactly the genuine outer reference', () => {
+    const clientJs = clientJsOf(`
+"use client"
+import { createSignal, createMemo } from '@barefootjs/client'
+
+export function Titles({ title }: { title: string }) {
+  const [items, setItems] = createSignal([{ a: 'x' }])
+  const label = createMemo(() => title + ':' + items().map((title) => title.a).join(','))
+  return <div><span>{label()}</span><button onClick={() => setItems([])}>x</button></div>
+}
+`)
+    const template = templateLambdaOf(clientJs, 'Titles')
+    // outer ref rewritten…
+    expect(template).toContain('_p.title +')
+    // …inner param and its references untouched
+    expect(template).toMatch(/\(\s*title\s*\)\s*=>\s*title\.a/)
+    expect(template).not.toMatch(/\(\s*_p\.title\s*\)\s*=>/)
+  })
+
+  test('a loop-shadowed record const is not folded into a template span', () => {
+    const clientJs = clientJsOf(`
+const tone = { a: 'outer-a', b: 'outer-b' }
+
+export function Tones({ items, k }: { items: { id: number; a: string; b: string }[]; k: string }) {
+  return <ul>{items.map((tone) => <li key={tone.id} data-t={\`t \${tone[k]}\`}>{tone.a}</li>)}</ul>
+}
+`)
+    const template = templateLambdaOf(clientJs, 'Tones')
+    // The span must read the row binding, not the outer record literal.
+    expect(template).toContain('tone[_p.k]')
+    expect(template).not.toContain('outer-a')
+  })
+})

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -6074,6 +6074,11 @@ function tryResolveTemplateSpanFromConst(
 ): IRTemplatePart[] | null {
   // ${IDENT}
   if (ts.isIdentifier(expr)) {
+    // #2222-family: inside a loop callback the name may be the loop's
+    // item/index binding shadowing a same-named const — resolving the
+    // const would bake the outer value into every row. Fall back to
+    // the bare-expression path, which sees the loop binding.
+    if (ctx.loopParams.has(expr.text)) return null
     const constInfo = findLocalConst(expr.text, ctx.analyzer)
     if (!constInfo) return null
     const ast = parseConstInitializer(constInfo)
@@ -6087,6 +6092,10 @@ function tryResolveTemplateSpanFromConst(
   // ${IDENT[KEY]}
   if (ts.isElementAccessExpression(expr)) {
     if (!ts.isIdentifier(expr.expression)) return null
+    // Same loop-shadowing guard as the ${IDENT} arm: `tone[k]` inside
+    // `items.map((tone) => …)` must read the row's `tone`, not a
+    // same-named module/component record const.
+    if (ctx.loopParams.has(expr.expression.text)) return null
     const constInfo = findLocalConst(expr.expression.text, ctx.analyzer)
     if (!constInfo) return null
     const ast = parseConstInitializer(constInfo)

--- a/packages/jsx/src/prop-rewrite.ts
+++ b/packages/jsx/src/prop-rewrite.ts
@@ -3,39 +3,165 @@
  *
  * Walks the TypeScript AST to identify destructured prop names used as
  * value references (not as object keys, property access targets, or
- * shorthand properties), then applies targeted regex replacement.
+ * shorthand properties), then splices `_p.` onto exactly those
+ * references in the emitted text via a second scope-aware walk over
+ * the text's own AST.
+ *
+ * Scope model: a name bound INSIDE the expression — a nested arrow /
+ * function parameter, a block-scoped declaration, a catch variable —
+ * refers to that binding, not the prop, for the whole binding's scope.
+ * Both the discovery walk and the rewrite walk carry the same binding
+ * stack, so `items.map((title) => title.a)` never turns into the
+ * syntactically invalid `.map((_p.title) => _p.title.a)` when `title`
+ * is also a prop. (Names bound by loop callbacks that ENCLOSE the
+ * expression are the caller's job — see the `ctx.loopParams` filter in
+ * `jsx-to-ir.ts`'s `rewriteBarePropRefs` wrapper, #2222.)
  */
 
 import ts from 'typescript'
 import { PROPS_PARAM } from './ir-to-client-js/utils.ts'
 import { createTemplateAwareStringProtector } from './ir-to-client-js/html-template.ts'
 
+/** Collect every name introduced by a binding name (identifier or pattern). */
+function collectBindingNames(name: ts.BindingName, out: Set<string>): void {
+  if (ts.isIdentifier(name)) {
+    out.add(name.text)
+    return
+  }
+  for (const el of name.elements) {
+    if (ts.isBindingElement(el)) collectBindingNames(el.name, out)
+  }
+}
+
+/**
+ * Names bound by `n` for its subtree, or null when `n` introduces no
+ * scope. Function-likes bind their parameters (and a function
+ * expression its own name); blocks bind their statement-level
+ * variable/function declarations; catch clauses bind their variable.
+ */
+function scopeFrameOf(n: ts.Node): Set<string> | null {
+  if (ts.isFunctionLike(n)) {
+    const frame = new Set<string>()
+    for (const p of n.parameters) collectBindingNames(p.name, frame)
+    if ((ts.isFunctionExpression(n) || ts.isFunctionDeclaration(n)) && n.name) frame.add(n.name.text)
+    return frame.size > 0 ? frame : null
+  }
+  if (ts.isBlock(n)) {
+    const frame = new Set<string>()
+    for (const st of n.statements) {
+      if (ts.isVariableStatement(st)) {
+        for (const d of st.declarationList.declarations) collectBindingNames(d.name, frame)
+      } else if (ts.isFunctionDeclaration(st) && st.name) {
+        frame.add(st.name.text)
+      }
+    }
+    return frame.size > 0 ? frame : null
+  }
+  if (ts.isCatchClause(n) && n.variableDeclaration) {
+    const frame = new Set<string>()
+    collectBindingNames(n.variableDeclaration.name, frame)
+    return frame.size > 0 ? frame : null
+  }
+  return null
+}
+
+/**
+ * Depth-first walk that maintains the binding stack described above and
+ * reports every identifier along with whether a binding within `root`
+ * currently shadows it.
+ */
+function walkWithScope(
+  root: ts.Node,
+  visit: (ident: ts.Identifier, parent: ts.Node | undefined, shadowed: boolean) => void,
+): void {
+  const scopeStack: Set<string>[] = []
+  const isShadowed = (name: string) => scopeStack.some(frame => frame.has(name))
+  function rec(n: ts.Node, parent?: ts.Node) {
+    const frame = scopeFrameOf(n)
+    if (frame) scopeStack.push(frame)
+    if (ts.isIdentifier(n)) visit(n, parent, isShadowed(n.text))
+    ts.forEachChild(n, child => rec(child, n))
+    if (frame) scopeStack.pop()
+  }
+  rec(root)
+}
+
+/**
+ * True when `n` sits in a non-value position where a prop rewrite must
+ * never apply: an object-literal key, a member-access name, a binding
+ * position (parameter / variable / binding-element name), or a type
+ * reference.
+ */
+function isNonValuePosition(n: ts.Identifier, parent: ts.Node | undefined): boolean {
+  if (!parent) return false
+  if (ts.isPropertyAssignment(parent) && parent.name === n) return true
+  if (ts.isPropertyAccessExpression(parent) && parent.name === n) return true
+  if (ts.isQualifiedName(parent) && parent.right === n) return true
+  if ((ts.isParameter(parent) || ts.isVariableDeclaration(parent) || ts.isBindingElement(parent)) && parent.name === n) return true
+  if (ts.isTypeReferenceNode(parent)) return true
+  return false
+}
+
 /**
  * Walk an AST node for destructured-prop value references and add
  * each found name to `out`. Same skip rules as the rewrite path —
- * object-literal keys, shorthand properties, and property-access
- * names are excluded so only true value references get picked up.
- * Exported for callers that need the raw discovery set (e.g. the
- * branch-local prop-dep cache from #1425).
+ * object-literal keys, shorthand properties, property-access names,
+ * and names shadowed by a binding inside `node` are excluded so only
+ * true value references get picked up. Exported for callers that need
+ * the raw discovery set (e.g. the branch-local prop-dep cache from
+ * #1425).
  */
 export function collectAstPropRefs(
   node: ts.Node,
   propNames: Set<string>,
   out: Set<string>,
 ): void {
-  function visit(n: ts.Node, parent?: ts.Node) {
-    if (ts.isIdentifier(n) && propNames.has(n.text)) {
-      // Skip: object literal key  { org: ... }
-      if (parent && ts.isPropertyAssignment(parent) && parent.name === n) return
-      // Skip: shorthand property  { org }
-      if (parent && ts.isShorthandPropertyAssignment(parent) && parent.name === n) return
-      // Skip: property access name  foo.org
-      if (parent && ts.isPropertyAccessExpression(parent) && parent.name === n) return
-      out.add(n.text)
+  walkWithScope(node, (n, parent, shadowed) => {
+    if (shadowed || !propNames.has(n.text)) return
+    if (parent && ts.isShorthandPropertyAssignment(parent) && parent.name === n) return
+    if (isNonValuePosition(n, parent)) return
+    out.add(n.text)
+  })
+}
+
+/**
+ * Scope-aware rewrite: parse `text` as an expression, walk it with the
+ * binding stack, and splice `${PROPS_PARAM}.` onto exactly the
+ * identifier references that are (a) in `propRefs` and (b) not
+ * shadowed by a binding inside the text. Shorthand properties expand
+ * (`{ org }` → `{ org: _p.org }`) so the result stays syntactically
+ * valid.
+ *
+ * Returns null when `text` does not parse cleanly as an expression —
+ * the caller falls back to the legacy regex rewrite.
+ */
+function applyScopedPropRefRewrite(text: string, propRefs: Set<string>): string | null {
+  // Wrap in parens so object literals and arrows parse as expressions.
+  const prefix = '('
+  const sf = ts.createSourceFile('__bf_prop_rewrite.ts', `${prefix}${text}\n)`, ts.ScriptTarget.Latest, true)
+  const parseDiagnostics = (sf as unknown as { parseDiagnostics?: unknown[] }).parseDiagnostics
+  if (parseDiagnostics && parseDiagnostics.length > 0) return null
+
+  const edits: Array<{ start: number; end: number; replacement: string }> = []
+  walkWithScope(sf, (n, parent, shadowed) => {
+    if (shadowed || !propRefs.has(n.text)) return
+    if (isNonValuePosition(n, parent)) return
+    const start = n.getStart(sf) - prefix.length
+    const end = n.getEnd() - prefix.length
+    if (start < 0 || end > text.length) return
+    if (parent && ts.isShorthandPropertyAssignment(parent) && parent.name === n) {
+      edits.push({ start, end, replacement: `${n.text}: ${PROPS_PARAM}.${n.text}` })
+      return
     }
-    ts.forEachChild(n, child => visit(child, n))
+    edits.push({ start, end, replacement: `${PROPS_PARAM}.${n.text}` })
+  })
+
+  if (edits.length === 0) return text
+  let result = text
+  for (const edit of edits.sort((a, b) => b.start - a.start)) {
+    result = result.slice(0, edit.start) + edit.replacement + result.slice(edit.end)
   }
-  visit(node)
+  return result
 }
 
 /**
@@ -43,6 +169,10 @@ export function collectAstPropRefs(
  * type-stripped expression text. Idempotent under `_p.X` (negative
  * lookbehind on `_p\\.`) and skips object-literal keys via the
  * post-match `{,` + `:` shape check.
+ *
+ * Legacy fallback for text that doesn't parse as a standalone
+ * expression — it cannot see scopes, so `applyScopedPropRefRewrite`
+ * is always tried first.
  */
 export function applyRegexPropRefRewrite(
   text: string,
@@ -77,8 +207,8 @@ export function applyRegexPropRefRewrite(
  * @param extraPropRefs - Optional prop names known to appear in
  *   `text` via substitution sources the AST walk can't see (e.g.
  *   `text` was produced by inlining a branch-local whose initializer
- *   references the prop). The post-match `_p\\.` lookbehind keeps
- *   the regex idempotent, so passing an over-broad set is safe.
+ *   references the prop). The rewrite only touches genuine value
+ *   references, so passing an over-broad set is safe.
  */
 export function rewriteBarePropRefs(
   text: string,
@@ -95,5 +225,5 @@ export function rewriteBarePropRefs(
     }
   }
   if (foundPropRefs.size === 0) return undefined
-  return applyRegexPropRefRewrite(text, foundPropRefs)
+  return applyScopedPropRefRewrite(text, foundPropRefs) ?? applyRegexPropRefRewrite(text, foundPropRefs)
 }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2389,6 +2389,14 @@
         "go-template": {
           "kind": "render",
           "reason": "a dynamic-key element access on a loop row (`tone[k]`) renders empty at execute time — the emitted template contains no baked const (correct post-fix), but the row lookup resolves to nothing (https://github.com/piconic-ai/barefootjs/issues/2491)"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "a dynamic-key element access on a loop row (`tone[k]`) diverges on real Mojolicious at render time (same silent-empty family as ERB/Go/Twig; the Perl-side mechanism needs a dig) (https://github.com/piconic-ai/barefootjs/issues/2491)"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "a dynamic-key element access on a loop row (`tone[k]`) renders empty on real PHP Twig — the row lookup resolves to nothing at render time (Jinja/minijinja render it correctly, so this is the PHP-side data-shape/access path, not the emission) (https://github.com/piconic-ai/barefootjs/issues/2491)"
         }
       },
       "loop-param-shadows-spread-const": {

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 301,
+    "totalFixtures": 307,
     "fixtures": {
       "aliased-destructured-prop": {
         "blade": {
@@ -1848,6 +1848,12 @@
         "xslate": {
           "kind": "render",
           "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)"
+        }
+      },
+      "callback-param-shadows-prop": {
+        "go-template": {
+          "kind": "render",
+          "reason": "JS-computed signal/memo initializers (`[…].map(…).join(…)`, memo over signal + prop) don't seed Go SSR — renders `[]` / empty where every other adapter renders the computed value; hydration snaps to correct (https://github.com/piconic-ai/barefootjs/issues/2492)"
         }
       },
       "composite-row-child-aliased-prop": {
@@ -2339,6 +2345,82 @@
           ]
         }
       },
+      "loop-destructured-param-condition": {
+        "go-template": {
+          "kind": "render",
+          "reason": "a destructured .map() param binding used as a row ternary CONDITION emits the root-scope `{{if $.Active}}` — `renderConditionExpr` omits `loopBindingStack`, unlike `identifierToGoRef` (text positions resolve the same binding correctly) (https://github.com/piconic-ai/barefootjs/issues/2486)"
+        }
+      },
+      "loop-param-shadows-bool-prop": {
+        "blade": {
+          "kind": "render",
+          "reason": "a .map() param sharing a boolean prop's name is routed through the bool lowering in attribute position (renders \"true\"/\"false\" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "a .map() param sharing a boolean prop's name is routed through the bool lowering in attribute position (renders \"true\"/\"false\" instead of the row string) — `collectBooleanTypedProps` lacks the loop-bound-name subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "a .map() param sharing a boolean prop's name is routed through the bool lowering in attribute position (renders \"true\"/\"false\" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "a .map() param sharing a boolean prop's name is routed through the bool lowering in attribute position (renders \"true\"/\"false\" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "a .map() param sharing a boolean prop's name is routed through the bool lowering in attribute position (renders \"true\"/\"false\" instead of the row string) — `collectBooleanTypedProps` lacks the loop-bound-name subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "a .map() param sharing a boolean prop's name is routed through the bool lowering in attribute position (`bf.bool_str` renders \"true\"/\"false\" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "a .map() param sharing a boolean prop's name is routed through the bool lowering in attribute position (renders \"true\"/\"false\" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)"
+        }
+      },
+      "loop-param-shadows-record-template-span": {
+        "erb": {
+          "kind": "render",
+          "reason": "a dynamic-key element access on a loop row (`tone[k]`) renders empty: row hashes deserialize with SYMBOL keys while the dynamic key is a STRING, so `tone[\"a\"]` is nil (https://github.com/piconic-ai/barefootjs/issues/2491)"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "a dynamic-key element access on a loop row (`tone[k]`) renders empty at execute time — the emitted template contains no baked const (correct post-fix), but the row lookup resolves to nothing (https://github.com/piconic-ai/barefootjs/issues/2491)"
+        }
+      },
+      "loop-param-shadows-spread-const": {
+        "blade": {
+          "kind": "render",
+          "reason": "a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check (the live `loopBoundNames` map exists but is not consulted on this path), so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "spreading a loop row object mangles attribute names (`id` → `-i-d`, `title` → `-title`); the spread VALUE is correctly row-scoped, distinguishing this from the template-adapter const-shadow hole #2489 (https://github.com/piconic-ai/barefootjs/issues/2490)"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)"
+        }
+      },
       "map-array-builder-body": {
         "blade": {
           "kind": "refusal",
@@ -2437,6 +2519,12 @@
           "codes": [
             "BF021"
           ]
+        }
+      },
+      "nested-loop-tail-content": {
+        "go-template": {
+          "kind": "render",
+          "reason": "outer-row content AFTER a nested inner loop renders through non-loop arms (spread lowers to the component-root `.Spread_0`) — `inLoop` is cleared, not restored, by the inner loop's exit; the same content BEFORE the inner loop emits correctly (https://github.com/piconic-ai/barefootjs/issues/2487)"
         }
       },
       "preamble-cells": {
@@ -2843,6 +2931,10 @@
         "description": "Aliased destructured prop ({ n: count }) keeps the rename (#2460)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/aliased-destructured-prop.ts"
       },
+      "callback-param-shadows-prop": {
+        "description": "Nested callback param sharing a prop name stays a param in the CSR template (no invalid `_p.`…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/callback-param-shadows-prop.ts"
+      },
       "composite-row-child-aliased-prop": {
         "description": "Nested child in a dynamic loop row destructures a renamed prop ({ n: count })",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/composite-row-child-aliased-prop.ts"
@@ -2879,6 +2971,22 @@
         "description": "Off-subset `.flatMap()` projection (typeof) — JS-runtime faithful, DSL diagnostic",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/flatmap-typeof-projection.ts"
       },
+      "loop-destructured-param-condition": {
+        "description": "Destructured .map() param binding used as a row ternary condition stays row-scoped",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/loop-destructured-param-condition.ts"
+      },
+      "loop-param-shadows-bool-prop": {
+        "description": ".map() param sharing a boolean prop name renders the row value, not a bool lowering",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/loop-param-shadows-bool-prop.ts"
+      },
+      "loop-param-shadows-record-template-span": {
+        "description": ".map() param shadowing a record const stays row-scoped inside a `${base[key]}` template span",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/loop-param-shadows-record-template-span.ts"
+      },
+      "loop-param-shadows-spread-const": {
+        "description": ".map() param shadowing an object const spreads the row value, not the outer const",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/loop-param-shadows-spread-const.ts"
+      },
       "map-array-builder-body": {
         "description": "imperative array-builder .map() body — JS-runtime verbatim, DSL refuses (BF021)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/map-array-builder-body.ts"
@@ -2886,6 +2994,10 @@
       "map-array-builder-escaping": {
         "description": "special characters in array-builder leaf text escape identically at SSR and CSR",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/map-array-builder-escaping.ts"
+      },
+      "nested-loop-tail-content": {
+        "description": "Outer-row content after a nested inner loop still renders row-scoped (spread over a row field)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/nested-loop-tail-content.ts"
       },
       "preamble-cells": {
         "description": "keyed .map() row with a preamble-built leaf child — patched in place on same-key update, not frozen",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1891,7 +1891,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 184,
+          "pass": 183,
           "total": 200,
           "gaps": [
             {
@@ -1935,6 +1935,10 @@
               "issues": []
             },
             {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
               "fixture": "preamble-cells",
               "issues": []
             },
@@ -1969,7 +1973,7 @@
           ]
         },
         "twig": {
-          "pass": 182,
+          "pass": 181,
           "total": 200,
           "gaps": [
             {
@@ -2016,6 +2020,10 @@
             },
             {
               "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -2835,7 +2843,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 269,
+          "pass": 268,
           "total": 288,
           "gaps": [
             {
@@ -2883,6 +2891,10 @@
               "issues": []
             },
             {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
@@ -2925,7 +2937,7 @@
           ]
         },
         "twig": {
-          "pass": 267,
+          "pass": 266,
           "total": 288,
           "gaps": [
             {
@@ -2976,6 +2988,10 @@
             },
             {
               "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -3177,12 +3193,24 @@
           "total": 14
         },
         "mojolicious": {
-          "pass": 14,
-          "total": 14
+          "pass": 13,
+          "total": 14,
+          "gaps": [
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            }
+          ]
         },
         "twig": {
-          "pass": 14,
-          "total": 14
+          "pass": 13,
+          "total": 14,
+          "gaps": [
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            }
+          ]
         },
         "xslate": {
           "pass": 14,
@@ -3525,7 +3553,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 226,
+          "pass": 225,
           "total": 238,
           "gaps": [
             {
@@ -3550,6 +3578,10 @@
             },
             {
               "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -3581,7 +3613,7 @@
           ]
         },
         "twig": {
-          "pass": 225,
+          "pass": 224,
           "total": 238,
           "gaps": [
             {
@@ -3606,6 +3638,10 @@
             },
             {
               "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -4339,7 +4375,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 137,
+          "pass": 136,
           "total": 154,
           "gaps": [
             {
@@ -4376,6 +4412,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -4421,7 +4461,7 @@
           ]
         },
         "twig": {
-          "pass": 135,
+          "pass": 134,
           "total": 154,
           "gaps": [
             {
@@ -4464,6 +4504,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -4737,9 +4781,13 @@
           ]
         },
         "mojolicious": {
-          "pass": 53,
+          "pass": 52,
           "total": 55,
           "gaps": [
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -4753,9 +4801,13 @@
           ]
         },
         "twig": {
-          "pass": 52,
+          "pass": 51,
           "total": 55,
           "gaps": [
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
             {
               "fixture": "loop-param-shadows-spread-const",
               "issues": []
@@ -4917,9 +4969,13 @@
           ]
         },
         "mojolicious": {
-          "pass": 29,
+          "pass": 28,
           "total": 30,
           "gaps": [
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
             {
               "fixture": "tag-cloud",
               "issues": []
@@ -4927,9 +4983,13 @@
           ]
         },
         "twig": {
-          "pass": 29,
+          "pass": 28,
           "total": 30,
           "gaps": [
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
             {
               "fixture": "tag-cloud",
               "issues": []
@@ -8112,7 +8172,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 95,
+          "pass": 94,
           "total": 101,
           "gaps": [
             {
@@ -8121,6 +8181,10 @@
             },
             {
               "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -8142,7 +8206,7 @@
           ]
         },
         "twig": {
-          "pass": 94,
+          "pass": 93,
           "total": 101,
           "gaps": [
             {
@@ -8151,6 +8215,10 @@
             },
             {
               "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -8462,46 +8530,6 @@
           ]
         },
         "mojolicious": {
-          "pass": 160,
-          "total": 168,
-          "gaps": [
-            {
-              "fixture": "every-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "filter-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "find-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "preamble-cells",
-              "issues": []
-            },
-            {
-              "fixture": "some-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "static-array-from-props-with-component",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            }
-          ]
-        },
-        "twig": {
           "pass": 159,
           "total": 168,
           "gaps": [
@@ -8523,6 +8551,54 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "preamble-cells",
+              "issues": []
+            },
+            {
+              "fixture": "some-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            }
+          ]
+        },
+        "twig": {
+          "pass": 158,
+          "total": 168,
+          "gaps": [
+            {
+              "fixture": "every-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 69,
+      "total": 70,
       "cells": {
         "hono": {
-          "pass": 69,
-          "total": 69
+          "pass": 70,
+          "total": 70
         },
         "blade": {
-          "pass": 57,
-          "total": 69,
+          "pass": 58,
+          "total": 70,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 58,
-          "total": 69,
+          "pass": 59,
+          "total": 70,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -132,8 +132,12 @@
         },
         "go-template": {
           "pass": 57,
-          "total": 69,
+          "total": 70,
           "gaps": [
+            {
+              "fixture": "callback-param-shadows-prop",
+              "issues": []
+            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -189,8 +193,8 @@
           ]
         },
         "jinja": {
-          "pass": 57,
-          "total": 69,
+          "pass": 58,
+          "total": 70,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -247,8 +251,8 @@
           ]
         },
         "minijinja": {
-          "pass": 57,
-          "total": 69,
+          "pass": 58,
+          "total": 70,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -305,8 +309,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 58,
-          "total": 69,
+          "pass": 59,
+          "total": 70,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -357,8 +361,8 @@
           ]
         },
         "twig": {
-          "pass": 57,
-          "total": 69,
+          "pass": 58,
+          "total": 70,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -415,8 +419,8 @@
           ]
         },
         "xslate": {
-          "pass": 57,
-          "total": 69,
+          "pass": 58,
+          "total": 70,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -486,15 +490,15 @@
       }
     },
     "array-method": {
-      "total": 66,
+      "total": 67,
       "cells": {
         "hono": {
-          "pass": 66,
-          "total": 66
+          "pass": 67,
+          "total": 67
         },
         "blade": {
-          "pass": 63,
-          "total": 66,
+          "pass": 64,
+          "total": 67,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -511,8 +515,8 @@
           ]
         },
         "erb": {
-          "pass": 63,
-          "total": 66,
+          "pass": 64,
+          "total": 67,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -530,8 +534,12 @@
         },
         "go-template": {
           "pass": 63,
-          "total": 66,
+          "total": 67,
           "gaps": [
+            {
+              "fixture": "callback-param-shadows-prop",
+              "issues": []
+            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -547,8 +555,8 @@
           ]
         },
         "jinja": {
-          "pass": 63,
-          "total": 66,
+          "pass": 64,
+          "total": 67,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -565,8 +573,8 @@
           ]
         },
         "minijinja": {
-          "pass": 63,
-          "total": 66,
+          "pass": 64,
+          "total": 67,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -583,8 +591,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 63,
-          "total": 66,
+          "pass": 64,
+          "total": 67,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -601,8 +609,8 @@
           ]
         },
         "twig": {
-          "pass": 63,
-          "total": 66,
+          "pass": 64,
+          "total": 67,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -619,8 +627,8 @@
           ]
         },
         "xslate": {
-          "pass": 63,
-          "total": 66,
+          "pass": 64,
+          "total": 67,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -650,15 +658,15 @@
       }
     },
     "arrow": {
-      "total": 63,
+      "total": 64,
       "cells": {
         "hono": {
-          "pass": 63,
-          "total": 63
+          "pass": 64,
+          "total": 64
         },
         "blade": {
-          "pass": 54,
-          "total": 63,
+          "pass": 55,
+          "total": 64,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -703,8 +711,8 @@
           ]
         },
         "erb": {
-          "pass": 55,
-          "total": 63,
+          "pass": 56,
+          "total": 64,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -744,8 +752,12 @@
         },
         "go-template": {
           "pass": 54,
-          "total": 63,
+          "total": 64,
           "gaps": [
+            {
+              "fixture": "callback-param-shadows-prop",
+              "issues": []
+            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -789,8 +801,8 @@
           ]
         },
         "jinja": {
-          "pass": 54,
-          "total": 63,
+          "pass": 55,
+          "total": 64,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -835,8 +847,8 @@
           ]
         },
         "minijinja": {
-          "pass": 54,
-          "total": 63,
+          "pass": 55,
+          "total": 64,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -881,8 +893,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 55,
-          "total": 63,
+          "pass": 56,
+          "total": 64,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -921,8 +933,8 @@
           ]
         },
         "twig": {
-          "pass": 54,
-          "total": 63,
+          "pass": 55,
+          "total": 64,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -967,8 +979,8 @@
           ]
         },
         "xslate": {
-          "pass": 54,
-          "total": 63,
+          "pass": 55,
+          "total": 64,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1026,15 +1038,15 @@
       }
     },
     "binary": {
-      "total": 81,
+      "total": 82,
       "cells": {
         "hono": {
-          "pass": 81,
-          "total": 81
+          "pass": 82,
+          "total": 82
         },
         "blade": {
-          "pass": 72,
-          "total": 81,
+          "pass": 73,
+          "total": 82,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1081,8 +1093,8 @@
           ]
         },
         "erb": {
-          "pass": 73,
-          "total": 81,
+          "pass": 74,
+          "total": 82,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1124,8 +1136,12 @@
         },
         "go-template": {
           "pass": 72,
-          "total": 81,
+          "total": 82,
           "gaps": [
+            {
+              "fixture": "callback-param-shadows-prop",
+              "issues": []
+            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1171,8 +1187,8 @@
           ]
         },
         "jinja": {
-          "pass": 72,
-          "total": 81,
+          "pass": 73,
+          "total": 82,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1219,8 +1235,8 @@
           ]
         },
         "minijinja": {
-          "pass": 72,
-          "total": 81,
+          "pass": 73,
+          "total": 82,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1267,8 +1283,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 73,
-          "total": 81,
+          "pass": 74,
+          "total": 82,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1309,8 +1325,8 @@
           ]
         },
         "twig": {
-          "pass": 72,
-          "total": 81,
+          "pass": 73,
+          "total": 82,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1357,8 +1373,8 @@
           ]
         },
         "xslate": {
-          "pass": 72,
-          "total": 81,
+          "pass": 73,
+          "total": 82,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1434,11 @@
       }
     },
     "call": {
-      "total": 194,
+      "total": 200,
       "cells": {
         "hono": {
-          "pass": 193,
-          "total": 194,
+          "pass": 199,
+          "total": 200,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1433,8 +1449,8 @@
           ]
         },
         "blade": {
-          "pass": 178,
-          "total": 194,
+          "pass": 182,
+          "total": 200,
           "gaps": [
             {
               "fixture": "composite-row-child-aliased-prop",
@@ -1476,6 +1492,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -1513,8 +1537,8 @@
           ]
         },
         "erb": {
-          "pass": 180,
-          "total": 194,
+          "pass": 183,
+          "total": 200,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1546,6 +1570,18 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -1583,9 +1619,13 @@
           ]
         },
         "go-template": {
-          "pass": 179,
-          "total": 194,
+          "pass": 180,
+          "total": 200,
           "gaps": [
+            {
+              "fixture": "callback-param-shadows-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1622,6 +1662,22 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-destructured-param-condition",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
+              "issues": []
+            },
+            {
+              "fixture": "nested-loop-tail-content",
               "issues": []
             },
             {
@@ -1659,8 +1715,8 @@
           ]
         },
         "jinja": {
-          "pass": 178,
-          "total": 194,
+          "pass": 182,
+          "total": 200,
           "gaps": [
             {
               "fixture": "composite-row-child-aliased-prop",
@@ -1702,6 +1758,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -1739,8 +1803,8 @@
           ]
         },
         "minijinja": {
-          "pass": 178,
-          "total": 194,
+          "pass": 182,
+          "total": 200,
           "gaps": [
             {
               "fixture": "composite-row-child-aliased-prop",
@@ -1782,6 +1846,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -1819,8 +1891,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 179,
-          "total": 194,
+          "pass": 184,
+          "total": 200,
           "gaps": [
             {
               "fixture": "composite-row-child-aliased-prop",
@@ -1856,6 +1928,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -1893,8 +1969,8 @@
           ]
         },
         "twig": {
-          "pass": 178,
-          "total": 194,
+          "pass": 182,
+          "total": 200,
           "gaps": [
             {
               "fixture": "composite-row-child-aliased-prop",
@@ -1936,6 +2012,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -1973,8 +2057,8 @@
           ]
         },
         "xslate": {
-          "pass": 178,
-          "total": 194,
+          "pass": 182,
+          "total": 200,
           "gaps": [
             {
               "fixture": "composite-row-child-aliased-prop",
@@ -2016,6 +2100,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2066,18 +2158,22 @@
       }
     },
     "conditional": {
-      "total": 23,
+      "total": 24,
       "cells": {
         "hono": {
-          "pass": 23,
-          "total": 23
+          "pass": 24,
+          "total": 24
         },
         "blade": {
           "pass": 21,
-          "total": 23,
+          "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2088,10 +2184,14 @@
         },
         "erb": {
           "pass": 21,
-          "total": 23,
+          "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2102,10 +2202,14 @@
         },
         "go-template": {
           "pass": 21,
-          "total": 23,
+          "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2116,10 +2220,14 @@
         },
         "jinja": {
           "pass": 21,
-          "total": 23,
+          "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2130,10 +2238,14 @@
         },
         "minijinja": {
           "pass": 21,
-          "total": 23,
+          "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2143,8 +2255,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 21,
-          "total": 23,
+          "pass": 22,
+          "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2158,10 +2270,14 @@
         },
         "twig": {
           "pass": 21,
-          "total": 23,
+          "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2172,10 +2288,14 @@
         },
         "xslate": {
           "pass": 21,
-          "total": 23,
+          "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2198,11 +2318,11 @@
       }
     },
     "identifier": {
-      "total": 282,
+      "total": 288,
       "cells": {
         "hono": {
-          "pass": 281,
-          "total": 282,
+          "pass": 287,
+          "total": 288,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2213,8 +2333,8 @@
           ]
         },
         "blade": {
-          "pass": 263,
-          "total": 282,
+          "pass": 267,
+          "total": 288,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2260,6 +2380,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2305,8 +2433,8 @@
           ]
         },
         "erb": {
-          "pass": 265,
-          "total": 282,
+          "pass": 268,
+          "total": 288,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2342,6 +2470,18 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2387,11 +2527,15 @@
           ]
         },
         "go-template": {
-          "pass": 264,
-          "total": 282,
+          "pass": 265,
+          "total": 288,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
+              "issues": []
+            },
+            {
+              "fixture": "callback-param-shadows-prop",
               "issues": []
             },
             {
@@ -2433,11 +2577,27 @@
               "issues": []
             },
             {
+              "fixture": "loop-destructured-param-condition",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
+              "issues": []
+            },
+            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
+              "issues": []
+            },
+            {
+              "fixture": "nested-loop-tail-content",
               "issues": []
             },
             {
@@ -2475,8 +2635,8 @@
           ]
         },
         "jinja": {
-          "pass": 263,
-          "total": 282,
+          "pass": 267,
+          "total": 288,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2522,6 +2682,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2567,8 +2735,8 @@
           ]
         },
         "minijinja": {
-          "pass": 263,
-          "total": 282,
+          "pass": 267,
+          "total": 288,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2614,6 +2782,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2659,8 +2835,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 264,
-          "total": 282,
+          "pass": 269,
+          "total": 288,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2700,6 +2876,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -2745,8 +2925,8 @@
           ]
         },
         "twig": {
-          "pass": 263,
-          "total": 282,
+          "pass": 267,
+          "total": 288,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2792,6 +2972,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2837,8 +3025,8 @@
           ]
         },
         "xslate": {
-          "pass": 263,
-          "total": 282,
+          "pass": 267,
+          "total": 288,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
@@ -2884,6 +3072,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2942,43 +3138,55 @@
       }
     },
     "index-access": {
-      "total": 13,
+      "total": 14,
       "cells": {
         "hono": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         },
         "blade": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         },
         "erb": {
           "pass": 13,
-          "total": 13
+          "total": 14,
+          "gaps": [
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            }
+          ]
         },
         "go-template": {
           "pass": 13,
-          "total": 13
+          "total": 14,
+          "gaps": [
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            }
+          ]
         },
         "jinja": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         },
         "minijinja": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         },
         "mojolicious": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         },
         "twig": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         },
         "xslate": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         }
       },
       "source": {
@@ -2994,15 +3202,15 @@
       }
     },
     "literal": {
-      "total": 232,
+      "total": 238,
       "cells": {
         "hono": {
-          "pass": 232,
-          "total": 232
+          "pass": 238,
+          "total": 238
         },
         "blade": {
-          "pass": 221,
-          "total": 232,
+          "pass": 225,
+          "total": 238,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3022,6 +3230,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3053,8 +3269,8 @@
           ]
         },
         "erb": {
-          "pass": 221,
-          "total": 232,
+          "pass": 224,
+          "total": 238,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3074,6 +3290,18 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3105,9 +3333,13 @@
           ]
         },
         "go-template": {
-          "pass": 221,
-          "total": 232,
+          "pass": 222,
+          "total": 238,
           "gaps": [
+            {
+              "fixture": "callback-param-shadows-prop",
+              "issues": []
+            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3126,6 +3358,22 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-destructured-param-condition",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
+              "issues": []
+            },
+            {
+              "fixture": "nested-loop-tail-content",
               "issues": []
             },
             {
@@ -3157,8 +3405,8 @@
           ]
         },
         "jinja": {
-          "pass": 221,
-          "total": 232,
+          "pass": 225,
+          "total": 238,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3178,6 +3426,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3209,8 +3465,8 @@
           ]
         },
         "minijinja": {
-          "pass": 221,
-          "total": 232,
+          "pass": 225,
+          "total": 238,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3230,6 +3486,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3261,8 +3525,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 221,
-          "total": 232,
+          "pass": 226,
+          "total": 238,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3282,6 +3546,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -3313,8 +3581,8 @@
           ]
         },
         "twig": {
-          "pass": 221,
-          "total": 232,
+          "pass": 225,
+          "total": 238,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3334,6 +3602,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3365,8 +3641,8 @@
           ]
         },
         "xslate": {
-          "pass": 221,
-          "total": 232,
+          "pass": 225,
+          "total": 238,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3386,6 +3662,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3578,11 +3862,11 @@
       }
     },
     "member": {
-      "total": 150,
+      "total": 154,
       "cells": {
         "hono": {
-          "pass": 149,
-          "total": 150,
+          "pass": 153,
+          "total": 154,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3593,8 +3877,8 @@
           ]
         },
         "blade": {
-          "pass": 132,
-          "total": 150,
+          "pass": 135,
+          "total": 154,
           "gaps": [
             {
               "fixture": "composite-row-child-aliased-prop",
@@ -3636,6 +3920,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3681,8 +3969,8 @@
           ]
         },
         "erb": {
-          "pass": 134,
-          "total": 150,
+          "pass": 136,
+          "total": 154,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3714,6 +4002,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3760,8 +4056,12 @@
         },
         "go-template": {
           "pass": 133,
-          "total": 150,
+          "total": 154,
           "gaps": [
+            {
+              "fixture": "callback-param-shadows-prop",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3801,11 +4101,23 @@
               "issues": []
             },
             {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
+              "issues": []
+            },
+            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
+              "issues": []
+            },
+            {
+              "fixture": "nested-loop-tail-content",
               "issues": []
             },
             {
@@ -3843,8 +4155,8 @@
           ]
         },
         "jinja": {
-          "pass": 132,
-          "total": 150,
+          "pass": 135,
+          "total": 154,
           "gaps": [
             {
               "fixture": "composite-row-child-aliased-prop",
@@ -3886,6 +4198,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3931,8 +4247,8 @@
           ]
         },
         "minijinja": {
-          "pass": 132,
-          "total": 150,
+          "pass": 135,
+          "total": 154,
           "gaps": [
             {
               "fixture": "composite-row-child-aliased-prop",
@@ -3974,6 +4290,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -4019,8 +4339,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 133,
-          "total": 150,
+          "pass": 137,
+          "total": 154,
           "gaps": [
             {
               "fixture": "composite-row-child-aliased-prop",
@@ -4101,8 +4421,8 @@
           ]
         },
         "twig": {
-          "pass": 132,
-          "total": 150,
+          "pass": 135,
+          "total": 154,
           "gaps": [
             {
               "fixture": "composite-row-child-aliased-prop",
@@ -4144,6 +4464,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -4189,8 +4513,8 @@
           ]
         },
         "xslate": {
-          "pass": 132,
-          "total": 150,
+          "pass": 135,
+          "total": 154,
           "gaps": [
             {
               "fixture": "composite-row-child-aliased-prop",
@@ -4232,6 +4556,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -4290,16 +4618,20 @@
       }
     },
     "object-literal": {
-      "total": 52,
+      "total": 55,
       "cells": {
         "hono": {
-          "pass": 52,
-          "total": 52
+          "pass": 55,
+          "total": 55
         },
         "blade": {
-          "pass": 50,
-          "total": 52,
+          "pass": 52,
+          "total": 55,
           "gaps": [
+            {
+              "fixture": "loop-param-shadows-spread-const",
+              "issues": []
+            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -4313,9 +4645,17 @@
           ]
         },
         "erb": {
-          "pass": 50,
-          "total": 52,
+          "pass": 51,
+          "total": 55,
           "gaps": [
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
+              "issues": []
+            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -4330,8 +4670,20 @@
         },
         "go-template": {
           "pass": 50,
-          "total": 52,
+          "total": 55,
           "gaps": [
+            {
+              "fixture": "callback-param-shadows-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
+              "issues": []
+            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -4345,9 +4697,13 @@
           ]
         },
         "jinja": {
-          "pass": 50,
-          "total": 52,
+          "pass": 52,
+          "total": 55,
           "gaps": [
+            {
+              "fixture": "loop-param-shadows-spread-const",
+              "issues": []
+            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -4361,9 +4717,13 @@
           ]
         },
         "minijinja": {
-          "pass": 50,
-          "total": 52,
+          "pass": 52,
+          "total": 55,
           "gaps": [
+            {
+              "fixture": "loop-param-shadows-spread-const",
+              "issues": []
+            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -4377,8 +4737,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 50,
-          "total": 52,
+          "pass": 53,
+          "total": 55,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4393,9 +4753,13 @@
           ]
         },
         "twig": {
-          "pass": 50,
-          "total": 52,
+          "pass": 52,
+          "total": 55,
           "gaps": [
+            {
+              "fixture": "loop-param-shadows-spread-const",
+              "issues": []
+            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -4409,9 +4773,13 @@
           ]
         },
         "xslate": {
-          "pass": 50,
-          "total": 52,
+          "pass": 52,
+          "total": 55,
           "gaps": [
+            {
+              "fixture": "loop-param-shadows-spread-const",
+              "issues": []
+            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -4484,15 +4852,15 @@
       }
     },
     "template-literal": {
-      "total": 29,
+      "total": 30,
       "cells": {
         "hono": {
-          "pass": 29,
-          "total": 29
+          "pass": 30,
+          "total": 30
         },
         "blade": {
-          "pass": 28,
-          "total": 29,
+          "pass": 29,
+          "total": 30,
           "gaps": [
             {
               "fixture": "tag-cloud",
@@ -4502,8 +4870,12 @@
         },
         "erb": {
           "pass": 28,
-          "total": 29,
+          "total": 30,
           "gaps": [
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
             {
               "fixture": "tag-cloud",
               "issues": []
@@ -4512,8 +4884,12 @@
         },
         "go-template": {
           "pass": 28,
-          "total": 29,
+          "total": 30,
           "gaps": [
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
             {
               "fixture": "tag-cloud",
               "issues": []
@@ -4521,8 +4897,8 @@
           ]
         },
         "jinja": {
-          "pass": 28,
-          "total": 29,
+          "pass": 29,
+          "total": 30,
           "gaps": [
             {
               "fixture": "tag-cloud",
@@ -4531,8 +4907,8 @@
           ]
         },
         "minijinja": {
-          "pass": 28,
-          "total": 29,
+          "pass": 29,
+          "total": 30,
           "gaps": [
             {
               "fixture": "tag-cloud",
@@ -4541,8 +4917,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 28,
-          "total": 29,
+          "pass": 29,
+          "total": 30,
           "gaps": [
             {
               "fixture": "tag-cloud",
@@ -4551,8 +4927,8 @@
           ]
         },
         "twig": {
-          "pass": 28,
-          "total": 29,
+          "pass": 29,
+          "total": 30,
           "gaps": [
             {
               "fixture": "tag-cloud",
@@ -4561,8 +4937,8 @@
           ]
         },
         "xslate": {
-          "pass": 28,
-          "total": 29,
+          "pass": 29,
+          "total": 30,
           "gaps": [
             {
               "fixture": "tag-cloud",
@@ -5449,15 +5825,15 @@
       }
     },
     "array-method:join": {
-      "total": 38,
+      "total": 39,
       "cells": {
         "hono": {
-          "pass": 38,
-          "total": 38
+          "pass": 39,
+          "total": 39
         },
         "blade": {
-          "pass": 36,
-          "total": 38,
+          "pass": 37,
+          "total": 39,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5470,8 +5846,8 @@
           ]
         },
         "erb": {
-          "pass": 36,
-          "total": 38,
+          "pass": 37,
+          "total": 39,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5485,8 +5861,12 @@
         },
         "go-template": {
           "pass": 36,
-          "total": 38,
+          "total": 39,
           "gaps": [
+            {
+              "fixture": "callback-param-shadows-prop",
+              "issues": []
+            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -5498,8 +5878,8 @@
           ]
         },
         "jinja": {
-          "pass": 36,
-          "total": 38,
+          "pass": 37,
+          "total": 39,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5512,8 +5892,8 @@
           ]
         },
         "minijinja": {
-          "pass": 36,
-          "total": 38,
+          "pass": 37,
+          "total": 39,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5526,8 +5906,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 36,
-          "total": 38,
+          "pass": 37,
+          "total": 39,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5540,8 +5920,8 @@
           ]
         },
         "twig": {
-          "pass": 36,
-          "total": 38,
+          "pass": 37,
+          "total": 39,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5554,8 +5934,8 @@
           ]
         },
         "xslate": {
-          "pass": 36,
-          "total": 38,
+          "pass": 37,
+          "total": 39,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -6668,15 +7048,15 @@
       }
     },
     "binary:+": {
-      "total": 18,
+      "total": 19,
       "cells": {
         "hono": {
-          "pass": 18,
-          "total": 18
+          "pass": 19,
+          "total": 19
         },
         "blade": {
-          "pass": 17,
-          "total": 18,
+          "pass": 18,
+          "total": 19,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6687,8 +7067,8 @@
           ]
         },
         "erb": {
-          "pass": 17,
-          "total": 18,
+          "pass": 18,
+          "total": 19,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6700,8 +7080,12 @@
         },
         "go-template": {
           "pass": 17,
-          "total": 18,
+          "total": 19,
           "gaps": [
+            {
+              "fixture": "callback-param-shadows-prop",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -6711,8 +7095,8 @@
           ]
         },
         "jinja": {
-          "pass": 17,
-          "total": 18,
+          "pass": 18,
+          "total": 19,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6723,8 +7107,8 @@
           ]
         },
         "minijinja": {
-          "pass": 17,
-          "total": 18,
+          "pass": 18,
+          "total": 19,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6735,8 +7119,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 17,
-          "total": 18,
+          "pass": 18,
+          "total": 19,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6747,8 +7131,8 @@
           ]
         },
         "twig": {
-          "pass": 17,
-          "total": 18,
+          "pass": 18,
+          "total": 19,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6759,8 +7143,8 @@
           ]
         },
         "xslate": {
-          "pass": 17,
-          "total": 18,
+          "pass": 18,
+          "total": 19,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -7539,18 +7923,26 @@
       }
     },
     "literal:number": {
-      "total": 96,
+      "total": 101,
       "cells": {
         "hono": {
-          "pass": 96,
-          "total": 96
+          "pass": 101,
+          "total": 101
         },
         "blade": {
-          "pass": 91,
-          "total": 96,
+          "pass": 94,
+          "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7572,11 +7964,23 @@
           ]
         },
         "erb": {
-          "pass": 91,
-          "total": 96,
+          "pass": 93,
+          "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7598,11 +8002,27 @@
           ]
         },
         "go-template": {
-          "pass": 91,
-          "total": 96,
+          "pass": 92,
+          "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "loop-destructured-param-condition",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
+              "issues": []
+            },
+            {
+              "fixture": "nested-loop-tail-content",
               "issues": []
             },
             {
@@ -7624,11 +8044,19 @@
           ]
         },
         "jinja": {
-          "pass": 91,
-          "total": 96,
+          "pass": 94,
+          "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7650,11 +8078,19 @@
           ]
         },
         "minijinja": {
-          "pass": 91,
-          "total": 96,
+          "pass": 94,
+          "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7676,11 +8112,15 @@
           ]
         },
         "mojolicious": {
-          "pass": 91,
-          "total": 96,
+          "pass": 95,
+          "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -7702,11 +8142,19 @@
           ]
         },
         "twig": {
-          "pass": 91,
-          "total": 96,
+          "pass": 94,
+          "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7728,11 +8176,19 @@
           ]
         },
         "xslate": {
-          "pass": 91,
-          "total": 96,
+          "pass": 94,
+          "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-bool-prop",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7767,15 +8223,15 @@
       }
     },
     "literal:string": {
-      "total": 165,
+      "total": 168,
       "cells": {
         "hono": {
-          "pass": 165,
-          "total": 165
+          "pass": 168,
+          "total": 168
         },
         "blade": {
-          "pass": 157,
-          "total": 165,
+          "pass": 159,
+          "total": 168,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7795,6 +8251,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7814,8 +8274,8 @@
           ]
         },
         "erb": {
-          "pass": 157,
-          "total": 165,
+          "pass": 158,
+          "total": 168,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7835,6 +8295,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7855,8 +8323,12 @@
         },
         "go-template": {
           "pass": 157,
-          "total": 165,
+          "total": 168,
           "gaps": [
+            {
+              "fixture": "callback-param-shadows-prop",
+              "issues": []
+            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -7875,6 +8347,14 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7894,8 +8374,8 @@
           ]
         },
         "jinja": {
-          "pass": 157,
-          "total": 165,
+          "pass": 159,
+          "total": 168,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7915,6 +8395,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7934,8 +8418,8 @@
           ]
         },
         "minijinja": {
-          "pass": 157,
-          "total": 165,
+          "pass": 159,
+          "total": 168,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7958,6 +8442,10 @@
               "issues": []
             },
             {
+              "fixture": "loop-param-shadows-spread-const",
+              "issues": []
+            },
+            {
               "fixture": "preamble-cells",
               "issues": []
             },
@@ -7974,8 +8462,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 157,
-          "total": 165,
+          "pass": 160,
+          "total": 168,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8014,8 +8502,8 @@
           ]
         },
         "twig": {
-          "pass": 157,
-          "total": 165,
+          "pass": 159,
+          "total": 168,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8035,6 +8523,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -8054,8 +8546,8 @@
           ]
         },
         "xslate": {
-          "pass": 157,
-          "total": 165,
+          "pass": 159,
+          "total": 168,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8075,6 +8567,10 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {


### PR DESCRIPTION
Falsification round for the #2482 loop-lowering design review: the audit's unguarded name-resolution table was tested with real TSX. Five predicted holes reproduced; this PR fixes the two compiler-core ones, lands six conformance fixtures, and pins the adapter-side confirmations as known limitations (#2486–#2492).

## Compiler fixes (both silent-wrong or bundle-breaking before)

1. **Scope-aware `rewriteBarePropRefs`** (`packages/jsx/src/prop-rewrite.ts`). A nested callback parameter sharing a destructured prop's name was rewritten along with genuine prop refs — `createMemo(() => items().map((title) => title.a).join(','))` with a `title` prop emitted `.map((_p.title) => _p.title.a)` into the client bundle: a parse error that kills hydration for the whole file. The memo path regressed in #2478's commit (its call site was flagged by the #2482 audit the day it landed); the signal-initializer sibling predates it on main. Discovery and application now share a binding-stack walk (function-like params, block declarations, catch variables): discovery skips shadowed references, and application is a span-splice over the text's own parsed AST (per the repo's AST-not-regex convention) with the legacy regex kept only as a fallback for unparseable text. Mixed usage (`title + items().map((title) => …)`) rewrites exactly the genuine outer reference; shorthand properties expand to `{ title: _p.title }` to stay syntactically valid.

2. **Loop-param guard on `tryResolveTemplateSpanFromConst`** (`packages/jsx/src/jsx-to-ir.ts`). The `${IDENT}` / `${IDENT[KEY]}` template-span fold resolved against `localConstants` with no loop-scope check, so `` items.map((tone) => `t ${tone[k]}`) `` with a module `const tone = {…}` baked the OUTER record into a compile-time lookup part — every row rendered from the frozen const, on every adapter including the Hono reference and the CSR lambda. Both arms now bail via `ctx.loopParams` (the #2222/#2235 pattern) and fall back to the bare-expression path, which sees the row binding.

## Fixtures (6 new, `packages/adapter-tests/fixtures/`)

Regression armor for the fixes, reference-generated `expectedHtml`:
- `callback-param-shadows-prop` — signal + memo with a nested `.map((title) => …)` param colliding with the `title` prop (plus a mixed-usage memo).
- `loop-param-shadows-record-template-span` — `.map((tone) => …)` shadowing a module record const, read via `` `t ${tone[k]}` `` (key typed as the `'a' | 'b'` literal union so generated data points stay within the record's domain).

Pinned known limitations (each `renderDivergences` entry carries its issue URL):
- `loop-destructured-param-condition` — Go's `renderConditionExpr` resolves a destructured row binding to the root scope (`{{if $.Active}}`) (#2486).
- `nested-loop-tail-content` — Go's `inLoop` is cleared, not restored, by an inner loop's exit; outer-row content after the inner loop lowers through non-loop arms (#2487).
- `loop-param-shadows-bool-prop` — Twig-family + ERB + Mojo route a row value named like a boolean prop through the bool lowering (`collectBooleanTypedProps` never got the #2236 loop subtraction its sibling did) (#2488).
- `loop-param-shadows-spread-const` — Twig-family + ERB `emitSpread` resolves a spread identifier against `localConstants` with no shadow check, spreading the outer const on every row (#2489); Go pins the same fixture for an unrelated attr-name mangling (`id` → `-i-d`) (#2490).

Landing the fixtures immediately caught three more Go/ERB holes the audit hadn't predicted (#2490, #2491 dynamic row-key lookup renders empty, #2492 JS-computed initializers don't seed Go SSR) — pinned in the same pass.

## Validation

Full local run of all 13 package suites on the final tree:
- adapter-tests 1874/1876 → after regenerating `coverage-map.json` the freshness gate passes (the one real fail); hono, twig, jinja, blade, xslate, rust, mojolicious, go-template, client, test: **0 fail**.
- erb: 8 fails, all `date-tolocale-named-tz` — the known local tzinfo-gem environment issue, red on clean main too.
- jsx: 2 fails = the two pre-existing `map-body-no-silent-divergence` cases already red on main; `tsc --noEmit` clean.
- New unit tests in `csr-template-scope-soundness.test.ts` (4: memo/signal/mixed rewrite + span-fold guard).
- Adapter render evidence for the pins: jinja/rust/erb/go rendered locally (pins verified green); twig/blade/xslate/mojo engines unavailable locally — pinned from emission-level evidence (probe outputs in the linked issues).
- `generated-data-points.json`, `coverage-map.json`, `compat.lock.json` regenerated (fresh dists built from repo root); changesets for `@barefootjs/jsx` + the 8 adapter packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpPtSg6rTe158671pknoD2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpPtSg6rTe158671pknoD2)_