### PR TITLE
feat(vite): add @barefootjs/vite plugin taking over the client-asset build

### DIFF
--- a/.changeset/vite-plugin-core.md
+++ b/.changeset/vite-plugin-core.md
@@ -1,0 +1,67 @@
+---
+"@barefootjs/vite": minor
+"@barefootjs/jsx": patch
+---
+
+Add `@barefootjs/vite`: a Vite plugin that takes over the client-asset half of `bf build`
+
+`bf build` currently owns the whole bundler job itself — esbuild invocation,
+externals/importmap, vendor chunk splitting, content hashing, tree-shaking,
+relative-import resolution, build caching (`packages/cli/src/lib/build.ts`,
+2400+ lines). `@barefootjs/vite` hands all of that to Vite/Rollup and keeps
+BarefootJS focused on its actual job: JSX → (template, client JS). The
+public surface is three options — `adapter`, `components`, `templates` —
+everything else (`minify`, `outDir`, content hashing, externals, chunk
+splitting, `base`) is stock Vite config the user already knows.
+
+Two engines, sharing one content-hash-keyed compile cache so no file is
+compiled more than necessary:
+
+- a **graph pass** (`transform`, `enforce: 'pre'`) — Rollup visits `.tsx`
+  modules reachable from `build.rollupOptions.input` (every `'use client'`
+  component under `components`); this plugin compiles each one and hands
+  back plain client JS, which survives Vite's built-in esbuild pass
+  untouched and gets bundled, hashed, tree-shaken, chunked, and minified
+  like any other module. A `resolveId` shim maps the compiler's
+  `./foo.client.js` sibling-import specifier (emitted only for relative
+  imports of client-signal-exporting modules) back to the real `./foo.tsx`
+  — alias imports need no shim, `resolve.alias` already resolves them.
+- an **eager pass** (`writeBundle`) — walks every `.tsx` under `components`
+  directly, not via Rollup's module graph. Server-only components (no
+  `'use client'`) never appear in that graph at all (nothing imports them
+  as a script) but still need a template — this pass is the only place
+  that happens, and it runs in `writeBundle` specifically because Vite's
+  manifest (`build.manifest`, forced on) is only final once Rollup has
+  hashed every output filename. For each `'use client'` component, its
+  entry's real hashed URL is resolved from the manifest and passed as
+  `AdapterGenerateOptions.scriptAssets` (see the `adapter-script-assets`
+  changeset) so the emitted template registers the actual, `base`-prefixed
+  built asset — never a shared-runtime script tag, since the runtime now
+  arrives as an ESM import of a shared chunk the browser follows on its
+  own.
+
+`@barefootjs/jsx`: `CompileOptions` gains `scriptAssets?: string[]`,
+threaded straight through to `adapter.generate()`. `AdapterGenerateOptions
+.scriptAssets` shipped in the prior PR, but nothing between it and
+`compileJSX`'s callers existed to reach it — this closes that gap. Plain
+resolved data forwarded unchanged, not a rewrite hook.
+
+`@barefootjs/client` is deliberately left WITHOUT a `sideEffects: false`
+declaration. Adding one looks correct — and Rollup does tree-shake the
+runtime down to just the exports a project uses, verified against a real
+`vite build` — but it breaks the package's own build: `bun build
+./src/index.ts --external '@barefootjs/client/reactive'` then drops the
+external re-export's import while keeping the `export { … }` list, so
+every name in `dist/index.js` becomes "not declared in this file" and
+every downstream consumer fails to load. Tree-shaking already works
+without the field; do not re-add it without fixing `build:js` first.
+
+Out of scope for this change (tracked as follow-ups): the dev server /
+HMR / full-reload story (`configureServer`), migrating the 19
+`integrations/*` example apps, and combining per-file adapter `types`
+output (e.g. Go's Props structs) into one backend-native file (Go's
+`components.go` combination — deduped `package`/import header plus a
+shared `randomID` helper — lives entirely in `@barefootjs/go-template`'s
+`barefoot.config.ts` factory today; this plugin has no equivalent hook
+yet, so it writes each component's raw `types` fragment to its own
+`.types` file next to its template instead of combining them).

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -230,6 +230,7 @@ function compileMultipleComponents(
       scriptBaseName,
       siblingTemplatesRegistered: options.siblingTemplatesRegistered,
       rewriteRelativeImport: options.rewriteRelativeImport,
+      scriptAssets: options.scriptAssets,
     })
     const moduleExports = generateModuleExports(
       componentIR,
@@ -671,6 +672,7 @@ export function compileJSX(
     scriptBaseName: options.scriptBaseName,
     siblingTemplatesRegistered: options.siblingTemplatesRegistered,
     rewriteRelativeImport: options.rewriteRelativeImport,
+    scriptAssets: options.scriptAssets,
   })
 
   // `templatesPerComponent` adapters (Mojolicious) emit non-JS template files

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -2225,6 +2225,19 @@ export interface CompileOptions {
    * byte-for-byte unchanged (SR8). Dev/profiling builds only.
    */
   profile?: boolean
+  /**
+   * Forwarded verbatim to `adapter.generate(..., { scriptAssets })` — see
+   * that field's docstring on `AdapterGenerateOptions` for the full
+   * precedence rules (`skipScriptRegistration` still wins; `[]` means "no
+   * scripts", distinct from `undefined`'s "use the legacy computed path").
+   *
+   * This is plain resolved data (an ordered URL list), not a rewrite
+   * callback — the caller (chiefly `@barefootjs/vite`) has already done all
+   * the resolution (bundling, hashing, manifest lookup) before calling
+   * `compileJSX`; the compiler only threads the list through to the
+   * adapter unchanged.
+   */
+  scriptAssets?: string[]
 }
 
 export interface FileOutput {

--- a/packages/vite/e2e-fixture/src/components/Counter.tsx
+++ b/packages/vite/e2e-fixture/src/components/Counter.tsx
@@ -1,0 +1,7 @@
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function Counter() {
+  const [count, setCount] = createSignal(0)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}

--- a/packages/vite/e2e-fixture/src/components/Greeting.tsx
+++ b/packages/vite/e2e-fixture/src/components/Greeting.tsx
@@ -1,0 +1,3 @@
+export function Greeting({ name }: { name: string }) {
+  return <p>Hello, {name}!</p>
+}

--- a/packages/vite/e2e-fixture/src/components/SharedCounter.tsx
+++ b/packages/vite/e2e-fixture/src/components/SharedCounter.tsx
@@ -1,0 +1,6 @@
+'use client'
+import { sharedCount, setSharedCount } from './counterState'
+
+export function SharedCounter() {
+  return <button onClick={() => setSharedCount(sharedCount() + 1)}>{sharedCount()}</button>
+}

--- a/packages/vite/e2e-fixture/src/components/counterState.tsx
+++ b/packages/vite/e2e-fixture/src/components/counterState.tsx
@@ -1,0 +1,5 @@
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+/* @client */
+export const [sharedCount, setSharedCount] = createSignal(0)

--- a/packages/vite/e2e-fixture/vite.config.ts
+++ b/packages/vite/e2e-fixture/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite'
+import { barefoot } from '../src/index.ts'
+import { GoTemplateAdapter } from '@barefootjs/go-template/adapter'
+
+// Manual smoke-test config, matching the design doc's example exactly
+// (adapter / components / templates — nothing else BarefootJS-specific).
+// Run with `bunx vite build` from this directory. Not used by the
+// automated test suite (e2e-vite-build.test.ts drives the same plugin via
+// Vite's Node API instead, which is more robust in CI), but kept here so
+// the plugin's real, file-based config-loading path has been exercised by
+// hand at least once.
+export default defineConfig({
+  base: '/static/build/',
+  build: { outDir: 'dist', emptyOutDir: true },
+  plugins: [
+    barefoot({
+      adapter: new GoTemplateAdapter({ packageName: 'main' }),
+      components: ['src/components'],
+      templates: 'internal/views',
+    }),
+  ],
+})

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@barefootjs/vite",
+  "version": "0.30.0",
+  "description": "Vite plugin for BarefootJS: Vite/Rollup owns bundling, hashing, chunking, tree-shaking and minification of client assets, BarefootJS keeps only the JSX to (template, client JS) compile",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "//publishConfig": "At pack time, swap-publish-config.mjs merges these overrides into the top-level so the published tarball resolves entry points to dist/ instead of src/.",
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "bun run build:js && bun run build:types",
+    "build:js": "bun build ./src/index.ts --root ./src --outdir ./dist --format esm --external vite --external @barefootjs/jsx --external @barefootjs/shared --external typescript",
+    "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
+    "test": "bun test",
+    "clean": "rm -rf dist",
+    "prepack": "node ../../scripts/swap-publish-config.mjs pack",
+    "postpack": "node ../../scripts/swap-publish-config.mjs unpack"
+  },
+  "keywords": [
+    "vite",
+    "vite-plugin",
+    "barefoot",
+    "ssr"
+  ],
+  "author": "kobaken <kentafly88@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piconic-ai/barefootjs",
+    "directory": "packages/vite"
+  },
+  "dependencies": {
+    "@barefootjs/shared": "workspace:*"
+  },
+  "peerDependencies": {
+    "@barefootjs/jsx": ">=0.2.0",
+    "vite": "^6.0.0"
+  },
+  "devDependencies": {
+    "@barefootjs/client": "workspace:*",
+    "@barefootjs/go-template": "workspace:*",
+    "@barefootjs/jsx": "workspace:*",
+    "typescript": "^5.0.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/packages/vite/src/__tests__/compile-cache.test.ts
+++ b/packages/vite/src/__tests__/compile-cache.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect } from 'bun:test'
+import { CompileCache } from '../compile-cache.ts'
+import type { CompileResult } from '@barefootjs/jsx'
+
+function fakeResult(tag: string): CompileResult {
+  return { files: [{ path: tag, content: tag, type: 'clientJs' }], errors: [] }
+}
+
+describe('CompileCache', () => {
+  test('compiles once for the same (path, content) pair', () => {
+    const cache = new CompileCache()
+    let calls = 0
+    const compile = () => {
+      calls++
+      return fakeResult('a')
+    }
+
+    const first = cache.getOrCompile('/a.tsx', 'content', compile)
+    const second = cache.getOrCompile('/a.tsx', 'content', compile)
+
+    expect(calls).toBe(1)
+    expect(first).toBe(second)
+  })
+
+  test('recompiles when the content changes', () => {
+    const cache = new CompileCache()
+    let calls = 0
+    const compile = () => {
+      calls++
+      return fakeResult(`v${calls}`)
+    }
+
+    const first = cache.getOrCompile('/a.tsx', 'v1', compile)
+    const second = cache.getOrCompile('/a.tsx', 'v2', compile)
+
+    expect(calls).toBe(2)
+    expect(first).not.toBe(second)
+  })
+
+  test('tracks distinct paths independently', () => {
+    const cache = new CompileCache()
+    let calls = 0
+    const compile = () => {
+      calls++
+      return fakeResult(`n${calls}`)
+    }
+
+    cache.getOrCompile('/a.tsx', 'same', compile)
+    cache.getOrCompile('/b.tsx', 'same', compile)
+
+    expect(calls).toBe(2)
+  })
+
+  test('peek returns undefined before any compile and the cached result after', () => {
+    const cache = new CompileCache()
+    expect(cache.peek('/a.tsx')).toBeUndefined()
+    const result = cache.getOrCompile('/a.tsx', 'content', () => fakeResult('a'))
+    expect(cache.peek('/a.tsx')).toBe(result)
+  })
+
+  test('clear() forces a recompile', () => {
+    const cache = new CompileCache()
+    let calls = 0
+    const compile = () => {
+      calls++
+      return fakeResult('a')
+    }
+    cache.getOrCompile('/a.tsx', 'content', compile)
+    cache.clear()
+    cache.getOrCompile('/a.tsx', 'content', compile)
+    expect(calls).toBe(2)
+  })
+})

--- a/packages/vite/src/__tests__/discover.test.ts
+++ b/packages/vite/src/__tests__/discover.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect, afterEach } from 'bun:test'
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { hasUseClientDirective, discoverComponentFiles, discoverComponents } from '../discover.ts'
+
+describe('hasUseClientDirective', () => {
+  test('detects a leading double-quoted directive', () => {
+    expect(hasUseClientDirective('"use client"\nexport function A() {}')).toBe(true)
+  })
+
+  test('detects a leading single-quoted directive', () => {
+    expect(hasUseClientDirective("'use client'\nexport function A() {}")).toBe(true)
+  })
+
+  test('skips leading block comments before the directive', () => {
+    expect(hasUseClientDirective('/* c */\n\'use client\'\nexport function A() {}')).toBe(true)
+  })
+
+  test('skips leading line comments before the directive', () => {
+    expect(hasUseClientDirective('// c\n\'use client\'\nexport function A() {}')).toBe(true)
+  })
+
+  test('returns false for a server-only file', () => {
+    expect(hasUseClientDirective('export function A() { return <div/> }')).toBe(false)
+  })
+
+  test('returns false when the directive is not the first statement', () => {
+    expect(hasUseClientDirective('const x = 1\n\'use client\'')).toBe(false)
+  })
+})
+
+describe('discoverComponentFiles', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  test('finds nested .tsx files and skips test/spec/preview variants', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-discover-'))
+    await mkdir(join(dir, 'nested'), { recursive: true })
+    await writeFile(join(dir, 'A.tsx'), 'export function A() {}')
+    await writeFile(join(dir, 'A.test.tsx'), 'export function A() {}')
+    await writeFile(join(dir, 'A.spec.tsx'), 'export function A() {}')
+    await writeFile(join(dir, 'A.preview.tsx'), 'export function A() {}')
+    await writeFile(join(dir, 'nested', 'B.tsx'), 'export function B() {}')
+    await writeFile(join(dir, 'not-a-component.ts'), 'export const x = 1')
+
+    const found = await discoverComponentFiles(dir)
+    const basenames = found.map(f => f.slice(dir.length + 1)).sort()
+    expect(basenames).toEqual(['A.tsx', 'nested/B.tsx'])
+  })
+
+  test('returns an empty array for a missing directory', async () => {
+    const found = await discoverComponentFiles(join(tmpdir(), 'does-not-exist-barefoot-vite'))
+    expect(found).toEqual([])
+  })
+})
+
+describe('discoverComponents', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  test('classifies each discovered file as client or server-only', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-discover-classify-'))
+    await writeFile(join(dir, 'Client.tsx'), '\'use client\'\nexport function Client() {}')
+    await writeFile(join(dir, 'Server.tsx'), 'export function Server() {}')
+
+    const found = await discoverComponents([dir], p => Bun.file(p).text())
+    const byName = Object.fromEntries(found.map(f => [f.absPath.slice(dir.length + 1), f.isClient]))
+    expect(byName['Client.tsx']).toBe(true)
+    expect(byName['Server.tsx']).toBe(false)
+  })
+})

--- a/packages/vite/src/__tests__/e2e-vite-build.test.ts
+++ b/packages/vite/src/__tests__/e2e-vite-build.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Real end-to-end coverage: actually runs `vite build` (via Vite's Node
+ * API — the same function the `vite` CLI binary itself calls) against the
+ * small fixture project under `../../e2e-fixture`, then asserts BOTH
+ * halves of the design:
+ *
+ *   - the client-asset half: Vite/Rollup produced hashed JS assets, and
+ *     the shared `@barefootjs/client` runtime collapsed into ONE shared
+ *     chunk imported by every entry (not duplicated per entry) — the
+ *     exact behavior the spike (R1/R3) proved.
+ *   - the template half: the emitted Go template for the `'use client'`
+ *     component contains a `{{.Scripts.Register "…"}}` call pointing at
+ *     the REAL, hashed, `base`-prefixed manifest URL, and the server-only
+ *     component (never reachable from Rollup's module graph) still got a
+ *     template, with no script registration at all.
+ *
+ * A plugin that only passes mocked unit tests hasn't been shown to work —
+ * this is the test that shows it.
+ */
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
+import { build } from 'vite'
+import { mkdtemp, rm, readFile, readdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { GoTemplateAdapter } from '@barefootjs/go-template/adapter'
+import { barefoot } from '../plugin.ts'
+
+const FIXTURE_ROOT = resolve(import.meta.dirname, '../../e2e-fixture')
+
+describe('e2e: vite build', () => {
+  let outDir: string
+  let templatesDir: string
+
+  beforeAll(async () => {
+    outDir = await mkdtemp(join(tmpdir(), 'barefoot-vite-dist-'))
+    templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-vite-views-'))
+
+    await build({
+      configFile: false,
+      root: FIXTURE_ROOT,
+      base: '/static/build/',
+      logLevel: 'warn',
+      build: {
+        outDir,
+        emptyOutDir: true,
+      },
+      plugins: [
+        barefoot({
+          adapter: new GoTemplateAdapter({ packageName: 'main' }),
+          components: ['src/components'],
+          templates: templatesDir,
+        }),
+      ],
+    })
+  }, 60_000)
+
+  afterAll(async () => {
+    await rm(outDir, { recursive: true, force: true })
+    await rm(templatesDir, { recursive: true, force: true })
+  })
+
+  test('emits a manifest with hashed entries for every "use client" component', async () => {
+    const manifest = JSON.parse(await readFile(resolve(outDir, '.vite/manifest.json'), 'utf8'))
+    const keys = Object.keys(manifest)
+    expect(keys.some(k => k.endsWith('Counter.tsx'))).toBe(true)
+    expect(keys.some(k => k.endsWith('SharedCounter.tsx'))).toBe(true)
+    expect(keys.some(k => k.endsWith('counterState.tsx'))).toBe(true)
+    // Greeting.tsx has no 'use client' directive — never an entry.
+    expect(keys.some(k => k.endsWith('Greeting.tsx'))).toBe(false)
+  })
+
+  test('the runtime collapses into one shared chunk imported by every client entry', async () => {
+    const manifest = JSON.parse(await readFile(resolve(outDir, '.vite/manifest.json'), 'utf8'))
+    const counterKey = Object.keys(manifest).find(k => k.endsWith('Counter.tsx') && !k.includes('Shared'))!
+    const sharedCounterKey = Object.keys(manifest).find(k => k.endsWith('SharedCounter.tsx'))!
+
+    const counterEntry = manifest[counterKey]
+    const sharedCounterEntry = manifest[sharedCounterKey]
+    expect(counterEntry.imports?.length).toBeGreaterThan(0)
+    expect(sharedCounterEntry.imports?.length).toBeGreaterThan(0)
+
+    // Both entries' shared-chunk import sets intersect on at least one
+    // chunk (the runtime) — i.e. it's a SHARED chunk, not duplicated.
+    const shared = (counterEntry.imports ?? []).filter((k: string) => (sharedCounterEntry.imports ?? []).includes(k))
+    expect(shared.length).toBeGreaterThan(0)
+
+    // That shared chunk is a real file on disk under outDir.
+    for (const key of shared) {
+      const file = manifest[key].file
+      const content = await readFile(resolve(outDir, file), 'utf8')
+      expect(content.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('SharedCounter\'s relative "./counterState.client.js" import resolved to the real counterState chunk (resolveId shim, R2)', async () => {
+    const manifest = JSON.parse(await readFile(resolve(outDir, '.vite/manifest.json'), 'utf8'))
+    const sharedCounterKey = Object.keys(manifest).find(k => k.endsWith('SharedCounter.tsx'))!
+    const stateKey = Object.keys(manifest).find(k => k.endsWith('counterState.tsx'))!
+    const sharedCounterEntry = manifest[sharedCounterKey]
+
+    // counterState.tsx is itself a rollupOptions.input entry (it has 'use
+    // client' too) AND is import-reachable from SharedCounter — Rollup
+    // resolves both to the identical module id, so SharedCounter's
+    // manifest row lists it directly as an entry-to-entry import.
+    expect(sharedCounterEntry.imports).toContain(stateKey)
+  })
+
+  test('the built client JS is plain JS Vite/esbuild could bundle and minify without re-parsing JSX (R1)', async () => {
+    const manifest = JSON.parse(await readFile(resolve(outDir, '.vite/manifest.json'), 'utf8'))
+    const counterKey = Object.keys(manifest).find(k => k.endsWith('Counter.tsx') && !k.includes('Shared'))!
+    const file = manifest[counterKey].file
+    const content = await readFile(resolve(outDir, file), 'utf8')
+    // Production build output is minified — identifiers like `hydrate` get
+    // renamed, so assert on what survives minification instead: the
+    // hydration template's literal markup (proof this went through as
+    // plain JS, not raw JSX esbuild would have needed a JSX transform for)
+    // and the total absence of the 'use client' directive / JSX attribute
+    // syntax a live JSX expression would still carry.
+    expect(content).toContain('<button bf="s1">')
+    expect(content).not.toContain('use client')
+    expect(content).not.toMatch(/onClick=\{/)
+  })
+
+  test('emits a Go template for the "use client" component with the real hashed, base-prefixed script URL', async () => {
+    const manifest = JSON.parse(await readFile(resolve(outDir, '.vite/manifest.json'), 'utf8'))
+    const counterKey = Object.keys(manifest).find(k => k.endsWith('Counter.tsx') && !k.includes('Shared'))!
+    const expectedUrl = `/static/build/${manifest[counterKey].file}`
+
+    const template = await readFile(resolve(templatesDir, 'Counter.tmpl'), 'utf8')
+    expect(template).toContain(`{{.Scripts.Register "${expectedUrl}"}}`)
+  })
+
+  test('emits a template for the server-only component (never in the Rollup graph) with NO script registration', async () => {
+    const manifest = JSON.parse(await readFile(resolve(outDir, '.vite/manifest.json'), 'utf8'))
+    expect(Object.keys(manifest).some(k => k.endsWith('Greeting.tsx'))).toBe(false)
+
+    const template = await readFile(resolve(templatesDir, 'Greeting.tmpl'), 'utf8')
+    expect(template).not.toContain('Scripts.Register')
+    expect(template).toContain('Hello')
+  })
+
+  test('the templates dir mirrors every discovered component, client and server-only alike', async () => {
+    const files = await readdir(templatesDir)
+    expect(files).toContain('Counter.tmpl')
+    expect(files).toContain('SharedCounter.tmpl')
+    expect(files).toContain('Greeting.tmpl')
+  })
+})

--- a/packages/vite/src/__tests__/emit.test.ts
+++ b/packages/vite/src/__tests__/emit.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect, afterEach } from 'bun:test'
+import { mkdtemp, rm, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { CompileResult, TemplateAdapter } from '@barefootjs/jsx'
+import { planEmits, writeEmits } from '../emit.ts'
+
+const fakeAdapter = { extension: '.tmpl', templatesPerComponent: false } as TemplateAdapter
+const perComponentAdapter = { extension: '.tmpl', templatesPerComponent: true } as TemplateAdapter
+
+describe('planEmits', () => {
+  test('plans a markedTemplate + ssrDefaults + types output, mirroring source position', () => {
+    const result: CompileResult = {
+      files: [
+        { path: '/src/components/ui/button/index.html', content: '<button/>', type: 'markedTemplate' },
+        { path: '/src/components/ui/button/index.ssr-defaults.json', content: '{}', type: 'ssrDefaults' },
+        { path: '/src/components/ui/button/index.types', content: 'type ButtonProps struct{}', type: 'types' },
+      ],
+      errors: [],
+    }
+
+    const targets = planEmits(result, '/src/components/ui/button/index.tsx', ['/src/components'], fakeAdapter)
+    const byPath = Object.fromEntries(targets.map(t => [t.relPath, t.content]))
+
+    expect(byPath['ui/button/index.tmpl']).toBe('<button/>')
+    expect(byPath['ui/button/index.ssr-defaults.json']).toBe('{}')
+    expect(byPath['ui/button/index.types']).toBe('type ButtonProps struct{}')
+  })
+
+  test('names per-component templates after the component, for templatesPerComponent adapters', () => {
+    const result: CompileResult = {
+      files: [
+        { path: '/x', content: 'toast body', type: 'markedTemplate', componentName: 'Toast' },
+        { path: '/x', content: 'toaster body', type: 'markedTemplate', componentName: 'Toaster' },
+      ],
+      errors: [],
+    }
+
+    const targets = planEmits(result, '/src/components/ui/toast/index.tsx', ['/src/components'], perComponentAdapter)
+    const byPath = Object.fromEntries(targets.map(t => [t.relPath, t.content]))
+
+    expect(byPath['ui/toast/Toast.tmpl']).toBe('toast body')
+    expect(byPath['ui/toast/Toaster.tmpl']).toBe('toaster body')
+  })
+
+  test('plans nothing for a state-only compile with no markedTemplate output', () => {
+    const result: CompileResult = {
+      files: [{ path: '/x', content: 'export const x = 1', type: 'clientJs' }],
+      errors: [],
+    }
+    const targets = planEmits(result, '/src/components/state.tsx', ['/src/components'], fakeAdapter)
+    expect(targets).toEqual([])
+  })
+})
+
+describe('writeEmits', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  test('creates nested directories and writes every target', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-emit-'))
+    await writeEmits(dir, [
+      { relPath: 'ui/button/index.tmpl', content: '<button/>' },
+      { relPath: 'top.tmpl', content: 'top' },
+    ])
+
+    expect(await readFile(join(dir, 'ui/button/index.tmpl'), 'utf8')).toBe('<button/>')
+    expect(await readFile(join(dir, 'top.tmpl'), 'utf8')).toBe('top')
+  })
+})

--- a/packages/vite/src/__tests__/manifest.test.ts
+++ b/packages/vite/src/__tests__/manifest.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from 'bun:test'
+import type { Manifest } from 'vite'
+import { joinBaseAndFile, resolveScriptAssets } from '../manifest.ts'
+
+describe('joinBaseAndFile', () => {
+  test('joins a trailing-slash base with the manifest file path', () => {
+    expect(joinBaseAndFile('/static/build/', 'assets/Counter-abc123.js')).toBe(
+      '/static/build/assets/Counter-abc123.js',
+    )
+  })
+
+  test('joins a base without a trailing slash', () => {
+    expect(joinBaseAndFile('/static/build', 'assets/Counter-abc123.js')).toBe(
+      '/static/build/assets/Counter-abc123.js',
+    )
+  })
+
+  test('treats "./" and "" as no-prefix', () => {
+    expect(joinBaseAndFile('./', 'assets/Counter-abc123.js')).toBe('assets/Counter-abc123.js')
+    expect(joinBaseAndFile('', 'assets/Counter-abc123.js')).toBe('assets/Counter-abc123.js')
+  })
+
+  test('works with a full absolute-origin base', () => {
+    expect(joinBaseAndFile('https://cdn.example.com/app/', 'assets/x.js')).toBe(
+      'https://cdn.example.com/app/assets/x.js',
+    )
+  })
+})
+
+describe('resolveScriptAssets', () => {
+  const manifest: Manifest = {
+    'src/components/Counter.tsx': {
+      file: 'assets/Counter-abc123.js',
+      isEntry: true,
+      imports: ['_shared.js'],
+    },
+    '_shared.js': {
+      file: 'assets/shared-def456.js',
+    },
+  }
+
+  test('resolves the single entry URL for a known manifest key', () => {
+    expect(resolveScriptAssets(manifest, 'src/components/Counter.tsx', '/static/build/')).toEqual([
+      '/static/build/assets/Counter-abc123.js',
+    ])
+  })
+
+  test('returns [] for a manifest key with no entry — the server-only-component case', () => {
+    expect(resolveScriptAssets(manifest, 'src/components/Greeting.tsx', '/static/build/')).toEqual([])
+  })
+
+  test('does NOT include shared-chunk imports — only the entry\'s own file', () => {
+    const assets = resolveScriptAssets(manifest, 'src/components/Counter.tsx', '/static/build/')
+    expect(assets).toHaveLength(1)
+    expect(assets[0]).not.toContain('shared-def456')
+  })
+})

--- a/packages/vite/src/__tests__/paths.test.ts
+++ b/packages/vite/src/__tests__/paths.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from 'bun:test'
+import {
+  toPosixRelative,
+  relativeUnderComponentDir,
+  withExtension,
+  perComponentRelPath,
+  buildRelativeImportRewriter,
+} from '../paths.ts'
+
+describe('toPosixRelative', () => {
+  test('produces a forward-slash relative path', () => {
+    expect(toPosixRelative('/proj', '/proj/src/components/Counter.tsx')).toBe('src/components/Counter.tsx')
+  })
+})
+
+describe('relativeUnderComponentDir', () => {
+  test('returns the path under the matching componentDir, with extension', () => {
+    expect(relativeUnderComponentDir('/proj/src/components/ui/Button.tsx', ['/proj/src/components'])).toBe(
+      'ui/Button.tsx',
+    )
+  })
+
+  test('falls back to the basename when no componentDir matches', () => {
+    expect(relativeUnderComponentDir('/elsewhere/Button.tsx', ['/proj/src/components'])).toBe('Button.tsx')
+  })
+})
+
+describe('withExtension', () => {
+  test('swaps .tsx for the given extension', () => {
+    expect(withExtension('ui/Button.tsx', '.tmpl')).toBe('ui/Button.tmpl')
+  })
+
+  test('swaps .ts for the given extension', () => {
+    expect(withExtension('state.ts', '.ssr-defaults.json')).toBe('state.ssr-defaults.json')
+  })
+})
+
+describe('perComponentRelPath', () => {
+  test('names the file after the component, in the same directory', () => {
+    expect(perComponentRelPath('ui/toast/index.tsx', 'Toast', '.tmpl')).toBe('ui/toast/Toast.tmpl')
+  })
+
+  test('handles a top-level file with no subdirectory', () => {
+    expect(perComponentRelPath('Button.tsx', 'Button', '.tmpl')).toBe('Button.tmpl')
+  })
+})
+
+describe('buildRelativeImportRewriter', () => {
+  test('re-anchors an import to a sibling still under componentDirs', () => {
+    const rewrite = buildRelativeImportRewriter(
+      '/proj/src/components/ui/button/index.tsx',
+      '/views/ui/button/index.tmpl',
+      ['/proj/src/components'],
+      '/views',
+    )
+    expect(rewrite('../slot')).toBe('../slot')
+  })
+
+  test('re-relativises an import to a file outside componentDirs from the new output position', () => {
+    const rewrite = buildRelativeImportRewriter(
+      '/proj/src/components/ui/button/index.tsx',
+      '/views/ui/button/index.tmpl',
+      ['/proj/src/components'],
+      '/views',
+    )
+    // '../../../types' from the source resolves to /proj/src/types — the
+    // shared file didn't move, only the template's own position did, so
+    // the rewritten specifier re-relativises from the template's new home
+    // (/views/ui/button/) back to that same absolute file.
+    expect(rewrite('../../../types')).toBe('../../../proj/src/types')
+  })
+})

--- a/packages/vite/src/__tests__/plugin.test.ts
+++ b/packages/vite/src/__tests__/plugin.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests calling the plugin's own hooks directly (no real Vite build —
+ * see `e2e-vite-build.test.ts` for that). Each test targets one bullet
+ * from the PR's testing requirements: config-hook output shape, the
+ * resolveId mapping, transform returning compiled client JS, and the
+ * writeBundle→manifest→scriptAssets resolution including the `[]`
+ * server-only case.
+ */
+import { describe, test, expect, afterEach } from 'bun:test'
+import { mkdtemp, rm, mkdir, writeFile, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { testAdapter } from '@barefootjs/jsx'
+import { GoTemplateAdapter } from '@barefootjs/go-template/adapter'
+import { barefoot } from '../plugin.ts'
+import type { BarefootViteOptions } from '../types.ts'
+
+// biome-ignore lint: hooks are called directly, bypassing Vite's own
+// dispatch/typing — casting to `any` is the standard way to unit-test a
+// Vite plugin's hooks in isolation.
+type AnyPlugin = any
+
+function makePlugin(
+  componentsDir: string,
+  templatesDir: string,
+  adapter: BarefootViteOptions['adapter'] = testAdapter,
+): AnyPlugin {
+  return barefoot({
+    adapter,
+    components: [componentsDir],
+    templates: templatesDir,
+  })
+}
+
+describe('config hook', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  test('sets appType custom, forces build.manifest, and keys rollupOptions.input by ONLY "use client" files', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-plugin-config-'))
+    await mkdir(join(dir, 'src/components'), { recursive: true })
+    await writeFile(join(dir, 'src/components/Counter.tsx'), '\'use client\'\nexport function Counter() { return <div/> }')
+    await writeFile(join(dir, 'src/components/Greeting.tsx'), 'export function Greeting() { return <div/> }')
+
+    const plugin = makePlugin('src/components', 'internal/views')
+    const result = await plugin.config({ root: dir }, { command: 'build', mode: 'production' })
+
+    expect(result.appType).toBe('custom')
+    expect(result.build.manifest).toBe(true)
+    const inputPaths = Object.values(result.build.rollupOptions.input) as string[]
+    expect(inputPaths).toEqual([resolve(dir, 'src/components/Counter.tsx')])
+  })
+
+  test('produces no entries when nothing under components has "use client"', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-plugin-config-'))
+    await mkdir(join(dir, 'src/components'), { recursive: true })
+    await writeFile(join(dir, 'src/components/Greeting.tsx'), 'export function Greeting() { return <div/> }')
+
+    const plugin = makePlugin('src/components', 'internal/views')
+    const result = await plugin.config({ root: dir }, { command: 'build', mode: 'production' })
+
+    expect(Object.keys(result.build.rollupOptions.input)).toEqual([])
+  })
+})
+
+describe('resolveId hook', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  test('resolves the compiler\'s ./foo.client.js specifier back to ./foo.tsx', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-plugin-resolveid-'))
+    await mkdir(join(dir, 'src/components'), { recursive: true })
+    await writeFile(join(dir, 'src/components/signals.tsx'), '\'use client\'\nexport const x = 1')
+
+    const plugin = makePlugin('src/components', 'internal/views')
+    const importer = join(dir, 'src/components/consumer.tsx')
+    const resolved = plugin.resolveId('./signals.client.js', importer)
+
+    expect(resolved).toBe(join(dir, 'src/components/signals.tsx'))
+  })
+
+  test('leaves a bare/alias specifier untouched (returns null)', () => {
+    const plugin = makePlugin('src/components', 'internal/views')
+    expect(plugin.resolveId('@/components/signals.client.js', '/a/consumer.tsx')).toBeNull()
+  })
+})
+
+describe('transform hook', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  async function setup() {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-plugin-transform-'))
+    await mkdir(join(dir, 'src/components'), { recursive: true })
+    const plugin = makePlugin('src/components', 'internal/views')
+    await plugin.config({ root: dir }, { command: 'build', mode: 'production' })
+    plugin.configResolved({
+      root: dir,
+      base: '/',
+      build: { outDir: 'dist', manifest: true },
+    })
+    return plugin
+  }
+
+  test('returns compiled client JS (not raw JSX) for a "use client" .tsx under components', async () => {
+    const plugin = await setup()
+    const source = '\'use client\'\nimport { createSignal } from \'@barefootjs/client\'\nexport function Counter() {\n  const [count, setCount] = createSignal(0)\n  return <button onClick={() => setCount(count() + 1)}>{count()}</button>\n}\n'
+    const id = join(dir, 'src/components/Counter.tsx')
+
+    const out = plugin.transform(source, id)
+
+    expect(out).not.toBeNull()
+    expect(out.code).toContain('createSignal')
+    expect(out.code).not.toContain('use client')
+    // The compiled output is plain JS: any JSX syntax that remains only
+    // does so as a quoted string inside the hydration template literal
+    // (`template: (_p) => \`<button ...>\``), never as a live JSX
+    // expression the browser would need a JSX transform to parse.
+    expect(out.code).toContain('hydrate(')
+    expect(out.code).toMatch(/template:\s*\(_p\) => `<button/)
+  })
+
+  test('returns null for a .tsx file outside the configured components dirs', async () => {
+    const plugin = await setup()
+    const out = plugin.transform('export function X() { return <div/> }', join(dir, 'Outside.tsx'))
+    expect(out).toBeNull()
+  })
+
+  test('returns null for a non-.tsx file', async () => {
+    const plugin = await setup()
+    const out = plugin.transform('export const x = 1', join(dir, 'src/components/util.ts'))
+    expect(out).toBeNull()
+  })
+})
+
+describe('writeBundle: manifest → scriptAssets resolution', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  test('bakes the manifest-resolved URL into the template for a "use client" component, and emits no script registration for a server-only one', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-plugin-writebundle-'))
+    await mkdir(join(dir, 'src/components'), { recursive: true })
+    await writeFile(
+      join(dir, 'src/components/Counter.tsx'),
+      '\'use client\'\nimport { createSignal } from \'@barefootjs/client\'\nexport function Counter() {\n  const [count, setCount] = createSignal(0)\n  return <button onClick={() => setCount(count() + 1)}>{count()}</button>\n}\n',
+    )
+    await writeFile(
+      join(dir, 'src/components/Greeting.tsx'),
+      'export function Greeting() { return <p>Hi</p> }',
+    )
+
+    const templatesDir = join(dir, 'internal/views')
+    // GoTemplateAdapter, not testAdapter: script registration ({{.Scripts
+    // .Register "..."}}}) is exactly the surface this test asserts on, and
+    // testAdapter (used elsewhere in this file for cheap transform/resolveId
+    // coverage) doesn't implement `scriptAssets` at all — see PR1's
+    // changeset, which wires scriptAssets into every DSL-template adapter
+    // but not the CSR-oriented test adapter.
+    const adapter = new GoTemplateAdapter({ packageName: 'main' })
+    const plugin = makePlugin('src/components', 'internal/views', adapter)
+    await plugin.config({ root: dir }, { command: 'build', mode: 'production' })
+    plugin.configResolved({
+      root: dir,
+      base: '/static/build/',
+      build: { outDir: 'dist', manifest: true },
+    })
+
+    // Fabricate the manifest Vite would have written by the time
+    // `writeBundle` fires — this test targets scriptAssets resolution in
+    // isolation, without paying for a real Vite build (see
+    // e2e-vite-build.test.ts for that).
+    await mkdir(join(dir, 'dist/.vite'), { recursive: true })
+    await writeFile(
+      join(dir, 'dist/.vite/manifest.json'),
+      JSON.stringify({
+        'src/components/Counter.tsx': { file: 'assets/Counter-abc123.js', isEntry: true },
+      }),
+    )
+
+    await plugin.writeBundle()
+
+    const counterTpl = await readFile(join(templatesDir, `Counter${adapter.extension}`), 'utf8')
+    const greetingTpl = await readFile(join(templatesDir, `Greeting${adapter.extension}`), 'utf8')
+
+    expect(counterTpl).toContain('{{.Scripts.Register "/static/build/assets/Counter-abc123.js"}}')
+    // Server-only: never in the manifest → scriptAssets resolves to [] →
+    // no script registration text at all.
+    expect(greetingTpl).not.toContain('Scripts.Register')
+    expect(greetingTpl).toContain('Hi')
+  })
+})

--- a/packages/vite/src/__tests__/resolve-client-js.test.ts
+++ b/packages/vite/src/__tests__/resolve-client-js.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect, afterEach } from 'bun:test'
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveClientJsSpecifier } from '../resolve-client-js.ts'
+
+describe('resolveClientJsSpecifier', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  test('maps a relative ./foo.client.js specifier back to ./foo.tsx', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-resolve-'))
+    await writeFile(join(dir, 'signals.tsx'), '\'use client\'\nexport const x = 1')
+    const importer = join(dir, 'consumer.tsx')
+
+    const resolved = resolveClientJsSpecifier('./signals.client.js', importer)
+    expect(resolved).toBe(join(dir, 'signals.tsx'))
+  })
+
+  test('maps a ../ relative specifier from a nested importer', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-resolve-'))
+    await mkdir(join(dir, 'nested'), { recursive: true })
+    await writeFile(join(dir, 'signals.tsx'), '\'use client\'\nexport const x = 1')
+    const importer = join(dir, 'nested', 'consumer.tsx')
+
+    const resolved = resolveClientJsSpecifier('../signals.client.js', importer)
+    expect(resolved).toBe(join(dir, 'signals.tsx'))
+  })
+
+  test('returns null when the target .tsx file does not exist on disk', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-resolve-'))
+    const importer = join(dir, 'consumer.tsx')
+    expect(resolveClientJsSpecifier('./missing.client.js', importer)).toBeNull()
+  })
+
+  test('returns null for a non-.client.js specifier', () => {
+    expect(resolveClientJsSpecifier('./signals.ts', '/a/consumer.tsx')).toBeNull()
+    expect(resolveClientJsSpecifier('./signals', '/a/consumer.tsx')).toBeNull()
+  })
+
+  test('returns null for an alias (bare) specifier — Vite\'s resolve.alias handles it natively (R2)', () => {
+    expect(resolveClientJsSpecifier('@/components/signals.client.js', '/a/consumer.tsx')).toBeNull()
+  })
+
+  test('returns null for a bare package specifier', () => {
+    expect(resolveClientJsSpecifier('some-package/signals.client.js', '/a/consumer.tsx')).toBeNull()
+  })
+
+  test('returns null when there is no importer', () => {
+    expect(resolveClientJsSpecifier('./signals.client.js', undefined)).toBeNull()
+  })
+})

--- a/packages/vite/src/compile-cache.ts
+++ b/packages/vite/src/compile-cache.ts
@@ -1,0 +1,56 @@
+/**
+ * Content-hash keyed cache of full `CompileResult` objects.
+ *
+ * Both the graph pass (`transform`, driven by Rollup visiting `.tsx`
+ * modules) and the eager pass (`writeBundle`, driven by a directory walk
+ * that isn't gated on the module graph at all — see the design's rationale
+ * for why server-only components need it) call `compileFile()` for the
+ * same source files. Keying by content hash rather than just by file path
+ * means a file edited between the two passes (or across a `--watch`
+ * rebuild) always recompiles, while an unchanged file is compiled exactly
+ * once no matter which pass reaches it first.
+ */
+import { createHash } from 'node:crypto'
+import type { CompileResult } from '@barefootjs/jsx'
+
+function hashContent(content: string): string {
+  return createHash('sha256').update(content).digest('hex')
+}
+
+interface CacheRow {
+  hash: string
+  result: CompileResult
+}
+
+export class CompileCache {
+  private rows = new Map<string, CacheRow>()
+
+  /**
+   * Return the cached `CompileResult` for `absPath` if its content hash
+   * matches what's cached; otherwise call `compile()`, cache the result,
+   * and return it. `compile()` runs at most once per distinct
+   * `(absPath, content)` pair.
+   */
+  getOrCompile(
+    absPath: string,
+    content: string,
+    compile: () => CompileResult,
+  ): CompileResult {
+    const hash = hashContent(content)
+    const cached = this.rows.get(absPath)
+    if (cached && cached.hash === hash) return cached.result
+
+    const result = compile()
+    this.rows.set(absPath, { hash, result })
+    return result
+  }
+
+  /** Look up a previously cached result without recompiling. */
+  peek(absPath: string): CompileResult | undefined {
+    return this.rows.get(absPath)?.result
+  }
+
+  clear(): void {
+    this.rows.clear()
+  }
+}

--- a/packages/vite/src/discover.ts
+++ b/packages/vite/src/discover.ts
@@ -1,0 +1,99 @@
+/**
+ * Component discovery: which `.tsx` files live under the configured
+ * `components` dirs, and which of those carry a `'use client'` directive.
+ *
+ * `hasUseClientDirective` and `discoverComponentFiles` are ported verbatim
+ * from `packages/cli/src/lib/build.ts` (same behavior, same test coverage
+ * intent) rather than imported from `@barefootjs/cli` — that package's
+ * `exports` map only publishes the `bf` binary entry point, not this
+ * internal module path, and pulling in the CLI's esbuild-heavy dependency
+ * graph for two small pure functions would be the wrong shape for a Vite
+ * plugin. See CLAUDE.md: "reuse or port it, don't reinvent."
+ */
+import { readdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+/** Does `content` start with a `'use client'` / `"use client"` directive
+ * (after skipping leading block/line comments)? */
+export function hasUseClientDirective(content: string): boolean {
+  let trimmed = content.trimStart()
+  // Skip block comments
+  while (trimmed.startsWith('/*')) {
+    const endIndex = trimmed.indexOf('*/')
+    if (endIndex === -1) break
+    trimmed = trimmed.slice(endIndex + 2).trimStart()
+  }
+  // Skip line comments
+  while (trimmed.startsWith('//')) {
+    const endIndex = trimmed.indexOf('\n')
+    if (endIndex === -1) break
+    trimmed = trimmed.slice(endIndex + 1).trimStart()
+  }
+  return trimmed.startsWith('"use client"') || trimmed.startsWith("'use client'")
+}
+
+/**
+ * Recursively discover `.tsx` component files in a directory.
+ * Skips `.test.tsx`, `.spec.tsx`, and `.preview.tsx` files.
+ */
+export async function discoverComponentFiles(
+  dir: string,
+  options?: { skipDirs?: string[] }
+): Promise<string[]> {
+  const results: string[] = []
+  const skipDirs = options?.skipDirs ? new Set(options.skipDirs) : null
+
+  let entries: { name: string; isDirectory(): boolean }[]
+  try {
+    entries = (await readdir(dir, { withFileTypes: true })).sort((a, b) =>
+      String(a.name).localeCompare(String(b.name))
+    )
+  } catch {
+    return results
+  }
+
+  for (const entry of entries) {
+    const fullPath = resolve(dir, String(entry.name))
+    if (entry.isDirectory()) {
+      if (skipDirs?.has(String(entry.name))) continue
+      results.push(...await discoverComponentFiles(fullPath, options))
+    } else if (
+      String(entry.name).endsWith('.tsx') &&
+      !String(entry.name).endsWith('.test.tsx') &&
+      !String(entry.name).endsWith('.spec.tsx') &&
+      !String(entry.name).endsWith('.preview.tsx')
+    ) {
+      results.push(fullPath)
+    }
+  }
+
+  return results
+}
+
+export interface DiscoveredComponent {
+  /** Absolute path to the `.tsx` source file. */
+  absPath: string
+  /** Whether the file's content starts with a `'use client'` directive. */
+  isClient: boolean
+}
+
+/**
+ * Scan every configured `components` directory (absolute paths) for `.tsx`
+ * files and classify each as client (`'use client'`) or server-only.
+ */
+export async function discoverComponents(
+  componentDirs: string[],
+  readFile: (absPath: string) => Promise<string>,
+): Promise<DiscoveredComponent[]> {
+  const seen = new Set<string>()
+  const out: DiscoveredComponent[] = []
+  for (const dir of componentDirs) {
+    for (const absPath of await discoverComponentFiles(dir)) {
+      if (seen.has(absPath)) continue
+      seen.add(absPath)
+      const content = await readFile(absPath)
+      out.push({ absPath, isClient: hasUseClientDirective(content) })
+    }
+  }
+  return out
+}

--- a/packages/vite/src/emit.ts
+++ b/packages/vite/src/emit.ts
@@ -1,0 +1,69 @@
+/**
+ * Turn a `CompileResult` into on-disk files under the configured
+ * `templates` dir, mirroring the component's position under its
+ * `components` source dir.
+ *
+ * Adapter-generated `types` output (e.g. Go's per-component Props struct +
+ * `NewXxxProps` constructor) is written RAW, one file per source, rather
+ * than combined into a single backend-native file (Go's `components.go`).
+ * Combining is a real per-language operation — for Go specifically it
+ * means stripping each fragment's `package`/import header and injecting a
+ * single shared `randomID` helper the individual fragments assume exists
+ * (see `@barefootjs/go-template/build`'s `combineGoTypes`) — and today
+ * that combination step lives entirely OUTSIDE the core CLI pipeline, in
+ * each adapter's own `barefoot.config.ts` factory (`createConfig`'s
+ * `postBuild` hook). This plugin has no `postBuild`-equivalent option (and
+ * per this PR's scope, isn't adding one), so per-language combination is
+ * left as a follow-up — either a new optional `TemplateAdapter` method, or
+ * a dedicated post-processing step outside this plugin. Each `.types`
+ * fragment is written next to its template so it's visible on disk, but
+ * treat it as source material, not a ready-to-compile file.
+ */
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { CompileResult, TemplateAdapter } from '@barefootjs/jsx'
+import { perComponentRelPath, relativeUnderComponentDir, withExtension } from './paths.ts'
+
+export interface EmitTarget {
+  /** POSIX path, relative to the `templates` dir. */
+  relPath: string
+  content: string
+}
+
+export function planEmits(
+  result: CompileResult,
+  absPath: string,
+  componentDirs: readonly string[],
+  adapter: TemplateAdapter,
+): EmitTarget[] {
+  const relUnderComponentDir = relativeUnderComponentDir(absPath, componentDirs)
+  const targets: EmitTarget[] = []
+
+  for (const tpl of result.files.filter(f => f.type === 'markedTemplate')) {
+    const relPath = adapter.templatesPerComponent && tpl.componentName
+      ? perComponentRelPath(relUnderComponentDir, tpl.componentName, adapter.extension)
+      : withExtension(relUnderComponentDir, adapter.extension)
+    targets.push({ relPath, content: tpl.content })
+  }
+
+  for (const ssr of result.files.filter(f => f.type === 'ssrDefaults')) {
+    const relPath = adapter.templatesPerComponent && ssr.componentName
+      ? perComponentRelPath(relUnderComponentDir, ssr.componentName, '.ssr-defaults.json')
+      : withExtension(relUnderComponentDir, '.ssr-defaults.json')
+    targets.push({ relPath, content: ssr.content })
+  }
+
+  for (const types of result.files.filter(f => f.type === 'types')) {
+    targets.push({ relPath: withExtension(relUnderComponentDir, '.types'), content: types.content })
+  }
+
+  return targets
+}
+
+export async function writeEmits(templatesDir: string, targets: EmitTarget[]): Promise<void> {
+  for (const target of targets) {
+    const outPath = resolve(templatesDir, target.relPath)
+    await mkdir(dirname(outPath), { recursive: true })
+    await writeFile(outPath, target.content)
+  }
+}

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,0 +1,3 @@
+export { barefoot } from './plugin.ts'
+export { barefoot as default } from './plugin.ts'
+export type { BarefootViteOptions } from './types.ts'

--- a/packages/vite/src/manifest.ts
+++ b/packages/vite/src/manifest.ts
@@ -1,0 +1,45 @@
+/**
+ * `scriptAssets` resolution from Vite's build manifest (`build.manifest =
+ * true`, forced on by this plugin's `config` hook). By `writeBundle` time
+ * the manifest is final — every entry's hashed output filename is known —
+ * which is exactly why template emission happens there and not in
+ * `transform` (see the design's "script URL late-binding" section).
+ */
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import type { Manifest } from 'vite'
+
+/** Read and parse the manifest Vite just wrote to `outDir`. `manifestOption`
+ * mirrors `build.manifest`: `true` → the default `.vite/manifest.json`
+ * path; a string → that custom path, relative to `outDir`. */
+export async function loadManifest(outDir: string, manifestOption: boolean | string): Promise<Manifest> {
+  const relPath = typeof manifestOption === 'string' ? manifestOption : '.vite/manifest.json'
+  const content = await readFile(resolve(outDir, relPath), 'utf8')
+  return JSON.parse(content) as Manifest
+}
+
+/** Join a Vite `base` (may or may not have a trailing slash; may be a full
+ * URL, an absolute path, or `'./'`) with a manifest-relative file path
+ * (never starts with `/`) into the URL an adapter should register. */
+export function joinBaseAndFile(base: string, file: string): string {
+  if (base === '' || base === './') return file
+  return base.endsWith('/') ? `${base}${file}` : `${base}/${file}`
+}
+
+/**
+ * The ordered `scriptAssets` list for one component's entry, per the
+ * design: just the entry's own hashed file — shared chunks (including the
+ * `@barefootjs/client` runtime) arrive as ESM imports the browser follows
+ * on its own, so they need no separate registration. `[]` when the entry
+ * isn't in the manifest (e.g. a `'use client'` file whose compile produced
+ * no client JS at all, or a stale discovery/build mismatch).
+ */
+export function resolveScriptAssets(
+  manifest: Manifest,
+  manifestKey: string,
+  base: string,
+): string[] {
+  const entry = manifest[manifestKey]
+  if (!entry) return []
+  return [joinBaseAndFile(base, entry.file)]
+}

--- a/packages/vite/src/paths.ts
+++ b/packages/vite/src/paths.ts
@@ -1,0 +1,90 @@
+/**
+ * Path helpers for mirroring a component's position under a configured
+ * `components` source dir into the `templates` output dir — the same
+ * "on-disk layout mirrors source layout" convention `packages/cli/src/lib/
+ * build.ts` uses (`effectiveNamesFor` / `effectiveOutName` /
+ * `buildRelativeImportRewriter`), ported and simplified for this plugin's
+ * needs rather than imported: `@barefootjs/cli`'s only published entry
+ * point is the `bf` binary, and that module pulls in the CLI's whole
+ * esbuild-based build pipeline (being retired by this very package) as a
+ * side effect of import.
+ */
+import { basename, dirname, relative, resolve, sep } from 'node:path'
+
+/** Posix-normalized path of `absPath` relative to `root` (manifest keys and
+ * Rollup `input` specifiers both want forward slashes regardless of OS). */
+export function toPosixRelative(root: string, absPath: string): string {
+  return relative(root, absPath).split(sep).join('/')
+}
+
+/**
+ * `absPath`'s position relative to whichever `componentDirs` entry
+ * contains it (POSIX, WITH extension) — e.g. `ui/button/index.tsx` for
+ * `<componentDir>/ui/button/index.tsx`. Falls back to the bare basename
+ * when the file isn't under any configured dir (shouldn't happen for
+ * discovered files, but keeps this total).
+ */
+export function relativeUnderComponentDir(absPath: string, componentDirs: readonly string[]): string {
+  for (const dir of componentDirs) {
+    if (absPath === dir) continue
+    if (absPath.startsWith(dir + sep)) {
+      return absPath.slice(dir.length + 1).split(sep).join('/')
+    }
+  }
+  return basename(absPath)
+}
+
+/** Swap `.tsx`/`.ts` for `newExtension` (e.g. adapter.extension, or
+ * `.ssr-defaults.json`) on a POSIX relative path. */
+export function withExtension(relPath: string, newExtension: string): string {
+  return relPath.replace(/\.tsx?$/, newExtension)
+}
+
+/**
+ * Output path (relative to `templatesDir`, still POSIX) for a
+ * `templatesPerComponent` adapter's per-component file — same directory as
+ * the source file's mirror, named after the exported component instead of
+ * the source basename (Mojolicious-style template lookup by component
+ * name).
+ */
+export function perComponentRelPath(relUnderComponentDir: string, componentName: string, extension: string): string {
+  const dir = dirname(relUnderComponentDir)
+  return dir === '.' ? `${componentName}${extension}` : `${dir}/${componentName}${extension}`
+}
+
+/**
+ * Build a `rewriteRelativeImport` function for `compileJSX` — re-anchors a
+ * relative specifier written in `sourcePath` so it still resolves once the
+ * template is emitted to `outputPath` under `templatesDir` instead of
+ * living beside its source. Ported from `packages/cli/src/lib/build.ts`'s
+ * `buildRelativeImportRewriter` (same behavior); ported rather than
+ * imported for the reason in this file's header comment. Only exercised by
+ * adapters whose templates carry real `import` statements (Hono-shaped
+ * JS-runtime adapters) — Go/Mojo/etc. templates have no import syntax and
+ * never call this.
+ */
+export function buildRelativeImportRewriter(
+  sourcePath: string,
+  outputPath: string,
+  componentDirs: readonly string[],
+  templatesDir: string,
+): (importPath: string) => string {
+  const sourceDir = dirname(sourcePath)
+  const outputDir = dirname(outputPath)
+
+  return (importPath: string): string => {
+    const srcAbs = resolve(sourceDir, importPath)
+    let targetAbs = srcAbs
+    for (const componentDir of componentDirs) {
+      if (srcAbs === componentDir || srcAbs.startsWith(componentDir + sep)) {
+        const relUnderComponentDir = srcAbs === componentDir ? '' : srcAbs.slice(componentDir.length + 1)
+        targetAbs = relUnderComponentDir ? resolve(templatesDir, relUnderComponentDir) : templatesDir
+        break
+      }
+    }
+    let rewritten = relative(outputDir, targetAbs)
+    if (rewritten === '') rewritten = '.'
+    if (!rewritten.startsWith('.')) rewritten = './' + rewritten
+    return rewritten
+  }
+}

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -1,0 +1,211 @@
+/**
+ * `@barefootjs/vite` — takes over the client-asset half of `bf build`.
+ * Vite/Rollup owns bundling, hashing, chunking, tree-shaking and
+ * minification; BarefootJS keeps only the JSX → (template, client JS)
+ * compile. See `spike-findings.md` (R1-R3) for the mechanics this plugin
+ * is built on, and the design doc for the two-engine architecture:
+ *
+ *   1. graph pass (`transform`) — Rollup visits `.tsx` modules it can
+ *      reach from `build.rollupOptions.input`; this plugin compiles each
+ *      one and hands back plain client JS for Rollup to bundle, hash,
+ *      tree-shake, chunk, and minify like any other module.
+ *   2. eager pass (`writeBundle`) — walks every `.tsx` under `components`
+ *      directly, NOT via the module graph. Server-only components (no
+ *      `'use client'`) never appear in the graph at all (nothing imports
+ *      them as a script, so Rollup never visits them) but still need a
+ *      template — this pass is the only place that happens. Runs in
+ *      `writeBundle` specifically because the Vite manifest is only final
+ *      once Rollup has finished hashing output filenames.
+ *
+ * Both passes share one `CompileCache` (§4) so a given file's content is
+ * compiled at most twice: once canonically (`scriptAssets: []`, cached,
+ * shared by both passes — this is the ONLY compile a server-only file, or
+ * any file whose real `scriptAssets` also turns out to be `[]`, ever
+ * needs) and, only for a `'use client'` file whose manifest entry resolves
+ * to a non-empty URL list, one further compile with the real
+ * `scriptAssets` to bake the correct URL into the template. That second
+ * compile is unavoidable within `compileJSX`'s current API shape: a
+ * component's template and its client JS are produced by ONE call, but
+ * only the template depends on `scriptAssets` (client JS comes from an
+ * entirely separate codegen path `adapter.generate()` never touches) — and
+ * `scriptAssets` can't be known until Rollup has already hashed the
+ * bundle, which requires `transform` to have already run. So `transform`
+ * unavoidably compiles once per file before the real URL exists, and
+ * `writeBundle` MUST recompile once more, only for the strict subset of
+ * files whose true `scriptAssets` differs from the cached `[]` canonical
+ * form, to get a template with the correct URL baked in.
+ */
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import type { Plugin, ResolvedConfig } from 'vite'
+import {
+  compileJSX,
+  formatError,
+  type CompileResult,
+} from '@barefootjs/jsx'
+import type { BarefootViteOptions } from './types.ts'
+import { CompileCache } from './compile-cache.ts'
+import { discoverComponents, type DiscoveredComponent } from './discover.ts'
+import { resolveClientJsSpecifier } from './resolve-client-js.ts'
+import { buildRelativeImportRewriter, toPosixRelative } from './paths.ts'
+import { loadManifest, resolveScriptAssets } from './manifest.ts'
+import { planEmits, writeEmits } from './emit.ts'
+
+const PLUGIN_NAME = 'barefoot'
+
+function reportErrors(result: CompileResult, source: string, projectDir: string): void {
+  const errors = result.errors.filter(e => e.severity === 'error')
+  const warnings = result.errors.filter(e => e.severity === 'warning')
+  for (const warning of warnings) {
+    console.warn(formatError(warning, source, { projectDir }))
+  }
+  if (errors.length > 0) {
+    const messages = errors.map(e => formatError(e, source, { projectDir })).join('\n\n')
+    throw new Error(`[${PLUGIN_NAME}] compile failed:\n\n${messages}`)
+  }
+}
+
+export function barefoot(options: BarefootViteOptions): Plugin {
+  const cache = new CompileCache()
+
+  // Populated (redundantly but cheaply — a directory walk, no compiling)
+  // once in `config` with a best-effort root, so `rollupOptions.input` can
+  // be set; then again in `configResolved` with Vite's authoritative
+  // `root`, which is what `resolveId` / `transform` / `writeBundle` use.
+  let componentDirs: string[] = []
+  let templatesDir = ''
+  let resolvedConfig: ResolvedConfig | undefined
+
+  // Re-anchors a relative import written in `absPath` so it still resolves
+  // once the template is emitted under `templatesDir`. Pure function of
+  // (absPath, componentDirs, templatesDir) — safe to compute for every
+  // compile, including the canonical `transform`-time one where it's
+  // unused (client JS generation never reads `rewriteRelativeImport`).
+  function rewriterFor(absPath: string): (importPath: string) => string {
+    const outputPathGuess = resolve(templatesDir, toPosixRelative(resolvedConfig!.root, absPath))
+    return buildRelativeImportRewriter(absPath, outputPathGuess, componentDirs, templatesDir)
+  }
+
+  function compileCanonical(absPath: string, content: string): CompileResult {
+    return cache.getOrCompile(absPath, content, () =>
+      compileJSX(content, absPath, {
+        adapter: options.adapter,
+        sourceMaps: true,
+        // The canonical, cacheable compile always uses an empty
+        // scriptAssets ("no scripts") — the one input every discovered
+        // file (server-only or client) shares regardless of its eventual
+        // manifest entry. Everything except the template's script
+        // registration is identical no matter what `scriptAssets` is, so
+        // this single compile is reused as-is for every server-only
+        // component and any client component that turns out to need no
+        // scripts. See this module's docstring.
+        scriptAssets: [],
+        rewriteRelativeImport: rewriterFor(absPath),
+      }),
+    )
+  }
+
+  function isUnderComponentDir(absPath: string): boolean {
+    return componentDirs.some(dir => absPath === dir || absPath.startsWith(`${dir}/`))
+  }
+
+  return {
+    name: PLUGIN_NAME,
+    enforce: 'pre',
+
+    async config(userConfig) {
+      // Best-effort root for the eager discovery this hook needs to set
+      // `rollupOptions.input` — Vite hasn't resolved the real root yet at
+      // this point in its own lifecycle (that only exists once
+      // `configResolved` fires), so this assumes the common case of
+      // running Vite from the project root with no `root` override. If
+      // that assumption doesn't hold for a given project, `configResolved`
+      // still recomputes everything `resolveId`/`transform`/`writeBundle`
+      // actually use against Vite's real resolved root — only the
+      // convenience `rollupOptions.input` keys this hook picks could be
+      // off, not correctness.
+      const guessedRoot = userConfig.root ? resolve(process.cwd(), userConfig.root) : process.cwd()
+      const dirs = options.components.map(d => resolve(guessedRoot, d))
+      const found = await discoverComponents(dirs, absPath => readFile(absPath, 'utf8'))
+
+      const input: Record<string, string> = {}
+      for (const c of found) {
+        if (!c.isClient) continue
+        input[toPosixRelative(guessedRoot, c.absPath)] = c.absPath
+      }
+
+      return {
+        appType: 'custom',
+        build: {
+          manifest: true,
+          rollupOptions: { input },
+        },
+      }
+    },
+
+    configResolved(config) {
+      resolvedConfig = config
+      componentDirs = options.components.map(d => resolve(config.root, d))
+      templatesDir = resolve(config.root, options.templates)
+    },
+
+    resolveId(source, importer) {
+      return resolveClientJsSpecifier(source, importer)
+    },
+
+    transform(code, id) {
+      if (!id.endsWith('.tsx')) return null
+      if (!isUnderComponentDir(id)) return null
+
+      const result = compileCanonical(id, code)
+      reportErrors(result, code, resolvedConfig?.root ?? process.cwd())
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      if (!clientJs) return null
+
+      const map = result.files.find(f => f.type === 'sourceMap' && f.path === `${clientJs.path}.map`)
+      return {
+        code: clientJs.content,
+        map: map ? JSON.parse(map.content) : null,
+      }
+    },
+
+    async writeBundle() {
+      const config = resolvedConfig
+      if (!config) return
+
+      // Authoritative discovery — Vite's real root, not `config`'s guess.
+      const discovered: DiscoveredComponent[] = await discoverComponents(
+        componentDirs,
+        absPath => readFile(absPath, 'utf8'),
+      )
+
+      const outDir = resolve(config.root, config.build.outDir)
+      const manifest = await loadManifest(outDir, config.build.manifest)
+
+      for (const component of discovered) {
+        const content = await readFile(component.absPath, 'utf8')
+        const canonical = compileCanonical(component.absPath, content)
+        reportErrors(canonical, content, config.root)
+
+        let result = canonical
+        if (component.isClient) {
+          const manifestKey = toPosixRelative(config.root, component.absPath)
+          const scriptAssets = resolveScriptAssets(manifest, manifestKey, config.base)
+          if (scriptAssets.length > 0) {
+            result = compileJSX(content, component.absPath, {
+              adapter: options.adapter,
+              sourceMaps: true,
+              scriptAssets,
+              rewriteRelativeImport: rewriterFor(component.absPath),
+            })
+            reportErrors(result, content, config.root)
+          }
+        }
+
+        const targets = planEmits(result, component.absPath, componentDirs, options.adapter)
+        await writeEmits(templatesDir, targets)
+      }
+    },
+  }
+}

--- a/packages/vite/src/resolve-client-js.ts
+++ b/packages/vite/src/resolve-client-js.ts
@@ -1,0 +1,34 @@
+/**
+ * `resolveId` shim: maps the compiler's synthesized `./foo.client.js`
+ * sibling-import specifier back to the real `./foo.tsx` source file on
+ * disk. There is no `.client.js` file for Vite to find — the compiler only
+ * ever read `foo.tsx`.
+ *
+ * Scope, per the spike (spike-findings.md, R2): the `.client.js` rewrite
+ * (`packages/jsx/src/ir-to-client-js/imports.ts:177`, gated by
+ * `analyzer.ts`'s `scanImportedClientSignals`) only ever fires for
+ * **relative** specifiers (`./`, `../`) that import a module exporting
+ * client signals — alias imports (`@/components/foo`) are never rewritten
+ * by the compiler, so they reach Vite as plain bare specifiers that
+ * `resolve.alias` already resolves natively (proven in the spike: both
+ * resolution paths converge on the same module id and Rollup dedupes them
+ * into one shared chunk). Do NOT add alias handling here.
+ */
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+
+const CLIENT_JS_SUFFIX = '.client.js'
+
+/**
+ * Resolve `source` (an import specifier seen by Vite's `resolveId`) to the
+ * real `.tsx` file it stands in for, or `null` if this shim doesn't apply.
+ */
+export function resolveClientJsSpecifier(source: string, importer: string | undefined): string | null {
+  if (!source.endsWith(CLIENT_JS_SUFFIX)) return null
+  if (!source.startsWith('./') && !source.startsWith('../')) return null
+  if (!importer) return null
+
+  const candidateBase = resolve(dirname(importer), source.slice(0, -CLIENT_JS_SUFFIX.length))
+  const tsxPath = `${candidateBase}.tsx`
+  return existsSync(tsxPath) ? tsxPath : null
+}

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -1,0 +1,26 @@
+import type { TemplateAdapter } from '@barefootjs/jsx'
+
+/**
+ * Public options for the `barefoot()` Vite plugin. Exactly three
+ * BarefootJS-specific fields — everything else (bundling, hashing,
+ * chunking, tree-shaking, minification, dev server, `base`, `outDir`) is
+ * stock Vite config. Do not add more fields here; see the design doc for
+ * the full list of options this deliberately drops in favor of Vite's own
+ * equivalents (`minify` → `build.minify`, `externals` → Rollup's automatic
+ * chunk splitting, `clientJsBasePath`/`barefootJsPath` → `base` + manifest
+ * resolution, etc).
+ */
+export interface BarefootViteOptions {
+  /** A constructed `TemplateAdapter` instance (e.g. `new
+   * GoTemplateAdapter({ packageName: 'main' })`). Not a factory function —
+   * the plugin never constructs adapters itself. */
+  adapter: TemplateAdapter
+  /** Source directories to scan for `.tsx` components, relative to the
+   * Vite project root (or absolute). */
+  components: string[]
+  /** Where compiled templates, `ssrDefaults`, and adapter-generated types
+   * land — relative to the Vite project root (or absolute). This is a
+   * backend source directory the server-side app reads, NOT
+   * `build.outDir` (which is Vite's client-asset output). */
+  templates: string
+}

--- a/packages/vite/tsconfig.json
+++ b/packages/vite/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ES2022"
+    ],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": [
+      "node"
+    ],
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/__tests__"
+  ]
+}


### PR DESCRIPTION
**Stack 2/7** — targets #2494, not `main`. Review that one first.

## Why

`bf build` owns the entire bundler job today: esbuild invocation, externals/importmap, vendor chunk splitting, content hashing, tree-shaking, relative-import resolution, build caching — `packages/cli/src/lib/build.ts` is 2469 lines of it. Every one of those is something Vite/Rollup already does. This PR hands that half over and leaves BarefootJS with its actual job: JSX → (template, client JS).

## API

Three barefoot options. Everything else is stock Vite.

```ts
export default defineConfig({
  base: '/static/build/',
  build: { outDir: 'static/build' },
  plugins: [barefoot({
    adapter: new GoTemplateAdapter({ packageName: 'main' }),
    components: ['src/components'],
    templates: 'internal/views',
  })],
})
```

`minify`, `contentHash`, `externals`, `externalsBasePath`, `bundleEntries`, `outDir`, `runtimeBundle`, `runtimeKeep`, `localImportPrefixes`, `postBuild`, `outputLayout`, `clientJsBasePath`, `barefootJsPath` all become stock Vite config the user already knows.

## Two engines

**Graph pass** (`transform`, `enforce: 'pre'`) — compiles each `.tsx` Rollup reaches from `rollupOptions.input` and returns plain client JS. A spike confirmed that output survives Vite's built-in esbuild pass untouched in both dev and build, so no virtual-id indirection is needed. A `resolveId` shim maps the compiler's `./foo.client.js` sibling specifier (`ir-to-client-js/imports.ts:177`) back to the real `./foo.tsx`. Alias imports deliberately get no shim: that rewrite is gated on relative specifiers only (`analyzer.ts:3834`), so aliases reach Vite as plain bare specifiers `resolve.alias` already handles.

**Eager pass** (`writeBundle`) — walks every `.tsx` under `components` directly rather than via the module graph. This is the load-bearing part: server-only components (no `"use client"`) never enter Rollup's graph at all, because nothing imports them as a script, yet they still need templates. It runs in `writeBundle` specifically because Vite's manifest is only final once Rollup has hashed every filename — which is what makes the real script URL available.

Both share one content-hash-keyed compile cache.

## Script URL late-binding

Each `"use client"` component's hashed entry is resolved from the manifest and passed as `AdapterGenerateOptions.scriptAssets` (#2494). Just the entry — shared chunks including the `@barefootjs/client` runtime arrive as ESM imports the browser follows on its own, so the separate runtime `<script>` registration disappears entirely.

`CompileOptions.scriptAssets` threads the list through to `adapter.generate()`. #2494 added the adapter-side option with nothing able to reach it; this closes that gap. It is plain resolved data forwarded unchanged — not a rewrite hook, so it does not conflict with the CLAUDE.md rule against tool-specific output-rewriting options.

Also declares the `sideEffects: false` that `@barefootjs/client`'s `package.json` was missing. Tree-shaking already worked without it (verified against a real build), but the declaration should be explicit.

## Testing

56 tests pass, 0 fail. The one that matters is a real `vite build` run against a fixture project via Vite's Node API, asserting both halves:

- hashed assets exist, and the runtime collapses into **one shared chunk** imported by every entry rather than being duplicated per entry;
- `SharedCounter`'s relative `./counterState.client.js` import resolves to the real `counterState` chunk (the `resolveId` shim);
- built client JS is plain JS that went through minification with no JSX left (`onClick={` absent, hydration markup present);
- the emitted Go template carries `{{.Scripts.Register "/static/build/<hashed>.js"}}` with the real manifest URL;
- the server-only component — provably absent from the manifest — still gets a template, with no script registration.

A plugin that only passes mocked unit tests hasn't been shown to work; that last pair is the point.

## Known gap, blocks the gin migration

Adapter `types` output is **not** combined into one backend-native file. Go's `components.go` (deduped `package`/import header plus a shared `randomID` helper) is assembled today by `@barefootjs/go-template`'s `barefoot.config.ts` factory via the `postBuild` hook; this plugin has no equivalent, so it writes each component's raw `types` fragment to its own `.types` file next to its template. That must be solved before the gin integration can build — it is the first thing stack 4 has to deal with.

## Out of scope

Dev server / HMR / full-reload (`configureServer`) is stack 3. Migrating the 19 `integrations/*` apps is stack 4+. Deleting `lib/build.ts` and `barefoot.config.ts` is stack 7. Hono is untouched: it emits scripts through `transformMarkedTemplate` + a runtime `BfScripts` component rather than `AdapterGenerateOptions`, so it needs its own strategy — arguably an easier one, since request-time resolution suits manifest late-binding better than codegen baking does.

## Follow-up

`writeBundle` compiles a client component twice — once canonically (cached, shared with `transform`) and once more with the real `scriptAssets` to bake the URL in. Only the template depends on `scriptAssets`, and it cannot be known until Rollup has hashed the bundle, which requires `transform` to have already run. Worth revisiting for large projects, but it needs an API narrower than `compileJSX` to fix properly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ)_