### PR TITLE
fix(perl): give BarefootJS::Date its own $VERSION so PAUSE indexes it

### DIFF
--- a/.changeset/perl-meta-provides-version.md
+++ b/.changeset/perl-meta-provides-version.md
@@ -1,0 +1,23 @@
+---
+"@barefootjs/perl": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Fix `BarefootJS::Date` dropping out of the CPAN index.
+
+`BarefootJS-0.30.0` was the first release to ship META `provides` (built by
+`Module::Metadata` in `Makefile.PL`). A dist with `provides` makes PAUSE index
+from META instead of scanning the `.pm` files, and the two disagree about
+inline packages: the file scanner hands every package in a file that file's
+`$VERSION`, while `Module::Metadata` reports each package's *own* `$VERSION`.
+`BarefootJS::Date`, declared inline in `lib/BarefootJS.pm`, has none — so it
+reached PAUSE with a version of `undef`, which compares as *lower* than the
+`0.029000` indexed from 0.29.0 and was rejected with "Decreasing version
+number". It would have stayed pinned at 0.29.0 through every future release.
+
+`BarefootJS::Date` now carries its own literal `$VERSION`, and
+`scripts/sync-perl-versions.ts` bumps every `our $VERSION` line in a module
+rather than only the first, so a file holding more than one package stays in
+lockstep. A `t/meta_provides.t` in each of the three Perl dists asserts that
+every package in META `provides` declares a version and that they all match.

--- a/.changeset/perl-meta-provides-version.md
+++ b/.changeset/perl-meta-provides-version.md
@@ -19,5 +19,9 @@ number". It would have stayed pinned at 0.29.0 through every future release.
 `BarefootJS::Date` now carries its own literal `$VERSION`, and
 `scripts/sync-perl-versions.ts` bumps every `our $VERSION` line in a module
 rather than only the first, so a file holding more than one package stays in
-lockstep. A `t/meta_provides.t` in each of the three Perl dists asserts that
-every package in META `provides` declares a version and that they all match.
+lockstep. That rewrite now also runs unconditionally: it used to sit behind a
+skip that reads only the primary module's *first* `$VERSION`, which would have
+let a drifted line hide behind an in-sync one indefinitely. The skip now gates
+only the once-per-release bookkeeping (the `Changes` entry and the `cpanfile`
+pin). A `t/meta_provides.t` in each of the three Perl dists asserts that every
+package in META `provides` declares a version and that they all match.

--- a/packages/adapter-mojolicious/MANIFEST
+++ b/packages/adapter-mojolicious/MANIFEST
@@ -10,4 +10,5 @@ MANIFEST
 Makefile.PL
 t/dev_reload.t
 t/manifest_defaults.t
+t/meta_provides.t
 t/render_named.t

--- a/packages/adapter-mojolicious/t/meta_provides.t
+++ b/packages/adapter-mojolicious/t/meta_provides.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+
+use Test2::V0;
+
+use FindBin qw($Bin);
+use Module::Metadata;
+
+# PAUSE indexability of META's `provides`.
+#
+# Makefile.PL populates META_MERGE's `provides` from
+# `Module::Metadata->provides`, and shipping `provides` makes PAUSE index
+# from META instead of scanning the .pm files. Module::Metadata reports the
+# version of each package's *own* `our $VERSION`, so a package declared
+# inline in a file that carries a $VERSION for a different package lands in
+# META with no version; PAUSE turns that into the string "undef", reads it as
+# a decreasing version number against the last indexed release, and freezes
+# the package out of the index. BarefootJS::Date hit this between 0.29.0 and
+# 0.30.0 -- see packages/adapter-perl/t/meta_provides.t for the full story.
+# This dist shares the same Makefile.PL pattern, so it guards the same
+# invariant.
+
+my $provides = Module::Metadata->provides(version => 2, dir => "$Bin/../lib");
+
+ok(%$provides, 'META provides lists at least one package');
+
+my %by_version;
+for my $pkg (sort keys %$provides) {
+    my $version = $provides->{$pkg}{version};
+    ok(
+        defined $version && length $version,
+        "$pkg declares its own \$VERSION (in $provides->{$pkg}{file})",
+    ) or diag(
+        "Add `our \$VERSION = \"<dist version>\";` to `package $pkg;`.\n"
+      . "A literal is required: Module::Metadata evaluates the version line\n"
+      . "in a Safe compartment, so `\$Some::Other::VERSION` collapses to 0."
+    );
+    push @{ $by_version{ defined $version ? $version : '(undef)' } }, $pkg;
+}
+
+is(
+    scalar keys %by_version,
+    1,
+    'every package in provides carries the same $VERSION',
+) or diag(
+    join "\n",
+    map { "  $_: " . join(', ', @{ $by_version{$_} }) } sort keys %by_version
+);
+
+done_testing;

--- a/packages/adapter-perl/MANIFEST
+++ b/packages/adapter-perl/MANIFEST
@@ -15,6 +15,7 @@ t/dev_reload.t
 t/format_date.t
 t/helper_vectors.t
 t/manifest_components.t
+t/meta_provides.t
 t/search_params.t
 t/spread_attrs.t
 t/template_primitives.t

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -2010,6 +2010,20 @@ sub spread_attrs ($self, $bag) {
 # ---------------------------------------------------------------------------
 package BarefootJS::Date;
 
+# Must carry its own literal $VERSION. META's `provides` is built by
+# Module::Metadata (see Makefile.PL), which reads each package's own
+# $VERSION and reports undef for one that has none -- and since a dist
+# with `provides` makes PAUSE index from META instead of scanning the
+# .pm files, an undef here is what PAUSE compares against the previously
+# indexed version. That reads as a *decreasing* version number and the
+# package drops out of the index -- which is what happened to this one in
+# BarefootJS-0.30.0, freezing it at the 0.29.0 tarball. It has to be
+# a literal string: Module::Metadata evaluates the version line in a Safe
+# compartment where `$BarefootJS::VERSION` is not visible and collapses to
+# 0. scripts/sync-perl-versions.ts bumps every `our $VERSION` line in the
+# file, so this stays in lockstep with the package version above.
+our $VERSION = "0.30.0";
+
 sub new {
     my ($class, $epoch_ms) = @_;
     return bless { epoch_ms => $epoch_ms }, $class;

--- a/packages/adapter-perl/t/meta_provides.t
+++ b/packages/adapter-perl/t/meta_provides.t
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+
+use Test2::V0;
+
+use FindBin qw($Bin);
+use Module::Metadata;
+
+# PAUSE indexability of META's `provides`.
+#
+# Makefile.PL populates META_MERGE's `provides` from
+# `Module::Metadata->provides`. A dist that ships `provides` makes PAUSE
+# index from META instead of scanning the .pm files, and Module::Metadata
+# reports the version of each package's *own* `our $VERSION` -- not the
+# file's. A package declared inline in a file that already carries a
+# $VERSION for a different package (BarefootJS::Date inside BarefootJS.pm)
+# therefore lands in META with no version at all. PAUSE turns that into the
+# literal string "undef", compares it against the version it indexed last
+# release, and rejects the package with "Decreasing version number" -- so it
+# silently freezes at whatever release last had a version, while every other
+# package in the dist moves on. That is exactly what happened to
+# BarefootJS::Date between 0.29.0 and 0.30.0.
+#
+# The file-scanning fallback masks this: it hands every package in a file the
+# file's $VERSION, which is why the problem only appeared once `provides` was
+# added. Guard the invariant here rather than at release time.
+
+my $provides = Module::Metadata->provides(version => 2, dir => "$Bin/../lib");
+
+ok(%$provides, 'META provides lists at least one package');
+
+my %by_version;
+for my $pkg (sort keys %$provides) {
+    my $version = $provides->{$pkg}{version};
+    ok(
+        defined $version && length $version,
+        "$pkg declares its own \$VERSION (in $provides->{$pkg}{file})",
+    ) or diag(
+        "Add `our \$VERSION = \"<dist version>\";` to `package $pkg;`.\n"
+      . "A literal is required: Module::Metadata evaluates the version line\n"
+      . "in a Safe compartment, so `\$Some::Other::VERSION` collapses to 0."
+    );
+    push @{ $by_version{ defined $version ? $version : '(undef)' } }, $pkg;
+}
+
+is(
+    scalar keys %by_version,
+    1,
+    'every package in provides carries the same $VERSION',
+) or diag(
+    join "\n",
+    map { "  $_: " . join(', ', @{ $by_version{$_} }) } sort keys %by_version
+);
+
+done_testing;

--- a/packages/adapter-xslate/MANIFEST
+++ b/packages/adapter-xslate/MANIFEST
@@ -6,4 +6,5 @@ CONTRIBUTING.md
 SECURITY.md
 MANIFEST
 Makefile.PL
+t/meta_provides.t
 t/render.t

--- a/packages/adapter-xslate/t/meta_provides.t
+++ b/packages/adapter-xslate/t/meta_provides.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+
+use Test2::V0;
+
+use FindBin qw($Bin);
+use Module::Metadata;
+
+# PAUSE indexability of META's `provides`.
+#
+# Makefile.PL populates META_MERGE's `provides` from
+# `Module::Metadata->provides`, and shipping `provides` makes PAUSE index
+# from META instead of scanning the .pm files. Module::Metadata reports the
+# version of each package's *own* `our $VERSION`, so a package declared
+# inline in a file that carries a $VERSION for a different package lands in
+# META with no version; PAUSE turns that into the string "undef", reads it as
+# a decreasing version number against the last indexed release, and freezes
+# the package out of the index. BarefootJS::Date hit this between 0.29.0 and
+# 0.30.0 -- see packages/adapter-perl/t/meta_provides.t for the full story.
+# This dist shares the same Makefile.PL pattern, so it guards the same
+# invariant.
+
+my $provides = Module::Metadata->provides(version => 2, dir => "$Bin/../lib");
+
+ok(%$provides, 'META provides lists at least one package');
+
+my %by_version;
+for my $pkg (sort keys %$provides) {
+    my $version = $provides->{$pkg}{version};
+    ok(
+        defined $version && length $version,
+        "$pkg declares its own \$VERSION (in $provides->{$pkg}{file})",
+    ) or diag(
+        "Add `our \$VERSION = \"<dist version>\";` to `package $pkg;`.\n"
+      . "A literal is required: Module::Metadata evaluates the version line\n"
+      . "in a Safe compartment, so `\$Some::Other::VERSION` collapses to 0."
+    );
+    push @{ $by_version{ defined $version ? $version : '(undef)' } }, $pkg;
+}
+
+is(
+    scalar keys %by_version,
+    1,
+    'every package in provides carries the same $VERSION',
+) or diag(
+    join "\n",
+    map { "  $_: " . join(', ', @{ $by_version{$_} }) } sort keys %by_version
+);
+
+done_testing;

--- a/scripts/sync-perl-versions.ts
+++ b/scripts/sync-perl-versions.ts
@@ -7,7 +7,11 @@
 //
 // For each entry in PACKAGES:
 //   1. Read the bumped version from package.json.
-//   2. Update `our $VERSION` in every Perl module listed under `modules`.
+//   2. Update every `our $VERSION` line in every Perl module listed under
+//      `modules` — a file may declare more than one package (BarefootJS.pm
+//      also holds BarefootJS::Date), and each one needs its own literal
+//      $VERSION or META's `provides` reports it as undef and PAUSE drops it
+//      from the index as a decreasing version number.
 //   3. Insert the versioned entry immediately after {{$NEXT}} in Changes,
 //      keeping the placeholder in place for the next release cycle.
 //   4. Pin each cpanfile dependency listed under `cpanfileRequires` to the
@@ -78,7 +82,7 @@ for (const pkg of PACKAGES) {
     const modulePath = join(pkgDir, mod);
     const source = readFileSync(modulePath, 'utf8');
     const updated = source.replace(
-      /^our \$VERSION = ".+?";/m,
+      /^our \$VERSION = ".+?";/gm,
       `our $VERSION = "${version}";`,
     );
     if (updated === source) {

--- a/scripts/sync-perl-versions.ts
+++ b/scripts/sync-perl-versions.ts
@@ -11,7 +11,10 @@
 //      `modules` — a file may declare more than one package (BarefootJS.pm
 //      also holds BarefootJS::Date), and each one needs its own literal
 //      $VERSION or META's `provides` reports it as undef and PAUSE drops it
-//      from the index as a decreasing version number.
+//      from the index as a decreasing version number. This step is
+//      idempotent and always runs, so drift is repaired rather than
+//      inherited; steps 3-4 are once-per-release and are skipped for a dist
+//      that was not bumped in this cycle.
 //   3. Insert the versioned entry immediately after {{$NEXT}} in Changes,
 //      keeping the placeholder in place for the next release cycle.
 //   4. Pin each cpanfile dependency listed under `cpanfileRequires` to the
@@ -67,17 +70,24 @@ for (const pkg of PACKAGES) {
 
   const { version } = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'));
 
-  // Skip if the primary module already reflects the target version — this
-  // package was not bumped in the current release cycle.
+  // Whether this dist was bumped in the current release cycle. The primary
+  // module's first $VERSION is the marker changeset moves, so it answers the
+  // question — but it answers ONLY that question. It is not evidence that
+  // every other $VERSION line agrees, so it gates the once-per-release
+  // bookkeeping below (Changes entry, cpanfile pin) and nothing else.
   const primaryPath = join(pkgDir, pkg.modules[0]);
   const primarySource = readFileSync(primaryPath, 'utf8');
   const currentVersionMatch = primarySource.match(/^our \$VERSION = "(.+?)";/m);
-  if (currentVersionMatch?.[1] === version) {
-    console.log(`Skipping ${pkg.dir} — already at ${version}`);
-    continue;
-  }
+  const alreadyReleased = currentVersionMatch?.[1] === version;
 
-  // Update $VERSION in every Perl module belonging to this dist.
+  // Update every `our $VERSION` line in every Perl module belonging to this
+  // dist. Runs unconditionally: the rewrite is idempotent, and gating it on
+  // `alreadyReleased` would let a drifted line hide forever behind an
+  // in-sync first line — a second package inside a file (BarefootJS::Date in
+  // BarefootJS.pm), or a module added to `modules` after its dist's last
+  // bump. That is how Evaluator/SearchParams sat at 0.14.0 for releases on
+  // end, and META `provides` turns any such drift into a package PAUSE
+  // refuses to index.
   for (const mod of pkg.modules) {
     const modulePath = join(pkgDir, mod);
     const source = readFileSync(modulePath, 'utf8');
@@ -85,12 +95,17 @@ for (const pkg of PACKAGES) {
       /^our \$VERSION = ".+?";/gm,
       `our $VERSION = "${version}";`,
     );
-    if (updated === source) {
+    if (!/^our \$VERSION = ".+?";/m.test(source)) {
       console.warn(`[warn] $VERSION not updated in ${mod} — pattern not found`);
-    } else {
+    } else if (updated !== source) {
       writeFileSync(modulePath, updated);
       console.log(`Updated $VERSION → ${version} in ${mod}`);
     }
+  }
+
+  if (alreadyReleased) {
+    console.log(`Skipping Changes/cpanfile for ${pkg.dir} — already at ${version}`);
+    continue;
   }
 
   // Pin cpanfile dependency floors to this release (step 4 above).


### PR DESCRIPTION
## What happened

The PAUSE indexer report for `BarefootJS-0.30.0.tar.gz` carried two independent problems.

### 1. `BarefootJS::Date` — "Decreasing version number" (fixed here)

```
module : BarefootJS::Date
version: undef
in file: lib/BarefootJS.pm
status : Not indexed because BarefootJS-0.29.0/lib/BarefootJS.pm in
         K/KF/KFLY/BarefootJS-0.29.0.tar.gz has a higher version
         number (0.029000)
```

0.30.0 is the first release to ship META `provides` — added in 0dfec18 for CPANTS Kwalitee, built by `Module::Metadata->provides` in `Makefile.PL`. A dist that carries `provides` makes PAUSE index **from META** instead of scanning the `.pm` files (`META-driven index: yes` in the report), and the two paths disagree about inline packages:

- the **file scanner** hands every package in a file that file's `$VERSION` — which is why `BarefootJS::Date` (and `BarefootJS::_TZProbe`) were indexed at `0.029000` from 0.29.0;
- **`Module::Metadata`** reports each package's *own* `our $VERSION`.

`BarefootJS::Date` is declared inline in `lib/BarefootJS.pm` and has never had its own `$VERSION`, so it reached PAUSE as `undef`. `PAUSE::dist::_index_by_meta` normalizes that to the string `"undef"`, `CPAN::Version` compares it as lower than the `0.029000` on record, and `update_package` rejects it with `EVERFALLING`. Left alone it would have stayed pinned to the 0.29.0 tarball through every future release.

Reproduced on the pre-fix tree:

```
$ perl -MModule::Metadata -e '...provides(version=>2, dir=>"lib")'
BarefootJS                 v0.30.0    lib/BarefootJS.pm
BarefootJS::Date           (UNDEF)    lib/BarefootJS.pm      <-- here
BarefootJS::DevReload      v0.30.0    lib/BarefootJS/DevReload.pm
BarefootJS::Evaluator      v0.30.0    lib/BarefootJS/Evaluator.pm
BarefootJS::SearchParams   v0.30.0    lib/BarefootJS/SearchParams.pm
```

### 2. `ERROR: Database error occurred during index update` (**not** fixed here — PAUSE-side)

That line is PAUSE's `E_DB_XACTFAIL`: `mldistwatch` runs the whole dist's index work in one transaction, retries it three times, and on total failure rolls everything back and skips the dist. The per-package "Successfully indexed" lines in the report are written to `INDEX_STATUS` *before* the commit, so they survive a rollback and the report reads as a success that never landed.

It did not land. `02packages.details.txt` still reads:

```
BarefootJS                     0.029000  K/KF/KFLY/BarefootJS-0.29.0.tar.gz
BarefootJS::Date               0.029000  K/KF/KFLY/BarefootJS-0.29.0.tar.gz
BarefootJS::DevReload          0.029000  K/KF/KFLY/BarefootJS-0.29.0.tar.gz
BarefootJS::Evaluator          0.014000  K/KF/KFLY/BarefootJS-0.29.0.tar.gz
BarefootJS::SearchParams       0.014000  K/KF/KFLY/BarefootJS-0.29.0.tar.gz
```

— every package still on the 0.29.0 tarball, and MetaCPAN has no `BarefootJS-0.30.0` release at all, though the tarball is present under `authors/id/K/KF/KFLY/`. The two sibling dists uploaded in the same release (`Mojolicious-Plugin-BarefootJS-0.30.0`, `BarefootJS-Backend-Xslate-0.30.0`) indexed cleanly at `v0.30.0`, so this is specific to that one indexing run, not to the dist's contents. `E_DB_XACTFAIL` is distinct from `EDBERR` — the latter reports the DB error string, this one does not, so the cause is not recoverable from outside PAUSE.

Nothing in this repo fixes it. Either request a reindex of `BarefootJS-0.30.0.tar.gz` from the PAUSE menu ("Force Reindexing"; runs on a cron, up to an hour), or let the patch release this changeset produces supersede it. Worth verifying afterwards that `BarefootJS::Date` actually moved off the 0.29.0 tarball in `02packages`.

## Changes

- **`packages/adapter-perl/lib/BarefootJS.pm`** — `package BarefootJS::Date;` now declares `our $VERSION = "0.30.0";`. It has to be a **literal**: `Module::Metadata` evaluates the version line in a `Safe` compartment where `$BarefootJS::VERSION` is not visible, so the DRY-looking alias collapses to `0` (verified). `CPAN::Version->vgt("v0.30.0", "0.029000")` is true, so the package will index on the next upload.
- **`scripts/sync-perl-versions.ts`** — the `$VERSION` rewrite was `/m` (first match only), which would have left the new line stranded at 0.30.0 forever. Now `/gm`, so every `our $VERSION` in a module tracks the release. Verified by bumping `package.json` to 0.30.1 in a scratch run: both lines in `BarefootJS.pm` moved.
- **`t/meta_provides.t`** in all three Perl dists (+ MANIFEST entries) — asserts every package in META `provides` declares a version and that they all match. Fails on the pre-fix tree (`BarefootJS::Date` undef, 2 distinct versions), passes after. Applied to all three because they share the same `Makefile.PL` pattern and the same trap, following the precedent of 0dfec18.
- **changeset** — `patch` for `@barefootjs/perl` / `@barefootjs/mojolicious` / `@barefootjs/xslate`, so the fix actually ships to CPAN.

## Testing

`t/meta_provides.t` runs under `make test` in `ci-perl-dist.yml`, which already covers all three dists. Locally verified red-then-green against a copy of the pre-fix `BarefootJS.pm`; `perl -c lib/BarefootJS.pm` and `biome check` clean.

## Not changed

`BarefootJS::_TZProbe` is indexed at `0.029000` from 0.29.0 but is excluded from `provides` (`Module::Metadata` skips any package with an `_`-prefixed component). That's the right outcome — it's a private probe — but the stale `02packages` row will linger until the 0.29.0 tarball is deleted or PAUSE's "forget a package version" form is used. Harmless; left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_011z5oAc37tyMPK16wde7dV1)_