### PR TITLE
feat(vite): add the @barefootjs/vite dev server

### DIFF
--- a/.changeset/vite-plugin-dev-server.md
+++ b/.changeset/vite-plugin-dev-server.md
@@ -1,0 +1,71 @@
+---
+"@barefootjs/vite": minor
+---
+
+Add the dev server: `configureServer` wires `vite dev` up to real BarefootJS templates
+
+The prior PR gave `@barefootjs/vite` its build-time engines (`transform` for
+client JS, `writeBundle` for templates). This PR adds the third:
+`configureServer`, so `vite dev` emits real, working templates too — not
+just `vite build`.
+
+- **`server.watcher.add(componentDirs)` is mandatory, not a nicety.** Vite's
+  own chokidar watcher only reliably covers its project `root` (plus config
+  file dependencies) and whatever it has personally transformed as a module
+  (`ensureWatchedFile`). Server-only components (no `'use client'`) are
+  never transformed as modules — nothing ever imports them as a script —
+  and in this monorepo's real layouts `components` dirs are commonly
+  siblings of, not descendants of, the Vite project root (an app's
+  `vite.config.ts` root is the backend app dir; components live in a shared
+  `ui/`-style directory next to it). Without the explicit `add`, editing
+  such a file is silently invisible to the dev server. The e2e suite pins
+  this with a dedicated server instance that never fetches any `'use
+  client'` component over HTTP, specifically to rule out Vite's own
+  `ensureWatchedFile` accidentally covering the gap.
+- **Every tracked `.tsx` change re-runs the WHOLE eager pass**, not a
+  dependency-tracked diff. A change to a shared signal module or a child
+  component changes the *parent's* template too; anything less than a full
+  re-run needs the dependency tracking this migration is deleting from the
+  legacy CLI's `build-cache.ts`. The eager pass's existing content-hash
+  `CompileCache` absorbs the cost — an unchanged file's compile is a cache
+  hit regardless of which pass reaches it.
+- **`scriptAssets` for a dev `'use client'` component** is `[origin +
+  '/@vite/client', origin + <the component's own dev module URL>]` — the
+  HMR/full-reload socket, then the component itself, served exactly like
+  any other dev module via the SAME `transform` hook `vite build` uses (no
+  dev-only compile path). Server-only components still get `[]`. The
+  origin is resolved from the httpServer's ACTUAL bound port
+  (`httpServer.address()`), never the configured one, because Vite
+  auto-increments past an in-use port unless `strictPort` is set — and it's
+  written back onto `server.config.server.origin` so Vite's own asset-URL
+  rewriting (`import.meta.url`, CSS `url()`) agrees with what this plugin
+  bakes into templates.
+- **`server.cors` gets a localhost-only default, ONLY when the user hasn't
+  set one.** The page is rendered by the backend on its own origin; its
+  module scripts come from Vite on another — a cross-origin split Vite 6+'s
+  same-origin CORS default would reject outright. The plugin option surface
+  stays exactly `adapter` / `components` / `templates`; no fourth
+  `devOrigin`-shaped option was added to support this. Done in the `config`
+  hook (not `configureServer`) so it's plain, synchronously mergeable data
+  Vite applies before installing its own CORS middleware, not a hook-timing
+  bet against Vite's internal setup order.
+- **Dev-artifact marker.** `templates/.barefootjs-dev-build` is written
+  alongside every dev-emitted template and removed by the next `vite build`
+  — a warning that the directory currently holds dev-only URLs
+  (`http://localhost:<port>/...`) that will break if committed or deployed.
+  A per-adapter template comment (Go `{{/* … */}}`, ERB `<%# … %>`, etc.)
+  would pinpoint the problem more precisely, but needs new surface on every
+  `TemplateAdapter` implementation across 9+ adapter packages unrelated to
+  the dev server itself — out of scope here. This single marker file is the
+  fallback the design brief explicitly allows in that case.
+
+Full reload (`server.ws.send({ type: 'full-reload' })`), not fine-grained
+HMR, is correct here and not a placeholder: the page HTML is rendered by the
+backend (Go/PHP/Ruby), not by Vite, so a component's compiled output can
+only take effect on the next full backend render. Fine-grained HMR would
+need to cross a boundary this architecture doesn't have yet.
+
+Out of scope for this change: migrating any `integrations/*` app to the new
+plugin, `packages/cli`, and combining adapter `types` output into one
+backend-native file (still tracked as a follow-up, unrelated to the dev
+server).

--- a/.changeset/vite-plugin-dev-server.md
+++ b/.changeset/vite-plugin-dev-server.md
@@ -65,6 +65,43 @@ backend (Go/PHP/Ruby), not by Vite, so a component's compiled output can
 only take effect on the next full backend render. Fine-grained HMR would
 need to cross a boundary this architecture doesn't have yet.
 
+Three fixes from review, all with regression coverage:
+
+- **`server.cors: false` was silently overridden.** The "fill in only when
+  unset" check was `!userConfig.server?.cors`, and `!false` is `true` — a
+  user explicitly disabling CORS got the localhost default instead, the
+  opposite of what they asked for. Fixed to check `=== undefined`
+  specifically; falsy-but-set (`false`) now survives untouched, same as any
+  other explicit value.
+- **Adding or deleting a component file during a dev session did nothing.**
+  Only `'change'` was handled; chokidar emits `'add'` and `'unlink'`
+  separately. A new file got no template until some unrelated file
+  happened to change and dragged it along on the next full pass; a deleted
+  file's template lingered on disk forever. Both are now handled: `'add'`
+  triggers the same eager pass as `'change'` (it already re-discovers
+  everything from disk, so no special-casing is needed for a new file);
+  `'unlink'` additionally needs to know WHICH on-disk files to remove for a
+  source that no longer exists to re-derive that from — solved by having
+  the eager pass record what it last emitted per source file
+  (`lastEmitsByAbsPath`), consulted (and then discarded, along with the
+  now-stale `CompileCache` entry) when a file disappears.
+- **Rapid successive changes could run overlapping eager passes**, all
+  writing the same template files with no serialization — a save-twice-
+  quickly, a multi-file save, or a `git checkout` touching many files could
+  trigger this, exactly the race the legacy CLI's `watch()`
+  (`packages/cli/src/lib/build.ts`) debounced at 100ms to avoid. Added
+  `debounced-serial-runner.ts`: a small, dependency-free primitive that
+  debounces a burst of triggers into one run and, if a run is already in
+  flight when the debounce fires, queues exactly one follow-up instead of
+  starting a second overlapping one — a change arriving mid-pass is
+  delayed, never dropped, and at most one pass is ever active. Proven
+  deterministically in its own unit tests (via manually-resolved promises
+  standing in for the real eager pass, since the real one finishes in
+  low-single-digit milliseconds — far too fast to reliably force a
+  wall-clock race in an e2e test); backed by an end-to-end test confirming
+  real rapid disk writes converge on the correct final template content
+  with no corruption and no crash.
+
 Out of scope for this change: migrating any `integrations/*` app to the new
 plugin, `packages/cli`, and combining adapter `types` output into one
 backend-native file (still tracked as a follow-up, unrelated to the dev

--- a/packages/vite/e2e-fixture-dev/components/Counter.tsx
+++ b/packages/vite/e2e-fixture-dev/components/Counter.tsx
@@ -1,0 +1,7 @@
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function Counter() {
+  const [count, setCount] = createSignal(0)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}

--- a/packages/vite/e2e-fixture-dev/components/Greeting.tsx
+++ b/packages/vite/e2e-fixture-dev/components/Greeting.tsx
@@ -1,0 +1,3 @@
+export function Greeting({ name }: { name: string }) {
+  return <p>Hello, {name}!</p>
+}

--- a/packages/vite/src/__tests__/debounced-serial-runner.test.ts
+++ b/packages/vite/src/__tests__/debounced-serial-runner.test.ts
@@ -1,0 +1,131 @@
+import { describe, test, expect } from 'bun:test'
+import { createDebouncedSerialRunner } from '../debounced-serial-runner.ts'
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(r => setTimeout(r, ms))
+}
+
+/** A controllable async task: `resolveCall(n)` releases the nth call, and
+ * `activeCount`/`maxActiveCount` track how many calls were in flight at
+ * once — the thing this whole module exists to keep at 1. */
+function controllableTask() {
+  const calls: Array<{ resolve: () => void }> = []
+  let activeCount = 0
+  let maxActiveCount = 0
+
+  const task = () =>
+    new Promise<void>(resolvePromise => {
+      activeCount++
+      maxActiveCount = Math.max(maxActiveCount, activeCount)
+      calls.push({
+        resolve: () => {
+          activeCount--
+          resolvePromise()
+        },
+      })
+    })
+
+  return {
+    task,
+    resolveCall(n: number) {
+      calls[n]?.resolve()
+    },
+    get callCount() {
+      return calls.length
+    },
+    get maxActiveCount() {
+      return maxActiveCount
+    },
+  }
+}
+
+describe('createDebouncedSerialRunner', () => {
+  test('a single trigger() runs the task once, after the debounce window', async () => {
+    let calls = 0
+    const runner = createDebouncedSerialRunner(async () => { calls++ }, 20, () => {})
+
+    runner.trigger()
+    expect(calls).toBe(0) // debounced — not yet
+    await sleep(60)
+    expect(calls).toBe(1)
+  })
+
+  test('a burst of trigger() calls within the debounce window collapses into ONE run', async () => {
+    let calls = 0
+    const runner = createDebouncedSerialRunner(async () => { calls++ }, 30, () => {})
+
+    for (let i = 0; i < 10; i++) {
+      runner.trigger()
+      await sleep(5) // well under the 30ms debounce — keeps re-arming it
+    }
+    await sleep(80)
+    expect(calls).toBe(1)
+  })
+
+  test('trigger() during an in-flight run does NOT start a second, overlapping call', async () => {
+    const c = controllableTask()
+    const runner = createDebouncedSerialRunner(c.task, 10, () => {})
+
+    runner.trigger()
+    await sleep(30) // debounce fires, first call starts and is now stuck awaiting resolveCall(0)
+    expect(c.callCount).toBe(1)
+
+    // A change arrives mid-pass.
+    runner.trigger()
+    await sleep(30) // long past the debounce window — but the first call is still in flight
+    expect(c.callCount).toBe(1) // no second call started while the first is running
+
+    c.resolveCall(0)
+    await sleep(20) // the queued follow-up now gets its turn
+    expect(c.callCount).toBe(2)
+
+    c.resolveCall(1)
+    await sleep(20)
+    expect(c.maxActiveCount).toBe(1) // never more than one task in flight, at any point
+  })
+
+  test('several trigger() calls while a run is in flight coalesce into exactly ONE follow-up, not one per trigger', async () => {
+    const c = controllableTask()
+    const runner = createDebouncedSerialRunner(c.task, 10, () => {})
+
+    runner.trigger()
+    await sleep(30)
+    expect(c.callCount).toBe(1)
+
+    // Five more changes land while the first pass is still running.
+    for (let i = 0; i < 5; i++) {
+      runner.trigger()
+      await sleep(15) // each spaced past the debounce window on its own
+    }
+
+    c.resolveCall(0)
+    await sleep(30)
+    expect(c.callCount).toBe(2) // exactly one follow-up, not five
+
+    c.resolveCall(1)
+    await sleep(20)
+    expect(c.callCount).toBe(2) // and nothing further queued after that
+  })
+
+  test('a rejected task is reported via onError and does not wedge future runs', async () => {
+    let calls = 0
+    const errors: unknown[] = []
+    const runner = createDebouncedSerialRunner(
+      async () => {
+        calls++
+        if (calls === 1) throw new Error('boom')
+      },
+      10,
+      err => errors.push(err),
+    )
+
+    runner.trigger()
+    await sleep(30)
+    expect(calls).toBe(1)
+    expect(errors).toHaveLength(1)
+
+    runner.trigger()
+    await sleep(30)
+    expect(calls).toBe(2) // the runner recovered — a later trigger still runs
+  })
+})

--- a/packages/vite/src/__tests__/dev-server.test.ts
+++ b/packages/vite/src/__tests__/dev-server.test.ts
@@ -1,0 +1,138 @@
+import { describe, test, expect } from 'bun:test'
+import type { ViteDevServer } from 'vite'
+import {
+  DEFAULT_DEV_CORS_ORIGIN,
+  DEV_ARTIFACT_MARKER_CONTENT,
+  DEV_ARTIFACT_MARKER_FILENAME,
+  devModuleUrl,
+  devRequestPath,
+  devScriptAssets,
+  resolveDevOrigin,
+} from '../dev-server.ts'
+
+describe('devRequestPath', () => {
+  test('a file under root becomes a root-relative path, no leading slash', () => {
+    expect(devRequestPath({ root: '/proj/app' }, '/proj/app/src/components/Counter.tsx')).toBe(
+      'src/components/Counter.tsx',
+    )
+  })
+
+  test('a file OUTSIDE root uses the /@fs/ absolute-path passthrough (no leading slash)', () => {
+    // The realistic layout this plugin has to support: an app's
+    // `vite.config.ts` root is the backend app dir, while `components`
+    // lives in a sibling `ui/`-style directory.
+    expect(devRequestPath({ root: '/proj/app' }, '/proj/ui/components/Counter.tsx')).toBe(
+      '@fs/proj/ui/components/Counter.tsx',
+    )
+  })
+
+  test('root itself resolves to the empty path', () => {
+    expect(devRequestPath({ root: '/proj/app' }, '/proj/app')).toBe('')
+  })
+})
+
+describe('devModuleUrl', () => {
+  test('joins origin + base + request path for an in-root file', () => {
+    expect(
+      devModuleUrl({ root: '/proj/app', base: '/' }, 'http://localhost:5173', '/proj/app/src/components/Counter.tsx'),
+    ).toBe('http://localhost:5173/src/components/Counter.tsx')
+  })
+
+  test('honors a non-default base', () => {
+    expect(
+      devModuleUrl(
+        { root: '/proj/app', base: '/static/build/' },
+        'http://localhost:5173',
+        '/proj/app/src/components/Counter.tsx',
+      ),
+    ).toBe('http://localhost:5173/static/build/src/components/Counter.tsx')
+  })
+
+  test('honors base together with an out-of-root /@fs/ path', () => {
+    expect(
+      devModuleUrl(
+        { root: '/proj/app', base: '/static/build/' },
+        'http://localhost:5173',
+        '/proj/ui/components/Counter.tsx',
+      ),
+    ).toBe('http://localhost:5173/static/build/@fs/proj/ui/components/Counter.tsx')
+  })
+})
+
+describe('devScriptAssets', () => {
+  test('returns [@vite/client, the component module URL], in that order', () => {
+    const config = { root: '/proj/app', base: '/' }
+    expect(devScriptAssets(config, 'http://localhost:5173', '/proj/app/src/components/Counter.tsx')).toEqual([
+      'http://localhost:5173/@vite/client',
+      'http://localhost:5173/src/components/Counter.tsx',
+    ])
+  })
+})
+
+describe('resolveDevOrigin', () => {
+  function fakeServer(overrides: {
+    origin?: string
+    port?: number
+    address?: { port: number } | string | null
+  }): ViteDevServer {
+    return {
+      config: {
+        server: {
+          origin: overrides.origin,
+          port: overrides.port,
+        },
+      },
+      httpServer:
+        overrides.address === undefined
+          ? null
+          : ({ address: () => overrides.address } as unknown as ViteDevServer['httpServer']),
+      // biome-ignore lint: minimal fake, only the fields resolveDevOrigin reads are real
+    } as any
+  }
+
+  test('returns the user-configured origin unchanged when set', () => {
+    const server = fakeServer({ origin: 'https://example.com' })
+    expect(resolveDevOrigin(server)).toBe('https://example.com')
+  })
+
+  test('derives from the ACTUAL bound port (httpServer.address()), not the configured port', () => {
+    // The case `strictPort: false` (the default) makes this matter: Vite
+    // auto-increments past an in-use configured port.
+    const server = fakeServer({ port: 5173, address: { port: 5174 } })
+    expect(resolveDevOrigin(server)).toBe('http://localhost:5174')
+  })
+
+  test('writes the computed default back onto server.config.server.origin', () => {
+    const server = fakeServer({ port: 5173, address: { port: 5174 } })
+    resolveDevOrigin(server)
+    expect(server.config.server.origin).toBe('http://localhost:5174')
+  })
+
+  test('falls back to the configured port when there is no httpServer (middleware mode)', () => {
+    const server = fakeServer({ port: 5173 })
+    expect(resolveDevOrigin(server)).toBe('http://localhost:5173')
+  })
+})
+
+describe('DEFAULT_DEV_CORS_ORIGIN', () => {
+  test('matches localhost and 127.0.0.1 at any port', () => {
+    expect(DEFAULT_DEV_CORS_ORIGIN.test('http://localhost:3010')).toBe(true)
+    expect(DEFAULT_DEV_CORS_ORIGIN.test('https://127.0.0.1:8080')).toBe(true)
+    expect(DEFAULT_DEV_CORS_ORIGIN.test('http://localhost')).toBe(true)
+  })
+
+  test('does NOT match an arbitrary remote origin', () => {
+    expect(DEFAULT_DEV_CORS_ORIGIN.test('https://evil.example.com')).toBe(false)
+  })
+})
+
+describe('dev-artifact marker', () => {
+  test('filename is a dotfile so it does not read as a template', () => {
+    expect(DEV_ARTIFACT_MARKER_FILENAME.startsWith('.')).toBe(true)
+  })
+
+  test('content warns against committing/deploying and names the fix', () => {
+    expect(DEV_ARTIFACT_MARKER_CONTENT).toContain('DEV BUILD OUTPUT')
+    expect(DEV_ARTIFACT_MARKER_CONTENT).toContain('vite build')
+  })
+})

--- a/packages/vite/src/__tests__/e2e-vite-dev.test.ts
+++ b/packages/vite/src/__tests__/e2e-vite-dev.test.ts
@@ -65,6 +65,20 @@ function captureWsSends(server: ViteDevServer): { sent: unknown[]; restore: () =
   return { sent, restore: () => { server.ws.send = originalSend } }
 }
 
+function captureLoggerErrors(server: ViteDevServer): { errors: unknown[]; restore: () => void } {
+  const errors: unknown[] = []
+  const originalError = server.config.logger.error.bind(server.config.logger)
+  server.config.logger.error = ((msg: string, opts?: unknown) => {
+    errors.push(msg)
+    return originalError(msg, opts as never)
+  }) as typeof server.config.logger.error
+  return { errors, restore: () => { server.config.logger.error = originalError } }
+}
+
+function countFullReloads(sent: unknown[]): number {
+  return sent.filter(m => (m as { type?: string }).type === 'full-reload').length
+}
+
 async function startDevServer(templatesDir: string, extraServerOptions: Record<string, unknown> = {}) {
   const server = await createServer({
     configFile: false,
@@ -184,10 +198,76 @@ describe('e2e: vite dev server', () => {
         return tpl !== null && tpl.includes('data-edited="counter-marker"')
       })
 
-      expect(sent.some(m => (m as { type?: string }).type === 'full-reload')).toBe(true)
+      expect(countFullReloads(sent)).toBeGreaterThanOrEqual(1)
     } finally {
       restore()
       await writeFile(COUNTER_PATH, originalCounterSource)
+    }
+  })
+
+  // The deterministic proof that passes never overlap and a mid-pass
+  // trigger is coalesced into exactly one follow-up (not dropped, not
+  // duplicated) is `debounced-serial-runner.test.ts` — it controls task
+  // completion directly via manually-resolved promises, which a real e2e
+  // test cannot: this fixture's eager pass finishes in low single-digit
+  // milliseconds, far too fast to reliably force a real "change arrives
+  // while a pass is in flight" race through wall-clock timing alone. This
+  // test is the complementary end-to-end confirmation: real rapid disk
+  // writes, through the real watcher, into the real debounced runner,
+  // converge on the correct final state with no corruption and no crash.
+  test('rapid successive edits converge on the final content with no corruption or errors', async () => {
+    const { sent, restore: restoreWs } = captureWsSends(server)
+    const { errors, restore: restoreLogger } = captureLoggerErrors(server)
+    const EDIT_COUNT = 8
+
+    try {
+      // Fire edits back-to-back, faster than the 100ms watcher debounce —
+      // simulates a save-twice-quickly / multi-file-save / `git checkout`.
+      for (let i = 1; i <= EDIT_COUNT; i++) {
+        await writeFile(
+          COUNTER_PATH,
+          originalCounterSource.replace('<button onClick=', `<button data-edit-n="${i}" onClick=`),
+        )
+      }
+
+      // Give the debounce window plus a full eager pass time to settle.
+      await waitFor(async () => {
+        const tpl = await readIfExists(join(templatesDir, 'Counter.tmpl'))
+        return tpl !== null && tpl.includes(`data-edit-n="${EDIT_COUNT}"`)
+      })
+      // Settle further: if an overlapping/racing pass were still in
+      // flight and about to clobber the file with stale content, a short
+      // wait would catch it reverting.
+      await new Promise(r => setTimeout(r, 300))
+
+      const finalTemplate = await readFile(join(templatesDir, 'Counter.tmpl'), 'utf8')
+      expect(finalTemplate).toContain(`data-edit-n="${EDIT_COUNT}"`)
+      // Not just the last edit "eventually" landing — no EARLIER edit's
+      // marker should still be present either (that would mean two
+      // template-writing passes raced and left mixed output).
+      for (let i = 1; i < EDIT_COUNT; i++) {
+        expect(finalTemplate).not.toContain(`data-edit-n="${i}"`)
+      }
+
+      expect(errors).toEqual([])
+      const reloadCount = countFullReloads(sent)
+      expect(reloadCount).toBeGreaterThanOrEqual(1)
+      // A soft signal, not the proof (see the comment above the test): with
+      // 8 back-to-back writes this fast, the underlying watcher's own
+      // polling interval typically coalesces most of them into far fewer
+      // raw events before this plugin's debounce even runs — so this
+      // mainly guards against a REGRESSION to one-reload-per-write (e.g. a
+      // watcher config change to non-polling native events), not against
+      // debouncing being removed outright.
+      expect(reloadCount).toBeLessThan(EDIT_COUNT)
+    } finally {
+      restoreWs()
+      restoreLogger()
+      await writeFile(COUNTER_PATH, originalCounterSource)
+      await waitFor(async () => {
+        const tpl = await readIfExists(join(templatesDir, 'Counter.tmpl'))
+        return tpl !== null && !tpl.includes('data-edit-n=')
+      })
     }
   })
 })
@@ -256,5 +336,75 @@ describe('e2e: vite dev server — user-supplied server.cors is not overwritten'
     }))
 
     expect(server.config.server.cors).toEqual({ origin: 'https://my-own-cors-policy.example.com' })
+  })
+})
+
+describe('e2e: vite dev server — user-supplied server.cors: false is not overwritten', () => {
+  let server: ViteDevServer
+  let templatesDir: string
+
+  afterAll(async () => {
+    await server?.close()
+    await rm(templatesDir, { recursive: true, force: true })
+  })
+
+  test('server.cors: false (explicitly disabled) survives untouched, unlike an unset value', async () => {
+    templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-vite-dev-views-cors-false-'))
+    ;({ server } = await startDevServer(templatesDir, { cors: false }))
+
+    // `!false` is `true` — a naive "fill in if falsy" check would replace
+    // this with the localhost default. Only "fill in if unset" is correct.
+    expect(server.config.server.cors).toBe(false)
+  })
+})
+
+describe('e2e: vite dev server — creating and deleting a component file', () => {
+  // Its own server + templates dir, and its own component file (never
+  // touched by any other describe block), so these tests can freely
+  // create/delete `.tsx` files without disturbing shared fixture state.
+  let server: ViteDevServer
+  let templatesDir: string
+  const WIDGET_PATH = join(COMPONENTS_DIR, 'Widget.tsx')
+
+  beforeAll(async () => {
+    templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-vite-dev-views-addunlink-'))
+    ;({ server } = await startDevServer(templatesDir))
+    await waitFor(async () => (await readIfExists(join(templatesDir, 'Counter.tmpl'))) !== null)
+  }, 30_000)
+
+  afterAll(async () => {
+    await rm(WIDGET_PATH, { force: true })
+    await server?.close()
+    await rm(templatesDir, { recursive: true, force: true })
+  })
+
+  test('creating a new component file mid-session emits a template for it and reloads', async () => {
+    const { sent, restore } = captureWsSends(server)
+    try {
+      await writeFile(WIDGET_PATH, 'export function Widget() { return <p>brand new</p> }\n')
+
+      await waitFor(async () => (await readIfExists(join(templatesDir, 'Widget.tmpl'))) !== null)
+      const template = await readFile(join(templatesDir, 'Widget.tmpl'), 'utf8')
+      expect(template).toContain('brand new')
+      expect(countFullReloads(sent)).toBeGreaterThanOrEqual(1)
+    } finally {
+      restore()
+    }
+  })
+
+  test('deleting a component file removes its emitted template and reloads', async () => {
+    // Widget.tsx and Widget.tmpl both exist already, from the previous
+    // test (bun test runs a describe's tests in declaration order).
+    expect(await readIfExists(join(templatesDir, 'Widget.tmpl'))).not.toBeNull()
+
+    const { sent, restore } = captureWsSends(server)
+    try {
+      await rm(WIDGET_PATH)
+
+      await waitFor(async () => (await readIfExists(join(templatesDir, 'Widget.tmpl'))) === null)
+      expect(countFullReloads(sent)).toBeGreaterThanOrEqual(1)
+    } finally {
+      restore()
+    }
   })
 })

--- a/packages/vite/src/__tests__/e2e-vite-dev.test.ts
+++ b/packages/vite/src/__tests__/e2e-vite-dev.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Real end-to-end coverage of `configureServer`: actually starts a Vite dev
+ * server (via Vite's Node `createServer` API, the same function the `vite`
+ * CLI itself calls) against `../../e2e-fixture-dev`, then drives it over
+ * real HTTP/fs, mirroring `e2e-vite-build.test.ts`'s rigor for the build
+ * half.
+ *
+ * The fixture's `components` dir is a SIBLING of the Vite project root
+ * (`app/`), not a descendant — mirroring this monorepo's real layouts (an
+ * app's `vite.config.ts` root is the backend app dir; components live in a
+ * shared `ui/`-style directory next to it).
+ *
+ * The server-only regression (below) runs against its OWN dedicated server
+ * that never fetches any `'use client'` component over HTTP. That isolation
+ * matters: Vite's OWN internal `ensureWatchedFile` adds any file it has
+ * transformed as a module to the watcher, regardless of this plugin. Fetch
+ * Counter.tsx once and Vite itself starts watching THAT SPECIFIC FILE —
+ * which would silently paper over a missing `server.watcher.add()` call the
+ * moment a later test's "any change → full re-run" pass happens to also
+ * pick up Greeting.tsx's already-edited-on-disk content. Keeping the
+ * server-only regression on a server that never fetches Counter.tsx (or any
+ * other client component) means the ONLY way Greeting.tsx's edit can ever
+ * reach the watcher is this plugin's own explicit `server.watcher.add()` —
+ * see `plugin.ts`'s `configureServer`.
+ */
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
+import { createServer, type ViteDevServer } from 'vite'
+import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { GoTemplateAdapter } from '@barefootjs/go-template/adapter'
+import { barefoot } from '../plugin.ts'
+import { devRequestPath } from '../dev-server.ts'
+
+const FIXTURE_ROOT = resolve(import.meta.dirname, '../../e2e-fixture-dev')
+const APP_ROOT = join(FIXTURE_ROOT, 'app')
+const COMPONENTS_DIR = join(FIXTURE_ROOT, 'components')
+const COUNTER_PATH = join(COMPONENTS_DIR, 'Counter.tsx')
+const GREETING_PATH = join(COMPONENTS_DIR, 'Greeting.tsx')
+
+async function waitFor(check: () => Promise<boolean> | boolean, timeoutMs = 10_000): Promise<void> {
+  const start = Date.now()
+  for (;;) {
+    if (await check()) return
+    if (Date.now() - start > timeoutMs) throw new Error('waitFor: condition not met within timeout')
+    await new Promise(r => setTimeout(r, 50))
+  }
+}
+
+async function readIfExists(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+function captureWsSends(server: ViteDevServer): { sent: unknown[]; restore: () => void } {
+  const sent: unknown[] = []
+  const originalSend = server.ws.send.bind(server.ws)
+  server.ws.send = ((payload: unknown) => {
+    sent.push(payload)
+    return originalSend(payload as never)
+  }) as typeof server.ws.send
+  return { sent, restore: () => { server.ws.send = originalSend } }
+}
+
+async function startDevServer(templatesDir: string, extraServerOptions: Record<string, unknown> = {}) {
+  const server = await createServer({
+    configFile: false,
+    root: APP_ROOT,
+    logLevel: 'silent',
+    server: {
+      // Port 0 (OS-assigned) exercises the real requirement: the origin
+      // this plugin bakes into templates MUST come from the actually
+      // bound port (`httpServer.address()`), not the configured one.
+      port: 0,
+      strictPort: false,
+      fs: { allow: [FIXTURE_ROOT] },
+      // Polling sidesteps native fs-event flakiness some sandboxed /
+      // containerized filesystems have with inotify.
+      watch: { usePolling: true, interval: 30 },
+      ...extraServerOptions,
+    },
+    plugins: [
+      barefoot({
+        adapter: new GoTemplateAdapter({ packageName: 'main' }),
+        components: ['../components'],
+        templates: templatesDir,
+      }),
+    ],
+  })
+  await server.listen()
+
+  const address = server.httpServer!.address()
+  const port = typeof address === 'object' && address !== null ? address.port : 0
+  const baseUrl = `http://localhost:${port}`
+  return { server, baseUrl }
+}
+
+describe('e2e: vite dev server', () => {
+  let server: ViteDevServer
+  let templatesDir: string
+  let baseUrl: string
+  let originalCounterSource: string
+  let originalGreetingSource: string
+
+  beforeAll(async () => {
+    templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-vite-dev-views-'))
+    originalCounterSource = await readFile(COUNTER_PATH, 'utf8')
+    originalGreetingSource = await readFile(GREETING_PATH, 'utf8')
+    ;({ server, baseUrl } = await startDevServer(templatesDir))
+
+    // The initial eager pass runs off the httpServer's 'listening' event,
+    // asynchronously with respect to `server.listen()` resolving — wait
+    // for its output to actually land on disk before asserting on it.
+    await waitFor(async () => (await readIfExists(join(templatesDir, 'Counter.tmpl'))) !== null)
+    await waitFor(async () => (await readIfExists(join(templatesDir, 'Greeting.tmpl'))) !== null)
+  }, 30_000)
+
+  afterAll(async () => {
+    // Always restore fixture sources and tear down the server, even if an
+    // assertion above threw — a leaked dev server hangs the whole suite.
+    await writeFile(COUNTER_PATH, originalCounterSource).catch(() => {})
+    await writeFile(GREETING_PATH, originalGreetingSource).catch(() => {})
+    await server?.close()
+    await rm(templatesDir, { recursive: true, force: true })
+  })
+
+  test('fetching the "use client" component\'s module URL returns compiled client JS', async () => {
+    const requestPath = devRequestPath({ root: APP_ROOT }, COUNTER_PATH)
+    // Counter lives OUTSIDE the vite root, so this must resolve through
+    // Vite's `/@fs/` absolute-path passthrough.
+    expect(requestPath.startsWith('@fs/')).toBe(true)
+
+    const res = await fetch(`${baseUrl}/${requestPath}`)
+    expect(res.status).toBe(200)
+
+    const body = await res.text()
+    expect(body).toContain('createSignal')
+    expect(body).toContain('hydrate(')
+    expect(body).not.toContain('use client')
+    expect(body).not.toMatch(/onClick=\{/)
+  })
+
+  test('emitted templates carry dev-origin URLs, including the @vite/client entry', async () => {
+    const requestPath = devRequestPath({ root: APP_ROOT }, COUNTER_PATH)
+    const template = await readFile(join(templatesDir, 'Counter.tmpl'), 'utf8')
+
+    expect(template).toContain(`{{.Scripts.Register "${baseUrl}/@vite/client"}}`)
+    expect(template).toContain(`{{.Scripts.Register "${baseUrl}/${requestPath}"}}`)
+  })
+
+  test('the server-only component has no script registration, dev or otherwise', async () => {
+    const template = await readFile(join(templatesDir, 'Greeting.tmpl'), 'utf8')
+    expect(template).not.toContain('Scripts.Register')
+    expect(template).toContain('Hello')
+  })
+
+  test('the templates dir carries the dev-artifact marker while the dev server is running', async () => {
+    const marker = await readIfExists(join(templatesDir, '.barefootjs-dev-build'))
+    expect(marker).not.toBeNull()
+    expect(marker).toContain('DEV BUILD OUTPUT')
+  })
+
+  test('a request with a cross-origin Origin header gets the localhost-only CORS default', async () => {
+    const res = await fetch(`${baseUrl}/@vite/client`, {
+      headers: { Origin: 'http://localhost:3010' },
+    })
+    expect(res.headers.get('access-control-allow-origin')).toBe('http://localhost:3010')
+  })
+
+  test('editing a "use client" component re-emits its template and triggers full-reload', async () => {
+    const { sent, restore } = captureWsSends(server)
+    try {
+      const edited = originalCounterSource.replace(
+        '<button onClick=',
+        '<button data-edited="counter-marker" onClick=',
+      )
+      await writeFile(COUNTER_PATH, edited)
+
+      await waitFor(async () => {
+        const tpl = await readIfExists(join(templatesDir, 'Counter.tmpl'))
+        return tpl !== null && tpl.includes('data-edited="counter-marker"')
+      })
+
+      expect(sent.some(m => (m as { type?: string }).type === 'full-reload')).toBe(true)
+    } finally {
+      restore()
+      await writeFile(COUNTER_PATH, originalCounterSource)
+    }
+  })
+})
+
+describe('e2e: vite dev server — server-only component watcher regression', () => {
+  // Deliberately its OWN server that never fetches ANY component over HTTP
+  // (see this file's header comment for why that isolation is required for
+  // this specific regression to be meaningful).
+  let server: ViteDevServer
+  let templatesDir: string
+  let originalGreetingSource: string
+
+  beforeAll(async () => {
+    templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-vite-dev-views-serveronly-'))
+    originalGreetingSource = await readFile(GREETING_PATH, 'utf8')
+    ;({ server } = await startDevServer(templatesDir))
+
+    await waitFor(async () => (await readIfExists(join(templatesDir, 'Greeting.tmpl'))) !== null)
+  }, 30_000)
+
+  afterAll(async () => {
+    await writeFile(GREETING_PATH, originalGreetingSource).catch(() => {})
+    await server?.close()
+    await rm(templatesDir, { recursive: true, force: true })
+  })
+
+  test('editing the server-only component (no "use client", never fetched over HTTP) still re-emits and reloads', async () => {
+    // Greeting.tsx has no 'use client' directive, so it is NEVER part of
+    // Rollup's module graph and Vite never transforms/serves it as a
+    // module — the one path (`ensureWatchedFile`) that would otherwise get
+    // it onto the watcher for free. It also lives outside the vite `root`,
+    // so the default root-only chokidar watch doesn't cover it either. If
+    // `plugin.ts` ever drops its `server.watcher.add(componentDirs)` call,
+    // this test times out waiting for the reload.
+    const { sent, restore } = captureWsSends(server)
+    try {
+      const edited = originalGreetingSource.replace('<p>', '<p data-edited="greeting-marker">')
+      await writeFile(GREETING_PATH, edited)
+
+      await waitFor(async () => {
+        const tpl = await readIfExists(join(templatesDir, 'Greeting.tmpl'))
+        return tpl !== null && tpl.includes('data-edited="greeting-marker"')
+      })
+
+      expect(sent.some(m => (m as { type?: string }).type === 'full-reload')).toBe(true)
+    } finally {
+      restore()
+      await writeFile(GREETING_PATH, originalGreetingSource)
+    }
+  })
+})
+
+describe('e2e: vite dev server — user-supplied server.cors is not overwritten', () => {
+  let server: ViteDevServer
+  let templatesDir: string
+
+  afterAll(async () => {
+    await server?.close()
+    await rm(templatesDir, { recursive: true, force: true })
+  })
+
+  test('a user-configured server.cors survives untouched', async () => {
+    templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-vite-dev-views-cors-'))
+    ;({ server } = await startDevServer(templatesDir, {
+      cors: { origin: 'https://my-own-cors-policy.example.com' },
+    }))
+
+    expect(server.config.server.cors).toEqual({ origin: 'https://my-own-cors-policy.example.com' })
+  })
+})

--- a/packages/vite/src/__tests__/plugin.test.ts
+++ b/packages/vite/src/__tests__/plugin.test.ts
@@ -93,6 +93,23 @@ describe('config hook', () => {
     // we don't hand it a competing value to merge in.
     expect(result.server.cors).toBeUndefined()
   })
+
+  test('does NOT override an explicit server.cors: false (a falsy-but-set value)', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-plugin-config-'))
+    await mkdir(join(dir, 'src/components'), { recursive: true })
+
+    const plugin = makePlugin('src/components', 'internal/views')
+    const result = await plugin.config(
+      { root: dir, server: { cors: false } },
+      { command: 'serve', mode: 'development' },
+    )
+
+    // `server.cors = false` explicitly DISABLES cors — `!false` is `true`,
+    // so a naive `if (!userConfig.server?.cors)` check would wrongly treat
+    // this the same as "unset" and clobber it with the localhost default.
+    // The fix checks `=== undefined` specifically; this pins that.
+    expect(result.server.cors).toBeUndefined()
+  })
 })
 
 describe('resolveId hook', () => {

--- a/packages/vite/src/__tests__/plugin.test.ts
+++ b/packages/vite/src/__tests__/plugin.test.ts
@@ -64,6 +64,35 @@ describe('config hook', () => {
 
     expect(Object.keys(result.build.rollupOptions.input)).toEqual([])
   })
+
+  test('fills in a localhost-only server.cors default when the user set none', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-plugin-config-'))
+    await mkdir(join(dir, 'src/components'), { recursive: true })
+
+    const plugin = makePlugin('src/components', 'internal/views')
+    const result = await plugin.config({ root: dir }, { command: 'serve', mode: 'development' })
+
+    expect(result.server.cors).toBeDefined()
+    expect(result.server.cors.origin.test('http://localhost:3010')).toBe(true)
+    expect(result.server.cors.origin.test('https://evil.example.com')).toBe(false)
+  })
+
+  test('does NOT overwrite a user-supplied server.cors', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-plugin-config-'))
+    await mkdir(join(dir, 'src/components'), { recursive: true })
+
+    const plugin = makePlugin('src/components', 'internal/views')
+    const userCors = { origin: 'https://my-own-cors-policy.example.com' }
+    const result = await plugin.config(
+      { root: dir, server: { cors: userCors } },
+      { command: 'serve', mode: 'development' },
+    )
+
+    // The plugin's `server` return has no `cors` key at all in this case —
+    // Vite's config merge leaves the user's `server.cors` untouched only if
+    // we don't hand it a competing value to merge in.
+    expect(result.server.cors).toBeUndefined()
+  })
 })
 
 describe('resolveId hook', () => {

--- a/packages/vite/src/compile-cache.ts
+++ b/packages/vite/src/compile-cache.ts
@@ -50,6 +50,13 @@ export class CompileCache {
     return this.rows.get(absPath)?.result
   }
 
+  /** Drop a single file's cached entry — used when a file is deleted
+   * (dev watcher `'unlink'`) so a later file recreated at the same path
+   * never reuses a stale result keyed only by path, not content. */
+  delete(absPath: string): void {
+    this.rows.delete(absPath)
+  }
+
   clear(): void {
     this.rows.clear()
   }

--- a/packages/vite/src/debounced-serial-runner.ts
+++ b/packages/vite/src/debounced-serial-runner.ts
@@ -1,0 +1,69 @@
+/**
+ * Debounce + serialize an async task behind a single `trigger()` entry
+ * point. Built for `configureServer`'s watcher handlers: a burst of
+ * `'change'`/`'add'`/`'unlink'` events (save-twice-quickly, a multi-file
+ * save, a `git checkout` touching many files) must not start several
+ * overlapping eager passes writing the same template files — the legacy
+ * CLI's `watch()` (`packages/cli/src/lib/build.ts`) debounced at 100ms for
+ * exactly this reason.
+ *
+ * Two, deliberately separate, guarantees:
+ *  - **debounce**: `trigger()` calls within `debounceMs` of each other
+ *    collapse into a single scheduled run.
+ *  - **serialize + coalesce**: if `task()` is still running when the
+ *    debounce timer fires, this does NOT start a second, overlapping
+ *    call — it marks exactly one follow-up run, which starts the instant
+ *    the in-flight one finishes. A change arriving mid-pass is delayed,
+ *    never dropped, and at most one run is ever in flight.
+ *
+ * Deliberately minimal: no queue of distinct payloads, no rehashing —
+ * `task()` itself (the caller's full eager pass) is the unit of work, and
+ * it re-discovers everything from disk on every call, so "run it again"
+ * is always correct regardless of how many trigger()s piled up.
+ */
+export interface DebouncedSerialRunner {
+  /** Schedule a run, debounced. Safe to call from multiple event sources. */
+  trigger(): void
+}
+
+export function createDebouncedSerialRunner(
+  task: () => Promise<void>,
+  debounceMs: number,
+  onError: (err: unknown) => void,
+): DebouncedSerialRunner {
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  let running: Promise<void> | null = null
+  let rerunQueued = false
+
+  function runOnce(): void {
+    if (running) {
+      // A task is already in flight — don't start a second one racing it
+      // to write the same files. Queue exactly one follow-up instead;
+      // repeated triggers while running collapse into that same single
+      // follow-up (the `do`/`while` below re-checks the flag, not a count).
+      rerunQueued = true
+      return
+    }
+
+    running = (async () => {
+      do {
+        rerunQueued = false
+        await task()
+      } while (rerunQueued)
+    })()
+      .catch(onError)
+      .finally(() => {
+        running = null
+      })
+  }
+
+  return {
+    trigger() {
+      if (debounceTimer) clearTimeout(debounceTimer)
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null
+        runOnce()
+      }, debounceMs)
+    },
+  }
+}

--- a/packages/vite/src/dev-server.ts
+++ b/packages/vite/src/dev-server.ts
@@ -37,6 +37,15 @@ const FS_SERVE_PREFIX = '@fs'
  */
 export const DEFAULT_DEV_CORS_ORIGIN = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/
 
+/**
+ * Debounce window (ms) for the dev watcher's `'change'` / `'add'` /
+ * `'unlink'` handlers, matching the legacy CLI's `watch()`
+ * (`packages/cli/src/lib/build.ts`) — long enough to coalesce a
+ * save-twice-quickly or a multi-file save/`git checkout` into a single
+ * eager pass, short enough that a reload still feels instant.
+ */
+export const DEV_WATCH_DEBOUNCE_MS = 100
+
 /** Posix-normalize an absolute filesystem path (Windows uses `sep`; POSIX
  * paths already use `/`). */
 function toPosixAbsolute(absPath: string): string {

--- a/packages/vite/src/dev-server.ts
+++ b/packages/vite/src/dev-server.ts
@@ -1,0 +1,140 @@
+/**
+ * Dev-server-only helpers for the `configureServer` hook: computing the
+ * dev origin, building the two-URL `scriptAssets` list a `'use client'`
+ * component needs in dev (the `@vite/client` HMR/full-reload socket plus
+ * the component's own `.tsx` module), the localhost-only CORS default,
+ * and the on-disk marker that flags a `templates` directory as holding
+ * dev artifacts (localhost URLs baked in) rather than production output.
+ *
+ * The pure, easily-unit-tested pieces live here; the orchestration
+ * (compiling, writing files, wiring the watcher) stays in `plugin.ts`
+ * where the shared `CompileCache` / `componentDirs` / `templatesDir`
+ * closures already live.
+ */
+import { sep } from 'node:path'
+import type { ResolvedConfig, ViteDevServer } from 'vite'
+import { joinBaseAndFile } from './manifest.ts'
+
+/**
+ * Vite's absolute-path passthrough prefix (`/@fs/…`, `FS_PREFIX` in Vite's
+ * own source) for serving files outside the project root. Needed because
+ * `components` dirs are commonly siblings of the Vite project root in this
+ * monorepo's real layouts — an app's `vite.config.ts` root is the backend
+ * app directory, while shared components live in a sibling `ui/`-style
+ * directory Vite's default dev serving otherwise refuses (only `root` and
+ * its subdirectories are served as plain paths).
+ */
+const FS_SERVE_PREFIX = '@fs'
+
+/**
+ * Localhost-only CORS default this plugin fills in — ONLY when the user
+ * hasn't configured `server.cors` themselves (see the `config` hook in
+ * `plugin.ts`). Vite 6+ defaults `cors` to same-origin-only, which breaks
+ * the cross-origin split this plugin sets up (the page is rendered by the
+ * backend on its own origin; modules are served by Vite on another)
+ * unless something opts localhost origins in. Deliberately not a wildcard
+ * `true` — see the PR brief for the reasoning.
+ */
+export const DEFAULT_DEV_CORS_ORIGIN = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/
+
+/** Posix-normalize an absolute filesystem path (Windows uses `sep`; POSIX
+ * paths already use `/`). */
+function toPosixAbsolute(absPath: string): string {
+  return absPath.split(sep).join('/')
+}
+
+/**
+ * The request path (relative to `config.base`, no leading slash) a browser
+ * must use to reach `absPath` through Vite's dev server: a root-relative
+ * path when `absPath` is under `config.root`, or Vite's `/@fs/`
+ * absolute-path passthrough when it isn't.
+ */
+export function devRequestPath(config: Pick<ResolvedConfig, 'root'>, absPath: string): string {
+  const posixAbs = toPosixAbsolute(absPath)
+  const posixRoot = toPosixAbsolute(config.root)
+  if (posixAbs === posixRoot) return ''
+  if (posixAbs.startsWith(`${posixRoot}/`)) return posixAbs.slice(posixRoot.length + 1)
+  return `${FS_SERVE_PREFIX}${posixAbs}`
+}
+
+/** Full absolute URL (origin + `base` + request path) for `absPath` under
+ * the dev server. */
+export function devModuleUrl(
+  config: Pick<ResolvedConfig, 'root' | 'base'>,
+  origin: string,
+  absPath: string,
+): string {
+  return `${origin}${joinBaseAndFile(config.base, devRequestPath(config, absPath))}`
+}
+
+/**
+ * The ordered `scriptAssets` a `'use client'` component needs in dev: the
+ * `@vite/client` HMR/full-reload socket first (so the page always gets a
+ * live-reload connection), then the component's own module — Vite serves
+ * it plain-JS via this plugin's `transform` hook exactly like it would any
+ * other dev module, no different from a production entry. Per the design,
+ * server-only components (no `'use client'`) get `[]` — computed by the
+ * caller without consulting this function at all, see `plugin.ts`.
+ */
+export function devScriptAssets(
+  config: Pick<ResolvedConfig, 'root' | 'base'>,
+  origin: string,
+  absPath: string,
+): string[] {
+  return [
+    `${origin}${joinBaseAndFile(config.base, '@vite/client')}`,
+    devModuleUrl(config, origin, absPath),
+  ]
+}
+
+/**
+ * The dev origin to bake into `scriptAssets`: the user's own
+ * `server.origin` if they set one, otherwise `http://localhost:<port>`
+ * using the port Vite actually bound — NOT the configured port, which can
+ * be wrong (Vite auto-increments past an in-use port unless `strictPort`
+ * is set). Also writes the computed default back onto
+ * `server.config.server.origin` so Vite's OWN asset-URL rewriting
+ * (`import.meta.url`, CSS `url()`, etc.) agrees with the URLs this plugin
+ * bakes into templates — both need to match for the cross-origin split
+ * (page from the backend, assets from Vite) to work end to end.
+ *
+ * Call only after the server is actually listening (`httpServer`'s
+ * `'listening'` event) — the resolved port isn't known before then.
+ */
+export function resolveDevOrigin(server: ViteDevServer): string {
+  const configured = server.config.server.origin
+  if (configured) return configured
+
+  const address = server.httpServer?.address()
+  const port = address && typeof address === 'object' ? address.port : (server.config.server.port ?? 5173)
+  const origin = `http://localhost:${port}`
+  server.config.server.origin = origin
+  return origin
+}
+
+/**
+ * Filename of the marker BarefootJS writes at the root of `templates`
+ * while the dev server is running, so a stray `git add` or a production
+ * deploy of dev-only output (localhost URLs baked into every template) is
+ * obvious before it ships. `writeBundle` (the `vite build` path) removes
+ * it — see `plugin.ts`.
+ *
+ * A per-template, per-adapter comment (Go `{{/* … *\/}}`, ERB `<%# … %>`,
+ * etc.) would pinpoint the problem more precisely, but needs new surface
+ * on every `TemplateAdapter` implementation across 9+ adapter packages —
+ * out of scope for a dev-server PR that touches none of them. The brief
+ * explicitly allows this single-file fallback in that case.
+ */
+export const DEV_ARTIFACT_MARKER_FILENAME = '.barefootjs-dev-build'
+
+export const DEV_ARTIFACT_MARKER_CONTENT = `This directory currently holds DEV BUILD OUTPUT from @barefootjs/vite's
+dev server, not a production build.
+
+Every template in this directory has dev-only URLs baked into it
+(http://localhost:<port>/...) pointing at the Vite dev server. They will
+break if committed, deployed, or served without that dev server running.
+
+Run \`vite build\` to regenerate this directory with real, hashed,
+production asset URLs — the build overwrites every template here and
+removes this file.
+`

--- a/packages/vite/src/discover.ts
+++ b/packages/vite/src/discover.ts
@@ -33,6 +33,23 @@ export function hasUseClientDirective(content: string): boolean {
 }
 
 /**
+ * Is `name` (a bare filename, not a path) a component source file this
+ * plugin should discover/compile? `.tsx`, excluding `.test.tsx`,
+ * `.spec.tsx`, and `.preview.tsx`. Exported separately from
+ * `discoverComponentFiles` so the dev-server file watcher (`plugin.ts`'s
+ * `configureServer`) can apply the exact same filter to a single changed
+ * path without re-walking a directory.
+ */
+export function isComponentSourceFile(name: string): boolean {
+  return (
+    name.endsWith('.tsx') &&
+    !name.endsWith('.test.tsx') &&
+    !name.endsWith('.spec.tsx') &&
+    !name.endsWith('.preview.tsx')
+  )
+}
+
+/**
  * Recursively discover `.tsx` component files in a directory.
  * Skips `.test.tsx`, `.spec.tsx`, and `.preview.tsx` files.
  */
@@ -57,12 +74,7 @@ export async function discoverComponentFiles(
     if (entry.isDirectory()) {
       if (skipDirs?.has(String(entry.name))) continue
       results.push(...await discoverComponentFiles(fullPath, options))
-    } else if (
-      String(entry.name).endsWith('.tsx') &&
-      !String(entry.name).endsWith('.test.tsx') &&
-      !String(entry.name).endsWith('.spec.tsx') &&
-      !String(entry.name).endsWith('.preview.tsx')
-    ) {
+    } else if (isComponentSourceFile(String(entry.name))) {
       results.push(fullPath)
     }
   }

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -9,35 +9,50 @@
  *      reach from `build.rollupOptions.input`; this plugin compiles each
  *      one and hands back plain client JS for Rollup to bundle, hash,
  *      tree-shake, chunk, and minify like any other module.
- *   2. eager pass (`writeBundle`) — walks every `.tsx` under `components`
- *      directly, NOT via the module graph. Server-only components (no
- *      `'use client'`) never appear in the graph at all (nothing imports
- *      them as a script, so Rollup never visits them) but still need a
- *      template — this pass is the only place that happens. Runs in
- *      `writeBundle` specifically because the Vite manifest is only final
- *      once Rollup has finished hashing output filenames.
+ *   2. eager pass (`writeBundle` for `vite build`, `configureServer` for
+ *      `vite dev`) — walks every `.tsx` under `components` directly, NOT
+ *      via the module graph. Server-only components (no `'use client'`)
+ *      never appear in the graph at all (nothing imports them as a
+ *      script, so Rollup never visits them) but still need a template —
+ *      this pass is the only place that happens. The build variant runs
+ *      in `writeBundle` specifically because the Vite manifest is only
+ *      final once Rollup has finished hashing output filenames; the dev
+ *      variant runs once the dev server starts listening (the resolved
+ *      port is needed to build dev-origin URLs) and again on every
+ *      tracked `.tsx` change.
  *
  * Both passes share one `CompileCache` (§4) so a given file's content is
  * compiled at most twice: once canonically (`scriptAssets: []`, cached,
  * shared by both passes — this is the ONLY compile a server-only file, or
  * any file whose real `scriptAssets` also turns out to be `[]`, ever
- * needs) and, only for a `'use client'` file whose manifest entry resolves
- * to a non-empty URL list, one further compile with the real
- * `scriptAssets` to bake the correct URL into the template. That second
- * compile is unavoidable within `compileJSX`'s current API shape: a
- * component's template and its client JS are produced by ONE call, but
- * only the template depends on `scriptAssets` (client JS comes from an
- * entirely separate codegen path `adapter.generate()` never touches) — and
- * `scriptAssets` can't be known until Rollup has already hashed the
- * bundle, which requires `transform` to have already run. So `transform`
- * unavoidably compiles once per file before the real URL exists, and
- * `writeBundle` MUST recompile once more, only for the strict subset of
- * files whose true `scriptAssets` differs from the cached `[]` canonical
- * form, to get a template with the correct URL baked in.
+ * needs) and, only for a `'use client'` file whose real script list
+ * (manifest-resolved for build, dev-origin-based for dev) resolves to a
+ * non-empty URL list, one further compile with the real `scriptAssets` to
+ * bake the correct URL into the template. That second compile is
+ * unavoidable within `compileJSX`'s current API shape: a component's
+ * template and its client JS are produced by ONE call, but only the
+ * template depends on `scriptAssets` (client JS comes from an entirely
+ * separate codegen path `adapter.generate()` never touches) — and for the
+ * build variant, `scriptAssets` can't be known until Rollup has already
+ * hashed the bundle, which requires `transform` to have already run. So
+ * `transform` unavoidably compiles once per file before the real URL
+ * exists, and the eager pass MUST recompile once more, only for the
+ * strict subset of files whose true `scriptAssets` differs from the
+ * cached `[]` canonical form, to get a template with the correct URL
+ * baked in.
+ *
+ * Dev's `configureServer` intentionally does NOT diff what changed and
+ * recompile only that file's dependents — it re-runs the ENTIRE eager
+ * pass on every tracked change. A change to a shared signal module or a
+ * child component changes the *parent's* template too, so anything less
+ * than a full re-run needs dependency tracking (the complexity this
+ * migration is deleting from the legacy CLI's `build-cache.ts`). The
+ * content-hash `CompileCache` makes the full pass cheap: every unchanged
+ * file's `compileCanonical` call is a cache hit.
  */
-import { readFile } from 'node:fs/promises'
+import { readFile, rm, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
-import type { Plugin, ResolvedConfig } from 'vite'
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
 import {
   compileJSX,
   formatError,
@@ -45,11 +60,18 @@ import {
 } from '@barefootjs/jsx'
 import type { BarefootViteOptions } from './types.ts'
 import { CompileCache } from './compile-cache.ts'
-import { discoverComponents, type DiscoveredComponent } from './discover.ts'
+import { discoverComponents, isComponentSourceFile, type DiscoveredComponent } from './discover.ts'
 import { resolveClientJsSpecifier } from './resolve-client-js.ts'
 import { buildRelativeImportRewriter, toPosixRelative } from './paths.ts'
 import { loadManifest, resolveScriptAssets } from './manifest.ts'
 import { planEmits, writeEmits } from './emit.ts'
+import {
+  DEFAULT_DEV_CORS_ORIGIN,
+  DEV_ARTIFACT_MARKER_CONTENT,
+  DEV_ARTIFACT_MARKER_FILENAME,
+  devScriptAssets,
+  resolveDevOrigin,
+} from './dev-server.ts'
 
 const PLUGIN_NAME = 'barefoot'
 
@@ -109,6 +131,63 @@ export function barefoot(options: BarefootViteOptions): Plugin {
     return componentDirs.some(dir => absPath === dir || absPath.startsWith(`${dir}/`))
   }
 
+  /**
+   * Shared eager-pass body: compile + emit a template for every discovered
+   * component, resolving each `'use client'` component's real
+   * `scriptAssets` via the caller-supplied `resolveScriptAssetsFor` (the
+   * manifest for `writeBundle`, dev-origin URLs for `configureServer`).
+   * See this module's docstring for why both callers need the FULL
+   * discovered set every time, not just what changed.
+   */
+  async function emitTemplatesFor(
+    discovered: DiscoveredComponent[],
+    projectDir: string,
+    resolveScriptAssetsFor: (component: DiscoveredComponent) => string[],
+  ): Promise<void> {
+    for (const component of discovered) {
+      const content = await readFile(component.absPath, 'utf8')
+      const canonical = compileCanonical(component.absPath, content)
+      reportErrors(canonical, content, projectDir)
+
+      let result = canonical
+      if (component.isClient) {
+        const scriptAssets = resolveScriptAssetsFor(component)
+        if (scriptAssets.length > 0) {
+          result = compileJSX(content, component.absPath, {
+            adapter: options.adapter,
+            sourceMaps: true,
+            scriptAssets,
+            rewriteRelativeImport: rewriterFor(component.absPath),
+          })
+          reportErrors(result, content, projectDir)
+        }
+      }
+
+      const targets = planEmits(result, component.absPath, componentDirs, options.adapter)
+      await writeEmits(templatesDir, targets)
+    }
+  }
+
+  /**
+   * Dev variant of the eager pass: discovers every component fresh (a
+   * changed file's new content must be picked up — `CompileCache` keys on
+   * content hash, so a stale in-memory listing is harmless, but a stale
+   * listing that MISSES a newly added file would not be) and bakes
+   * `devOrigin`-based `scriptAssets` instead of manifest-resolved ones.
+   * Also (re)writes the dev-artifact marker — see `dev-server.ts`.
+   */
+  async function runDevEagerPass(devOrigin: string): Promise<void> {
+    const config = resolvedConfig
+    if (!config) return
+
+    const discovered = await discoverComponents(componentDirs, absPath => readFile(absPath, 'utf8'))
+    await emitTemplatesFor(discovered, config.root, component =>
+      devScriptAssets(config, devOrigin, component.absPath),
+    )
+
+    await writeFile(resolve(templatesDir, DEV_ARTIFACT_MARKER_FILENAME), DEV_ARTIFACT_MARKER_CONTENT)
+  }
+
   return {
     name: PLUGIN_NAME,
     enforce: 'pre',
@@ -134,12 +213,29 @@ export function barefoot(options: BarefootViteOptions): Plugin {
         input[toPosixRelative(guessedRoot, c.absPath)] = c.absPath
       }
 
+      // Cross-origin dev default: the page comes from the backend, its
+      // module scripts from Vite — two different origins. Vite 6+ defaults
+      // `cors` to same-origin-only, which would reject those cross-origin
+      // module requests outright. Fill in a localhost-only default ONLY
+      // when the user hasn't set `server.cors` themselves — this stays a
+      // 3-option plugin (`adapter` / `components` / `templates`); no 4th
+      // `devOrigin`-style option is added for this. Done here in `config`
+      // (not `configureServer`) so it lands before Vite installs its own
+      // CORS middleware, and so it's plain, synchronously-testable data
+      // instead of a hook-timing dependency on Vite's internal
+      // configureServer/middleware install order.
+      const serverDefaults: Record<string, unknown> = {}
+      if (!userConfig.server?.cors) {
+        serverDefaults.cors = { origin: DEFAULT_DEV_CORS_ORIGIN }
+      }
+
       return {
         appType: 'custom',
         build: {
           manifest: true,
           rollupOptions: { input },
         },
+        server: serverDefaults,
       }
     },
 
@@ -183,29 +279,66 @@ export function barefoot(options: BarefootViteOptions): Plugin {
       const outDir = resolve(config.root, config.build.outDir)
       const manifest = await loadManifest(outDir, config.build.manifest)
 
-      for (const component of discovered) {
-        const content = await readFile(component.absPath, 'utf8')
-        const canonical = compileCanonical(component.absPath, content)
-        reportErrors(canonical, content, config.root)
+      await emitTemplatesFor(discovered, config.root, component => {
+        const manifestKey = toPosixRelative(config.root, component.absPath)
+        return resolveScriptAssets(manifest, manifestKey, config.base)
+      })
 
-        let result = canonical
-        if (component.isClient) {
-          const manifestKey = toPosixRelative(config.root, component.absPath)
-          const scriptAssets = resolveScriptAssets(manifest, manifestKey, config.base)
-          if (scriptAssets.length > 0) {
-            result = compileJSX(content, component.absPath, {
-              adapter: options.adapter,
-              sourceMaps: true,
-              scriptAssets,
-              rewriteRelativeImport: rewriterFor(component.absPath),
-            })
-            reportErrors(result, content, config.root)
-          }
-        }
+      // A prior `vite dev` run may have left the dev-artifact marker (and
+      // dev-origin URLs) behind — this pass just overwrote every template
+      // with production URLs, so the marker is now stale. Best-effort:
+      // there may never have been one.
+      await rm(resolve(templatesDir, DEV_ARTIFACT_MARKER_FILENAME), { force: true })
+    },
 
-        const targets = planEmits(result, component.absPath, componentDirs, options.adapter)
-        await writeEmits(templatesDir, targets)
+    configureServer(server: ViteDevServer) {
+      // Mandatory: Vite's dev watcher only reliably covers the module
+      // graph plus whatever's under its own project `root`. Server-only
+      // components (no `'use client'`) never enter the module graph at
+      // all (nothing imports them as a script), and in this monorepo's
+      // real layouts `components` dirs are commonly siblings of — not
+      // descendants of — the Vite project root (an app's `vite.config.ts`
+      // root is the backend app dir; components live in a shared `ui/`
+      // directory next to it). Without this explicit `add`, editing such
+      // a file is silently invisible to the dev server: no watcher event,
+      // no re-emit, no reload. See `e2e-vite-dev.test.ts`'s server-only /
+      // out-of-root regression coverage.
+      for (const dir of componentDirs) {
+        server.watcher.add(dir)
       }
+
+      let devOrigin: string | undefined
+
+      async function runInitialPass(): Promise<void> {
+        devOrigin = resolveDevOrigin(server)
+        await runDevEagerPass(devOrigin)
+      }
+
+      if (server.httpServer) {
+        // The resolved port isn't known until the server actually starts
+        // listening — Vite auto-increments past an in-use configured port
+        // unless `strictPort` is set, so anything read earlier could be
+        // wrong. `configureServer` itself always runs before `listen()`.
+        server.httpServer.once('listening', () => {
+          runInitialPass().catch(err => server.config.logger.error(String(err)))
+        })
+      } else {
+        // Middleware mode: no `httpServer`, so no `'listening'` event ever
+        // fires. Run immediately with whatever origin is already
+        // configured (or the bare `localhost:<configured port>` fallback
+        // inside `resolveDevOrigin`).
+        runInitialPass().catch(err => server.config.logger.error(String(err)))
+      }
+
+      server.watcher.on('change', (file: string) => {
+        if (!isComponentSourceFile(file) || !isUnderComponentDir(file)) return
+        if (!devOrigin) return // initial pass (above) will cover this file once it runs
+
+        ;(async () => {
+          await runDevEagerPass(devOrigin!)
+          server.ws.send({ type: 'full-reload' })
+        })().catch(err => server.config.logger.error(String(err)))
+      })
     },
   }
 }

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -64,14 +64,16 @@ import { discoverComponents, isComponentSourceFile, type DiscoveredComponent } f
 import { resolveClientJsSpecifier } from './resolve-client-js.ts'
 import { buildRelativeImportRewriter, toPosixRelative } from './paths.ts'
 import { loadManifest, resolveScriptAssets } from './manifest.ts'
-import { planEmits, writeEmits } from './emit.ts'
+import { planEmits, writeEmits, type EmitTarget } from './emit.ts'
 import {
   DEFAULT_DEV_CORS_ORIGIN,
   DEV_ARTIFACT_MARKER_CONTENT,
   DEV_ARTIFACT_MARKER_FILENAME,
+  DEV_WATCH_DEBOUNCE_MS,
   devScriptAssets,
   resolveDevOrigin,
 } from './dev-server.ts'
+import { createDebouncedSerialRunner } from './debounced-serial-runner.ts'
 
 const PLUGIN_NAME = 'barefoot'
 
@@ -89,6 +91,15 @@ function reportErrors(result: CompileResult, source: string, projectDir: string)
 
 export function barefoot(options: BarefootViteOptions): Plugin {
   const cache = new CompileCache()
+
+  // What `emitTemplatesFor` last wrote for a given source file, keyed by
+  // absolute path. The ONLY consumer is the dev watcher's `'unlink'`
+  // handler: when a component file is deleted, this is how it knows which
+  // on-disk template/ssrDefaults/types files to remove without having to
+  // re-derive the (possibly `templatesPerComponent`, i.e. named after the
+  // exported component rather than the source file) output path from a
+  // file that no longer exists to read.
+  const lastEmitsByAbsPath = new Map<string, EmitTarget[]>()
 
   // Populated (redundantly but cheaply — a directory walk, no compiling)
   // once in `config` with a best-effort root, so `rollupOptions.input` can
@@ -164,7 +175,28 @@ export function barefoot(options: BarefootViteOptions): Plugin {
       }
 
       const targets = planEmits(result, component.absPath, componentDirs, options.adapter)
+      lastEmitsByAbsPath.set(component.absPath, targets)
       await writeEmits(templatesDir, targets)
+    }
+  }
+
+  /**
+   * Remove whatever `emitTemplatesFor` last wrote for each of `absPaths`
+   * (a deleted component's template, `ssrDefaults`, and `.types` fragment)
+   * and forget it — both from the emit-tracking map and the compile
+   * cache, so a file later recreated at the same path never reuses a
+   * stale cached result. Best-effort: `rm(..., { force: true })` so a
+   * file already gone (or never successfully written) isn't an error.
+   */
+  async function removeEmitsFor(absPaths: Iterable<string>): Promise<void> {
+    for (const absPath of absPaths) {
+      const targets = lastEmitsByAbsPath.get(absPath)
+      lastEmitsByAbsPath.delete(absPath)
+      cache.delete(absPath)
+      if (!targets) continue
+      for (const target of targets) {
+        await rm(resolve(templatesDir, target.relPath), { force: true })
+      }
     }
   }
 
@@ -224,8 +256,14 @@ export function barefoot(options: BarefootViteOptions): Plugin {
       // CORS middleware, and so it's plain, synchronously-testable data
       // instead of a hook-timing dependency on Vite's internal
       // configureServer/middleware install order.
+      //
+      // Checked against `undefined` specifically, NOT falsiness: a user
+      // who writes `server.cors = false` to explicitly DISABLE CORS means
+      // exactly that, and `!false` is `true` — a truthiness check would
+      // silently override their choice with this default, the opposite of
+      // "only fill in when unset".
       const serverDefaults: Record<string, unknown> = {}
-      if (!userConfig.server?.cors) {
+      if (userConfig.server?.cors === undefined) {
         serverDefaults.cors = { origin: DEFAULT_DEV_CORS_ORIGIN }
       }
 
@@ -308,6 +346,33 @@ export function barefoot(options: BarefootViteOptions): Plugin {
       }
 
       let devOrigin: string | undefined
+      // Deleted files queued for cleanup by the `'unlink'` handler,
+      // drained by the runner's own task the next time it actually runs —
+      // NOT deleted synchronously in the handler, so an unlink that lands
+      // while a pass is already in flight for other reasons is still
+      // batched into the SAME follow-up run as everything else instead of
+      // racing it.
+      const pendingUnlinks = new Set<string>()
+
+      // One serialized, debounced entry point for every dev-watcher event
+      // this plugin reacts to (`change` / `add` / `unlink`). See
+      // `debounced-serial-runner.ts`: a burst of events collapses into one
+      // pass, an event arriving mid-pass is queued as exactly one
+      // follow-up (never dropped, never overlapped), and no distinction
+      // needs to be drawn between which files changed — the pass itself
+      // re-discovers everything from disk (see this module's docstring on
+      // why a diff-based re-run is the wrong shape here).
+      const devPassRunner = createDebouncedSerialRunner(
+        async () => {
+          if (!devOrigin) return // initial pass (below) will cover current disk state once it runs
+          await removeEmitsFor(pendingUnlinks)
+          pendingUnlinks.clear()
+          await runDevEagerPass(devOrigin)
+          server.ws.send({ type: 'full-reload' })
+        },
+        DEV_WATCH_DEBOUNCE_MS,
+        err => server.config.logger.error(String(err)),
+      )
 
       async function runInitialPass(): Promise<void> {
         devOrigin = resolveDevOrigin(server)
@@ -330,14 +395,29 @@ export function barefoot(options: BarefootViteOptions): Plugin {
         runInitialPass().catch(err => server.config.logger.error(String(err)))
       }
 
+      // `'change'`: an existing tracked file's content changed.
       server.watcher.on('change', (file: string) => {
         if (!isComponentSourceFile(file) || !isUnderComponentDir(file)) return
-        if (!devOrigin) return // initial pass (above) will cover this file once it runs
+        devPassRunner.trigger()
+      })
 
-        ;(async () => {
-          await runDevEagerPass(devOrigin!)
-          server.ws.send({ type: 'full-reload' })
-        })().catch(err => server.config.logger.error(String(err)))
+      // `'add'`: a brand-new component file. Without this, a file created
+      // mid-session gets no template at all until some OTHER file happens
+      // to change and drags it along on the next full pass — creating a
+      // component is completely ordinary, not an edge case.
+      server.watcher.on('add', (file: string) => {
+        if (!isComponentSourceFile(file) || !isUnderComponentDir(file)) return
+        devPassRunner.trigger()
+      })
+
+      // `'unlink'`: a tracked file was deleted. Its template would
+      // otherwise linger on disk forever — queue it for `removeEmitsFor`
+      // inside the same debounced/serialized pass rather than deleting
+      // synchronously here (see `pendingUnlinks` above).
+      server.watcher.on('unlink', (file: string) => {
+        if (!isComponentSourceFile(file) || !isUnderComponentDir(file)) return
+        pendingUnlinks.add(file)
+        devPassRunner.trigger()
       })
     },
   }


### PR DESCRIPTION
**Stack 3/7** — targets #2496, which targets #2494. Review those first.

## What

The dev half of the plugin. `vite dev` now serves each `"use client"` component's compiled client JS as a module, emits templates carrying dev-origin URLs, and reloads the page when a component changes — replacing today's "run `bf build --watch` in one terminal, the backend in another, and hope the sentinel poll notices."

The backend needs no changes. gin already re-parses its templates per request in dev (`integrations/gin/main.go`, `currentTemplates()` gated on `bfdev.IsDevDefault()`), precisely so a `build:watch` rebuild shows up on refresh, so writing templates to disk is sufficient. This also retires the `dist/.dev/build-id` sentinel the browser polls today — Vite's websocket replaces it.

## Design points worth reviewing

**`server.watcher.add()` on the component dirs is mandatory, not defensive.** Vite's watcher covers the module graph plus whatever is under its own `root`. Server-only components never enter the graph (nothing imports them as a script), and in realistic layouts the components dir is a *sibling* of the Vite root rather than a descendant — an app's `vite.config.ts` root is the backend app dir, components live in a shared dir next to it. Without the explicit add, editing such a file is silently invisible: no event, no re-emit, no reload.

**The dev pass re-runs the whole eager pass, deliberately.** A change to a shared signal module or a child component changes the *parent's* template, so anything less needs dependency tracking — the exact complexity this migration is deleting from the legacy CLI's `build-cache.ts`. The content-hash compile cache makes the full pass cheap: every unchanged file is a cache hit.

**CORS and origin resolve in different hooks.** The design doc put both in `config`; they are split here. The CORS default is plain mergeable data, so it lands in `config` where it precedes Vite's own CORS middleware and is synchronously testable, rather than depending on internal hook ordering. The origin can only resolve in `configureServer`'s `listening` handler, because the real port comes from `httpServer.address()` — with `strictPort: false` Vite auto-increments past a busy configured port, so anything read earlier can be wrong. Middleware mode (no `httpServer`, no `listening` event) falls back to running immediately.

**Dev `scriptAssets`** = `[origin + '/@vite/client', origin + <component dev module URL>]` for client components, `[]` for server-only. The component URL goes through Vite's `/@fs/` passthrough when the file is outside root.

**Dev-artifact marker**: `templates/.barefootjs-dev-build`, written on every dev pass and removed by `writeBundle`. This is the single-marker fallback rather than per-adapter template comments — doing it properly means new `TemplateAdapter` surface across nine adapter packages, which is not a dev-server PR's business.

## Testing

91 pass, 0 fail (up from 56). The dev tests start a real Vite dev server via `createServer` and assert over HTTP, mirroring how #2496's build test runs a real `vite build`.

One test-quality note worth recording: the first version of the "editing a server-only component reloads" regression **passed with `server.watcher.add()` deliberately disabled**. Vite's internal `ensureWatchedFile` adds any file it has transformed to the watcher regardless of this plugin, and since the eager pass re-emits everything on any change, an unrelated edit to an auto-watched component was enough to pick up the server-only file's already-changed disk content and pass by coincidence. It was rewritten onto a dedicated server instance that never fetches a client component over HTTP, then verified by disabling `watcher.add()` again and seeing it time out. Every fix below was checked the same way — disable the fix, confirm the test goes red, re-enable.

## Three fixes from review

- **`server.cors: false` was silently overridden.** The guard was `!userConfig.server?.cors`, which is also true for `false` — so a user explicitly disabling CORS got the plugin's default instead, the opposite of what they asked for. Now `=== undefined`, with a test pinning `false` specifically since that is the value distinguishing falsy from unset.
- **Creating or deleting a component mid-session did nothing.** Only `'change'` was subscribed; chokidar emits `'add'` and `'unlink'` separately, so a new component produced no template until some unrelated file changed, and a deleted one left its template on disk forever. Both are the same silently-invisible failure class as the watcher gap. `'unlink'` needs to delete files derived from a path that no longer exists, solved by having the emit pass record what it last wrote per source file and consulting that map on removal.
- **Rapid changes ran overlapping passes.** No serialization: save-twice, a multi-file save, or a `git checkout` started a second full pass mid-write against the same template files. Added a small dependency-free debounce+serialize primitive — one run per burst, and a change arriving during a run queues exactly one follow-up rather than starting a second or being dropped. The legacy CLI debounced at 100ms for the same reason.

The concurrency guarantee is proven deterministically in a unit test with manually-resolved promises; the e2e test adds a real 8-rapid-writes convergence check. The e2e reload *count* is documented in-test as a soft signal rather than proof, since chokidar's own polling already coalesces near-simultaneous writes before they reach the plugin.

## Out of scope

Fine-grained HMR — `full-reload` is correct here because the page HTML is rendered by the backend, not Vite, so a component change requires a backend re-render. Migrating `integrations/*` is stack 4+. Combining adapter `types` output into one backend-native file (Go's `components.go`) remains the known gap from #2496 and is stack 4's first problem.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ)_