### PR TITLE
fix(perl): ship the tests that were missing from the CPAN MANIFEST

### DIFF
--- a/.changeset/perl-manifest-ship-all-tests.md
+++ b/.changeset/perl-manifest-ship-all-tests.md
@@ -1,0 +1,29 @@
+---
+"@barefootjs/perl": patch
+"@barefootjs/mojolicious": patch
+---
+
+Ship the full test suite in the Perl CPAN tarballs.
+
+Only MANIFEST-listed files are packaged, and `make test` runs `t/*.t` off the
+working tree — so a test missing from MANIFEST passes in CI forever while never
+once running for a CPAN tester. Seven had accumulated in the `BarefootJS` dist
+(`eval_vectors`, `evaluator`, `omit`, `props_attr`, `query`, `render_child`,
+`scope_comment`) and one in `Mojolicious-Plugin-BarefootJS` (`scope_comment`).
+All eight are now listed.
+
+Each was checked against what a CPAN tester actually has: every dependency is
+either core or already declared in the dist's `cpanfile`, and no test reads a
+monorepo path at runtime. `t/eval_vectors.t` reads golden vectors from
+`packages/adapter-tests/`, which is monorepo-only, but guards them with
+`plan skip_all` exactly as the already-shipped `t/helper_vectors.t` does.
+`Mojolicious-Plugin-BarefootJS`'s `t/scope_comment.t` carries a
+`use lib "$Bin/../../adapter-perl/lib"` for monorepo runs; a missing directory
+is a no-op for `lib.pm`, and `requires 'BarefootJS'` resolves the module from
+`@INC` instead.
+
+Two CI checks in `ci-perl-dist.yml` keep this true. One fails if any `t/*.t` is
+absent from its dist's MANIFEST. The other extracts each built tarball outside
+the checkout and runs its suite there — the working-tree run has the whole
+monorepo on disk, so a shipped test that reaches outside its own dist passes
+there and only fails for a real user.

--- a/.github/workflows/ci-perl-dist.yml
+++ b/.github/workflows/ci-perl-dist.yml
@@ -44,6 +44,27 @@ jobs:
         # the full runtime chain for named-IANA-zone resolution in format_date.
         run: cpanm --notest Module::CPANfile Test2::Suite Text::Xslate Mojolicious DateTime
 
+      # Only MANIFEST-listed files are packaged, and `make test` runs t/*.t off
+      # the working tree — so a test missing from MANIFEST passes here forever
+      # while never once running for a CPAN tester. Seven such tests had
+      # accumulated in adapter-perl and one in adapter-mojolicious before this
+      # check existed. `make distcheck` would be the idiomatic tool but reports
+      # every unlisted file (package.json, CHANGELOG.md, …), so scope it to t/.
+      - name: Every t/*.t is listed in MANIFEST
+        run: |
+          status=0
+          for dist in packages/adapter-perl packages/adapter-xslate packages/adapter-mojolicious; do
+            missing=$(comm -23 \
+              <(cd "$dist" && ls t/*.t | sort) \
+              <(grep '^t/' "$dist/MANIFEST" | sort))
+            if [ -n "$missing" ]; then
+              echo "::error::$dist/MANIFEST is missing:"
+              echo "$missing" | sed 's/^/  /'
+              status=1
+            fi
+          done
+          exit $status
+
       # Core must be built and installed first so the backend dists can resolve
       # `requires 'BarefootJS'` from their cpanfile.
       - name: Build, test & install core (BarefootJS)
@@ -67,3 +88,24 @@ jobs:
           perl Makefile.PL
           make test
           make dist
+
+      # The runs above test the working tree, where the whole monorepo is on
+      # disk — a shipped test that reaches outside its own dist still passes.
+      # Re-run each tarball's suite from an extraction OUTSIDE the checkout,
+      # which is what a CPAN tester actually does: only MANIFEST-listed files
+      # exist, and only cpanfile-declared deps are installed. Tests that need
+      # monorepo-only fixtures (t/helper_vectors.t, t/eval_vectors.t) are
+      # expected to `plan skip_all` here rather than fail.
+      - name: Test each tarball standalone, outside the checkout
+        run: |
+          standalone=$(mktemp -d)
+          for tarball in \
+            packages/adapter-perl/BarefootJS-*.tar.gz \
+            packages/adapter-xslate/BarefootJS-Backend-Xslate-*.tar.gz \
+            packages/adapter-mojolicious/Mojolicious-Plugin-BarefootJS-*.tar.gz
+          do
+            echo "::group::$(basename "$tarball")"
+            tar xzf "$(realpath "$tarball")" -C "$standalone"
+            ( cd "$standalone/$(basename "$tarball" .tar.gz)" && perl Makefile.PL && make test )
+            echo "::endgroup::"
+          done

--- a/packages/adapter-mojolicious/MANIFEST
+++ b/packages/adapter-mojolicious/MANIFEST
@@ -12,3 +12,4 @@ t/dev_reload.t
 t/manifest_defaults.t
 t/meta_provides.t
 t/render_named.t
+t/scope_comment.t

--- a/packages/adapter-perl/MANIFEST
+++ b/packages/adapter-perl/MANIFEST
@@ -12,10 +12,17 @@ Makefile.PL
 README.md
 t/controller_cycle.t
 t/dev_reload.t
+t/eval_vectors.t
+t/evaluator.t
 t/format_date.t
 t/helper_vectors.t
 t/manifest_components.t
 t/meta_provides.t
+t/omit.t
+t/props_attr.t
+t/query.t
+t/render_child.t
+t/scope_comment.t
 t/search_params.t
 t/spread_attrs.t
 t/template_primitives.t


### PR DESCRIPTION
Follow-up to #2498, which surfaced this while reading the `make dist` output.

## The gap

Only MANIFEST-listed files are packaged, but `make test` runs `t/*.t` off the working tree. The two never disagree in CI, so a test left out of MANIFEST stays green forever while never once running for a CPAN tester. Eight had accumulated:

| Dist | Not shipped |
| --- | --- |
| `BarefootJS` | `eval_vectors` `evaluator` `omit` `props_attr` `query` `render_child` `scope_comment` |
| `Mojolicious-Plugin-BarefootJS` | `scope_comment` |

`BarefootJS-Backend-Xslate` had no drift.

## Shippable, checked rather than assumed

Not every unlisted test is simply an oversight — some genuinely cannot ship — so each was checked against what a CPAN tester actually has:

- **Dependencies** — every one is core (`Test::More`, `FindBin`, `JSON::PP`, `File::Spec`, `B`, `Scalar::Util`) or already declared in the dist's `cpanfile` (`Test2::V0`, `Mojolicious`, `BarefootJS`). Nothing new to declare.
- **Runtime paths** — no test reads a monorepo path except `t/eval_vectors.t`, which reads golden vectors from `packages/adapter-tests/` and guards them with `plan skip_all`, exactly as the already-shipped `t/helper_vectors.t` does. Shipping it matches that precedent.
- **`use lib` on a monorepo sibling** — `Mojolicious-Plugin-BarefootJS`'s `t/scope_comment.t` has `use lib "$Bin/../lib", "$Bin/../../adapter-perl/lib"`. This was the one that looked unshippable. It isn't: `lib.pm` treats a missing directory as a no-op (it does not die), and `requires 'BarefootJS', '0.30.0'` in the cpanfile resolves the module from `@INC` instead.

## Verification

Reconstructed each tarball from its MANIFEST alone into a directory outside the monorepo, with `BarefootJS` resolved as an installed dependency rather than through the sibling path, and ran the suites there:

```
BarefootJS (16 files)
  ok    t/evaluator.t          16 assertions      <-- newly shipped
  ok    t/omit.t                4 assertions      <-- newly shipped
  ok    t/props_attr.t          4 assertions      <-- newly shipped
  ok    t/query.t               5 assertions      <-- newly shipped
  ok    t/render_child.t        2 assertions      <-- newly shipped
  ok    t/scope_comment.t       3 assertions      <-- newly shipped
  SKIP  t/eval_vectors.t        eval vectors not available outside the monorepo checkout
  SKIP  t/helper_vectors.t      golden vectors not available outside the monorepo checkout
  (+ 8 previously shipped, all ok)

Mojolicious-Plugin-BarefootJS (5 files)
  ok    t/scope_comment.t       2 assertions      <-- newly shipped, sibling path genuinely absent
  (+ 4 previously shipped, all ok)
```

## Keeping it true

Two checks in `ci-perl-dist.yml`:

- **`Every t/*.t is listed in MANIFEST`** — catches the drift itself, at authoring time, with the missing filenames in the error. `make distcheck` is the idiomatic tool but reports every unlisted file (`package.json`, `CHANGELOG.md`, …), so this is scoped to `t/`.
- **`Test each tarball standalone, outside the checkout`** — extracts each built tarball to a temp dir and runs `perl Makefile.PL && make test` there. The working-tree run has the whole monorepo on disk, so a shipped test that reaches outside its own dist passes there and fails only for a real user. This is the check that makes "is it shippable?" answerable by CI instead of by inspection.

The first check alone would not have been safe to add without the second — it would have pushed toward listing tests without evidence they stand alone.

## Changeset

`patch` for `@barefootjs/perl` and `@barefootjs/mojolicious`, so the fuller suite reaches CPAN. The workflow change is CI-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_011z5oAc37tyMPK16wde7dV1)_