### PR TITLE
fix(adapters): position-accurate loop-bound-name guard for prop classification (#2488)

### DIFF
--- a/.changeset/loop-bound-name-position-accurate.md
+++ b/.changeset/loop-bound-name-position-accurate.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/twig": patch
+"@barefootjs/jinja": patch
+"@barefootjs/blade": patch
+"@barefootjs/xslate": patch
+"@barefootjs/rust": patch
+"@barefootjs/erb": patch
+"@barefootjs/mojolicious": patch
+---
+
+Fix a `.map()` callback param that shares a boolean-typed or nullable-optional prop's name being misclassified in attribute position: the row's string value was routed through the boolean/nullable-optional lowering (rendering "true"/"false", or gaining a spurious null guard) instead of the row's own value. The five Twig-family adapters (twig, jinja, blade, xslate, rust/minijinja) gain a position-accurate, ref-counted `loopBoundNames` map — ported from the ERB/Mojolicious adapters, which already had the map but were missing the guard at these two call sites. All seven adapters now check loop-bound position before routing through the boolean/nullable-optional lowering (#2488).

--- a/packages/adapter-blade/src/adapter/blade-adapter.ts
+++ b/packages/adapter-blade/src/adapter/blade-adapter.ts
@@ -437,6 +437,21 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
   private staticLoopSourceBoundNames: Set<string> = new Set()
 
   /**
+   * Names currently bound by an enclosing loop body — the block-param
+   * locals `renderLoop` introduces (item, index, per-binding destructure
+   * fields, `.map()` preamble declarations) — ref-counted so nested loops
+   * compose. This is the POSITION-ACCURATE twin of the coarse
+   * `staticLoopSourceBoundNames` above: that set is a whole-component
+   * union used only to guard static-const inlining (safe to over-suppress
+   * there — the fallback is just "don't inline"), whereas the boolean-prop
+   * and nullable-optional classification sites need to know whether a name
+   * is loop-bound AT THIS POSITION, because for those two the coarse
+   * fallback would silently mis-render a genuine prop occurrence outside
+   * the loop too (#2488).
+   */
+  private loopBoundNames: Map<string, number> = new Map()
+
+  /**
    * Optional, no-default props that are `None` when the caller omits them.
    * Their bare-reference attribute emission is guarded with a Blade
    * `isset($x)` test so the attribute DROPS rather than rendering `attr=""`
@@ -469,6 +484,7 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     this.booleanTypedProps = collectBooleanTypedProps(ir)
     this.localConstants = ir.metadata.localConstants ?? []
     this.staticLoopSourceBoundNames = collectLoopBoundNames(ir)
+    this.loopBoundNames.clear()
     this.nullableOptionalProps = collectNullableOptionalProps(ir)
     this.stringValueNames = collectStringValueNames(ir)
     this.moduleStringConsts = collectModuleStringConsts(ir.metadata.localConstants)
@@ -1068,7 +1084,37 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     const preambleLines = (loop.preamble?.declarations ?? []).map(
       d => `@php(${bladeVar(d.name)} = ${this.convertExpressionToBlade(d.raw, d.valueParsed)})`,
     )
+    // Names this loop binds in body scope, for the position-accurate
+    // `loopBoundNames` guard (#2488) — mirrors the ERB adapter's `loopBound`
+    // derivation, adapted to what THIS renderLoop actually binds: the
+    // for-header target(s) (`loopVar` / `objectIteration` key+value /
+    // `iterationShape === 'keys'`'s `param`), each `indexLocalLines` name
+    // (explicit index, or a destructure binding), and the `.map()`
+    // preamble's declared locals. Ref-counted so nested loops compose.
+    const loopBound: string[] = []
+    if (loop.objectIteration === 'entries') {
+      loopBound.push(loop.index ?? param, param)
+    } else if (loop.objectIteration === 'keys' || loop.objectIteration === 'values') {
+      loopBound.push(param)
+    } else if (loop.iterationShape === 'keys') {
+      loopBound.push(param)
+    } else if (supportableDestructure) {
+      loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
+      if (loop.index) loopBound.push(loop.index)
+    } else {
+      loopBound.push(param)
+      if (loop.index) loopBound.push(loop.index)
+    }
+    for (const d of loop.preamble?.declarations ?? []) loopBound.push(d.name)
+    for (const n of loopBound) {
+      this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
+    }
     const childrenUnderLoop = this.renderChildren(loop.children)
+    for (const n of loopBound) {
+      const c = (this.loopBoundNames.get(n) ?? 1) - 1
+      if (c <= 0) this.loopBoundNames.delete(n)
+      else this.loopBoundNames.set(n, c)
+    }
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -1480,7 +1526,11 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
         !isBooleanAttr(name) &&
         !value.presenceOrUndefined &&
         /^[A-Za-z_$][\w$]*$/.test(normalizedBareId) &&
-        this.nullableOptionalProps.has(normalizedBareId)
+        this.nullableOptionalProps.has(normalizedBareId) &&
+        // Inside a `.map()` callback, a param that shadows a nullable
+        // optional prop's name is the row binding, not the prop — skip the
+        // spurious `isset(...)` guard (#2488).
+        !this.isLoopBoundName(normalizedBareId)
       ) {
         const blade = this.convertExpressionToBlade(value.expr)
         const body = this.shouldBoolStr(value.expr, name)
@@ -1991,7 +2041,16 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
       bare = bare.slice(this.propsObjectName.length + 1)
     }
     if (!/^[A-Za-z_$][\w$]*$/.test(bare)) return false
+    // Inside a `.map()` callback, a param that shares a boolean prop's name
+    // is the ROW binding, not the prop — route it through plain string
+    // emission instead of `$bf->bool_str` (#2488).
+    if (this.isLoopBoundName(bare)) return false
     return this.booleanTypedProps.has(bare)
+  }
+
+  /** Position-accurate loop-bound-name check — see `loopBoundNames`'s docstring. */
+  private isLoopBoundName(name: string): boolean {
+    return this.loopBoundNames.has(name)
   }
 
   /**

--- a/packages/adapter-blade/src/adapter/blade-adapter.ts
+++ b/packages/adapter-blade/src/adapter/blade-adapter.ts
@@ -1097,7 +1097,9 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     } else if (loop.objectIteration === 'keys' || loop.objectIteration === 'values') {
       loopBound.push(param)
     } else if (loop.iterationShape === 'keys') {
-      loopBound.push(param)
+      // The header still binds the throwaway loop var; `param` is only the
+      // index alias set beneath it (#2488).
+      loopBound.push('__bf_item', param)
     } else if (supportableDestructure) {
       loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
       if (loop.index) loopBound.push(loop.index)

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -36,8 +36,6 @@ export const renderDivergences: RenderDivergences = {
   // #2482 audit follow-ups: loop-scope holes in per-adapter name
   // classification. Graduate by applying the loop-bound-name guards
   // described in each issue and deleting the line.
-  'loop-param-shadows-bool-prop':
-    'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
   'loop-param-shadows-spread-const':
     'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/packages/adapter-erb/src/adapter/erb-adapter.ts
+++ b/packages/adapter-erb/src/adapter/erb-adapter.ts
@@ -381,6 +381,10 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
       bare = bare.slice(this.propsObjectName.length + 1)
     }
     if (!/^[A-Za-z_$][\w$]*$/.test(bare)) return false
+    // Inside a `.map()` callback, a param that shares a boolean prop's name
+    // is the ROW binding, not the prop — route it through plain string
+    // emission instead of `bf.bool_str` (#2488).
+    if (this.isLoopBoundName(bare)) return false
     return this.booleanTypedProps.has(bare)
   }
 
@@ -1427,7 +1431,11 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
         !isBooleanAttr(name) &&
         !value.presenceOrUndefined &&
         /^[A-Za-z_$][\w$]*$/.test(normalizedBareId) &&
-        this.nullableOptionalProps.has(normalizedBareId)
+        this.nullableOptionalProps.has(normalizedBareId) &&
+        // Inside a `.map()` callback, a param that shadows a nullable
+        // optional prop's name is the row binding, not the prop — skip the
+        // spurious `.nil?` guard (#2488).
+        !this.isLoopBoundName(normalizedBareId)
       ) {
         const ruby = this.convertExpressionToRuby(value.expr)
         const body =

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -34,8 +34,6 @@ export const renderDivergences: RenderDivergences = {
   // #2482 audit follow-ups: loop-scope holes in per-adapter name
   // classification. Graduate by applying the loop-bound-name guards
   // described in each issue and deleting the line.
-  'loop-param-shadows-bool-prop':
-    'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the loop-bound-name subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
   'loop-param-shadows-spread-const':
     'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check (the live `loopBoundNames` map exists but is not consulted on this path), so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
   'loop-param-shadows-record-template-span':

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -286,6 +286,21 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
   private staticLoopSourceBoundNames: Set<string> = new Set()
 
   /**
+   * Names currently bound by an enclosing loop body — the block-param
+   * locals `renderLoop` introduces (item, index, per-binding destructure
+   * fields, `.map()` preamble declarations) — ref-counted so nested loops
+   * compose. This is the POSITION-ACCURATE twin of the coarse
+   * `staticLoopSourceBoundNames` above: that set is a whole-component
+   * union used only to guard static-const inlining (safe to over-suppress
+   * there — the fallback is just "don't inline"), whereas the boolean-prop
+   * and nullable-optional classification sites need to know whether a name
+   * is loop-bound AT THIS POSITION, because for those two the coarse
+   * fallback would silently mis-render a genuine prop occurrence outside
+   * the loop too (#2488).
+   */
+  private loopBoundNames: Map<string, number> = new Map()
+
+  /**
    * Optional, no-default props that are `None` when the caller omits them.
    * Their bare-reference attribute emission is guarded with a Jinja
    * `is defined and is not none` test so the attribute DROPS rather than
@@ -318,6 +333,7 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     this.booleanTypedProps = collectBooleanTypedProps(ir)
     this.localConstants = ir.metadata.localConstants ?? []
     this.staticLoopSourceBoundNames = collectLoopBoundNames(ir)
+    this.loopBoundNames.clear()
     this.nullableOptionalProps = collectNullableOptionalProps(ir)
     this.stringValueNames = collectStringValueNames(ir)
     this.moduleStringConsts = collectModuleStringConsts(ir.metadata.localConstants)
@@ -911,7 +927,37 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     const preambleLines = (loop.preamble?.declarations ?? []).map(
       d => `{% set ${jinjaIdent(d.name)} = ${this.convertExpressionToJinja(d.raw, d.valueParsed)} %}`,
     )
+    // Names this loop binds in body scope, for the position-accurate
+    // `loopBoundNames` guard (#2488) — mirrors the ERB adapter's `loopBound`
+    // derivation, adapted to what THIS renderLoop actually binds: the
+    // for-header target(s) (`loopVar` / `objectIteration` key+value /
+    // `iterationShape === 'keys'`'s `param`), each `indexLocalLines` name
+    // (explicit index, or a destructure binding), and the `.map()`
+    // preamble's declared locals. Ref-counted so nested loops compose.
+    const loopBound: string[] = []
+    if (loop.objectIteration === 'entries') {
+      loopBound.push(loop.index ?? param, param)
+    } else if (loop.objectIteration === 'keys' || loop.objectIteration === 'values') {
+      loopBound.push(param)
+    } else if (loop.iterationShape === 'keys') {
+      loopBound.push(param)
+    } else if (supportableDestructure) {
+      loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
+      if (loop.index) loopBound.push(loop.index)
+    } else {
+      loopBound.push(param)
+      if (loop.index) loopBound.push(loop.index)
+    }
+    for (const d of loop.preamble?.declarations ?? []) loopBound.push(d.name)
+    for (const n of loopBound) {
+      this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
+    }
     const childrenUnderLoop = this.renderChildren(loop.children)
+    for (const n of loopBound) {
+      const c = (this.loopBoundNames.get(n) ?? 1) - 1
+      if (c <= 0) this.loopBoundNames.delete(n)
+      else this.loopBoundNames.set(n, c)
+    }
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -1303,7 +1349,11 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
         !isBooleanAttr(name) &&
         !value.presenceOrUndefined &&
         /^[A-Za-z_$][\w$]*$/.test(normalizedBareId) &&
-        this.nullableOptionalProps.has(normalizedBareId)
+        this.nullableOptionalProps.has(normalizedBareId) &&
+        // Inside a `.map()` callback, a param that shadows a nullable
+        // optional prop's name is the row binding, not the prop — skip the
+        // spurious "is defined and is not none" guard (#2488).
+        !this.isLoopBoundName(normalizedBareId)
       ) {
         const jinja = this.convertExpressionToJinja(value.expr)
         const body = this.shouldBoolStr(value.expr, name)
@@ -1806,7 +1856,16 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
       bare = bare.slice(this.propsObjectName.length + 1)
     }
     if (!/^[A-Za-z_$][\w$]*$/.test(bare)) return false
+    // Inside a `.map()` callback, a param that shares a boolean prop's name
+    // is the ROW binding, not the prop — route it through plain string
+    // emission instead of `bf.bool_str` (#2488).
+    if (this.isLoopBoundName(bare)) return false
     return this.booleanTypedProps.has(bare)
+  }
+
+  /** Position-accurate loop-bound-name check — see `loopBoundNames`'s docstring. */
+  private isLoopBoundName(name: string): boolean {
+    return this.loopBoundNames.has(name)
   }
 
   /**

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -940,7 +940,9 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     } else if (loop.objectIteration === 'keys' || loop.objectIteration === 'values') {
       loopBound.push(param)
     } else if (loop.iterationShape === 'keys') {
-      loopBound.push(param)
+      // The header still binds the throwaway loop var; `param` is only the
+      // index alias set beneath it (#2488).
+      loopBound.push('__bf_item', param)
     } else if (supportableDestructure) {
       loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
       if (loop.index) loopBound.push(loop.index)

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -36,8 +36,6 @@ export const renderDivergences: RenderDivergences = {
   // #2482 audit follow-ups: loop-scope holes in per-adapter name
   // classification. Graduate by applying the loop-bound-name guards
   // described in each issue and deleting the line.
-  'loop-param-shadows-bool-prop':
-    'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
   'loop-param-shadows-spread-const':
     'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -388,6 +388,10 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       bare = bare.slice(this.propsObjectName.length + 1)
     }
     if (!/^[A-Za-z_$][\w$]*$/.test(bare)) return false
+    // Inside a `.map()` callback, a param that shares a boolean prop's name
+    // is the ROW binding, not the prop — route it through plain string
+    // emission instead of `bf->bool_str` (#2488).
+    if (this.loopBoundNames.has(bare)) return false
     return this.booleanTypedProps.has(bare)
   }
 
@@ -1365,7 +1369,11 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
         !isBooleanAttr(name) &&
         !value.presenceOrUndefined &&
         /^[A-Za-z_$][\w$]*$/.test(normalizedBareId) &&
-        this.nullableOptionalProps.has(normalizedBareId)
+        this.nullableOptionalProps.has(normalizedBareId) &&
+        // Inside a `.map()` callback, a param that shadows a nullable
+        // optional prop's name is the row binding, not the prop — skip the
+        // spurious `defined` guard (#2488).
+        !this.loopBoundNames.has(normalizedBareId)
       ) {
         const perl = this.convertExpressionToPerl(value.expr)
         const body =

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -33,12 +33,6 @@ export const renderDivergences: RenderDivergences = {
   'composite-row-child-aliased-prop':
     'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
 
-  // #2482 audit follow-up. Graduate by applying the loop-bound-name
-  // guard described in the issue and deleting the line. (The emitSpread
-  // sibling hole #2489 does NOT affect this adapter — its emitter
-  // consults the live `loopBoundNames` map on that path.)
-  'loop-param-shadows-bool-prop':
-    'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the loop-bound-name subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
   'loop-param-shadows-record-template-span':
     'a dynamic-key element access on a loop row (`tone[k]`) diverges on real Mojolicious at render time (same silent-empty family as ERB/Go/Twig; the Perl-side mechanism needs a dig) (https://github.com/piconic-ai/barefootjs/issues/2491)',
 }

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -978,10 +978,15 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     const loopBound: string[] = []
     if (loop.objectIteration === 'entries') {
       loopBound.push(loop.index ?? param, param)
-    } else if (loop.objectIteration === 'keys' || loop.objectIteration === 'values') {
-      loopBound.push(param)
+    } else if (loop.objectIteration === 'keys') {
+      // `|items` binds both slots; the unused one is a throwaway (#2488).
+      loopBound.push(param, '__bf_v')
+    } else if (loop.objectIteration === 'values') {
+      loopBound.push('__bf_k', param)
     } else if (loop.iterationShape === 'keys') {
-      loopBound.push(param)
+      // The header still binds the throwaway loop var; `param` is only the
+      // index alias set beneath it (#2488).
+      loopBound.push('__bf_item', param)
     } else if (supportableDestructure) {
       loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
       if (loop.index) loopBound.push(loop.index)

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -334,6 +334,21 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
   private staticLoopSourceBoundNames: Set<string> = new Set()
 
   /**
+   * Names currently bound by an enclosing loop body — the block-param
+   * locals `renderLoop` introduces (item, index, per-binding destructure
+   * fields, `.map()` preamble declarations) — ref-counted so nested loops
+   * compose. This is the POSITION-ACCURATE twin of the coarse
+   * `staticLoopSourceBoundNames` above: that set is a whole-component
+   * union used only to guard static-const inlining (safe to over-suppress
+   * there — the fallback is just "don't inline"), whereas the boolean-prop
+   * and nullable-optional classification sites need to know whether a name
+   * is loop-bound AT THIS POSITION, because for those two the coarse
+   * fallback would silently mis-render a genuine prop occurrence outside
+   * the loop too (#2488).
+   */
+  private loopBoundNames: Map<string, number> = new Map()
+
+  /**
    * Optional, no-default props that are `None` when the caller omits them.
    * Their bare-reference attribute emission is guarded with a Jinja
    * `is defined and is not none` test so the attribute DROPS rather than
@@ -366,6 +381,7 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     this.booleanTypedProps = collectBooleanTypedProps(ir)
     this.localConstants = ir.metadata.localConstants ?? []
     this.staticLoopSourceBoundNames = collectLoopBoundNames(ir)
+    this.loopBoundNames.clear()
     this.nullableOptionalProps = collectNullableOptionalProps(ir)
     this.stringValueNames = collectStringValueNames(ir)
     this.moduleStringConsts = collectModuleStringConsts(ir.metadata.localConstants)
@@ -952,7 +968,37 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     const preambleLines = (loop.preamble?.declarations ?? []).map(
       d => `{% set ${minijinjaIdent(d.name)} = ${this.convertExpressionToJinja(d.raw, d.valueParsed)} %}`,
     )
+    // Names this loop binds in body scope, for the position-accurate
+    // `loopBoundNames` guard (#2488) — mirrors the ERB adapter's `loopBound`
+    // derivation, adapted to what THIS renderLoop actually binds: the
+    // for-header target(s) (`loopVar` / `objectIteration` key+value /
+    // `iterationShape === 'keys'`'s `param`), each `indexLocalLines` name
+    // (explicit index, or a destructure binding), and the `.map()`
+    // preamble's declared locals. Ref-counted so nested loops compose.
+    const loopBound: string[] = []
+    if (loop.objectIteration === 'entries') {
+      loopBound.push(loop.index ?? param, param)
+    } else if (loop.objectIteration === 'keys' || loop.objectIteration === 'values') {
+      loopBound.push(param)
+    } else if (loop.iterationShape === 'keys') {
+      loopBound.push(param)
+    } else if (supportableDestructure) {
+      loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
+      if (loop.index) loopBound.push(loop.index)
+    } else {
+      loopBound.push(param)
+      if (loop.index) loopBound.push(loop.index)
+    }
+    for (const d of loop.preamble?.declarations ?? []) loopBound.push(d.name)
+    for (const n of loopBound) {
+      this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
+    }
     const childrenUnderLoop = this.renderChildren(loop.children)
+    for (const n of loopBound) {
+      const c = (this.loopBoundNames.get(n) ?? 1) - 1
+      if (c <= 0) this.loopBoundNames.delete(n)
+      else this.loopBoundNames.set(n, c)
+    }
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -1352,7 +1398,11 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
         !isBooleanAttr(name) &&
         !value.presenceOrUndefined &&
         /^[A-Za-z_$][\w$]*$/.test(normalizedBareId) &&
-        this.nullableOptionalProps.has(normalizedBareId)
+        this.nullableOptionalProps.has(normalizedBareId) &&
+        // Inside a `.map()` callback, a param that shadows a nullable
+        // optional prop's name is the row binding, not the prop — skip the
+        // spurious "is defined and is not none" guard (#2488).
+        !this.isLoopBoundName(normalizedBareId)
       ) {
         const jinja = this.convertExpressionToJinja(value.expr)
         const body = this.shouldBoolStr(value.expr, name)
@@ -1861,7 +1911,16 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
       bare = bare.slice(this.propsObjectName.length + 1)
     }
     if (!/^[A-Za-z_$][\w$]*$/.test(bare)) return false
+    // Inside a `.map()` callback, a param that shares a boolean prop's name
+    // is the ROW binding, not the prop — route it through plain string
+    // emission instead of `bf.bool_str` (#2488).
+    if (this.isLoopBoundName(bare)) return false
     return this.booleanTypedProps.has(bare)
+  }
+
+  /** Position-accurate loop-bound-name check — see `loopBoundNames`'s docstring. */
+  private isLoopBoundName(name: string): boolean {
+    return this.loopBoundNames.has(name)
   }
 
   /**

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -38,8 +38,6 @@ export const renderDivergences: RenderDivergences = {
   // #2482 audit follow-ups: loop-scope holes in per-adapter name
   // classification. Graduate by applying the loop-bound-name guards
   // described in each issue and deleting the line.
-  'loop-param-shadows-bool-prop':
-    'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
   'loop-param-shadows-spread-const':
     'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -988,7 +988,9 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     } else if (loop.objectIteration === 'keys' || loop.objectIteration === 'values') {
       loopBound.push(param)
     } else if (loop.iterationShape === 'keys') {
-      loopBound.push(param)
+      // The header still binds the throwaway loop var; `param` is only the
+      // index alias set beneath it (#2488).
+      loopBound.push('__bf_item', param)
     } else if (supportableDestructure) {
       loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
       if (loop.index) loopBound.push(loop.index)

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -337,6 +337,21 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
   private staticLoopSourceBoundNames: Set<string> = new Set()
 
   /**
+   * Names currently bound by an enclosing loop body — the block-param
+   * locals `renderLoop` introduces (item, index, per-binding destructure
+   * fields, `.map()` preamble declarations) — ref-counted so nested loops
+   * compose. This is the POSITION-ACCURATE twin of the coarse
+   * `staticLoopSourceBoundNames` above: that set is a whole-component
+   * union used only to guard static-const inlining (safe to over-suppress
+   * there — the fallback is just "don't inline"), whereas the boolean-prop
+   * and nullable-optional classification sites need to know whether a name
+   * is loop-bound AT THIS POSITION, because for those two the coarse
+   * fallback would silently mis-render a genuine prop occurrence outside
+   * the loop too (#2488).
+   */
+  private loopBoundNames: Map<string, number> = new Map()
+
+  /**
    * Optional, no-default props that are `None` when the caller omits them.
    * Their bare-reference attribute emission is guarded with a Twig
    * `is defined and is not null` test so the attribute DROPS rather than
@@ -369,6 +384,7 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     this.booleanTypedProps = collectBooleanTypedProps(ir)
     this.localConstants = ir.metadata.localConstants ?? []
     this.staticLoopSourceBoundNames = collectLoopBoundNames(ir)
+    this.loopBoundNames.clear()
     this.nullableOptionalProps = collectNullableOptionalProps(ir)
     this.stringValueNames = collectStringValueNames(ir)
     this.moduleStringConsts = collectModuleStringConsts(ir.metadata.localConstants)
@@ -959,7 +975,37 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     const preambleLines = (loop.preamble?.declarations ?? []).map(
       d => `{% set ${twigIdent(d.name)} = ${this.convertExpressionToTwig(d.raw, d.valueParsed)} %}`,
     )
+    // Names this loop binds in body scope, for the position-accurate
+    // `loopBoundNames` guard (#2488) — mirrors the ERB adapter's `loopBound`
+    // derivation, adapted to what THIS renderLoop actually binds: the
+    // for-header target(s) (`loopVar` / `objectIteration` key+value /
+    // `iterationShape === 'keys'`'s `param`), each `indexLocalLines` name
+    // (explicit index, or a destructure binding), and the `.map()`
+    // preamble's declared locals. Ref-counted so nested loops compose.
+    const loopBound: string[] = []
+    if (loop.objectIteration === 'entries') {
+      loopBound.push(loop.index ?? param, param)
+    } else if (loop.objectIteration === 'keys' || loop.objectIteration === 'values') {
+      loopBound.push(param)
+    } else if (loop.iterationShape === 'keys') {
+      loopBound.push(param)
+    } else if (supportableDestructure) {
+      loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
+      if (loop.index) loopBound.push(loop.index)
+    } else {
+      loopBound.push(param)
+      if (loop.index) loopBound.push(loop.index)
+    }
+    for (const d of loop.preamble?.declarations ?? []) loopBound.push(d.name)
+    for (const n of loopBound) {
+      this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
+    }
     const childrenUnderLoop = this.renderChildren(loop.children)
+    for (const n of loopBound) {
+      const c = (this.loopBoundNames.get(n) ?? 1) - 1
+      if (c <= 0) this.loopBoundNames.delete(n)
+      else this.loopBoundNames.set(n, c)
+    }
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -1350,7 +1396,11 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
         !isBooleanAttr(name) &&
         !value.presenceOrUndefined &&
         /^[A-Za-z_$][\w$]*$/.test(normalizedBareId) &&
-        this.nullableOptionalProps.has(normalizedBareId)
+        this.nullableOptionalProps.has(normalizedBareId) &&
+        // Inside a `.map()` callback, a param that shadows a nullable
+        // optional prop's name is the row binding, not the prop — skip the
+        // spurious "is defined and is not null" guard (#2488).
+        !this.isLoopBoundName(normalizedBareId)
       ) {
         const twig = this.convertExpressionToTwig(value.expr)
         const body = this.shouldBoolStr(value.expr, name)
@@ -1860,7 +1910,16 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
       bare = bare.slice(this.propsObjectName.length + 1)
     }
     if (!/^[A-Za-z_$][\w$]*$/.test(bare)) return false
+    // Inside a `.map()` callback, a param that shares a boolean prop's name
+    // is the ROW binding, not the prop — route it through plain string
+    // emission instead of `bf.bool_str` (#2488).
+    if (this.isLoopBoundName(bare)) return false
     return this.booleanTypedProps.has(bare)
+  }
+
+  /** Position-accurate loop-bound-name check — see `loopBoundNames`'s docstring. */
+  private isLoopBoundName(name: string): boolean {
+    return this.loopBoundNames.has(name)
   }
 
   /**

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -36,8 +36,6 @@ export const renderDivergences: RenderDivergences = {
   // #2482 audit follow-ups: loop-scope holes in per-adapter name
   // classification. Graduate by applying the loop-bound-name guards
   // described in each issue and deleting the line.
-  'loop-param-shadows-bool-prop':
-    'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (`bf.bool_str` renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
   'loop-param-shadows-spread-const':
     'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
   'loop-param-shadows-record-template-span':

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -260,6 +260,21 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   private staticLoopSourceBoundNames: Set<string> = new Set()
 
   /**
+   * Names currently bound by an enclosing loop body — the block-param
+   * locals `renderLoop` introduces (item, index, per-binding destructure
+   * fields, `.map()` preamble declarations) — ref-counted so nested loops
+   * compose. This is the POSITION-ACCURATE twin of the coarse
+   * `staticLoopSourceBoundNames` above: that set is a whole-component
+   * union used only to guard static-const inlining (safe to over-suppress
+   * there — the fallback is just "don't inline"), whereas the boolean-prop
+   * and nullable-optional classification sites need to know whether a name
+   * is loop-bound AT THIS POSITION, because for those two the coarse
+   * fallback would silently mis-render a genuine prop occurrence outside
+   * the loop too (#2488).
+   */
+  private loopBoundNames: Map<string, number> = new Map()
+
+  /**
    * Optional, no-default props that are `undef` when the caller omits them.
    * Their bare-reference attribute emission is guarded with Kolon `defined` so
    * the attribute DROPS rather than rendering `attr=""` (Hono-style nullish
@@ -292,6 +307,7 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     this.booleanTypedProps = collectBooleanTypedProps(ir)
     this.localConstants = ir.metadata.localConstants ?? []
     this.staticLoopSourceBoundNames = collectLoopBoundNames(ir)
+    this.loopBoundNames.clear()
     this.nullableOptionalProps = collectNullableOptionalProps(ir)
     this.stringValueNames = collectStringValueNames(ir)
     this.moduleStringConsts = collectModuleStringConsts(ir.metadata.localConstants)
@@ -889,7 +905,37 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     const preambleLines = (loop.preamble?.declarations ?? []).map(
       d => `: my $${d.name} = ${this.convertExpressionToKolon(d.raw, d.valueParsed)};`,
     )
+    // Names this loop binds in body scope, for the position-accurate
+    // `loopBoundNames` guard (#2488) — mirrors the ERB adapter's `loopBound`
+    // derivation, adapted to what THIS renderLoop actually binds: the
+    // for-header target(s) (`loopVar` / `objectIteration` key+value /
+    // `iterationShape === 'keys'`'s `param`), each `indexLocalLines` name
+    // (explicit index, or a destructure binding), and the `.map()`
+    // preamble's declared locals. Ref-counted so nested loops compose.
+    const loopBound: string[] = []
+    if (loop.objectIteration === 'entries') {
+      loopBound.push(loop.index ?? param, param)
+    } else if (loop.objectIteration === 'keys' || loop.objectIteration === 'values') {
+      loopBound.push(param)
+    } else if (loop.iterationShape === 'keys') {
+      loopBound.push(param)
+    } else if (supportableDestructure) {
+      loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
+      if (loop.index) loopBound.push(loop.index)
+    } else {
+      loopBound.push(param)
+      if (loop.index) loopBound.push(loop.index)
+    }
+    for (const d of loop.preamble?.declarations ?? []) loopBound.push(d.name)
+    for (const n of loopBound) {
+      this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
+    }
     const childrenUnderLoop = this.renderChildren(loop.children)
+    for (const n of loopBound) {
+      const c = (this.loopBoundNames.get(n) ?? 1) - 1
+      if (c <= 0) this.loopBoundNames.delete(n)
+      else this.loopBoundNames.set(n, c)
+    }
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -1269,7 +1315,11 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
         !isBooleanAttr(name) &&
         !value.presenceOrUndefined &&
         /^[A-Za-z_$][\w$]*$/.test(normalizedBareId) &&
-        this.nullableOptionalProps.has(normalizedBareId)
+        this.nullableOptionalProps.has(normalizedBareId) &&
+        // Inside a `.map()` callback, a param that shadows a nullable
+        // optional prop's name is the row binding, not the prop — skip the
+        // spurious `defined` guard (#2488).
+        !this.isLoopBoundName(normalizedBareId)
       ) {
         const perl = this.convertExpressionToKolon(value.expr)
         const body =
@@ -1750,7 +1800,16 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       bare = bare.slice(this.propsObjectName.length + 1)
     }
     if (!/^[A-Za-z_$][\w$]*$/.test(bare)) return false
+    // Inside a `.map()` callback, a param that shares a boolean prop's name
+    // is the ROW binding, not the prop — route it through plain string
+    // emission instead of `$bf.bool_str` (#2488).
+    if (this.isLoopBoundName(bare)) return false
     return this.booleanTypedProps.has(bare)
+  }
+
+  /** Position-accurate loop-bound-name check — see `loopBoundNames`'s docstring. */
+  private isLoopBoundName(name: string): boolean {
+    return this.loopBoundNames.has(name)
   }
 
   /**

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -914,11 +914,14 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // preamble's declared locals. Ref-counted so nested loops compose.
     const loopBound: string[] = []
     if (loop.objectIteration === 'entries') {
-      loopBound.push(loop.index ?? param, param)
+      // `.kv()` binds the pair var the key/value locals are derived from (#2488).
+      loopBound.push('__bf_pair', loop.index ?? param, param)
     } else if (loop.objectIteration === 'keys' || loop.objectIteration === 'values') {
       loopBound.push(param)
     } else if (loop.iterationShape === 'keys') {
-      loopBound.push(param)
+      // The header still binds the throwaway loop var; `param` is only the
+      // index alias derived from it beneath (#2488).
+      loopBound.push('__bf_item', param)
     } else if (supportableDestructure) {
       loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
       if (loop.index) loopBound.push(loop.index)

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -36,8 +36,6 @@ export const renderDivergences: RenderDivergences = {
   // #2482 audit follow-ups: loop-scope holes in per-adapter name
   // classification. Graduate by applying the loop-bound-name guards
   // described in each issue and deleting the line.
-  'loop-param-shadows-bool-prop':
-    'a .map() param sharing a boolean prop\'s name is routed through the bool lowering in attribute position (renders "true"/"false" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)',
   'loop-param-shadows-spread-const':
     'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2351,36 +2351,6 @@
           "reason": "a destructured .map() param binding used as a row ternary CONDITION emits the root-scope `{{if $.Active}}` — `renderConditionExpr` omits `loopBindingStack`, unlike `identifierToGoRef` (text positions resolve the same binding correctly) (https://github.com/piconic-ai/barefootjs/issues/2486)"
         }
       },
-      "loop-param-shadows-bool-prop": {
-        "blade": {
-          "kind": "render",
-          "reason": "a .map() param sharing a boolean prop's name is routed through the bool lowering in attribute position (renders \"true\"/\"false\" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "a .map() param sharing a boolean prop's name is routed through the bool lowering in attribute position (renders \"true\"/\"false\" instead of the row string) — `collectBooleanTypedProps` lacks the loop-bound-name subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "a .map() param sharing a boolean prop's name is routed through the bool lowering in attribute position (renders \"true\"/\"false\" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "a .map() param sharing a boolean prop's name is routed through the bool lowering in attribute position (renders \"true\"/\"false\" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "a .map() param sharing a boolean prop's name is routed through the bool lowering in attribute position (renders \"true\"/\"false\" instead of the row string) — `collectBooleanTypedProps` lacks the loop-bound-name subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "a .map() param sharing a boolean prop's name is routed through the bool lowering in attribute position (`bf.bool_str` renders \"true\"/\"false\" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "a .map() param sharing a boolean prop's name is routed through the bool lowering in attribute position (renders \"true\"/\"false\" instead of the row string) — `collectBooleanTypedProps` lacks the `collectLoopBoundNames` subtraction its sibling `collectStringValueNames` got in #2236 (https://github.com/piconic-ai/barefootjs/issues/2488)"
-        }
-      },
       "loop-param-shadows-record-template-span": {
         "erb": {
           "kind": "render",
@@ -2982,10 +2952,6 @@
       "loop-destructured-param-condition": {
         "description": "Destructured .map() param binding used as a row ternary condition stays row-scoped",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/loop-destructured-param-condition.ts"
-      },
-      "loop-param-shadows-bool-prop": {
-        "description": ".map() param sharing a boolean prop name renders the row value, not a bool lowering",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/loop-param-shadows-bool-prop.ts"
       },
       "loop-param-shadows-record-template-span": {
         "description": ".map() param shadowing a record const stays row-scoped inside a `${base[key]}` template span",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1449,7 +1449,7 @@
           ]
         },
         "blade": {
-          "pass": 182,
+          "pass": 183,
           "total": 200,
           "gaps": [
             {
@@ -1495,10 +1495,6 @@
               "issues": []
             },
             {
-              "fixture": "loop-param-shadows-bool-prop",
-              "issues": []
-            },
-            {
               "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
@@ -1537,7 +1533,7 @@
           ]
         },
         "erb": {
-          "pass": 183,
+          "pass": 184,
           "total": 200,
           "gaps": [
             {
@@ -1570,10 +1566,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -1715,7 +1707,7 @@
           ]
         },
         "jinja": {
-          "pass": 182,
+          "pass": 183,
           "total": 200,
           "gaps": [
             {
@@ -1758,10 +1750,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -1803,6 +1791,168 @@
           ]
         },
         "minijinja": {
+          "pass": 183,
+          "total": 200,
+          "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2356"
+              ]
+            },
+            {
+              "fixture": "every-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
+              ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-spread-const",
+              "issues": []
+            },
+            {
+              "fixture": "preamble-cells",
+              "issues": []
+            },
+            {
+              "fixture": "reduce-right-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "reduce-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "some-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "tag-cloud",
+              "issues": []
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 184,
+          "total": 200,
+          "gaps": [
+            {
+              "fixture": "composite-row-child-aliased-prop",
+              "issues": []
+            },
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2356"
+              ]
+            },
+            {
+              "fixture": "every-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
+              ]
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "loop-param-shadows-record-template-span",
+              "issues": []
+            },
+            {
+              "fixture": "preamble-cells",
+              "issues": []
+            },
+            {
+              "fixture": "reduce-right-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "reduce-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "some-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "tag-cloud",
+              "issues": []
+            }
+          ]
+        },
+        "twig": {
           "pass": 182,
           "total": 200,
           "gaps": [
@@ -1846,180 +1996,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
-            {
-              "fixture": "preamble-cells",
-              "issues": []
-            },
-            {
-              "fixture": "reduce-right-typeof-body",
-              "issues": []
-            },
-            {
-              "fixture": "reduce-typeof-body",
-              "issues": []
-            },
-            {
-              "fixture": "some-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "static-array-from-props",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            },
-            {
-              "fixture": "tag-cloud",
-              "issues": []
-            }
-          ]
-        },
-        "mojolicious": {
-          "pass": 183,
-          "total": 200,
-          "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
-            {
-              "fixture": "date-method-uncatalogued",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2356"
-              ]
-            },
-            {
-              "fixture": "every-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "filter-nested-find-predicate",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2320"
-              ]
-            },
-            {
-              "fixture": "filter-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "find-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            },
-            {
-              "fixture": "preamble-cells",
-              "issues": []
-            },
-            {
-              "fixture": "reduce-right-typeof-body",
-              "issues": []
-            },
-            {
-              "fixture": "reduce-typeof-body",
-              "issues": []
-            },
-            {
-              "fixture": "some-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "static-array-from-props",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            },
-            {
-              "fixture": "tag-cloud",
-              "issues": []
-            }
-          ]
-        },
-        "twig": {
-          "pass": 181,
-          "total": 200,
-          "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
-            {
-              "fixture": "date-method-uncatalogued",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2356"
-              ]
-            },
-            {
-              "fixture": "every-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "filter-nested-callback-predicate",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2320"
-              ]
-            },
-            {
-              "fixture": "filter-nested-find-predicate",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2320"
-              ]
-            },
-            {
-              "fixture": "filter-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "find-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -2065,7 +2041,7 @@
           ]
         },
         "xslate": {
-          "pass": 182,
+          "pass": 183,
           "total": 200,
           "gaps": [
             {
@@ -2108,10 +2084,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -2341,7 +2313,7 @@
           ]
         },
         "blade": {
-          "pass": 267,
+          "pass": 268,
           "total": 288,
           "gaps": [
             {
@@ -2391,10 +2363,6 @@
               "issues": []
             },
             {
-              "fixture": "loop-param-shadows-bool-prop",
-              "issues": []
-            },
-            {
               "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
@@ -2441,7 +2409,7 @@
           ]
         },
         "erb": {
-          "pass": 268,
+          "pass": 269,
           "total": 288,
           "gaps": [
             {
@@ -2478,10 +2446,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -2643,7 +2607,7 @@
           ]
         },
         "jinja": {
-          "pass": 267,
+          "pass": 268,
           "total": 288,
           "gaps": [
             {
@@ -2690,10 +2654,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -2743,7 +2703,7 @@
           ]
         },
         "minijinja": {
-          "pass": 267,
+          "pass": 268,
           "total": 288,
           "gaps": [
             {
@@ -2790,10 +2750,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -2843,7 +2799,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 268,
+          "pass": 269,
           "total": 288,
           "gaps": [
             {
@@ -2884,10 +2840,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -2937,7 +2889,7 @@
           ]
         },
         "twig": {
-          "pass": 266,
+          "pass": 267,
           "total": 288,
           "gaps": [
             {
@@ -2984,10 +2936,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -3041,7 +2989,7 @@
           ]
         },
         "xslate": {
-          "pass": 267,
+          "pass": 268,
           "total": 288,
           "gaps": [
             {
@@ -3088,10 +3036,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -3237,7 +3181,7 @@
           "total": 238
         },
         "blade": {
-          "pass": 225,
+          "pass": 226,
           "total": 238,
           "gaps": [
             {
@@ -3258,10 +3202,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -3297,7 +3237,7 @@
           ]
         },
         "erb": {
-          "pass": 224,
+          "pass": 225,
           "total": 238,
           "gaps": [
             {
@@ -3318,10 +3258,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -3433,7 +3369,7 @@
           ]
         },
         "jinja": {
-          "pass": 225,
+          "pass": 226,
           "total": 238,
           "gaps": [
             {
@@ -3454,10 +3390,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -3493,7 +3425,7 @@
           ]
         },
         "minijinja": {
-          "pass": 225,
+          "pass": 226,
           "total": 238,
           "gaps": [
             {
@@ -3514,10 +3446,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -3553,7 +3481,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 225,
+          "pass": 226,
           "total": 238,
           "gaps": [
             {
@@ -3574,10 +3502,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -3613,7 +3537,7 @@
           ]
         },
         "twig": {
-          "pass": 224,
+          "pass": 225,
           "total": 238,
           "gaps": [
             {
@@ -3634,10 +3558,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -3677,7 +3597,7 @@
           ]
         },
         "xslate": {
-          "pass": 225,
+          "pass": 226,
           "total": 238,
           "gaps": [
             {
@@ -3698,10 +3618,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -7990,15 +7906,11 @@
           "total": 101
         },
         "blade": {
-          "pass": 94,
+          "pass": 95,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -8024,15 +7936,11 @@
           ]
         },
         "erb": {
-          "pass": 93,
+          "pass": 94,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -8104,15 +8012,11 @@
           ]
         },
         "jinja": {
-          "pass": 94,
+          "pass": 95,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -8138,15 +8042,11 @@
           ]
         },
         "minijinja": {
-          "pass": 94,
+          "pass": 95,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -8172,15 +8072,11 @@
           ]
         },
         "mojolicious": {
-          "pass": 94,
+          "pass": 95,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -8206,15 +8102,11 @@
           ]
         },
         "twig": {
-          "pass": 93,
+          "pass": 94,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {
@@ -8244,15 +8136,11 @@
           ]
         },
         "xslate": {
-          "pass": 94,
+          "pass": 95,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-bool-prop",
               "issues": []
             },
             {


### PR DESCRIPTION
First of a stacked series addressing the seven adapter-side defects the #2482 audit turned up (#2486–#2492). This one fixes #2488.

## The bug

A `.map()` callback param that shares a **boolean-typed** prop's name is misclassified in attribute position — the row's string value routes through the boolean lowering, so `data-x` renders `"true"`/`"false"` instead of the row's value. The sibling **nullable-optional** prop set has the same hole, adding a spurious `is defined and is not null` guard around a row value.

```tsx
export function BoolPropShadow({ active, flags }: { active: boolean; flags: string[] }) {
  return <ul>{flags.map((active, i) => <li key={i} data-x={active}>{active}</li>)}</ul>
}
```

Root cause (#2482 audit, U19/U20): `collectBooleanTypedProps` and `collectNullableOptionalProps` are flat, scope-blind `Set<string>`. Their sibling `collectStringValueNames` — in the same file — got the `collectLoopBoundNames` subtraction in #2212/#2236; these two never did. The fix was applied per-function, not per-file.

## Why not the one-line coarse subtraction

The obvious fix is to copy `collectStringValueNames`' whole-component `collectLoopBoundNames` subtraction. **That would introduce a new silent-wrong case**, so this PR deliberately does not do it.

The coarse subtraction also suppresses the classification for a genuine occurrence *outside* the loop. For the string set that fallback is safe — the docstring reasons it out: you get numeric `+` instead of `~`, never wrong output. For the **boolean** set the fallback is wrong: an unclassified boolean prop renders through PHP's `(string) bool` as `"1"`/`""`, which is exactly the #1897 defect the boolean set exists to fix. Trading a loop-shadowing bug for a resurrected #1897 is not a fix.

## What this does instead

ERB and Mojolicious already carry a **position-accurate**, ref-counted `loopBoundNames` map — they just never consult it at these two sites. This PR ports that map to the five Twig-family adapters and routes all seven through it:

- **twig / jinja / blade / xslate / rust(minijinja)** gain `private loopBoundNames: Map<string, number>`, populated in `renderLoop` from the for-header target(s), destructure bindings, index, and `.map()` preamble locals, and released after the body — ref-counted so nested loops compose. Mirrors ERB's `loopBound` derivation.
- **All seven** now check the name's loop-bound status at `isBooleanTypedPropRef` and at the `nullableOptionalProps` condition in the attribute-value emitter. ERB and Mojolicious needed only the guard.

A name outside any loop keeps its classification; a name bound by an enclosing loop callback does not. No new silent-wrong case, and it is a step toward the shared scoped binding-resolution service that #2482's Option A recommends.

## Graduation

Deletes the `loop-param-shadows-bool-prop` pin from all seven adapters' `renderDivergences`. The fixture's `expectedHtml` was already correct (generated from the Hono reference), so it flips straight from "skipped, known-divergent" to live regression armor — Mojolicious goes from 1430 to 1433 passing tests purely because the fixture now renders.

## Validation

Full suites, run serially (see the note below):

| package | result |
|---|---|
| twig | 1276 pass, 0 fail |
| jinja | 1270 pass, 0 fail |
| blade | 1270 pass, 0 fail |
| xslate | 1271 pass, 0 fail |
| rust | 1269 pass, 0 fail |
| adapter-tests | 1875 pass, 0 fail |
| erb | 8 fail, all `date-tolocale-named-tz` — missing local tzinfo gem, identical on clean main |
| mojolicious | 1433 pass, 8 fail — same `date-tolocale-named-tz` set, byte-identical to main's baseline |

`bunx tsc --noEmit` clean in all seven packages. The `loop-param-shadows-bool-prop` fixture was confirmed to actually render (not skip) and pass on the three engines available locally: jinja, rust, erb. `compat.lock.json` / `support-matrix.lock.json` regenerated from freshly built dists.

One methodology note worth recording: an earlier run of these suites showed dozens of failures in rust and xslate, including loop-free fixtures like `counter`. Those were **resource contention**, not regressions — the suites were sharing cargo/Go/PHP/Perl build caches with a concurrently running agent. Re-run serially, every package matches its main baseline exactly. Mojolicious' four `claim-plan` failures under load were the same artifact (5–8s durations against a 5s per-test timeout); they pass targeted on both branches and vanish in a quiet full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpPtSg6rTe158671pknoD2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpPtSg6rTe158671pknoD2)_