### PR TITLE
fix(go-template): destructured loop bindings in conditions + inLoop save/restore (#2486, #2487)

### DIFF
--- a/.changeset/go-loop-scope-condition-and-nesting.md
+++ b/.changeset/go-loop-scope-condition-and-nesting.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix two loop-scope resolution bugs found by the #2482 audit. `renderConditionExpr` now checks `loopBindingStack` (innermost-first, before module-const inlining) so a destructured `.map()` param used as a row ternary condition resolves to the row-scoped field instead of a root-scope one (#2486). `inLoop` is now saved/restored around both loop-rendering paths instead of being unconditionally cleared, so a nested inner loop's exit no longer clobbers the outer loop's flag for its remaining tail content, e.g. a spread attribute after a nested loop no longer misroutes to the component-root slot mechanism (#2487).

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -5736,6 +5736,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     switch (expr.kind) {
       case 'identifier':
         {
+          // Destructure-param bindings (`.map(({ id, active }) => active ? …)`):
+          // resolve the binding name to its accessor on the range var the same
+          // way the value path (`identifier` in `ParsedExprEmitter`) does.
+          // Without this, a destructured name falls through to `rootFieldRef`
+          // and the condition emits a ROOT-scope field instead of the row's
+          // (#2486). Innermost-first, and BEFORE module-const inlining so a
+          // binding whose name collides with a module string const still
+          // resolves to the loop item — same ordering as `identifier` above.
+          for (let i = this.loopBindingStack.length - 1; i >= 0; i--) {
+            const acc = this.loopBindingStack[i].get(expr.name)
+            if (acc !== undefined) return plain(acc)
+          }
           const inlined = this.resolveModuleStringConst(expr.name)
           if (inlined !== null) return plain(inlined)
           const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
@@ -6281,6 +6293,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       goArray = `.${loop.childComponent.name}s`
     }
 
+    // Save/restore rather than plain assign: this loop's own body may contain
+    // a NESTED loop that also flips `inLoop` true→false around itself. Without
+    // saving, the inner loop's exit clobbers `inLoop` to `false` for the
+    // remainder of THIS (outer) loop's body, so any outer-scope content
+    // rendered after the nested loop wrongly takes the non-loop emission arms
+    // (e.g. spread attrs resolve to the component-root slot mechanism instead
+    // of the row-scoped field) (#2487).
+    const wasInLoopOuter = this.inLoop
     this.inLoop = true
     // Track Go template loop variables. The range *value* variable is the dot
     // context (`.`) and goes on `loopParamStack`; the range *index* variable
@@ -6361,7 +6381,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       this.loopBindingStack.pop()
       this.loopRestExcludeStack.pop()
     }
-    this.inLoop = false
+    this.inLoop = wasInLoopOuter
 
     // Apply sort if present: wrap the array in a sort pipeline before `range`.
     // Evaluator-first (#2018 P3): serialize the comparator body + emit
@@ -6429,6 +6449,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * return `''` here anyway.
    */
   private renderUnrolledStaticElementLoop(loop: IRLoop, items: readonly unknown[]): string {
+    // Save/restore, not a plain assign — see the matching comment in
+    // `renderLoop` (#2487): a nested loop inside this unrolled body must not
+    // clobber `inLoop` for the remainder of an outer loop's rendering.
+    const wasInLoopOuter = this.inLoop
     this.inLoop = true
     this.loopWrapperStack.push(false)
     this.loopKeyDepthStack.push(loop.depth)
@@ -6462,7 +6486,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.loopScalarItemStack.pop()
     this.loopKeyDepthStack.pop()
     this.loopWrapperStack.pop()
-    this.inLoop = false
+    this.inLoop = wasInLoopOuter
 
     return `{{bfComment "loop:${loop.markerId}"}}${body}{{bfComment "/loop:${loop.markerId}"}}`
   }

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -44,10 +44,8 @@ export const renderDivergences: RenderDivergences = {
   // #2482 audit follow-ups: loop-scope holes specific to this adapter's
   // four-stack scope tracking and its SSR seeding. Graduate by applying
   // the fix described in each issue and deleting the line.
-  'loop-destructured-param-condition':
-    'a destructured .map() param binding used as a row ternary CONDITION emits the root-scope `{{if $.Active}}` — `renderConditionExpr` omits `loopBindingStack`, unlike `identifierToGoRef` (text positions resolve the same binding correctly) (https://github.com/piconic-ai/barefootjs/issues/2486)',
   'nested-loop-tail-content':
-    'outer-row content AFTER a nested inner loop renders through non-loop arms (spread lowers to the component-root `.Spread_0`) — `inLoop` is cleared, not restored, by the inner loop\'s exit; the same content BEFORE the inner loop emits correctly (https://github.com/piconic-ai/barefootjs/issues/2487)',
+    'the `inLoop` clobber is FIXED (#2487) — outer-row content after a nested loop now takes the loop arms and the spread resolves row-scoped. Residual: the spread\'s attribute NAMES are still mangled by the Go-cased-key kebab conversion (`data-kind` → `-data-kind`), which is #2490; this entry graduates with that fix (https://github.com/piconic-ai/barefootjs/issues/2490)',
   'loop-param-shadows-spread-const':
     'spreading a loop row object mangles attribute names (`id` → `-i-d`, `title` → `-title`); the spread VALUE is correctly row-scoped, distinguishing this from the template-adapter const-shadow hole #2489 (https://github.com/piconic-ai/barefootjs/issues/2490)',
   'loop-param-shadows-record-template-span':

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2345,12 +2345,6 @@
           ]
         }
       },
-      "loop-destructured-param-condition": {
-        "go-template": {
-          "kind": "render",
-          "reason": "a destructured .map() param binding used as a row ternary CONDITION emits the root-scope `{{if $.Active}}` — `renderConditionExpr` omits `loopBindingStack`, unlike `identifierToGoRef` (text positions resolve the same binding correctly) (https://github.com/piconic-ai/barefootjs/issues/2486)"
-        }
-      },
       "loop-param-shadows-record-template-span": {
         "erb": {
           "kind": "render",
@@ -2502,7 +2496,7 @@
       "nested-loop-tail-content": {
         "go-template": {
           "kind": "render",
-          "reason": "outer-row content AFTER a nested inner loop renders through non-loop arms (spread lowers to the component-root `.Spread_0`) — `inLoop` is cleared, not restored, by the inner loop's exit; the same content BEFORE the inner loop emits correctly (https://github.com/piconic-ai/barefootjs/issues/2487)"
+          "reason": "the `inLoop` clobber is FIXED (#2487) — outer-row content after a nested loop now takes the loop arms and the spread resolves row-scoped. Residual: the spread's attribute NAMES are still mangled by the Go-cased-key kebab conversion (`data-kind` → `-data-kind`), which is #2490; this entry graduates with that fix (https://github.com/piconic-ai/barefootjs/issues/2490)"
         }
       },
       "preamble-cells": {
@@ -2948,10 +2942,6 @@
       "flatmap-typeof-projection": {
         "description": "Off-subset `.flatMap()` projection (typeof) — JS-runtime faithful, DSL diagnostic",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/flatmap-typeof-projection.ts"
-      },
-      "loop-destructured-param-condition": {
-        "description": "Destructured .map() param binding used as a row ternary condition stays row-scoped",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/loop-destructured-param-condition.ts"
       },
       "loop-param-shadows-record-template-span": {
         "description": ".map() param shadowing a record const stays row-scoped inside a `${base[key]}` template span",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1611,7 +1611,7 @@
           ]
         },
         "go-template": {
-          "pass": 180,
+          "pass": 181,
           "total": 200,
           "gaps": [
             {
@@ -1654,10 +1654,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-destructured-param-condition",
               "issues": []
             },
             {
@@ -2499,7 +2495,7 @@
           ]
         },
         "go-template": {
-          "pass": 265,
+          "pass": 266,
           "total": 288,
           "gaps": [
             {
@@ -2546,10 +2542,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-destructured-param-condition",
               "issues": []
             },
             {
@@ -3297,7 +3289,7 @@
           ]
         },
         "go-template": {
-          "pass": 222,
+          "pass": 223,
           "total": 238,
           "gaps": [
             {
@@ -3322,10 +3314,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-destructured-param-condition",
               "issues": []
             },
             {
@@ -7970,15 +7958,11 @@
           ]
         },
         "go-template": {
-          "pass": 92,
+          "pass": 93,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-destructured-param-condition",
               "issues": []
             },
             {


### PR DESCRIPTION
**Stacked on #2503** — review that one first; this PR's diff against it is only the Go adapter.

Second of the series addressing the seven adapter-side defects from the #2482 audit (#2486–#2492). Both fixes here match an existing correct precedent in the same file rather than inventing a mechanism.

## #2486 — condition position ignored destructured loop bindings

```tsx
rows.map(({ id, label, active }) => <li key={id}>{active ? <b>{label}</b> : <i>{label}</i>}</li>)
```

emitted the root-scope `{{if $.Active}}` for the ternary condition while sibling **text** positions in the same row correctly emitted `$__bf_item0.Label`. Against a root Input without that field it fails at execute time; with a same-named field every row renders the parent's branch.

`renderConditionExpr`'s `identifier` arm consulted `resolveModuleStringConst`, `loopParamStack`'s top, `isOuterLoopParam` and `loopVarRefCount` — but never `loopBindingStack`, which is the *only* stack destructured callbacks record their names on (they push `''` onto `loopParamStack`). The canonical resolver `identifierToGoRef` checks all four, and checks `loopBindingStack` **first** so a binding whose name collides with a module string const still resolves to the row.

The fix gives the condition arm the same innermost-first lookup in the same position. The `member` arm needed no change — it recurses through the identifier arm, which I verified rather than assumed.

## #2487 — `inLoop` was clobbered by a nested loop's exit

`inLoop` was set with a plain assignment and cleared with `= false`, so an inner loop's exit cleared it for the rest of the **outer** loop's body: outer-row content after a nested loop rendered through the non-loop arms (a spread lowered to the component-root `.Spread_0`). The same content placed *before* the inner loop emitted correctly — that contrast pins the mechanism.

Both pairs now save/restore. Every other loop-scope stack in these functions (`loopParamStack`, `loopBindingStack`, `loopWrapperStack`, `loopKeyDepthStack`, `loopScalarItemStack`) was already push/pop; only this boolean was not. The idiom matches `wasInLoop` used elsewhere in this same file, and the Twig adapter's `prevInLoop`.

## Graduation, and one entanglement worth flagging

`loop-destructured-param-condition` graduates — it renders at reference parity and its pin is deleted.

`nested-loop-tail-content` does **not** graduate yet, and the reason is interesting: the `inLoop` fix demonstrably works — the spread now takes the loop arm and renders each row's own value (`data-kind="a"` / `"b"` instead of the component-root slot). What it exposed underneath is that the row spread's attribute *names* are mangled by the Go-cased-key kebab conversion (`data-kind` → `-data-kind`), which is #2490. So fixing #2487 is what made #2490 visible on this fixture. The pin stays with its reason rewritten to say exactly that, and it graduates in the #2490 PR later in this stack.

## Validation

- `bunx tsc --noEmit -p .` clean.
- `loop-destructured-param-condition` renders through real Go (`GOTOOLCHAIN=go1.25.6`) and passes — confirmed it is no longer reported as skipped.
- Full `packages/adapter-go-template` suite is running as of opening this draft; I'll post the counts here and mark the PR ready once it's green. Note for anyone re-running locally: each Go conformance test spawns a real `go run`, so a cold cache produces spurious "timed out after 5000ms" failures — re-run warm before believing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpPtSg6rTe158671pknoD2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpPtSg6rTe158671pknoD2)_