### PR TITLE
fix(adapters): route dynamic index access through a runtime-polymorphic accessor (#2491)

### DIFF
--- a/.changeset/dynamic-row-key-access.md
+++ b/.changeset/dynamic-row-key-access.md
@@ -1,0 +1,8 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/twig": patch
+"@barefootjs/erb": patch
+"@barefootjs/mojolicious": patch
+---
+
+Fix a dynamic-key element access on a loop row (`tone[k]`, #2491) that rendered empty on ERB/Go/Twig and threw a fatal `Not an ARRAY reference` on Mojolicious. All four adapters previously made a compile-time GUESS about whether the index was a string key or a numeric index — a guess the shared analyzer can't resolve for a destructured `.map()` param, since it types the binding `{kind:'unknown'}` — and each guess failed for a different reason (exact-case map lookup, symbol-vs-string key mismatch, wrong deref form). The fix routes every dynamic index access through a runtime-polymorphic accessor instead, mirroring the passing engines (Jinja/minijinja `[]`, Blade's `data_get()`, Xslate's native `[]`): Go's `indexAccess` now emits `bf_get`, and `getFieldValue` gained a slice/array/string branch so it's a strict superset of the `index` builtin; Twig's `indexAccess` emits the built-in `attribute()` function instead of `[]` (which is not polymorphic against a `stdClass` receiver, unlike `.`); ERB and Mojolicious each gained a new `get(collection, key)` runtime helper (`bf.get` / `bf->get`) that dispatches on the receiver's runtime type. The existing numeric-index case (`selected()[index]`, data-table) keeps working unchanged on every adapter.

--- a/packages/adapter-erb/lib/barefoot_js.rb
+++ b/packages/adapter-erb/lib/barefoot_js.rb
@@ -800,9 +800,19 @@ module BarefootJS
 
         nil
       when Array
-        return nil unless key.is_a?(Numeric) || key.is_a?(String)
+        # Only an INTEGRAL index reads an element. `key.to_i` would be
+        # wrong on both ends: it coerces a non-numeric String to 0
+        # (`arr["nope"]` must be nil, not the first element) and it
+        # truncates a fractional number (JS `arr[1.2]` is a property
+        # lookup, i.e. undefined -- not index 1).
+        idx =
+          case key
+          when Integer then key
+          when Numeric then (key % 1).zero? ? key.to_i : nil
+          when String then (key =~ /\A-?\d+\z/ ? key.to_i : nil)
+          end
+        return nil if idx.nil?
 
-        idx = key.to_i
         # JS-semantics negative index is "not found" (`arr[-1] ===
         # undefined`), NOT Ruby's native from-the-end wraparound -- guard
         # it explicitly so this stays a superset of bracket access rather

--- a/packages/adapter-erb/lib/barefoot_js.rb
+++ b/packages/adapter-erb/lib/barefoot_js.rb
@@ -772,6 +772,47 @@ module BarefootJS
       string(recv).each_char.sum { |c| c.ord > 0xFFFF ? 2 : 1 }
     end
 
+    # Runtime-polymorphic element/key access for `arr[index]` /
+    # `hash[key]` (`emitIndexAccessRuby`, expr/operand.ts). Row hashes
+    # deserialize with `symbolize_names: true`, so a dynamic key whose
+    # runtime value is a String (e.g. a destructured `.map()` param used
+    # as a key, `tone[k]`) misses a Symbol-keyed Hash outright -- and the
+    # shared analyzer can't tell at compile time whether an index will
+    # turn out to be a string key or a numeric index (it types a
+    # destructured param `{kind:'unknown'}`), so no compile-time branch
+    # can pick the right access form (#2491). Mirrors `getFieldValue`'s
+    # (Go adapter, bf.go) case-tolerant lookup and Twig's `attribute()`:
+    # for a Hash, try the key as-is, then as a Symbol, then as a String;
+    # for an Array, index numerically; anything else has no lookup to
+    # perform.
+    def get(collection, key)
+      return nil if key.nil?
+
+      case collection
+      when Hash
+        return collection[key] if collection.key?(key)
+
+        sym = key.respond_to?(:to_sym) ? key.to_sym : nil
+        return collection[sym] if sym && collection.key?(sym)
+
+        str = key.to_s
+        return collection[str] if collection.key?(str)
+
+        nil
+      when Array
+        return nil unless key.is_a?(Numeric) || key.is_a?(String)
+
+        idx = key.to_i
+        # JS-semantics negative index is "not found" (`arr[-1] ===
+        # undefined`), NOT Ruby's native from-the-end wraparound -- guard
+        # it explicitly so this stays a superset of bracket access rather
+        # than a divergent one.
+        return nil if idx.negative?
+
+        collection[idx]
+      end
+    end
+
     # Mirrors Hono's own CSS-injection guard (`hono/jsx/utils.ts`'s
     # `hasUnsafeStyleValue` -- the ORACLE a dynamic `style={{...}}` value
     # must match, #2261): a hand-rolled structural scan for characters that

--- a/packages/adapter-erb/src/adapter/expr/operand.ts
+++ b/packages/adapter-erb/src/adapter/expr/operand.ts
@@ -8,12 +8,13 @@
  * rather than reading adapter instance state directly.
  *
  * `isStringTypedOperand` is byte-identical to the Mojo/Xslate adapters'
- * copy. `emitIndexAccessRuby` is ERB-specific: Ruby's `[]` operator is
- * syntactically the same for Array and Hash access (unlike Perl's
- * `->[]`/`->{}` split), but this runtime's object values are JSON-shaped
- * Ruby Hashes with SYMBOL keys — so a string-typed index still needs a
- * `.to_sym` conversion to become a valid Hash key, while a non-string
- * (numeric / loop-index) index passes straight through as an Array index.
+ * copy — NOTE: this is a stale pre-#2212 fork with no `identifier` arm;
+ * Mojo has since migrated to the shared analyzer-backed version. Left
+ * as-is here (out of scope for #2491; a separate cleanup).
+ * `emitIndexAccessRuby` no longer uses it: it always routes through the
+ * runtime's polymorphic `bf.get` helper (#2491) rather than guessing at
+ * compile time whether an index is a string key or numeric index — see
+ * its own docstring below.
  */
 
 import type { ParsedExpr } from '@barefootjs/jsx'
@@ -37,10 +38,19 @@ export function isStringTypedOperand(expr: ParsedExpr, isStringName: (n: string)
 }
 
 /**
- * Lower `arr[index]` to a Ruby `[]` access. A string-typed index reads a
- * JSON-shaped Hash by symbol key (`.to_sym`); any other index (the common
- * loop-index / arithmetic case, e.g. `selected()[index]`) reads an Array by
- * its (already-numeric) value.
+ * Lower `arr[index]` to the runtime's polymorphic `bf.get` accessor
+ * (`lib/barefoot_js.rb`) rather than guessing at compile time whether
+ * `index` is a string key or a numeric index (#2491). Row hashes
+ * deserialize with `symbolize_names: true`, so keys are Symbols while a
+ * dynamic key (e.g. a destructured `.map()` param used as a key,
+ * `tone[k]`) is a runtime String — `isStringTypedOperand` can't see
+ * that shape (the shared analyzer types it `{kind:'unknown'}`), so the
+ * previous `.to_sym`-or-not compile-time branch guessed wrong for that
+ * case and silently returned nil. `bf.get` tries the Hash key as-is,
+ * then as a Symbol, then as a String, and falls back to numeric Array
+ * indexing — a strict superset of the two hand-picked forms this used
+ * to emit, so the common loop-index case (`selected()[index]`) keeps
+ * working unchanged.
  */
 export function emitIndexAccessRuby(
   object: ParsedExpr,
@@ -48,8 +58,5 @@ export function emitIndexAccessRuby(
   emit: (e: ParsedExpr) => string,
   isStringName: (n: string) => boolean,
 ): string {
-  const i = emit(index)
-  return isStringTypedOperand(index, isStringName)
-    ? `${emit(object)}[(${i}).to_sym]`
-    : `${emit(object)}[${i}]`
+  return `bf.get(${emit(object)}, ${emit(index)})`
 }

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -36,6 +36,4 @@ export const renderDivergences: RenderDivergences = {
   // described in each issue and deleting the line.
   'loop-param-shadows-spread-const':
     'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check (the live `loopBoundNames` map exists but is not consulted on this path), so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
-  'loop-param-shadows-record-template-span':
-    'a dynamic-key element access on a loop row (`tone[k]`) renders empty: row hashes deserialize with SYMBOL keys while the dynamic key is a STRING, so `tone["a"]` is nil (https://github.com/piconic-ai/barefootjs/issues/2491)',
 }

--- a/packages/adapter-erb/test/bf_get_test.rb
+++ b/packages/adapter-erb/test/bf_get_test.rb
@@ -53,6 +53,17 @@ class BfGetTest < Minitest::Test
     assert_nil @bf.get(arr, -1)
   end
 
+  def test_array_non_integral_key_returns_nil
+    arr = %w[row0 row1 row2]
+    # `to_i` would coerce these to 0/1 and hand back an element JS never
+    # would: `arr["not-numeric"]` and `arr[1.2]` are both undefined.
+    assert_nil @bf.get(arr, 'not-numeric')
+    assert_nil @bf.get(arr, '')
+    assert_nil @bf.get(arr, 1.2)
+    # An integral Float still indexes, matching JS `arr[1.0]`.
+    assert_equal 'row1', @bf.get(arr, 1.0)
+  end
+
   def test_nil_collection_or_key_returns_nil
     assert_nil @bf.get(nil, 'a')
     assert_nil @bf.get({ a: 1 }, nil)

--- a/packages/adapter-erb/test/bf_get_test.rb
+++ b/packages/adapter-erb/test/bf_get_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'barefoot_js'
+
+# bf.get -- runtime-polymorphic element/key access for `arr[index]` /
+# `hash[key]` (`emitIndexAccessRuby`, expr/operand.ts). Regression for
+# #2491: a dynamic-key element access on a loop row (`tone[k]`) used to
+# guess at compile time whether the index was a string key or a numeric
+# index, and the guess broke when a row hash (symbolize_names: true, so
+# Symbol-keyed) was accessed by a runtime String key. `get` dispatches on
+# the receiver's runtime type instead of guessing.
+class BfGetPureBackend
+  def mark_raw(str)
+    str
+  end
+end
+
+class BfGetTest < Minitest::Test
+  def setup
+    @bf = BarefootJS::Context.new(BfGetPureBackend.new)
+  end
+
+  def test_hash_with_symbol_keys_and_string_lookup_key
+    row = { id: 1, a: 'row1-a', b: 'row1-b' }
+    assert_equal 'row1-a', @bf.get(row, 'a')
+    assert_equal 1, @bf.get(row, 'id')
+  end
+
+  def test_hash_with_string_keys
+    row = { 'id' => 1, 'a' => 'row1-a' }
+    assert_equal 'row1-a', @bf.get(row, 'a')
+    # A Symbol lookup key still resolves against a String-keyed Hash.
+    assert_equal 'row1-a', @bf.get(row, :a)
+  end
+
+  def test_hash_missing_key_returns_nil
+    row = { a: 'row1-a' }
+    assert_nil @bf.get(row, 'missing')
+  end
+
+  def test_array_numeric_index
+    arr = %w[row0 row1 row2]
+    assert_equal 'row1', @bf.get(arr, 1)
+    # A string-typed numeric index (the common loop-index emission
+    # shape) resolves the same as a genuine Integer.
+    assert_equal 'row2', @bf.get(arr, '2')
+  end
+
+  def test_array_out_of_range_returns_nil
+    arr = %w[row0 row1]
+    assert_nil @bf.get(arr, 5)
+    assert_nil @bf.get(arr, -1)
+  end
+
+  def test_nil_collection_or_key_returns_nil
+    assert_nil @bf.get(nil, 'a')
+    assert_nil @bf.get({ a: 1 }, nil)
+  end
+end

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -2530,9 +2530,17 @@ func fieldAsIndex(field any) (int, bool) {
 		return toInt(field), true
 	}
 	switch n := field.(type) {
+	// Only an INTEGRAL float is an index. JS `arr[1.2]` is a property
+	// lookup (undefined), not index 1, so truncating here would diverge.
 	case float32:
+		if float64(n) != math.Trunc(float64(n)) {
+			return 0, false
+		}
 		return int(n), true
 	case float64:
+		if n != math.Trunc(n) {
+			return 0, false
+		}
 		return int(n), true
 	case string:
 		i, err := strconv.Atoi(n)

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -2396,11 +2396,22 @@ func projectSortKey(item any, keyKind, keyName string) any {
 	return item
 }
 
-// getFieldValue extracts a struct field value using reflection. For
-// map receivers it falls back to case-variant lookup so JSON-decoded
-// user data (`map[string]any{"price": 30}`) and PascalCase-emitted
-// test data both resolve under a single key name. (#1487)
-func getFieldValue(item any, field string) any {
+// getFieldValue extracts a struct field, map entry, or slice/array/string
+// element using reflection, dispatching on the RUNTIME kind of `item`
+// rather than a compile-time guess about `field`'s shape (#2491: a
+// dynamic-key element access on a loop row, `tone[k]`, is only known to
+// be string- or number-shaped at execution time — routing it through a
+// single runtime-polymorphic accessor, mirroring Jinja/minijinja `[]`
+// and Blade's `data_get()`, replaces the compile-time either/or guess
+// that broke for one shape or the other). For map/struct receivers it
+// falls back to case-variant lookup so JSON-decoded user data
+// (`map[string]any{"price": 30}`) and PascalCase-emitted test data both
+// resolve under a single key name. (#1487) `field` is `any` (not
+// `string`) precisely so a genuine numeric index (`bf_get $arr $i`,
+// e.g. `selected()[index]`) round-trips as an int rather than being
+// forced through a string conversion — this is a strict superset of the
+// `index` builtin, not a replacement that narrows numeric-index support.
+func getFieldValue(item any, field any) any {
 	v := reflect.ValueOf(item)
 	// Defensive IsNil guards mirror `SpreadAttrs` — keeps the helper
 	// safe against typed-nil pointer / nil-interface items inside a
@@ -2418,6 +2429,34 @@ func getFieldValue(item any, field string) any {
 		v = v.Elem()
 	}
 
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		idx, ok := fieldAsIndex(field)
+		if !ok || idx < 0 || idx >= v.Len() {
+			return nil
+		}
+		return v.Index(idx).Interface()
+	}
+
+	if v.Kind() == reflect.String {
+		idx, ok := fieldAsIndex(field)
+		if !ok {
+			return nil
+		}
+		runes := []rune(v.String())
+		if idx < 0 || idx >= len(runes) {
+			return nil
+		}
+		return string(runes[idx])
+	}
+
+	// From here on only a string-shaped key can match a map or struct
+	// field — a numeric `field` (e.g. a loop index applied to a
+	// non-indexable receiver) has no lookup to perform.
+	fieldStr, ok := field.(string)
+	if !ok {
+		return nil
+	}
+
 	if v.Kind() == reflect.Map {
 		keyType := v.Type().Key()
 		if keyType.Kind() != reflect.String {
@@ -2433,15 +2472,15 @@ func getFieldValue(item any, field string) any {
 			}
 			return nil, false
 		}
-		if r, ok := lookup(field); ok {
+		if r, ok := lookup(fieldStr); ok {
 			return r
 		}
-		if cap := capitalize(field); cap != field {
+		if cap := capitalize(fieldStr); cap != fieldStr {
 			if r, ok := lookup(cap); ok {
 				return r
 			}
 		}
-		if low := decapitalize(field); low != field {
+		if low := decapitalize(fieldStr); low != fieldStr {
 			if r, ok := lookup(low); ok {
 				return r
 			}
@@ -2450,7 +2489,7 @@ func getFieldValue(item any, field string) any {
 		// all-caps key (`id` → `ID`), and `decapitalize("ID")` only
 		// lowers the first char (`iD`), so the JS-keyed map ("id") still
 		// misses. Try the fully-lowered key last to resolve it.
-		if lower := strings.ToLower(field); lower != field && lower != decapitalize(field) {
+		if lower := strings.ToLower(fieldStr); lower != fieldStr && lower != decapitalize(fieldStr) {
 			if r, ok := lookup(lower); ok {
 				return r
 			}
@@ -2462,7 +2501,7 @@ func getFieldValue(item any, field string) any {
 		return nil
 	}
 
-	fieldVal := v.FieldByName(field)
+	fieldVal := v.FieldByName(fieldStr)
 	if !fieldVal.IsValid() {
 		// Case-variant fallback: the evaluator carries the JS field name
 		// (`id` / `url`) against a Go-capitalised struct field (`ID` / `URL`),
@@ -2472,12 +2511,38 @@ func getFieldValue(item any, field string) any {
 		// match, so it stays safe. The legacy bf_sort/bf_reduce pass an
 		// already-capitalised name, so they hit the exact match above and never
 		// reach this fallback.
-		fieldVal = v.FieldByNameFunc(func(n string) bool { return strings.EqualFold(n, field) })
+		fieldVal = v.FieldByNameFunc(func(n string) bool { return strings.EqualFold(n, fieldStr) })
 		if !fieldVal.IsValid() {
 			return nil
 		}
 	}
 	return fieldVal.Interface()
+}
+
+// fieldAsIndex converts a `getFieldValue` key argument to a slice/array/
+// string element index. Accepts genuine numeric kinds (the loop-index
+// case, `bf_get $arr $i`) directly, and a numeric-looking string (a
+// dynamic key that happens to be digits) via `strconv.Atoi` so a
+// string-typed index used against an array-shaped receiver still
+// resolves rather than silently missing.
+func fieldAsIndex(field any) (int, bool) {
+	if isIntLike(field) {
+		return toInt(field), true
+	}
+	switch n := field.(type) {
+	case float32:
+		return int(n), true
+	case float64:
+		return int(n), true
+	case string:
+		i, err := strconv.Atoi(n)
+		if err != nil {
+			return 0, false
+		}
+		return i, true
+	default:
+		return 0, false
+	}
 }
 
 // AsMap normalizes a dynamically-typed prop value into a

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -1530,6 +1530,26 @@ func TestSort_FieldOnMapReceiver_TolerantToNilEntries(t *testing.T) {
 // `indexAccess` route every dynamic-key element access — including a
 // genuine numeric loop index (`selected()[i]`) — through one accessor
 // without a compile-time guess about which shape `field` will be.
+func TestGetFieldValue_NonIntegralIndexIsNotFound(t *testing.T) {
+	arr := []string{"row0", "row1", "row2"}
+	// JS `arr[1.2]` is a property lookup (undefined), not index 1 —
+	// truncating would diverge from every other adapter.
+	if got := getFieldValue(arr, 1.2); got != nil {
+		t.Errorf("getFieldValue(arr, 1.2) = %v, want nil", got)
+	}
+	if got := getFieldValue(arr, float32(0.5)); got != nil {
+		t.Errorf("getFieldValue(arr, 0.5) = %v, want nil", got)
+	}
+	// An integral float still indexes, matching JS `arr[1.0]`.
+	if got := getFieldValue(arr, 1.0); got != "row1" {
+		t.Errorf("getFieldValue(arr, 1.0) = %v, want row1", got)
+	}
+	// A non-numeric string key is not an index either.
+	if got := getFieldValue(arr, "not-numeric"); got != nil {
+		t.Errorf("getFieldValue(arr, \"not-numeric\") = %v, want nil", got)
+	}
+}
+
 func TestGetFieldValue_SliceNumericIndex(t *testing.T) {
 	items := []any{"row0", "row1", "row2"}
 	if got := getFieldValue(items, 1); got != "row1" {

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -1522,6 +1522,70 @@ func TestSort_FieldOnMapReceiver_TolerantToNilEntries(t *testing.T) {
 	// is that we didn't panic, and the result length is preserved.
 }
 
+// (#2491) `getFieldValue` (`bf_get`) is a strict superset of the `index`
+// builtin: it now dispatches on the receiver's reflected kind so a
+// slice/array/string receiver resolves a NUMERIC `field` the same way
+// `index` would, while a map/struct receiver still resolves a STRING
+// `field` through the existing case-tolerant lookup. This is what lets
+// `indexAccess` route every dynamic-key element access — including a
+// genuine numeric loop index (`selected()[i]`) — through one accessor
+// without a compile-time guess about which shape `field` will be.
+func TestGetFieldValue_SliceNumericIndex(t *testing.T) {
+	items := []any{"row0", "row1", "row2"}
+	if got := getFieldValue(items, 1); got != "row1" {
+		t.Errorf("getFieldValue(slice, 1) = %v, want row1", got)
+	}
+	// A named int type (e.g. a loop-index variable of a distinct
+	// underlying kind) must still resolve via `isIntLike`.
+	if got := getFieldValue(items, int64(2)); got != "row2" {
+		t.Errorf("getFieldValue(slice, int64(2)) = %v, want row2", got)
+	}
+}
+
+func TestGetFieldValue_SliceIndexOutOfRange(t *testing.T) {
+	items := []any{"row0", "row1"}
+	if got := getFieldValue(items, 5); got != nil {
+		t.Errorf("getFieldValue(slice, 5) = %v, want nil", got)
+	}
+	if got := getFieldValue(items, -1); got != nil {
+		t.Errorf("getFieldValue(slice, -1) = %v, want nil", got)
+	}
+}
+
+func TestGetFieldValue_ArrayNumericIndex(t *testing.T) {
+	arr := [3]int{10, 20, 30}
+	if got := getFieldValue(arr, 2); got != 30 {
+		t.Errorf("getFieldValue(array, 2) = %v, want 30", got)
+	}
+}
+
+func TestGetFieldValue_StringNumericIndex(t *testing.T) {
+	if got := getFieldValue("hello", 1); got != "e" {
+		t.Errorf("getFieldValue(string, 1) = %v, want e", got)
+	}
+	if got := getFieldValue("hello", 99); got != nil {
+		t.Errorf("getFieldValue(string, 99) = %v, want nil", got)
+	}
+}
+
+// This is the direct regression for #2491: a `.map((tone) => ...)` row
+// keyed PascalCase (`goFieldNameForKey`'s contract) accessed by a
+// dynamic STRING key (the loop param's runtime value, `k = "a"`) must
+// resolve case-tolerantly, same as a static `tone.a` would.
+func TestGetFieldValue_MapDynamicStringKey(t *testing.T) {
+	row := map[string]any{"ID": 1, "A": "row1-a", "B": "row1-b"}
+	if got := getFieldValue(row, "a"); got != "row1-a" {
+		t.Errorf(`getFieldValue(row, "a") = %v, want row1-a`, got)
+	}
+}
+
+func TestGetFieldValue_NumericFieldAgainstMapReturnsNil(t *testing.T) {
+	row := map[string]any{"A": "row1-a"}
+	if got := getFieldValue(row, 0); got != nil {
+		t.Errorf("getFieldValue(map, 0) = %v, want nil", got)
+	}
+}
+
 // =============================================================================
 // JS-compat callees (#1188): bf_json / bf_string / bf_number /
 // bf_floor / bf_ceil / bf_round / bf_replace.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4024,11 +4024,22 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   indexAccess(object: ParsedExpr, index: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    // Go's `index` builtin: `index $arr $i`. Both operands render through the
-    // same emitter so a loop-variable / arithmetic index lowers correctly. A
-    // multi-token operand (`bf_add $i 1`) must be parenthesised or Go parses it
-    // as extra `index` arguments.
-    return `index ${wrapIfMultiToken(emit(object))} ${wrapIfMultiToken(emit(index))}`
+    // Go's builtin `index` is exact-case only, and the shared analyzer
+    // types a dynamic index (e.g. a destructured .map() param used as a
+    // key, `tone[k]`) as `{kind:'unknown'}` — there is no compile-time
+    // witness available to guess whether the runtime value will be a
+    // string key or a numeric index (#2491). Route through the runtime's
+    // case-tolerant, kind-polymorphic `bf_get` (`getFieldValue`, bf.go)
+    // instead of guessing: it dispatches on the receiver's REFLECTED
+    // kind (map/struct vs slice/array/string) and accepts either a
+    // string or numeric `field` argument, so it's a strict superset of
+    // `index` — genuine numeric-index uses (`selected()[i]`) keep
+    // working, and string-keyed row lookups now resolve too. Both
+    // operands render through the same emitter so a loop-variable /
+    // arithmetic index lowers correctly. A multi-token operand
+    // (`bf_add $i 1`) must be parenthesised or Go parses it as extra
+    // `bf_get` arguments.
+    return `bf_get ${wrapIfMultiToken(emit(object))} ${wrapIfMultiToken(emit(index))}`
   }
 
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -48,8 +48,6 @@ export const renderDivergences: RenderDivergences = {
     'the `inLoop` clobber is FIXED (#2487) — outer-row content after a nested loop now takes the loop arms and the spread resolves row-scoped. Residual: the spread\'s attribute NAMES are still mangled by the Go-cased-key kebab conversion (`data-kind` → `-data-kind`), which is #2490; this entry graduates with that fix (https://github.com/piconic-ai/barefootjs/issues/2490)',
   'loop-param-shadows-spread-const':
     'spreading a loop row object mangles attribute names (`id` → `-i-d`, `title` → `-title`); the spread VALUE is correctly row-scoped, distinguishing this from the template-adapter const-shadow hole #2489 (https://github.com/piconic-ai/barefootjs/issues/2490)',
-  'loop-param-shadows-record-template-span':
-    'a dynamic-key element access on a loop row (`tone[k]`) renders empty at execute time — the emitted template contains no baked const (correct post-fix), but the row lookup resolves to nothing (https://github.com/piconic-ai/barefootjs/issues/2491)',
   'callback-param-shadows-prop':
     'JS-computed signal/memo initializers (`[…].map(…).join(…)`, memo over signal + prop) don\'t seed Go SSR — renders `[]` / empty where every other adapter renders the computed value; hydration snaps to correct (https://github.com/piconic-ai/barefootjs/issues/2492)',
 }

--- a/packages/adapter-mojolicious/src/adapter/expr/operand.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/operand.ts
@@ -12,14 +12,23 @@
  * (Perl's `->[]` vs `->{}` split has no Kolon equivalent).
  */
 
-import { isStringTypedOperand, type ParsedExpr } from '@barefootjs/jsx'
+import type { ParsedExpr } from '@barefootjs/jsx'
 
 /**
- * Lower `arr[index]` to a Perl deref. Perl distinguishes array
- * (`->[$i]`) from hash (`->{$k}`) access, which JS's single `[]` does
- * not — so we pick by the index expression's type: a string-typed key
- * derefs the hash, anything else (the common loop-index / arithmetic
- * case, e.g. `selected()[index]`) derefs the array. #1897.
+ * Lower `arr[index]` to the runtime's polymorphic `bf->get` accessor
+ * (`BarefootJS.pm`, adapter-perl) rather than guessing at compile time
+ * whether `index` is a string key or a numeric index (#2491). Perl
+ * distinguishes array (`->[$i]`) from hash (`->{$k}`) access, which
+ * JS's single `[]` does not — the previous compile-time guess (string-
+ * typed key → hash deref, else → array deref) FAILS FATALLY
+ * ("Not an ARRAY reference") whenever a dynamic key of unknowable type
+ * (e.g. a destructured `.map()` param used as a key, `tone[k]` — the
+ * shared analyzer types it `{kind:'unknown'}`) is applied to a hash-
+ * shaped row, because the guess defaults to the array branch. `bf->get`
+ * dispatches on the receiver's RUNTIME `ref` instead, so it's a strict
+ * superset of the two hand-picked deref forms this used to emit — the
+ * common loop-index case (`selected()[index]`, #1897) keeps working
+ * unchanged.
  */
 export function emitIndexAccessPerl(
   object: ParsedExpr,
@@ -27,8 +36,5 @@ export function emitIndexAccessPerl(
   emit: (e: ParsedExpr) => string,
   isStringName: (n: string) => boolean,
 ): string {
-  const i = emit(index)
-  return isStringTypedOperand(index, isStringName)
-    ? `${emit(object)}->{${i}}`
-    : `${emit(object)}->[${i}]`
+  return `bf->get(${emit(object)}, ${emit(index)})`
 }

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -33,6 +33,4 @@ export const renderDivergences: RenderDivergences = {
   'composite-row-child-aliased-prop':
     'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
 
-  'loop-param-shadows-record-template-span':
-    'a dynamic-key element access on a loop row (`tone[k]`) diverges on real Mojolicious at render time (same silent-empty family as ERB/Go/Twig; the Perl-side mechanism needs a dig) (https://github.com/piconic-ai/barefootjs/issues/2491)',
 }

--- a/packages/adapter-perl/MANIFEST
+++ b/packages/adapter-perl/MANIFEST
@@ -10,6 +10,7 @@ SECURITY.md
 MANIFEST
 Makefile.PL
 README.md
+t/bf_get.t
 t/controller_cycle.t
 t/dev_reload.t
 t/eval_vectors.t

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -992,6 +992,35 @@ sub length ($self, $recv) {
     return $n;
 }
 
+# `arr[index]` / `hash[key]` — a runtime-polymorphic dynamic-key element
+# access (`emitIndexAccessPerl`, expr/operand.ts). Perl's deref syntax
+# forces a compile-time choice between `->{$k}` (hash) and `->[$k]`
+# (array), but the shared analyzer can't tell at compile time whether a
+# dynamic key (e.g. a destructured `.map()` param used as a key,
+# `tone[k]`) will turn out string- or number-shaped — it types it
+# `{kind:'unknown'}`. The previous compile-time guess picked `->[$k]`
+# (array deref) whenever it couldn't prove string-typed, which is a
+# FATAL "Not an ARRAY reference" against a hash row (#2491). Dispatch on
+# the receiver's RUNTIME `ref` instead — mirrors the Go adapter's
+# `getFieldValue`/`bf_get` and Twig's `attribute()`.
+sub get ($self, $collection, $key) {
+    return undef unless defined $key;
+    if (ref($collection) eq 'HASH') {
+        return $collection->{$key};
+    }
+    if (ref($collection) eq 'ARRAY') {
+        return undef unless $key =~ /^-?\d+$/;
+        my $idx = $key + 0;
+        # JS-semantics negative index is "not found" (`arr[-1] ===
+        # undefined`), NOT Perl's native from-the-end wraparound — guard
+        # it explicitly so this stays a superset of `->[]`, not a
+        # divergent accessor.
+        return undef if $idx < 0 || $idx >= scalar @$collection;
+        return $collection->[$idx];
+    }
+    return undef;
+}
+
 # `isValidElement(x)` -- the framework "is this a renderable element (not
 # plain text)?" predicate `Slot`'s `asChild` pattern uses (#2266). Mirrors
 # JS's `'tag' in x && 'props' in x`: true only for a HASH ref carrying both

--- a/packages/adapter-perl/t/bf_get.t
+++ b/packages/adapter-perl/t/bf_get.t
@@ -1,0 +1,49 @@
+use Test2::V0;
+
+# bf->get — runtime-polymorphic dynamic-key element access (#2491):
+# `arr[index]` / `hash[key]` lowered from `emitIndexAccessPerl`
+# (adapter-mojolicious/src/adapter/expr/operand.ts). Regression for the
+# fatal "Not an ARRAY reference" a dynamic-key row access (`tone[k]`)
+# used to raise when the compile-time string/array guess picked the
+# array-deref branch against a hash-shaped row. `get` dispatches on the
+# receiver's runtime `ref` instead of guessing.
+
+use FindBin qw($Bin);
+use lib "$Bin/../lib";
+
+use BarefootJS;
+
+# Minimal pure-Perl backend: `get` is a pure function of $self + args, no
+# backend calls reached.
+{
+    package PureBackend;
+    sub new      { bless {}, shift }
+    sub mark_raw { $_[1] }
+}
+
+my $bf = bless { c => undef, config => {}, backend => PureBackend->new }, 'BarefootJS';
+
+subtest 'hash receiver — string key' => sub {
+    my $row = { id => 1, a => 'row1-a', b => 'row1-b' };
+    is $bf->get($row, 'a'),  'row1-a', 'string key resolves';
+    is $bf->get($row, 'id'), 1,        'string key resolves (numeric value)';
+    is $bf->get($row, 'missing'), undef, 'missing key -> undef';
+};
+
+subtest 'array receiver — numeric index' => sub {
+    my $arr = ['row0', 'row1', 'row2'];
+    is $bf->get($arr, 1),   'row1', 'integer index resolves';
+    is $bf->get($arr, '2'), 'row2', 'numeric-string index resolves';
+    is $bf->get($arr, 5),   undef,  'out-of-range index -> undef';
+    is $bf->get($arr, -1),  undef,  'negative index -> undef (JS semantics, not Perl wraparound)';
+};
+
+subtest 'edge cases' => sub {
+    is $bf->get(undef, 'a'),        undef, 'nil collection -> undef';
+    is $bf->get({ a => 1 }, undef), undef, 'nil key -> undef';
+    is $bf->get('not a ref', 'a'),  undef, 'scalar receiver -> undef';
+    my $arr = ['x'];
+    is $bf->get($arr, 'not-numeric'), undef, 'non-numeric key against array -> undef';
+};
+
+done_testing;

--- a/packages/adapter-twig/src/adapter/expr/emitters.ts
+++ b/packages/adapter-twig/src/adapter/expr/emitters.ts
@@ -167,10 +167,21 @@ export class TwigFilterEmitter implements ParsedExprEmitter {
   }
 
   indexAccess(object: ParsedExpr, index: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    // Twig's `[]` postfix is polymorphic (list index or hash key),
-    // mirroring JS — no list/hash split is needed. #1897 (data-table's
-    // `selected()[index]`).
-    return `${emit(object)}[${emit(index)}]`
+    // NOT `[]` — Twig compiles bracket syntax as ARRAY_CALL, which
+    // returns null against a PHP object receiver and never falls back
+    // to property access; it is NOT polymorphic (that was this
+    // comment's previous, incorrect claim — the polymorphic form is
+    // `.`, used by `member()` above, which is the actual source of the
+    // confusion). Props cross into PHP as `stdClass` (`json_decode`
+    // without assoc), so loop rows are objects, and a dynamic-key
+    // access (`tone[k]`) needs a runtime-polymorphic accessor rather
+    // than a compile-time guess about the key's shape (#2491). Twig's
+    // built-in `attribute()` function IS that accessor: verified to
+    // resolve stdClass properties, assoc-array keys, and numeric list
+    // indices identically to `.`. #1897 (data-table's
+    // `selected()[index]`) still works — `attribute()` is a strict
+    // superset of `[]` for that numeric-index case.
+    return `attribute(${emit(object)}, ${emit(index)})`
   }
 
   call(callee: ParsedExpr, args: ParsedExpr[], emit: (e: ParsedExpr) => string): string {
@@ -349,9 +360,17 @@ export class TwigTopLevelEmitter implements ParsedExprEmitter {
   }
 
   indexAccess(object: ParsedExpr, index: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    // Twig's `[]` postfix is polymorphic (list index or hash key),
-    // mirroring JS. #1897 (data-table's `selected()[index]`).
-    return `${emit(object)}[${emit(index)}]`
+    // NOT `[]` — see the top-level emitter's `indexAccess` docstring:
+    // Twig's bracket syntax compiles to ARRAY_CALL, which does not fall
+    // back to property access on a PHP object (`stdClass`) receiver, so
+    // it is NOT polymorphic the way `.` is. Route through the built-in
+    // `attribute()` function instead, which resolves stdClass
+    // properties, assoc-array keys, and numeric list indices uniformly
+    // — the runtime-polymorphic accessor a dynamic-key row access
+    // (`tone[k]`) needs (#2491). #1897 (data-table's
+    // `selected()[index]`) keeps working — `attribute()` is a strict
+    // superset of `[]` for that numeric-index case.
+    return `attribute(${emit(object)}, ${emit(index)})`
   }
 
   call(callee: ParsedExpr, args: ParsedExpr[], emit: (e: ParsedExpr) => string): string {

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -38,6 +38,4 @@ export const renderDivergences: RenderDivergences = {
   // described in each issue and deleting the line.
   'loop-param-shadows-spread-const':
     'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
-  'loop-param-shadows-record-template-span':
-    'a dynamic-key element access on a loop row (`tone[k]`) renders empty on real PHP Twig — the row lookup resolves to nothing at render time (Jinja/minijinja render it correctly, so this is the PHP-side data-shape/access path, not the emission) (https://github.com/piconic-ai/barefootjs/issues/2491)',
 }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2345,24 +2345,6 @@
           ]
         }
       },
-      "loop-param-shadows-record-template-span": {
-        "erb": {
-          "kind": "render",
-          "reason": "a dynamic-key element access on a loop row (`tone[k]`) renders empty: row hashes deserialize with SYMBOL keys while the dynamic key is a STRING, so `tone[\"a\"]` is nil (https://github.com/piconic-ai/barefootjs/issues/2491)"
-        },
-        "go-template": {
-          "kind": "render",
-          "reason": "a dynamic-key element access on a loop row (`tone[k]`) renders empty at execute time — the emitted template contains no baked const (correct post-fix), but the row lookup resolves to nothing (https://github.com/piconic-ai/barefootjs/issues/2491)"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "a dynamic-key element access on a loop row (`tone[k]`) diverges on real Mojolicious at render time (same silent-empty family as ERB/Go/Twig; the Perl-side mechanism needs a dig) (https://github.com/piconic-ai/barefootjs/issues/2491)"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "a dynamic-key element access on a loop row (`tone[k]`) renders empty on real PHP Twig — the row lookup resolves to nothing at render time (Jinja/minijinja render it correctly, so this is the PHP-side data-shape/access path, not the emission) (https://github.com/piconic-ai/barefootjs/issues/2491)"
-        }
-      },
       "loop-param-shadows-spread-const": {
         "blade": {
           "kind": "render",
@@ -2942,10 +2924,6 @@
       "flatmap-typeof-projection": {
         "description": "Off-subset `.flatMap()` projection (typeof) — JS-runtime faithful, DSL diagnostic",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/flatmap-typeof-projection.ts"
-      },
-      "loop-param-shadows-record-template-span": {
-        "description": ".map() param shadowing a record const stays row-scoped inside a `${base[key]}` template span",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/loop-param-shadows-record-template-span.ts"
       },
       "loop-param-shadows-spread-const": {
         "description": ".map() param shadowing an object const spreads the row value, not the outer const",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1533,7 +1533,7 @@
           ]
         },
         "erb": {
-          "pass": 184,
+          "pass": 185,
           "total": 200,
           "gaps": [
             {
@@ -1566,10 +1566,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -1611,7 +1607,7 @@
           ]
         },
         "go-template": {
-          "pass": 181,
+          "pass": 182,
           "total": 200,
           "gaps": [
             {
@@ -1654,10 +1650,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -1871,7 +1863,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 184,
+          "pass": 185,
           "total": 200,
           "gaps": [
             {
@@ -1911,10 +1903,6 @@
               "issues": []
             },
             {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            },
-            {
               "fixture": "preamble-cells",
               "issues": []
             },
@@ -1949,7 +1937,7 @@
           ]
         },
         "twig": {
-          "pass": 182,
+          "pass": 183,
           "total": 200,
           "gaps": [
             {
@@ -1992,10 +1980,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -2405,7 +2389,7 @@
           ]
         },
         "erb": {
-          "pass": 269,
+          "pass": 270,
           "total": 288,
           "gaps": [
             {
@@ -2442,10 +2426,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -2495,7 +2475,7 @@
           ]
         },
         "go-template": {
-          "pass": 266,
+          "pass": 267,
           "total": 288,
           "gaps": [
             {
@@ -2542,10 +2522,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -2791,7 +2767,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 269,
+          "pass": 270,
           "total": 288,
           "gaps": [
             {
@@ -2832,10 +2808,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -2881,7 +2853,7 @@
           ]
         },
         "twig": {
-          "pass": 267,
+          "pass": 268,
           "total": 288,
           "gaps": [
             {
@@ -2928,10 +2900,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -3101,24 +3069,12 @@
           "total": 14
         },
         "erb": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "go-template": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "jinja": {
           "pass": 14,
@@ -3129,24 +3085,12 @@
           "total": 14
         },
         "mojolicious": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "twig": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "xslate": {
           "pass": 14,
@@ -3229,7 +3173,7 @@
           ]
         },
         "erb": {
-          "pass": 225,
+          "pass": 226,
           "total": 238,
           "gaps": [
             {
@@ -3250,10 +3194,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -3289,7 +3229,7 @@
           ]
         },
         "go-template": {
-          "pass": 223,
+          "pass": 224,
           "total": 238,
           "gaps": [
             {
@@ -3314,10 +3254,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -3469,7 +3405,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 226,
+          "pass": 227,
           "total": 238,
           "gaps": [
             {
@@ -3490,10 +3426,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -3525,7 +3457,7 @@
           ]
         },
         "twig": {
-          "pass": 225,
+          "pass": 226,
           "total": 238,
           "gaps": [
             {
@@ -3546,10 +3478,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -3909,7 +3837,7 @@
           ]
         },
         "erb": {
-          "pass": 136,
+          "pass": 137,
           "total": 154,
           "gaps": [
             {
@@ -3942,10 +3870,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -3995,7 +3919,7 @@
           ]
         },
         "go-template": {
-          "pass": 133,
+          "pass": 134,
           "total": 154,
           "gaps": [
             {
@@ -4038,10 +3962,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -4279,7 +4199,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 136,
+          "pass": 137,
           "total": 154,
           "gaps": [
             {
@@ -4316,10 +4236,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -4365,7 +4281,7 @@
           ]
         },
         "twig": {
-          "pass": 134,
+          "pass": 135,
           "total": 154,
           "gaps": [
             {
@@ -4408,10 +4324,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -4593,13 +4505,9 @@
           ]
         },
         "erb": {
-          "pass": 51,
+          "pass": 52,
           "total": 55,
           "gaps": [
-            {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            },
             {
               "fixture": "loop-param-shadows-spread-const",
               "issues": []
@@ -4617,15 +4525,11 @@
           ]
         },
         "go-template": {
-          "pass": 50,
+          "pass": 51,
           "total": 55,
           "gaps": [
             {
               "fixture": "callback-param-shadows-prop",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -4685,13 +4589,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 52,
+          "pass": 53,
           "total": 55,
           "gaps": [
-            {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -4705,13 +4605,9 @@
           ]
         },
         "twig": {
-          "pass": 51,
+          "pass": 52,
           "total": 55,
           "gaps": [
-            {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            },
             {
               "fixture": "loop-param-shadows-spread-const",
               "issues": []
@@ -4825,13 +4721,9 @@
           ]
         },
         "erb": {
-          "pass": 28,
+          "pass": 29,
           "total": 30,
           "gaps": [
-            {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            },
             {
               "fixture": "tag-cloud",
               "issues": []
@@ -4839,13 +4731,9 @@
           ]
         },
         "go-template": {
-          "pass": 28,
+          "pass": 29,
           "total": 30,
           "gaps": [
-            {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            },
             {
               "fixture": "tag-cloud",
               "issues": []
@@ -4873,13 +4761,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 28,
+          "pass": 29,
           "total": 30,
           "gaps": [
-            {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            },
             {
               "fixture": "tag-cloud",
               "issues": []
@@ -4887,13 +4771,9 @@
           ]
         },
         "twig": {
-          "pass": 28,
+          "pass": 29,
           "total": 30,
           "gaps": [
-            {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            },
             {
               "fixture": "tag-cloud",
               "issues": []
@@ -7924,15 +7804,11 @@
           ]
         },
         "erb": {
-          "pass": 94,
+          "pass": 95,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -7958,15 +7834,11 @@
           ]
         },
         "go-template": {
-          "pass": 93,
+          "pass": 94,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -8056,15 +7928,11 @@
           ]
         },
         "mojolicious": {
-          "pass": 95,
+          "pass": 96,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -8086,15 +7954,11 @@
           ]
         },
         "twig": {
-          "pass": 94,
+          "pass": 95,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -8214,7 +8078,7 @@
           ]
         },
         "erb": {
-          "pass": 158,
+          "pass": 159,
           "total": 168,
           "gaps": [
             {
@@ -8238,10 +8102,6 @@
               "issues": []
             },
             {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            },
-            {
               "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
@@ -8262,7 +8122,7 @@
           ]
         },
         "go-template": {
-          "pass": 157,
+          "pass": 158,
           "total": 168,
           "gaps": [
             {
@@ -8287,10 +8147,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {
@@ -8402,6 +8258,46 @@
           ]
         },
         "mojolicious": {
+          "pass": 160,
+          "total": 168,
+          "gaps": [
+            {
+              "fixture": "every-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "filter-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "find-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "flatmap-typeof-projection",
+              "issues": []
+            },
+            {
+              "fixture": "preamble-cells",
+              "issues": []
+            },
+            {
+              "fixture": "some-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            }
+          ]
+        },
+        "twig": {
           "pass": 159,
           "total": 168,
           "gaps": [
@@ -8423,54 +8319,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
-              "issues": []
-            },
-            {
-              "fixture": "preamble-cells",
-              "issues": []
-            },
-            {
-              "fixture": "some-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "static-array-from-props-with-component",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            }
-          ]
-        },
-        "twig": {
-          "pass": 158,
-          "total": 168,
-          "gaps": [
-            {
-              "fixture": "every-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "filter-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "find-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-record-template-span",
               "issues": []
             },
             {


### PR DESCRIPTION
**Stacked on #2504** (which is stacked on #2503) — review those first; this PR's own diff is the four adapters' index-access emitters plus two runtime helpers.

Third of the series addressing the #2482 audit's adapter-side defects (#2486–#2492). This one fixes #2491.

## The bug

```tsx
items.map((tone) => <li key={tone.id} data-t={`t ${tone[k]}`}>{tone.a}</li>)
```
with `k: 'a'` renders `data-t="t "` on ERB, Go and Twig. On **Mojolicious it is worse than the issue records**: not an empty render but a fatal `Not an ARRAY reference` — a hard SSR failure. I've noted that on the issue.

## The insight

Jinja, minijinja, Blade and Xslate all render this correctly. What they have in common is not better type inference — it is that they **never decide at compile time** whether an index is a string key or a numeric index. Each routes dynamic access through an accessor that is polymorphic at runtime (Jinja/minijinja `getitem`, Blade `data_get()`, Xslate's native `[]`).

The four broken adapters each make a compile-time guess, and each guess fails for a *different* reason:

| adapter | guess | why it's wrong here |
|---|---|---|
| ERB | `isStringTypedOperand` → `[…]` vs `[(…).to_sym]` | rows deserialize with **symbol** keys; `k` is a String, so `tone["a"]` is nil. Its `isStringTypedOperand` is a stale pre-#2212 fork with no identifier arm, while its docstring claims byte-identity with Mojo's (which migrated to the shared one) |
| Mojolicious | same predicate → `->{…}` vs `->[…]` | picks the **ARRAY** deref on a hashref → fatal |
| Twig | `[]` "is polymorphic, mirroring JS" | false for Twig: bracket syntax compiles as `ARRAY_CALL`, which returns null for an object receiver and never falls back to property access the way `.` does. Props cross into PHP as `stdClass` |
| Go | builtin `index` | exact-case, but row maps carry the PascalCase keys the `goFieldNameForKey` contract bakes (the same contract that makes `tone.a` emit `.A`), while `k`'s value is the raw `"a"` |

Crucially, **the compile-time guess is not fixable by better inference**: the shared analyzer types `k` as `{kind:'unknown'}` for every adapter, so no type witness is reachable from any of them. Improving `isStringTypedOperand` would not have helped.

## The fix

Adopt the working adapters' approach in all four:

- **Go** — emit `bf_get` (the existing case-tolerant `getFieldValue` helper, already registered) instead of the builtin `index`. Added a slice/array branch to `getFieldValue` so it is a strict **superset** of `index` and genuine numeric indexing (`selected()[i]`, data-table) keeps working, with a Go unit test for the new branch.
- **Twig** — emit Twig's built-in `attribute(obj, key)`, which resolves stdClass, assoc arrays and numeric list indices alike. Both copies (top-level and filter-body emitters), plus the two stale comments asserting `[]` is polymorphic.
- **ERB / Mojolicious** — new `bf.get` / `bf->get` runtime helpers dispatching on the collection's actual type, with unit tests (`packages/adapter-erb/test/bf_get_test.rb`, `packages/adapter-perl/t/bf_get.t`).

## Graduation

Deletes the `loop-param-shadows-record-template-span` pin from all four adapters. The fixture becomes live regression armor across all nine backends.

## Validation

- `bunx tsc --noEmit` clean in all four packages.
- The fixture renders through the **real engine** and passes on all four: erb, twig, mojolicious, go-template — confirmed not skipped in any of them.
- Full suites running as of opening this draft; counts to follow before marking ready.

## Follow-up worth filing separately

ERB's `src/adapter/expr/operand.ts` keeps its own stale fork of `isStringTypedOperand` (no identifier arm, pre-#2212) while its docstring claims byte-identity with the Mojo/Xslate copies — Mojo has since migrated to the shared `@barefootjs/jsx` implementation. This PR makes the divergence moot for index-access but does not remove the fork; it is still live for the other call sites in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpPtSg6rTe158671pknoD2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpPtSg6rTe158671pknoD2)_