### PR TITLE
ci: decide releases from the registry, not from .changeset/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,8 @@ jobs:
     # default 6h, blocking every queued release run behind it.
     timeout-minutes: 30
     outputs:
-      published: ${{ steps.changesets.outputs.published }}
-      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+      published: ${{ steps.changesets.outputs.published == 'true' && 'true' || steps.fallback.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.published == 'true' && steps.changesets.outputs.publishedPackages || steps.fallback.outputs.publishedPackages }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -81,6 +81,53 @@ jobs:
           publish: bun run release:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Whether a release happens must not depend on what else merged.
+      #
+      # changesets/action decides between "open a Version PR" and "publish"
+      # from whether `.changeset/` is empty — global state any PR can change.
+      # A changeset landing on main between the Version PR being refreshed and
+      # merged turns that merge into another version PR, and the run goes green
+      # having released nothing (0.30.1: #2500 merged 29s before #2495).
+      #
+      # So decide from what is actually on npm instead. release:publish is
+      # idempotent and version-driven — it compares each package.json against
+      # the registry and skips what is already there — so this is a no-op in
+      # the ordinary case and a release in the case above. Guarded by the
+      # verify script so the ordinary case costs 22 small HTTP requests rather
+      # than a full build; exit 2 (could not reach a registry) deliberately
+      # does not trigger a publish.
+      - name: Publish anything main has that npm does not
+        id: fallback
+        if: steps.changesets.outputs.published != 'true'
+        run: |
+          set +e
+          bun scripts/verify-released.ts --npm
+          drift=$?
+          set -e
+          if [ "$drift" -eq 0 ]; then
+            echo "main matches npm — nothing to publish"
+            exit 0
+          fi
+          if [ "$drift" -ne 1 ]; then
+            echo "::error::could not determine what is published; not publishing"
+            exit 1
+          fi
+
+          echo "::warning::main is ahead of npm — publishing (changesets took the version path)"
+          bun run release:publish | tee publish.log
+
+          # Rebuild the shape changesets/action would have emitted, so
+          # cpan-release and every sibling native-registry job still fire.
+          # changeset-publish.ts prints one "New tag: <name>@<version>" per
+          # package it published — the same line the action itself parses.
+          entries=$(sed -n 's/^New tag: \(.*\)@\([^@]*\)$/{"name":"\1","version":"\2"}/p' publish.log | paste -sd, -)
+          if [ -z "$entries" ]; then
+            echo "::error::main was ahead of npm but nothing published — check the log above"
+            exit 1
+          fi
+          echo "published=true" >> "$GITHUB_OUTPUT"
+          echo "publishedPackages=[$entries]" >> "$GITHUB_OUTPUT"
 
   # Mirror whatever Changesets just published to npm onto JSR. Delegates to
   # the reusable jsr-publish.yml so the release-driven path and the manual

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,11 @@ jobs:
         id: fallback
         if: steps.changesets.outputs.published != 'true'
         run: |
+          # pipefail matters below: `bun run release:publish | tee` reports
+          # tee's status without it, so a failed publish would fall through to
+          # the parsing step and mark a partial release as a successful one —
+          # the exact silent-failure shape this whole step exists to remove.
+          set -o pipefail
           set +e
           bun scripts/verify-released.ts --npm
           drift=$?

--- a/scripts/verify-released.ts
+++ b/scripts/verify-released.ts
@@ -167,11 +167,23 @@ async function checkCpan(): Promise<Problem[]> {
       // One release wears three hats — "0.30.2" in the .pm literal, "v0.30.2"
       // in META/02packages, "0.030002" in PAUSE's numified form. Compare
       // through the parser that defines them.
-      const same = await perl('exit(version->parse($ARGV[0]) == version->parse($ARGV[1]) ? 0 : 1)', [
-        indexed,
-        version,
-      ])
-      if (same.exitCode !== 0) {
+      //
+      // `use version` is belt and braces: version:: is bootstrapped into the
+      // interpreter, so `version->parse` resolves even though version.pm is
+      // not in %INC, but nothing here should rest on that. 0 and 1 are the
+      // only answers — anything else (a die on unparseable input, say) is not
+      // a verdict, so it throws to exit 2 rather than reporting drift, the
+      // same rule httpGet follows.
+      const same = await perl(
+        'use version; exit(version->parse($ARGV[0]) == version->parse($ARGV[1]) ? 0 : 1)',
+        [indexed, version],
+      )
+      if (same.exitCode !== 0 && same.exitCode !== 1) {
+        throw new Error(
+          `comparing ${module} ${indexed} against ${version}: ${same.stderr.toString().trim()}`,
+        )
+      }
+      if (same.exitCode === 1) {
         found.push({ registry: 'CPAN', subject: module, expected: version, found: `indexed at ${indexed}` })
       }
     }

--- a/scripts/verify-released.ts
+++ b/scripts/verify-released.ts
@@ -1,0 +1,250 @@
+#!/usr/bin/env bun
+//
+// Ask the registries whether the versions on main are actually installable.
+//
+// Two release failures motivated this, and neither produced a red check,
+// because in both cases the pipeline believed it had succeeded:
+//
+//   - changesets/action decides whether to publish from whether `.changeset/`
+//     is empty. A changeset landing on main between the Version PR being
+//     refreshed and merged turns that merge into another version PR; the run
+//     goes green having released nothing, and every native-registry job (all
+//     gated on `published == 'true'`) skips with it. 0.30.1 was bumped on main
+//     and published nowhere this way.
+//   - PAUSE writes its per-module "Successfully indexed" lines BEFORE
+//     committing the index transaction, so they survive a rollback. The
+//     BarefootJS-0.30.0 report listed four modules as indexed while 02packages
+//     kept pointing at 0.29.0.
+//
+// So don't model the pipeline — ask npm and CPAN what is there.
+//
+// Two modes:
+//
+//   --npm    what release.yml runs to decide whether to publish. npm is
+//            synchronous, so "main is ahead of npm" is actionable at once, and
+//            acting on it is what makes releases independent of merge order.
+//   (full)   adds the two registries where "accepted" does not mean "live",
+//            because publishing to them is fire-and-forget:
+//
+//              CPAN       cpan-upload returns once PAUSE takes the tarball;
+//                         a separate indexer cron writes 02packages later,
+//                         and can fail on its own.
+//              Packagist  the job pushes a subtree split and POSTs to the
+//                         update API; Packagist then crawls the tag whenever
+//                         it gets round to it.
+//
+//            Neither failure turns anything red. PAUSE at least mails a
+//            report — though it is the report that said "Successfully indexed"
+//            for four modules whose index transaction had rolled back —
+//            while Packagist says nothing at all. Run by hand after a release:
+//
+//              bun scripts/verify-released.ts
+//
+//            PyPI, RubyGems, crates.io and JSR are deliberately absent. Their
+//            uploads are synchronous, so a failure is a failed step and
+//            already red; there is no state for a check to catch.
+//
+// Exit: 0 everything live, 1 something is not released, 2 could not tell.
+// 1 and 2 are distinct because exit 1 triggers a publish in release.yml — a
+// registry outage must not be able to read as "not published" and provoke one.
+
+import { resolve } from 'node:path'
+import { $ } from 'bun'
+
+const repoRoot = resolve(import.meta.dir, '..')
+const npmOnly = process.argv.includes('--npm')
+
+// npm package -> Perl dist. The module list per dist is deliberately NOT here:
+// it comes from Module::Metadata, the same call Makefile.PL makes to build
+// META's `provides` and therefore the same input PAUSE indexes from, so a
+// package added to a dist is checked instead of silently unverified.
+const CPAN_DISTS = [
+  { npm: '@barefootjs/perl', dir: 'packages/adapter-perl' },
+  { npm: '@barefootjs/xslate', dir: 'packages/adapter-xslate' },
+  { npm: '@barefootjs/mojolicious', dir: 'packages/adapter-mojolicious' },
+]
+
+// npm package -> Packagist package. The tag the release job pushes is
+// `v<version>`, which is the version Packagist records.
+const PACKAGIST = [
+  { npm: '@barefootjs/twig', dir: 'packages/adapter-twig', composer: 'barefootjs/twig' },
+  { npm: '@barefootjs/blade', dir: 'packages/adapter-blade', composer: 'barefootjs/blade' },
+  { npm: '@barefootjs/php', dir: 'packages/adapter-php', composer: 'barefootjs/php' },
+]
+
+interface Problem {
+  registry: 'npm' | 'CPAN' | 'Packagist'
+  subject: string
+  expected: string
+  found: string
+}
+
+/**
+ * `null` means the registry answered "no such thing" (404). Anything else that
+ * is not a success throws, and the caller turns that into exit 2 rather than a
+ * verdict — see the exit-code note above.
+ *
+ * curl rather than fetch: it matches how changeset-publish.ts already reaches
+ * the registry (`npm view`), and it keeps working behind an HTTP(S) proxy,
+ * which Bun's fetch does not reliably traverse.
+ */
+async function httpGet(url: string): Promise<string | null> {
+  const r = await $`curl -sS --max-time 30 -w ${'\n%{http_code}'} ${url}`.quiet().nothrow()
+  if (r.exitCode !== 0) throw new Error(`GET ${url}: ${r.stderr.toString().trim()}`)
+  const out = r.text()
+  const split = out.lastIndexOf('\n')
+  const status = Number(out.slice(split + 1).trim())
+  if (status === 404) return null
+  if (status < 200 || status >= 300) throw new Error(`GET ${url}: HTTP ${status}`)
+  return out.slice(0, split)
+}
+
+async function checkNpm(): Promise<Problem[]> {
+  const ignored: string[] =
+    (await Bun.file(resolve(repoRoot, '.changeset/config.json')).json()).ignore ?? []
+
+  const targets: { name: string; version: string }[] = []
+  for (const rel of [...new Bun.Glob('packages/*/package.json').scanSync(repoRoot)].sort()) {
+    const pkg = await Bun.file(resolve(repoRoot, rel)).json()
+    if (pkg.private || ignored.includes(pkg.name)) continue
+    targets.push({ name: pkg.name, version: pkg.version })
+  }
+  if (targets.length === 0) throw new Error('No publishable packages found — the glob is wrong')
+
+  console.log(`npm — checking ${targets.length} packages`)
+  const found: Problem[] = []
+  await Promise.all(
+    targets.map(async ({ name, version }) => {
+      // The version endpoint answers in a few hundred bytes; a packument for a
+      // long-lived package is megabytes, and this runs on every release.
+      if ((await httpGet(`https://registry.npmjs.org/${name}/${version}`)) !== null) return
+      const latest = await httpGet(`https://registry.npmjs.org/${name}/latest`)
+      found.push({
+        registry: 'npm',
+        subject: name,
+        expected: version,
+        found:
+          latest === null
+            ? 'not on npm at all'
+            : `latest published ${(JSON.parse(latest) as { version: string }).version}`,
+      })
+    }),
+  )
+  return found
+}
+
+async function checkCpan(): Promise<Problem[]> {
+  const perl = async (script: string, args: string[] = [], cwd = repoRoot) => {
+    const r = await $`perl -e ${script} ${args}`.cwd(cwd).quiet().nothrow()
+    return r
+  }
+
+  const found: Problem[] = []
+  for (const { npm, dir } of CPAN_DISTS) {
+    const version: string = (await Bun.file(resolve(repoRoot, dir, 'package.json')).json()).version
+
+    const r = await perl(
+      'use Module::Metadata; use JSON::PP;' +
+        'my $p = Module::Metadata->provides(version => 2, dir => "lib");' +
+        'print JSON::PP->new->canonical->encode([sort keys %$p]);',
+      [],
+      resolve(repoRoot, dir),
+    )
+    if (r.exitCode !== 0) throw new Error(`Module::Metadata failed in ${dir}: ${r.stderr.toString().trim()}`)
+    const modules: string[] = JSON.parse(r.text())
+
+    console.log(`CPAN — ${npm} @ ${version}: checking ${modules.length} modules`)
+    for (const module of modules) {
+      // cpanmetadb serves 02packages — the file that decides what `cpanm Foo`
+      // installs, and the file PAUSE failed to write in the 0.30.0 incident.
+      // MetaCPAN is a downstream view of it and lags.
+      const body = await httpGet(`https://cpanmetadb.plackperl.org/v1.0/package/${module}`)
+      const indexed = body?.match(/^version:\s*(\S+)$/m)?.[1] ?? null
+      if (indexed === null) {
+        found.push({ registry: 'CPAN', subject: module, expected: version, found: 'not indexed' })
+        continue
+      }
+      // One release wears three hats — "0.30.2" in the .pm literal, "v0.30.2"
+      // in META/02packages, "0.030002" in PAUSE's numified form. Compare
+      // through the parser that defines them.
+      const same = await perl('exit(version->parse($ARGV[0]) == version->parse($ARGV[1]) ? 0 : 1)', [
+        indexed,
+        version,
+      ])
+      if (same.exitCode !== 0) {
+        found.push({ registry: 'CPAN', subject: module, expected: version, found: `indexed at ${indexed}` })
+      }
+    }
+  }
+  return found
+}
+
+async function checkPackagist(): Promise<Problem[]> {
+  const found: Problem[] = []
+  console.log(`Packagist — checking ${PACKAGIST.length} packages`)
+  for (const { npm, dir, composer } of PACKAGIST) {
+    const version: string = (await Bun.file(resolve(repoRoot, dir, 'package.json')).json()).version
+    const body = await httpGet(`https://repo.packagist.org/p2/${composer}.json`)
+    const versions: string[] =
+      body === null
+        ? []
+        : (Object.values((JSON.parse(body) as { packages: Record<string, { version: string }[]> }).packages)
+            .flat()
+            .map((v) => v.version) ?? [])
+    if (versions.includes(`v${version}`)) continue
+    found.push({
+      registry: 'Packagist',
+      subject: `${composer} (${npm})`,
+      expected: `v${version}`,
+      found: versions.length ? `newest published ${versions[0]}` : 'nothing published',
+    })
+  }
+  return found
+}
+
+let problems: Problem[]
+try {
+  problems = [
+    ...(await checkNpm()),
+    ...(npmOnly ? [] : [...(await checkCpan()), ...(await checkPackagist())]),
+  ]
+} catch (err) {
+  console.error(`\nCould not determine release state: ${err instanceof Error ? err.message : err}`)
+  process.exit(2)
+}
+
+if (problems.length === 0) {
+  console.log('\nEverything on main is live on its registry.')
+  process.exit(0)
+}
+
+console.error(`\n${problems.length} version(s) on main are not released:\n`)
+for (const p of problems) {
+  console.error(`  ${p.registry.padEnd(9)}  ${p.subject}`)
+  console.error(`             main says ${p.expected} — ${p.found}`)
+}
+
+if (problems.some((p) => p.registry === 'Packagist')) {
+  console.error(
+    '\nPackagist: the release job pushes the subtree split and its tag, then\n' +
+      'POSTs to the update API — which only asks Packagist to crawl. Check that\n' +
+      'the tag exists on the split repository first; if it does, re-trigger the\n' +
+      'crawl from the package page. Nothing here needs a version bump.',
+  )
+}
+
+if (problems.some((p) => p.registry === 'CPAN')) {
+  console.error(
+    '\nCPAN: uploading is not indexing. cpan-upload returns as soon as PAUSE\n' +
+      'accepts the tarball; the module becomes installable only once the\n' +
+      'indexer writes 02packages, which can lag an hour and can fail on its own\n' +
+      '(a rolled-back transaction still mails "Successfully indexed"). Right\n' +
+      'after a release, re-run later. If it persists, read the PAUSE report —\n' +
+      'one module stuck while its siblings moved usually means META `provides`\n' +
+      'gave it no version, which PAUSE reads as a decreasing version number.\n' +
+      'PAUSE rejects a re-upload of the same version, so this needs a human:\n' +
+      'force a reindex, or ship the next patch.',
+  )
+}
+
+process.exit(1)


### PR DESCRIPTION
Two files. One step in `release.yml`, and the script it asks.

## The defect

**Whether a release happens depends on what else merged.** `changesets/action` picks between "open a Version PR" and "publish" from whether `.changeset/` is empty — global state any PR can change. #2500 merged **29 seconds** before Version PR #2495, so at merge time main still carried a changeset. The action took the version path and exited successfully having released nothing; `cpan-release` and every sibling native-registry job is gated on `published == 'true'`, so they all skipped in the same breath. 0.30.1 sat on main, published nowhere, with a fully green run.

## Fix: decide from the registry

`release:publish` is **already idempotent and version-driven** — `changeset-publish.ts` compares each `package.json` against npm and skips what is already there. Nothing about it depends on changesets' state. The only thing missing was a reason to call it.

So `release.yml` gains one step: if the action didn't publish and main is ahead of npm, publish. A no-op in the ordinary case, a release in the case above. It rebuilds the `publishedPackages` shape from the `New tag: <name>@<version>` lines `changeset-publish.ts` prints — the same lines `changesets/action` itself parses — so the downstream registry jobs still fire.

Merge timing stops mattering. A stray changeset now delays the *version bump*, never the *publish*.

## Exit codes are load-bearing

`scripts/verify-released.ts` is what that step asks. One of its exit codes triggers a publish, so there are three, not two:

| | |
| --- | --- |
| `0` | everything on main is live → nothing to do |
| `1` | something really is unreleased → publish |
| `2` | a registry could not be reached → **do not** publish, fail the step |

A lookup that did not complete must never read as "not published". That would provoke a spurious publish, and treating outages as release failures is how a check like this gets ignored — at which point it is worse than not having it.

## The CPAN half is a manual command, on purpose

The script also checks CPAN. Nothing runs it automatically, and an earlier draft of this PR that added a daily workflow for it has been dropped.

The reason is that **bad news already arrives**. PAUSE mails a report for every upload, and `update_package` re-evaluates every module in `provides` each time, so a still-stuck module is re-reported on every subsequent upload too. Both of this week's CPAN problems were caught that way — the 0.30.0 database error and the `BarefootJS::Date` regression.

What is hard is *reading* it. PAUSE writes its per-module status lines to `INDEX_STATUS` **before** committing the index transaction, so they survive a rollback and end up contradicting the error above them:

```
ERROR: Database error occurred during index update
...
Status: Successfully indexed
     module : BarefootJS                status : indexed
     module : BarefootJS::DevReload     status : indexed
     module : BarefootJS::Evaluator     status : indexed
     module : BarefootJS::SearchParams  status : indexed
```

Four modules reported indexed; `02packages` never moved off 0.29.0. So the value is not a notification — it is a straight answer to the one question the report cannot be trusted on:

```
$ bun scripts/verify-released.ts
npm — checking 22 packages
CPAN — @barefootjs/perl @ 0.30.2: checking 5 modules
CPAN — @barefootjs/xslate @ 0.30.2: checking 1 modules
CPAN — @barefootjs/mojolicious @ 0.30.2: checking 3 modules

Everything on main is live on its registry.
```

Automating it would have added a workflow, an issue-filing path, and a scheduled run that fails on PAUSE's hour of indexing lag — for a failure mode that already emails you.

## Verification

All three exit paths, against the live registries:

```
$ bun scripts/verify-released.ts                                          exit 0
  (output above — main at 0.30.2, everything live)

$ # @barefootjs/perl bumped to 99.99.99
  npm   @barefootjs/perl   main says 99.99.99 — latest published 0.30.2   exit 1

$ # registry host made unresolvable
Could not determine release state: GET .../@barefootjs/rust/0.30.2:
  curl: (56) CONNECT tunnel failed, response 403                          exit 2
```

`publishedPackages` reconstruction checked against a sample log, scoped and unscoped names both:

```
[{"name":"@barefootjs/perl","version":"0.30.3"},{"name":"create-barefootjs","version":"0.30.3"}]
```

Every `run:` block passes `bash -n`; the workflow parses; `biome check` clean.

## Notes

- **No changeset** — only `scripts/` and `.github/workflows/`, and `changeset-check.yml` requires one only for `packages/*/src`. Which matters here specifically: a changeset landing on main is what broke the last release, and this PR cannot repeat it.
- The module list for the CPAN half is **not** in the script — it comes from `Module::Metadata->provides`, the same call `Makefile.PL` makes to build META's `provides`, so it is the same input PAUSE indexes from and a package added to a dist is checked rather than silently unverified.
- Version comparison goes through Perl's own parser: one release wears three hats — `0.30.2` in the `.pm` literal, `v0.30.2` in META/02packages, `0.030002` in PAUSE's numified form.