### PR TITLE
fix(go-template): return row-spread attribute names to their JS spelling (#2490)

### DIFF
--- a/.changeset/go-row-spread-attr-names.md
+++ b/.changeset/go-row-spread-attr-names.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix Go-template SSR mangling attribute NAMES (`id` → `-i-d`, `title` → `-title`, `data-kind` → `-data-kind`) when a `.map()` row object — or a field read off one (`{...row.extra}`) — is spread onto its row element, while the spread values were already correctly row-scoped. The row's dot context is necessarily keyed Go-style (`ID`/`Title`/`DataKind`) — the same field-access contract that makes `attrs.id` emit `{{.ID}}` — and that capitalization broke the shared `toAttrName` helper's camelCase→kebab conversion. The fix adds a new `bf_js_keys` runtime helper that un-cases keys back to their original JS names, applied at both the loop-row whole-item spread site AND the loop-row member-expression spread site (`{...row.extra}`) — the latter is a no-op when the field's keys already arrived JS-native and corrective when they arrived Go-cased, so the emission no longer has to guess which convention a `Record<string, string>` field was seeded with. `toAttrName`, `SpreadAttrs`, and `Omit` (all pinned for JS-runtime byte-parity / already-correct json-tag recovery) are untouched.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -1027,6 +1027,12 @@ func jsKeyFromGoCasedKey(key string) string {
 	for runLen < len(key) && key[runLen] >= 'A' && key[runLen] <= 'Z' {
 		runLen++
 	}
+	// An initialism may carry trailing digits (`utf8` → `UTF8`); without
+	// consuming them the lookup misses and `UTF8` decapitalizes to the
+	// wrong `uTF8`.
+	for runLen < len(key) && key[runLen] >= '0' && key[runLen] <= '9' {
+		runLen++
+	}
 	if runLen >= 2 {
 		if _, ok := goInitialisms[strings.ToLower(key[:runLen])]; ok {
 			return strings.ToLower(key[:runLen]) + key[runLen:]

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -200,6 +200,14 @@ func FuncMap() template.FuncMap {
 		// JSX intrinsic-element spread lowering (#1407)
 		"bf_spread_attrs": SpreadAttrs,
 
+		// Reverse the loop-row field-access Go-casing before a whole-item
+		// spread reaches `bf_spread_attrs` (#2490): a row's dot context is
+		// necessarily keyed `ID`/`Title`/`DataKind` (the same casing that
+		// makes `attrs.id` emit `{{.ID}}`), and `toAttrName`'s
+		// camelCase→kebab conversion mangles an uppercase-led key
+		// (`ID` → `-i-d`). See JSKeys' docstring for the recovery rule.
+		"bf_js_keys": JSKeys,
+
 		// Destructure object-rest spread-onto-element residual (#2087):
 		// "every field except these" for a struct/map, keyed by json tag.
 		"bf_omit": Omit,
@@ -976,6 +984,110 @@ func Omit(item any, excludeKeys ...string) map[string]any {
 			if _, skip := exclude[key]; skip {
 				continue
 			}
+			val := rv.MapIndex(k)
+			if val.IsValid() {
+				out[key] = val.Interface()
+			}
+		}
+	}
+	return out
+}
+
+// goInitialisms mirrors GO_INITIALISMS
+// (packages/adapter-go-template/src/adapter/lib/go-naming.ts) — the Go-side
+// copy `jsKeyFromGoCasedKey` needs to recognize a whole-word initialism run
+// the same way the TS-side `capitalizeFieldName` produced it (#2490). Keep
+// both lists in sync by hand; there is no shared source between the two
+// languages.
+var goInitialisms = map[string]struct{}{
+	"id": {}, "url": {}, "http": {}, "https": {}, "api": {}, "json": {}, "xml": {},
+	"html": {}, "css": {}, "sql": {}, "ip": {}, "tcp": {}, "udp": {}, "dns": {},
+	"ssh": {}, "tls": {}, "ssl": {}, "uri": {}, "uid": {}, "uuid": {}, "ascii": {},
+	"utf8": {}, "eof": {}, "grpc": {}, "rpc": {}, "cpu": {}, "gpu": {}, "ram": {}, "os": {},
+}
+
+// jsKeyFromGoCasedKey inverts `capitalizeFieldName` (go-naming.ts): recovers
+// the JS-original property name from a Go-cased map key produced by the
+// row's field-access contract (#2490). A leading run of 2+ uppercase ASCII
+// letters that, lowercased, is a whole-word Go initialism lowers as a
+// block (`ID` → `id`, matching `capitalizeFieldName`'s `id` → `ID`
+// whole-word branch); otherwise only the first rune lowers (`Title` →
+// `title`, `DataKind` → `dataKind` — kebab-casing that back to
+// `data-kind` is `toAttrName`'s job, not this function's). A key whose
+// first rune is already lowercase (not Go-cased) is returned unchanged.
+func jsKeyFromGoCasedKey(key string) string {
+	if key == "" {
+		return key
+	}
+	first, _ := utf8.DecodeRuneInString(key)
+	if !unicode.IsUpper(first) {
+		return key
+	}
+	runLen := 0
+	for runLen < len(key) && key[runLen] >= 'A' && key[runLen] <= 'Z' {
+		runLen++
+	}
+	if runLen >= 2 {
+		if _, ok := goInitialisms[strings.ToLower(key[:runLen])]; ok {
+			return strings.ToLower(key[:runLen]) + key[runLen:]
+		}
+	}
+	return decapitalize(key)
+}
+
+// JSKeys reverses the loop-row Go-casing described above for a WHOLE
+// receiver, keyed by ORIGINAL JS property name — the counterpart to
+// `SpreadAttrs`' `bf_js_keys` registration, applied ONLY to the loop-row
+// whole-item spread path (`{...row}` where `row` is the bare `.map()`
+// param, #2490).
+//
+// Struct receiver: prefer each field's `json` tag when present (same
+// json-tag recovery `Omit` already does above — the tag carries the
+// ORIGINAL source property name verbatim, robust to composite/hyphenated
+// names a pure un-casing can't reconstruct); fall back to
+// `jsKeyFromGoCasedKey` on the bare field name when no tag is set.
+//
+// Map receiver: `jsKeyFromGoCasedKey` per key.
+//
+// Anything else (nil, a non-struct/non-map interface) returns an empty
+// map rather than panicking.
+func JSKeys(item any) map[string]any {
+	out := map[string]any{}
+	rv := reflect.ValueOf(item)
+	for rv.Kind() == reflect.Interface || rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return out
+		}
+		rv = rv.Elem()
+	}
+	switch rv.Kind() {
+	case reflect.Struct:
+		rt := rv.Type()
+		for i := 0; i < rt.NumField(); i++ {
+			field := rt.Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			key := jsKeyFromGoCasedKey(field.Name)
+			if tag, ok := field.Tag.Lookup("json"); ok {
+				if comma := strings.Index(tag, ","); comma >= 0 {
+					tag = tag[:comma]
+				}
+				if tag == "-" {
+					continue
+				}
+				if tag != "" {
+					key = tag
+				}
+			}
+			out[key] = rv.Field(i).Interface()
+		}
+	case reflect.Map:
+		for _, k := range rv.MapKeys() {
+			if k.Kind() != reflect.String {
+				continue
+			}
+			key := jsKeyFromGoCasedKey(k.String())
 			val := rv.MapIndex(k)
 			if val.IsValid() {
 				out[key] = val.Interface()

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -1968,6 +1968,17 @@ func TestJSKeys(t *testing.T) {
 		}
 	})
 
+	t.Run("initialism with trailing digits round-trips", func(t *testing.T) {
+		// `capitalizeFieldName` maps the catalogued initialism `utf8` to
+		// `UTF8`; the inverse must consume the digit run too, or it
+		// decapitalizes to the wrong `uTF8`.
+		got := JSKeys(map[string]any{"UTF8": "y", "ID": "1"})
+		want := map[string]any{"utf8": "y", "id": "1"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("JSKeys(map w/ UTF8) = %v, want %v", got, want)
+		}
+	})
+
 	t.Run("map with Go-cased keys", func(t *testing.T) {
 		got := JSKeys(map[string]any{"ID": "1", "Title": "first", "DataKind": "a"})
 		want := map[string]any{"id": "1", "title": "first", "dataKind": "a"}

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -3,6 +3,7 @@ package bf
 import (
 	"html/template"
 	"math"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -1936,6 +1937,75 @@ func TestSpreadAttrs(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestJSKeys covers the loop-row Go-casing reversal (#2490): struct via
+// json tag, map via the `capitalizeFieldName` inverse, and the end-to-end
+// composition with `SpreadAttrs` that motivated the helper.
+func TestJSKeys(t *testing.T) {
+	t.Run("struct with json tags", func(t *testing.T) {
+		type row struct {
+			ID       string `json:"id"`
+			Title    string `json:"title"`
+			DataKind string `json:"data-kind"`
+		}
+		got := JSKeys(row{ID: "1", Title: "first", DataKind: "a"})
+		want := map[string]any{"id": "1", "title": "first", "data-kind": "a"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("JSKeys(struct) = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("struct without json tag falls back to un-cased field name", func(t *testing.T) {
+		type row struct {
+			ID    string
+			Title string
+		}
+		got := JSKeys(row{ID: "1", Title: "first"})
+		want := map[string]any{"id": "1", "title": "first"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("JSKeys(struct, no tags) = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("map with Go-cased keys", func(t *testing.T) {
+		got := JSKeys(map[string]any{"ID": "1", "Title": "first", "DataKind": "a"})
+		want := map[string]any{"id": "1", "title": "first", "dataKind": "a"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("JSKeys(map) = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("map with already-lowercase keys is unchanged", func(t *testing.T) {
+		got := JSKeys(map[string]any{"id": "1", "data-kind": "a"})
+		want := map[string]any{"id": "1", "data-kind": "a"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("JSKeys(map, lowercase) = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("nil returns empty map", func(t *testing.T) {
+		got := JSKeys(nil)
+		if len(got) != 0 {
+			t.Errorf("JSKeys(nil) = %v, want empty", got)
+		}
+	})
+
+	t.Run("non-struct/non-map returns empty map", func(t *testing.T) {
+		got := JSKeys("x")
+		if len(got) != 0 {
+			t.Errorf("JSKeys(string) = %v, want empty", got)
+		}
+	})
+
+	t.Run("end-to-end composition with SpreadAttrs", func(t *testing.T) {
+		bag := map[string]any{"ID": "1", "Title": "first", "DataKind": "a"}
+		got := SpreadAttrs(JSKeys(bag))
+		want := template.HTMLAttr(`data-kind="a" id="1" title="first"`)
+		if got != want {
+			t.Errorf("SpreadAttrs(JSKeys(bag)) = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestStyleToCss(t *testing.T) {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -6839,7 +6839,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const trimmed = value.expr.trim()
         const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
         if (currentLoopParam && trimmed === currentLoopParam) {
-          return `{{bf_spread_attrs .}}`
+          // The row's keys are Go-cased by the field-access contract: the
+          // same lowering that makes `attrs.id` emit `{{.ID}}`
+          // (`goFieldNameForKey` → `capitalizeFieldName`) requires the
+          // seeded row map/struct to be keyed `ID`/`Title`/`DataKind`.
+          // `bf_js_keys` (bf.go) undoes just that capitalization — struct
+          // via json tag, map via the `capitalizeFieldName` inverse —
+          // before `toAttrName`'s UNCHANGED camelCase→kebab conversion
+          // sees the real JS names (#2490).
+          return `{{bf_spread_attrs (bf_js_keys .)}}`
         }
         // Destructure object-rest spread onto an element (`{...rest}`, #2087
         // Phase B): `rest` alone would spread the WHOLE item (every field,
@@ -6848,17 +6856,29 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // exactly those sibling keys. Only a spread whose expr is the BARE
         // rest name matches (`isLowerableLoopDestructure`'s admitted shape);
         // anything else (`{...fn(rest)}`) already refused at the IR gate.
+        // `Omit` already recovers original names via json tag (struct) /
+        // passthrough (map), so this arm does NOT need `bf_js_keys`.
         const restInfo = this.lookupRestExclude(trimmed)
         if (restInfo) {
           const excludeArgs = restInfo.excludeKeys.map(k => JSON.stringify(k)).join(' ')
           const omitArgs = excludeArgs ? `${restInfo.parent} ${excludeArgs}` : restInfo.parent
           return `{{bf_spread_attrs (bf_omit ${omitArgs})}}`
         }
+        // A field/member read off the loop row (`{...g.extra}`) — same
+        // Go-casing exposure as the bare-item case above, PLUS an
+        // ambiguity the compiler can't resolve at compile time: a
+        // `Record<string, string>` field's runtime map could have been
+        // seeded with JS-native data keys (`data-kind`) OR Go-cased
+        // field-name keys, and nothing in the TYPE says which. `bf_js_keys`
+        // is a no-op on an already-lowercase-first-rune key (lowercasing
+        // `data-kind`'s first rune changes nothing) and corrective on a
+        // Go-cased one, so wrapping here is safe for both conventions
+        // rather than betting on one (#2490).
         const goExpr = this.convertExpressionToGo(value.expr)
         // `convertExpressionToGo` already pushes BF101 for unsupported
         // expressions and returns `""`; pass through so the template still
         // compiles.
-        return `{{bf_spread_attrs ${goExpr}}}`
+        return `{{bf_spread_attrs (bf_js_keys ${goExpr})}}`
       }
       return `{{bf_spread_attrs .${value.slotId}}}`
     },

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -6878,7 +6878,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // `convertExpressionToGo` already pushes BF101 for unsupported
         // expressions and returns `""`; pass through so the template still
         // compiles.
-        return `{{bf_spread_attrs (bf_js_keys ${goExpr})}}`
+        // `goExpr` is not necessarily a single token — a member spread can
+        // lower to a pipeline (`bf_get . $.K`), which the template parser
+        // would otherwise read as extra ARGUMENTS to `bf_js_keys`.
+        return `{{bf_spread_attrs (bf_js_keys ${wrapIfMultiToken(goExpr)})}}`
       }
       return `{{bf_spread_attrs .${value.slotId}}}`
     },

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -44,10 +44,6 @@ export const renderDivergences: RenderDivergences = {
   // #2482 audit follow-ups: loop-scope holes specific to this adapter's
   // four-stack scope tracking and its SSR seeding. Graduate by applying
   // the fix described in each issue and deleting the line.
-  'nested-loop-tail-content':
-    'the `inLoop` clobber is FIXED (#2487) — outer-row content after a nested loop now takes the loop arms and the spread resolves row-scoped. Residual: the spread\'s attribute NAMES are still mangled by the Go-cased-key kebab conversion (`data-kind` → `-data-kind`), which is #2490; this entry graduates with that fix (https://github.com/piconic-ai/barefootjs/issues/2490)',
-  'loop-param-shadows-spread-const':
-    'spreading a loop row object mangles attribute names (`id` → `-i-d`, `title` → `-title`); the spread VALUE is correctly row-scoped, distinguishing this from the template-adapter const-shadow hole #2489 (https://github.com/piconic-ai/barefootjs/issues/2490)',
   'callback-param-shadows-prop':
     'JS-computed signal/memo initializers (`[…].map(…).join(…)`, memo over signal + prop) don\'t seed Go SSR — renders `[]` / empty where every other adapter renders the computed value; hydration snaps to correct (https://github.com/piconic-ai/barefootjs/issues/2492)',
 }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2354,10 +2354,6 @@
           "kind": "render",
           "reason": "a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check (the live `loopBoundNames` map exists but is not consulted on this path), so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)"
         },
-        "go-template": {
-          "kind": "render",
-          "reason": "spreading a loop row object mangles attribute names (`id` → `-i-d`, `title` → `-title`); the spread VALUE is correctly row-scoped, distinguishing this from the template-adapter const-shadow hole #2489 (https://github.com/piconic-ai/barefootjs/issues/2490)"
-        },
         "jinja": {
           "kind": "render",
           "reason": "a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)"
@@ -2473,12 +2469,6 @@
           "codes": [
             "BF021"
           ]
-        }
-      },
-      "nested-loop-tail-content": {
-        "go-template": {
-          "kind": "render",
-          "reason": "the `inLoop` clobber is FIXED (#2487) — outer-row content after a nested loop now takes the loop arms and the spread resolves row-scoped. Residual: the spread's attribute NAMES are still mangled by the Go-cased-key kebab conversion (`data-kind` → `-data-kind`), which is #2490; this entry graduates with that fix (https://github.com/piconic-ai/barefootjs/issues/2490)"
         }
       },
       "preamble-cells": {
@@ -2936,10 +2926,6 @@
       "map-array-builder-escaping": {
         "description": "special characters in array-builder leaf text escape identically at SSR and CSR",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/map-array-builder-escaping.ts"
-      },
-      "nested-loop-tail-content": {
-        "description": "Outer-row content after a nested inner loop still renders row-scoped (spread over a row field)",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/nested-loop-tail-content.ts"
       },
       "preamble-cells": {
         "description": "keyed .map() row with a preamble-built leaf child — patched in place on same-key update, not frozen",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1607,7 +1607,7 @@
           ]
         },
         "go-template": {
-          "pass": 182,
+          "pass": 184,
           "total": 200,
           "gaps": [
             {
@@ -1650,14 +1650,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
-            {
-              "fixture": "nested-loop-tail-content",
               "issues": []
             },
             {
@@ -2161,15 +2153,11 @@
           ]
         },
         "go-template": {
-          "pass": 21,
+          "pass": 22,
           "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2475,7 +2463,7 @@
           ]
         },
         "go-template": {
-          "pass": 267,
+          "pass": 269,
           "total": 288,
           "gaps": [
             {
@@ -2525,19 +2513,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "nested-loop-tail-content",
               "issues": []
             },
             {
@@ -3229,7 +3209,7 @@
           ]
         },
         "go-template": {
-          "pass": 224,
+          "pass": 226,
           "total": 238,
           "gaps": [
             {
@@ -3254,14 +3234,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
-            {
-              "fixture": "nested-loop-tail-content",
               "issues": []
             },
             {
@@ -3919,7 +3891,7 @@
           ]
         },
         "go-template": {
-          "pass": 134,
+          "pass": 136,
           "total": 154,
           "gaps": [
             {
@@ -3965,19 +3937,11 @@
               "issues": []
             },
             {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
             {
               "fixture": "map-array-builder-escaping",
-              "issues": []
-            },
-            {
-              "fixture": "nested-loop-tail-content",
               "issues": []
             },
             {
@@ -4525,15 +4489,11 @@
           ]
         },
         "go-template": {
-          "pass": 51,
+          "pass": 52,
           "total": 55,
           "gaps": [
             {
               "fixture": "callback-param-shadows-prop",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7834,19 +7794,11 @@
           ]
         },
         "go-template": {
-          "pass": 94,
+          "pass": 96,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
-            {
-              "fixture": "nested-loop-tail-content",
               "issues": []
             },
             {
@@ -8122,7 +8074,7 @@
           ]
         },
         "go-template": {
-          "pass": 158,
+          "pass": 159,
           "total": 168,
           "gaps": [
             {
@@ -8147,10 +8099,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {


### PR DESCRIPTION
**Stacked on #2505 → main** (#2503 and #2504 have merged). Fourth of the series addressing the #2482 audit's adapter-side defects (#2486–#2492). This one fixes #2490 and finishes off #2487's fixture.

## The bug

Spreading a `.map()` row object onto a row element mangled the attribute **names**: `id` → `-i-d`, `title` → `-title`, `data-kind` → `-data-kind`. The values were correct and row-scoped.

## Why the keys are Go-cased in the first place

This is not an accident that can simply be removed. The same lowering that makes `attrs.id` emit `{{.ID}}` (`goFieldNameForKey` → `capitalizeFieldName`) *requires* the seeded row to be keyed `ID`/`Title`/`DataKind` — otherwise the field access itself breaks. `SpreadAttrs` then hands those Go names to `toAttrName`, whose camelCase→kebab conversion prefixes a dash for a leading uppercase letter.

So the fix has to undo the capitalization at the spread site, not at the conversion. `toAttrName` and `SpreadAttrs` keep their behavior untouched — including the deliberately pinned `SpreadAttrs({"XData": …})` → `-x-data` JS/Go byte-parity case (#1411), which still passes.

## The fix

New `bf_js_keys` runtime helper (`JSKeys` in `bf.go`) recovers each key's JS spelling:
- **struct** receivers via their `json` tag — the same recovery `Omit` already does;
- **map** receivers via the inverse of `capitalizeFieldName`: lowercase a leading initialism run whole (`ID` → `id`), otherwise just the first rune (`DataKind` → `dataKind`).

Note it is the **composition** that produces the right name, not the helper alone: `dataKind` then flows through the unchanged `toAttrName` and comes back out as `data-kind`. The unit tests assert the composition, not just the helper.

Applied to **both** in-loop spread arms:
- the bare whole-item spread (`{...attrs}`), and
- the member-expression spread (`{...g.extra}`).

The second arm matters and was not in the original plan. The adapter cannot tell from a `Record<string, string>` whether the bag was seeded with data keys or field-name keys — and `bf_js_keys` is a no-op on keys that are already JS-native, so covering both arms is robust to either convention rather than depending on one being right. (Which is also why this PR does *not* touch the test harness's recursive key-casing: making the emission convention-agnostic is the more durable fix.)

The non-loop `Spread_0` path and the `bf_omit` destructure-rest arm are untouched — the latter already recovers original names via json tags, which I verified rather than assumed by testing `rest-destructure-object-spread-in-map`.

## Review follow-ups (a0ffddb → 985829b)

Two real bugs Copilot caught, both fixed:

- **`bf_js_keys` assumed a single-token operand.** A member spread can lower to a *pipeline*, and since the parent PR #2505 routes dynamic index access through `bf_get`, `bf_get . $.K` is now a reachable operand — Go's parser would have read those tokens as extra **arguments** to `bf_js_keys`. Wrapped with the existing `wrapIfMultiToken`. This is a stack interaction: neither PR alone exposes it.
- **Digit-carrying initialisms didn't round-trip.** `utf8` is in `GO_INITIALISMS` and `capitalizeFieldName` maps it to `UTF8`, but the inverse stopped its run at `[A-Z]+`, so the lookup missed and produced `uTF8`. The run now consumes trailing digits, with a `UTF8` case added to `TestJSKeys`.

## Graduation — two pins, one of them from the parent PR

- `loop-param-shadows-spread-const` — this issue's own pin.
- `nested-loop-tail-content` — its `inLoop` half was fixed in #2504, and this mangling was its only remaining blocker. Worth noting the chain: fixing #2487 is what made #2490 *visible* on that fixture, because before it the spread never reached the loop arm at all.

## Validation

- `go test ./...` in `packages/adapter-go-template/runtime` — new table-driven tests for struct/json-tag recovery, map un-casing, already-lowercase keys (unchanged), the `UTF8` round-trip, and the end-to-end `SpreadAttrs(JSKeys(...))` composition. The pinned `XData` case still passes unchanged.
- Full `packages/adapter-go-template` suite: **1538 pass, 0 fail**.
- `loop-param-shadows-spread-const`, `nested-loop-tail-content`, and the `rest-destructure-object-spread-in-map` regression check: **10 pass, 0 fail**, all rendering through real Go (none skipped).
- `bunx tsc --noEmit -p .` clean.

(An earlier run on this branch was invalidated by a disk-full condition in the sandbox that made every `go run` fail — flagging it for anyone reading CI history here. The counts above are from a clean re-run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpPtSg6rTe158671pknoD2