### PR TITLE
fix: seed JS-computed signal/memo initializers on Go SSR (#2492)

### DIFF
--- a/.changeset/go-computed-initializer-seeding.md
+++ b/.changeset/go-computed-initializer-seeding.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Fix a signal/memo initializer shaped as a `.map(cb).join(sep)` chain (or a `+`-concatenation over one, e.g. `title + ':' + items().map(t => t.a).join(',')`) not seeding on Go SSR (#2492). The shared analyzer's `inferTypeFromValue` heuristic didn't special-case a trailing `.join(...)` suffix, so a signal ending in `.join(...)` mistyped as `array` (from the leading `[`) instead of `string`, producing a `nil` Go slice that stringifies as `[]`; it now yields `string` before the array check runs, affecting every adapter's type inference. On the Go template adapter, `computeMemoInitialValueOrNull`'s hand-matched memo-shape catalogue had no arm for a `.map().join()` chain (or the fixture's composite `+`-concatenation over one), so it fell through to the Go zero value (`""`); a signal's own `.map().join()` initializer landed in `convertInitialValue`'s new `string` branch with the same gap. Both now lower through a new `mapJoinChainToGo`/`matchMapJoinChain` pair (`value-lowering.ts`) that emits `bf.Join(bf.MapEval(...))`, reusing the existing runtime evaluator functions — no new Go runtime code. Graduates the `callback-param-shadows-prop` pin in `render-divergences.ts`.

--- a/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
@@ -20,7 +20,12 @@ import type { GoEmitContext } from '../emit-context.ts'
 import type { PropFallbackVar } from '../lib/types.ts'
 import { capitalizeFieldName } from '../lib/go-naming.ts'
 import { escapeGoString } from '../lib/go-emit.ts'
-import { convertInitialValue, getSignalInitialValueAsGo } from '../value/value-lowering.ts'
+import {
+  convertInitialValue,
+  getSignalInitialValueAsGo,
+  mapJoinChainToGo,
+  matchMapJoinChain,
+} from '../value/value-lowering.ts'
 import { typeInfoToGo } from '../type/type-codegen.ts'
 import { computeTemplateLiteralMemoInitialValue } from './template-interp.ts'
 import { resolveBlockBodyMemoModuleConst, computeObjectMemoInitialValue } from './memo-value.ts'
@@ -570,6 +575,60 @@ export function memoInitialFromParsedBody(
   if (body.kind === 'identifier') {
     const param = propsParams.find(p => p.name === body.name)
     if (param) return `in.${capitalizeFieldName(body.name)}`
+  }
+
+  // () => <a> + <b> + … — a string-concatenation chain whose every leaf is a
+  // string literal, a prop reference, or a `.map(cb).join(sep)` chain
+  // (#2492's `joined` memo: `title + ':' + items().map((title) =>
+  // title.a).join(',')`). Doesn't grow into a general `binary` catalogue
+  // entry — only fires for a pure `+` tree resolvable end-to-end via
+  // `resolveStringConcatChainGo`; any other leaf shape falls through to the
+  // caller's zero-value default, same as any other unsupported shape.
+  if (body.kind === 'binary' && body.op === '+') {
+    const concatGo = resolveStringConcatChainGo(ctx, body, signals, propsParams, propFallbackVars, propRef)
+    if (concatGo !== null) return concatGo
+  }
+
+  return null
+}
+
+/**
+ * `<expr> + <expr> + …` chain whose every leaf resolves to a Go string
+ * expression: a string literal, a prop reference (`propRef`, hoisted-aware),
+ * or a `.map(cb).join(sep)` chain ({@link matchMapJoinChain} /
+ * {@link mapJoinChainToGo} — `value-lowering.ts`, #2492). Recurses on nested
+ * `+` so a left-associative chain (`a + b + c` parses as `(a + b) + c`)
+ * resolves leaf-by-leaf.
+ *
+ * @returns the concatenated Go expression, or null when any leaf isn't one
+ *   of the three shapes above
+ */
+function resolveStringConcatChainGo(
+  ctx: GoEmitContext,
+  expr: ParsedExpr,
+  signals: { getter: string; initialValue: string; type?: TypeInfo }[],
+  propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
+  propFallbackVars: ReadonlyMap<string, PropFallbackVar>,
+  propRef: (propName: string) => string,
+): string | null {
+  if (expr.kind === 'binary' && expr.op === '+') {
+    const l = resolveStringConcatChainGo(ctx, expr.left, signals, propsParams, propFallbackVars, propRef)
+    const r = resolveStringConcatChainGo(ctx, expr.right, signals, propsParams, propFallbackVars, propRef)
+    return l !== null && r !== null ? `${l} + ${r}` : null
+  }
+
+  if (expr.kind === 'literal' && expr.literalType === 'string') {
+    return JSON.stringify(expr.value)
+  }
+
+  const propName = propsMemberName(expr) ?? (expr.kind === 'identifier' ? expr.name : null)
+  if (propName && propsParams.some(p => p.name === propName)) {
+    return propRef(propName)
+  }
+
+  const chain = matchMapJoinChain(expr)
+  if (chain) {
+    return mapJoinChainToGo(ctx, chain, signals, propsParams, propFallbackVars)
   }
 
   return null

--- a/packages/adapter-go-template/src/adapter/value/value-lowering.ts
+++ b/packages/adapter-go-template/src/adapter/value/value-lowering.ts
@@ -6,10 +6,17 @@
  */
 
 import type { ParsedExpr, TypeInfo } from '@barefootjs/jsx'
+import {
+  asCallbackMethodCall,
+  freeVarsInBody,
+  materializeGetterCalls,
+  serializeParsedExpr,
+} from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
 import type { PropFallbackVar } from '../lib/types.ts'
 import { capitalizeFieldName } from '../lib/go-naming.ts'
+import { escapeGoString } from '../lib/go-emit.ts'
 import { parsedLiteralToGo } from './parsed-literal-to-go.ts'
 import { collapseLiteralUnion } from '../type/type-codegen.ts'
 
@@ -102,6 +109,20 @@ export function convertInitialValue(
       }
       if (value.startsWith('"') && value.endsWith('"')) {
         return value
+      }
+      // A `.map(cb).join(sep)` chain (#2492): the analyzer's `.join()`
+      // trailing-suffix rule (`inferTypeFromValue`) types a signal carrying
+      // this shape `string`, so it lands HERE rather than the `array`
+      // branch below — bake it the same way a memo's derived `.map().join()`
+      // value bakes (`memoInitialFromParsedBody`'s sibling arm in
+      // `memo-compute.ts`), through the runtime evaluator's `MapEval` +
+      // `Join` composition, instead of falling to the `""` zero value.
+      if (preParsed) {
+        const chain = matchMapJoinChain(preParsed)
+        if (chain) {
+          const chainGo = mapJoinChainToGo(ctx, chain, [], propsParams ?? [], EMPTY_PROP_FALLBACK_VARS)
+          if (chainGo !== null) return chainGo
+        }
       }
       return '""'
     }
@@ -242,4 +263,155 @@ export function getSignalInitialValueAsGo(
   }
 
   return '0'
+}
+
+/**
+ * A value-producing `.map(cb).join(sep)` chain — `<object>.map((param) =>
+ * <body>).join(<sepExpr>)` — the constructor-Go-source analogue of the
+ * template-position `bf_join (bf_map_eval …)` lowering (`emitMapEval`,
+ * `go-emit.ts`). `.join(...)` folds to the `array-method` IR node at parse
+ * time (`expression-parser.ts`); its `object` is recognised as a `.map(cb)`
+ * callback call via `asCallbackMethodCall` (the same recognition
+ * `matchFilterArmMemo`, `memo-compute.ts`, uses for `.filter`). Returns the
+ * receiver array, the mapper arrow, and the join separator argument (absent
+ * when `.join()` was called with no argument — JS defaults to `,`), or null
+ * when `expr` isn't this shape.
+ */
+export function matchMapJoinChain(expr: ParsedExpr): {
+  object: ParsedExpr
+  arrow: Extract<ParsedExpr, { kind: 'arrow' }>
+  sepArg?: ParsedExpr
+} | null {
+  if (expr.kind !== 'array-method' || expr.method !== 'join') return null
+  const mapCb = asCallbackMethodCall(expr.object)
+  if (!mapCb || mapCb.method !== 'map') return null
+  return { object: mapCb.object, arrow: mapCb.arrow, sepArg: expr.args[0] }
+}
+
+/**
+ * Resolve a `.map().join()` chain's receiver array to a Go expression — a
+ * signal-backed field, a prop field, or an inline array literal.
+ *
+ * A SIGNAL receiver (`items()`) re-derives the signal's own initial value
+ * from ITS OWN initializer (`convertInitialValue`, baked against the
+ * synthesised element struct in `state.synthStructTypes` when one was
+ * inferred for it) rather than referencing a struct field — this expression
+ * is itself one field value inside the SAME `<Props>{ ... }` composite
+ * literal the signal's own field is being built into, so it can't reference
+ * a sibling field by name. Mirrors `resolveGetterValueAsGo` /
+ * `getSignalInitialValueAsGo`'s existing convention of re-deriving a
+ * referenced signal rather than pointing at a not-yet-assigned field.
+ *
+ * A PROP receiver (`props.X` / bare destructured `X`) resolves to a bare
+ * `in.<Field>` reference, mirroring `matchFilterArmMemo`'s `itemsField` (no
+ * nillable-scalar type assertion — the receiver is an array, never one of
+ * the scalar kinds that assertion guards).
+ *
+ * An array-LITERAL receiver bakes element-by-element: an object element goes
+ * through `objectLiteralToGoMap` (a plain `map[string]interface{}`, source-
+ * cased keys) rather than `jsLiteralToGo`'s struct-backed baking, since this
+ * nested literal is a `.map()` RECEIVER, not a signal's own typed value, and
+ * so has no named struct synthesised for it.
+ *
+ * @returns the Go expression, or null when the receiver isn't one of the
+ *   three shapes above, or an object-array-literal element doesn't bake.
+ */
+function resolveMapJoinBaseAsGo(
+  ctx: GoEmitContext,
+  object: ParsedExpr,
+  signals: { getter: string; initialValue: string; type?: TypeInfo; parsed?: ParsedExpr }[],
+  propsParams: { name: string }[],
+): string | null {
+  if (object.kind === 'call' && object.callee.kind === 'identifier' && object.args.length === 0) {
+    const calleeName = object.callee.name
+    const sig = signals.find(s => s.getter === calleeName)
+    if (sig) {
+      const bakeType = ctx.state.synthStructTypes.get(sig.getter) ?? sig.type ?? { kind: 'array', raw: 'unknown[]' }
+      return convertInitialValue(ctx, sig.initialValue, bakeType, propsParams, sig.parsed)
+    }
+  }
+
+  const propName =
+    object.kind === 'member' && !object.computed && object.object.kind === 'identifier' && object.object.name === 'props'
+      ? object.property
+      : object.kind === 'identifier'
+        ? object.name
+        : null
+  if (propName && propsParams.some(p => p.name === propName)) {
+    return `in.${capitalizeFieldName(propName)}`
+  }
+
+  if (object.kind === 'array-literal') {
+    if (object.elements.length === 0) return '[]interface{}{}'
+    const elems: string[] = []
+    for (const el of object.elements) {
+      const go = el.kind === 'object-literal' ? objectLiteralToGoMap(ctx, el) : parsedLiteralToGo(ctx, el)
+      if (go === null) return null
+      elems.push(go)
+    }
+    return `[]interface{}{${elems.join(', ')}}`
+  }
+
+  return null
+}
+
+/**
+ * Lower a `.map(cb).join(sep)` chain (matched by {@link matchMapJoinChain})
+ * to a `bf.Join(bf.MapEval(<items>, "<projJSON>", "<param>", <envMap>),
+ * <sep>)` Go expression — the constructor-source analogue of
+ * `matchFilterArmMemo`'s `bf.FilterEval` emit (`memo-compute.ts`), reusing
+ * the SAME two runtime evaluator functions (`MapEval`, `eval.go`; `Join`,
+ * `bf.go`) the template-position `bf_map_eval`/`bf_join` lowering already
+ * calls. Shared by a memo's derived value (`memoInitialFromParsedBody`'s
+ * concatenation-chain arm) and a SIGNAL's own initializer
+ * (`convertInitialValue`'s `string` branch, #2492).
+ *
+ * @returns the Go expression, or null when the receiver doesn't resolve
+ *   ({@link resolveMapJoinBaseAsGo}), the projection body isn't
+ *   representable to the runtime evaluator (`serializeParsedExpr` refusal),
+ *   a captured free variable doesn't resolve, or the separator isn't a
+ *   string literal (a dynamic separator — out of scope for this arm).
+ */
+export function mapJoinChainToGo(
+  ctx: GoEmitContext,
+  chain: { object: ParsedExpr; arrow: Extract<ParsedExpr, { kind: 'arrow' }>; sepArg?: ParsedExpr },
+  signals: { getter: string; initialValue: string; type?: TypeInfo; parsed?: ParsedExpr }[],
+  propsParams: { name: string }[],
+  propFallbackVars: ReadonlyMap<string, PropFallbackVar>,
+): string | null {
+  const itemsGo = resolveMapJoinBaseAsGo(ctx, chain.object, signals, propsParams)
+  if (itemsGo === null) return null
+
+  const knownGetterNames = new Set(signals.map(s => s.getter))
+  const materialized = materializeGetterCalls(chain.arrow.body, knownGetterNames)
+  const projJSON = serializeParsedExpr(materialized)
+  if (projJSON === null) return null
+
+  const paramName = chain.arrow.params[0] ?? '_'
+  const freeVars = freeVarsInBody(materialized, new Set(chain.arrow.params))
+  const envEntries: string[] = []
+  for (const name of freeVars) {
+    const sig = signals.find(s => s.getter === name)
+    let goExpr: string | null = null
+    if (sig) {
+      goExpr = getSignalInitialValueAsGo(ctx, sig.initialValue, propsParams, propFallbackVars, sig.type)
+    } else if (propsParams.some(p => p.name === name)) {
+      const hoisted = propFallbackVars.get(name)
+      goExpr = hoisted ? hoisted.varName : `in.${capitalizeFieldName(name)}`
+    }
+    if (goExpr === null) return null
+    envEntries.push(`${JSON.stringify(name)}: ${goExpr}`)
+  }
+  const envMap = `map[string]any{${envEntries.join(', ')}}`
+
+  let sepGo: string
+  if (!chain.sepArg) {
+    sepGo = JSON.stringify(',')
+  } else if (chain.sepArg.kind === 'literal' && chain.sepArg.literalType === 'string') {
+    sepGo = JSON.stringify(chain.sepArg.value)
+  } else {
+    return null
+  }
+
+  return `bf.Join(bf.MapEval(${itemsGo}, "${escapeGoString(projJSON)}", ${JSON.stringify(paramName)}, ${envMap}), ${sepGo})`
 }

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -40,10 +40,4 @@ export const renderDivergences: RenderDivergences = {
   // `skipJsx` entries).
   'aliased-destructured-prop':
     'aliased destructured prop `{ n: count }` loses its rename — the Input struct field is Count `json:"count"`, so the caller-side struct literal keyed by the real prop name fails `go run` outright (unknown field N, exit 1) (https://github.com/piconic-ai/barefootjs/issues/2460)',
-
-  // #2482 audit follow-ups: loop-scope holes specific to this adapter's
-  // four-stack scope tracking and its SSR seeding. Graduate by applying
-  // the fix described in each issue and deleting the line.
-  'callback-param-shadows-prop':
-    'JS-computed signal/memo initializers (`[…].map(…).join(…)`, memo over signal + prop) don\'t seed Go SSR — renders `[]` / empty where every other adapter renders the computed value; hydration snaps to correct (https://github.com/piconic-ai/barefootjs/issues/2492)',
 }

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -3564,6 +3564,7 @@ function inferTypeFromValue(value: string): TypeInfo {
   //   .length / .size       → number
   //   .some(...) / .every(...) / .includes(...)           → boolean
   //   .indexOf(...) / .findIndex(...) / .lastIndexOf(...) → number
+  //   .join(...)             → string
   //   .at(...) / .find(...) → unknown (element type; can't recover here)
   if (/\.(length|size)\s*$/.test(trimmed)) {
     return { kind: 'primitive', raw: 'number', primitive: 'number' }
@@ -3573,6 +3574,10 @@ function inferTypeFromValue(value: string): TypeInfo {
   }
   if (/\.(indexOf|findIndex|findLastIndex|lastIndexOf)\s*\([\s\S]*\)\s*$/.test(trimmed)) {
     return { kind: 'primitive', raw: 'number', primitive: 'number' }
+  }
+  // .join() always returns a string in JS, regardless of element type.
+  if (/\.join\s*\([\s\S]*\)\s*$/.test(trimmed)) {
+    return { kind: 'primitive', raw: 'string', primitive: 'string' }
   }
 
   // Number

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1850,12 +1850,6 @@
           "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)"
         }
       },
-      "callback-param-shadows-prop": {
-        "go-template": {
-          "kind": "render",
-          "reason": "JS-computed signal/memo initializers (`[…].map(…).join(…)`, memo over signal + prop) don't seed Go SSR — renders `[]` / empty where every other adapter renders the computed value; hydration snaps to correct (https://github.com/piconic-ai/barefootjs/issues/2492)"
-        }
-      },
       "composite-row-child-aliased-prop": {
         "blade": {
           "kind": "render",
@@ -2874,10 +2868,6 @@
       "aliased-destructured-prop": {
         "description": "Aliased destructured prop ({ n: count }) keeps the rename (#2460)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/aliased-destructured-prop.ts"
-      },
-      "callback-param-shadows-prop": {
-        "description": "Nested callback param sharing a prop name stays a param in the CSR template (no invalid `_p.`…",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/callback-param-shadows-prop.ts"
       },
       "composite-row-child-aliased-prop": {
         "description": "Nested child in a dynamic loop row destructures a renamed prop ({ n: count })",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -131,13 +131,9 @@
           ]
         },
         "go-template": {
-          "pass": 57,
+          "pass": 58,
           "total": 70,
           "gaps": [
-            {
-              "fixture": "callback-param-shadows-prop",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -533,13 +529,9 @@
           ]
         },
         "go-template": {
-          "pass": 63,
+          "pass": 64,
           "total": 67,
           "gaps": [
-            {
-              "fixture": "callback-param-shadows-prop",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -751,13 +743,9 @@
           ]
         },
         "go-template": {
-          "pass": 54,
+          "pass": 55,
           "total": 64,
           "gaps": [
-            {
-              "fixture": "callback-param-shadows-prop",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1135,13 +1123,9 @@
           ]
         },
         "go-template": {
-          "pass": 72,
+          "pass": 73,
           "total": 82,
           "gaps": [
-            {
-              "fixture": "callback-param-shadows-prop",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1607,13 +1591,9 @@
           ]
         },
         "go-template": {
-          "pass": 184,
+          "pass": 185,
           "total": 200,
           "gaps": [
-            {
-              "fixture": "callback-param-shadows-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2463,15 +2443,11 @@
           ]
         },
         "go-template": {
-          "pass": 269,
+          "pass": 270,
           "total": 288,
           "gaps": [
             {
               "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
-            {
-              "fixture": "callback-param-shadows-prop",
               "issues": []
             },
             {
@@ -3209,13 +3185,9 @@
           ]
         },
         "go-template": {
-          "pass": 226,
+          "pass": 227,
           "total": 238,
           "gaps": [
-            {
-              "fixture": "callback-param-shadows-prop",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3891,13 +3863,9 @@
           ]
         },
         "go-template": {
-          "pass": 136,
+          "pass": 137,
           "total": 154,
           "gaps": [
-            {
-              "fixture": "callback-param-shadows-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4489,13 +4457,9 @@
           ]
         },
         "go-template": {
-          "pass": 52,
+          "pass": 53,
           "total": 55,
           "gaps": [
-            {
-              "fixture": "callback-param-shadows-prop",
-              "issues": []
-            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -5664,13 +5628,9 @@
           ]
         },
         "go-template": {
-          "pass": 36,
+          "pass": 37,
           "total": 39,
           "gaps": [
-            {
-              "fixture": "callback-param-shadows-prop",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -6883,13 +6843,9 @@
           ]
         },
         "go-template": {
-          "pass": 17,
+          "pass": 18,
           "total": 19,
           "gaps": [
-            {
-              "fixture": "callback-param-shadows-prop",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -8074,13 +8030,9 @@
           ]
         },
         "go-template": {
-          "pass": 159,
+          "pass": 160,
           "total": 168,
           "gaps": [
-            {
-              "fixture": "callback-param-shadows-prop",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []


### PR DESCRIPTION
**Stacked on #2510 → #2505 → #2504 → #2503.** Last of the series addressing the #2482 audit's adapter-side defects — with this one, all of #2486–#2492 are fixed and every pin those issues created has graduated.

## The bug

A signal or memo whose initializer is a JS method chain was not seeded at SSR on Go. From `callback-param-shadows-prop`:

```tsx
const [first] = createSignal([{ a: 'p' }].map((title) => title.a).join(','))
const joined = createMemo(() => title + ':' + items().map((title) => title.a).join(','))
```

Go rendered `<span>[]</span><output></output>`; all seven template-string adapters render `<span>p</span><output>T:x,y</output>`.

## Two independent causes with the same shape

**Signal half — a shared type-inference bug.** `inferTypeFromValue` special-cases several trailing suffixes (`.length`, `.some(…)`, `.indexOf(…)`) but not `.join(…)`, so the leading-`[` array check won and the signal was typed `array`. That produced a `[]interface{}` Go field which the value lowering could not bake — `parsedLiteralToGo` defers on a method chain, by its documented null-means-defer contract — leaving it nil, and Go prints a nil slice as `[]`.

Worth being precise about that `[]`, because it looks like a half-seeded array and isn't: nothing about the inner `[{a:'p'}]` is ever baked. The field is genuinely unseeded; `[]` is just how Go stringifies nil. `.join()` always returns a string in JS, so typing it as one is a plain correctness fix, not a heuristic tweak.

**Memo half — separate machinery.** `memoInitialFromParsedBody` is a hand-matched shape catalogue (template literals, ternaries, `??`, arithmetic, a filter arm, bare getters). Nothing matched a `+`-binary of a prop and a `.map().join()` chain over a signal getter, so it fell through to the Go zero value `""`. Note the memo's *type* was already right — `collectMemo` has a TS-checker fallback that `collectSignal` lacks.

## The fix

Part A adds the `.join(…)` case to `inferTypeFromValue` (`@barefootjs/jsx`, so it affects every adapter's type info).

Part B adds a `.map().join()` arm following the catalogue's **own precedent**: the existing filter arm emits `bf.FilterEval(...)` as Go *source* inside the generated constructor, and this one emits `bf.Join(bf.MapEval(...))` using runtime functions that already exist (`eval.go`, `bf.go`) — no new runtime code. The arm is added after every existing match so it only fires where the code currently returns null, and the same resolution is added to the signal path in `convertInitialValue`.

## Two things I deliberately did not do

**Did not patch the test harness.** Teaching `test-render.ts` to call `evaluateSignalInit` would make this fixture pass with a much smaller diff — and would leave real Go SSR rendering `[]`. `signal-init-eval.ts`'s docstring explicitly forbids calling it from a build path, and the issue is filed against production behavior, so that shortcut would have been a green checkmark over a live bug.

**Did not restructure the catalogue.** This PR does grow the hand-matched shape catalogue that #2482's review criticized as a root cause. The structural alternative is a general `ParsedExpr` → Go **source** expression emitter, parallel to the existing `ParsedExpr` → Go **template** emitter (Go already has the general lowering for JSX expression positions — it just isn't wired to constructor-time seeding). That deserves its own issue and its own review, not to be smuggled into a bug fix, so I'm flagging it here rather than attempting it.

## Validation

Part A is a shared-compiler change, so the blast radius is every adapter — suites run serially:

| package | result |
|---|---|
| adapter-go-template | 1552 pass, 0 fail |
| adapter-tests | 1875 pass, 0 fail |
| adapter-hono | 1364 pass, 0 fail |
| adapter-jinja | 1270 pass, 0 fail |
| jsx | 2910 pass, 2 fail — the two pre-existing `map-body-no-silent-divergence` cases that are red on main too |

`bunx tsc --noEmit` clean in `packages/jsx` and `packages/adapter-go-template`. The fixture renders through real Go and passes (6 pass, 0 fail, not skipped). Locks regenerated from freshly built dists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpPtSg6rTe158671pknoD2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpPtSg6rTe158671pknoD2)_