### PR TITLE
feat(blade,jinja,erb): add /vite subpaths and migrate their seven integrations

### DIFF
--- a/.changeset/vite-blade-vite-laravel-blade-migration.md
+++ b/.changeset/vite-blade-vite-laravel-blade-migration.md
@@ -1,0 +1,78 @@
+---
+"@barefootjs/blade": minor
+---
+
+Add `@barefootjs/blade/vite`, a composed Vite plugin for PHP/Blade
+
+A new subpath exporting `barefoot` (named AND default, matching core's own
+`packages/vite/src/index.ts` shape, and `@barefootjs/go-template/vite`'s /
+`@barefootjs/hono/vite`'s naming, exactly):
+
+```ts
+import { barefoot } from '@barefootjs/blade/vite'
+
+export default defineConfig({
+  base: '/integrations/laravel/client/',
+  build: { outDir: 'dist/client' },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    templates: 'dist/templates',
+  }),
+})
+```
+
+No `adapter` option — this constructs `BladeAdapter` itself.
+
+## Turns out to be MORE mechanical than Go's, not less
+
+The brief asked: does writing `@barefootjs/go-template/vite` a second time
+(for a template-string adapter, not a compiled-binary one) stay mechanical,
+or does it reveal that the Go reference was Go-specific? Answer: the shape
+transcribes perfectly, but two of Go's three moving pieces turn out to be
+Go-only weight this port sheds outright, not carries over:
+
+- **No `afterEmit`-driven type combination at all.** Go's `postBuild`
+  (`./build.ts`'s `createConfig`) has real default behavior: combine every
+  file's Props-struct fragment into one `components.go`, because Go's
+  per-file fragments share a `randomID` helper and a package header, and an
+  unused import fails the build outright. Reading `@barefootjs/blade/
+  build.ts`'s `createConfig` shows it has **no default `postBuild` of its
+  own** — it only forwards a caller-supplied one verbatim, because
+  `BladeAdapter.generate()` never produces a `types` section (`sections.types`
+  is always `''` — PHP templates have no imports/types/exports to combine).
+  So `@barefootjs/blade/vite`'s `afterEmit` does nothing for `types` at all;
+  there is no Go-shaped combining step to port because there is nothing to
+  combine, and no compiler to please by removing an unused import.
+- **No `adapterOptions` field either.** `BladeAdapterOptions`'s only two
+  fields, `clientJsBasePath`/`barefootJsPath`, are dead code once Vite
+  drives the build: `BladeAdapter.generateScriptRegistrations` only falls
+  back to them when `scriptAssets` is `undefined`, and core's `barefoot()`
+  plugin ALWAYS passes a resolved `scriptAssets` array. Unlike Go
+  (`packageName`, still real) or Hono (`clientJsFilename`, still real),
+  Blade has no adapter option left with any effect — so this options
+  interface omits the field rather than plumbing through something that
+  would always be ignored.
+- **`assets` DOES port over, unchanged in shape.** A hand-written
+  `client/router-entry.ts` (the `@barefootjs/router` blog bootstrap) still
+  needs its Vite-resolved URL exposed to the PHP app, the same problem Go/
+  Hono solve with the same `assets` option and companion config-capture
+  plugin (`configResolved`/`configureServer` closures feeding `afterEmit`,
+  since `AfterEmitContext` deliberately carries neither). The ONE real
+  difference: the generated file is plain **JSON** (`dist/bf-assets.json`),
+  not generated Go/TS source — PHP reads it at request time (no compile
+  step), so there's nothing to commit; unlike Go's `bf_assets.go` (checked
+  in, because Go must compile a static map into the binary), this file
+  lives under `dist/` (already gitignored) and is regenerated fresh on
+  every build, dev or production.
+
+## Conclusion for the design brief's question
+
+`@barefootjs/go-template/vite`'s SHAPE (adapter construction + optional
+`afterEmit` + optional `assets`) generalizes cleanly — nothing in it needed
+bending to fit Blade. But its CONTENT is more Go-specific than the shape:
+the type-combination machinery and the `adapterOptions` passthrough are
+both artifacts of Go being a compiled language with real adapter-side
+runtime configuration, not general template-adapter needs. A template
+adapter with no compile step and no adapter-side runtime configuration
+(Blade, and — per the same reasoning — Jinja2 and ERB) needs
+STRICTLY LESS than Go's reference, not an equal amount reshaped.

--- a/.changeset/vite-blade-vite-laravel-blade-migration.md
+++ b/.changeset/vite-blade-vite-laravel-blade-migration.md
@@ -93,16 +93,16 @@ mocked/fixture-scale builds:
    inlines them as JS defaults. Blade has neither — `stash_from_ssr_
    defaults`-equivalent PHP reads them from a JSON side-channel at request
    time. The legacy CLI wrote ONE combined `dist/templates/manifest.json`;
-   `@barefootjs/vite`'s core plugin instead writes one `<Name>.ssr-
-   defaults.json` per component (`packages/vite/src/emit.ts`'s `planEmits`
-   — the SAME "per-file, not combined" choice its own docstring already
-   makes for `types`, just not previously exercised by a consumer that
-   needs the combined shape). Fixed on the READ side, not by adding
-   combining back into `vite.ts`: `ExampleApp::manifest()` now globs
-   `dist/templates/*.ssr-defaults.json` and reassembles the same
-   `{ [component]: { ssrDefaults: {...} } }` map every call site already
-   expected — zero change to `stashFromSsrDefaults()`/`registerBlogChild()`,
-   and zero new logic in `@barefootjs/blade/vite` itself.
+   `@barefootjs/vite`'s core plugin only wrote one `<Name>.ssr-
+   defaults.json` per component. First pass here closed the gap on the
+   READ side (`ExampleApp::manifest()` glob-and-reassembling the per-
+   component files) — review correctly pushed back: that's seven copies of
+   identical reconstruction logic across three languages for a build
+   ARTIFACT the pipeline used to just hand over. Fixed in core instead
+   (see the `@barefootjs/vite` changeset in this same PR): `manifest.json`
+   is now written alongside the per-component files, matching the legacy
+   shape exactly. `ExampleApp::manifest()` is back to a single
+   `json_decode` of that one file — byte-for-byte the pre-migration code.
 
 ## Conclusion for the design brief's question
 

--- a/.changeset/vite-blade-vite-laravel-blade-migration.md
+++ b/.changeset/vite-blade-vite-laravel-blade-migration.md
@@ -65,6 +65,45 @@ Go-only weight this port sheds outright, not carries over:
   lives under `dist/` (already gitignored) and is regenerated fresh on
   every build, dev or production.
 
+## Two more things a real migration surfaced that unit tests didn't
+
+Writing `vite.ts` and its unit tests was mechanical and green on the first
+try. Actually running `vite build` against `integrations/laravel`'s real
+`vite.config.ts` found two more things, neither caught by `vite.test.ts`'s
+mocked/fixture-scale builds:
+
+1. **`expr/emitters.ts`'s TS constructor-parameter-property syntax breaks
+   `vite build`, not `bun test`.** Vite's own config loader
+   (`bundleConfigFile`) marks every BARE (non-relative) import as
+   `external`, so `import { barefoot } from '@barefootjs/blade/vite'` in
+   `vite.config.ts` ends up loaded by Node's OWN native TypeScript
+   type-stripping (default-on since Node 22.18/23.6), not esbuild — and
+   Node's strip-only mode does not support parameter properties
+   (`SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]`), only plain
+   annotations. `go-template`'s and `hono`'s adapter code happen not to use
+   this syntax anywhere reachable from their own `vite.ts`, so this was
+   invisible until Blade's (and — same fix applied — Jinja's/ERB's)
+   `expr/emitters.ts`, which does, was loaded the same way. Fixed by
+   rewriting the two affected constructors (`BladeFilterEmitter`,
+   `BladeTopLevelEmitter`) as plain field declarations + explicit
+   assignment — behaviorally identical, Node-native-TS-safe.
+2. **`ssrDefaults` needs a runtime-read manifest for Blade the way Go/Hono
+   never did.** Go bakes `ssrDefaults` directly into each component's
+   generated `NewXxxProps` constructor; Hono's self-contained `.tsx` file
+   inlines them as JS defaults. Blade has neither — `stash_from_ssr_
+   defaults`-equivalent PHP reads them from a JSON side-channel at request
+   time. The legacy CLI wrote ONE combined `dist/templates/manifest.json`;
+   `@barefootjs/vite`'s core plugin instead writes one `<Name>.ssr-
+   defaults.json` per component (`packages/vite/src/emit.ts`'s `planEmits`
+   — the SAME "per-file, not combined" choice its own docstring already
+   makes for `types`, just not previously exercised by a consumer that
+   needs the combined shape). Fixed on the READ side, not by adding
+   combining back into `vite.ts`: `ExampleApp::manifest()` now globs
+   `dist/templates/*.ssr-defaults.json` and reassembles the same
+   `{ [component]: { ssrDefaults: {...} } }` map every call site already
+   expected — zero change to `stashFromSsrDefaults()`/`registerBlogChild()`,
+   and zero new logic in `@barefootjs/blade/vite` itself.
+
 ## Conclusion for the design brief's question
 
 `@barefootjs/go-template/vite`'s SHAPE (adapter construction + optional

--- a/.changeset/vite-component-manifest.md
+++ b/.changeset/vite-component-manifest.md
@@ -1,0 +1,72 @@
+---
+"@barefootjs/vite": minor
+---
+
+Write a combined `manifest.json` (matching the legacy CLI's shape exactly), alongside the per-component `.ssr-defaults.json` files
+
+`@barefootjs/vite`'s core `barefoot()` plugin already wrote one
+`<Name>.ssr-defaults.json` per component next to its template — a
+deliberate per-file choice (see `emit.ts`'s own docstring on why `types`
+fragments are written raw, not combined). What it didn't write was the
+legacy CLI's single combined `dist/templates/manifest.json`, keyed by
+component, that every PHP/Python/Ruby backend driving a `templatesPerComponent`
+adapter (Blade/Jinja2/ERB) reads `ssrDefaults` from at REQUEST time — there
+is no compile step for these languages to bake an optional-prop-derived
+signal's SSR seed value into source the way Go's generated `NewXxxProps`
+constructor or Hono's self-contained `.tsx` file can.
+
+Caught in review of the Blade/Jinja/ERB `/vite` PR: the first pass closed
+this gap on the READ side — each of Laravel/Blade/Django/FastAPI/Flask/
+Rails/Sinatra glob-and-reassembled the identical `{ [component]: {
+ssrDefaults } }` shape from the per-component files. That worked, but it
+was seven copies of the same reconstruction logic across three languages,
+absorbing a difference the pipeline used to paper over for free — and
+stack 7 (removing the legacy CLI) would have made "the new pipeline
+doesn't emit a manifest" a silent, undiffable capability regression.
+
+Fixed in core instead: `buildManifestEntry` (new, `component-manifest.ts`)
+reproduces `packages/cli/src/lib/build-cache.ts`'s `ManifestEntry` /
+`ManifestComponentEntry` shape and `packages/cli/src/lib/build.ts`'s
+manifest-building logic, verified by reading both directly (not inferred
+from a consumer):
+
+- Keyed by the source file's path relative to its `components` dir, extension
+  stripped (`Counter`, or `ui/toast/index` for a multi-export file) — same
+  as the legacy CLI's `baseNameNoExt`.
+- `ssrDefaults` is an ABSENT key (not `{}`) when a component has none —
+  verified with a fabricated no-ssrDefaults `CompileResult` in
+  `component-manifest.test.ts`, since a subtle `{}`-vs-absent difference
+  here would silently break a consumer's `array_key_exists`/`'x' in y`
+  check in a way E2E might not catch.
+- `components` (a `templatesPerComponent` adapter's per-exported-component
+  rows) is present even for a single-component file, matching the legacy
+  CLI's own unconditional-when-`templatesPerComponent` behavior.
+- Pairs `markedTemplate`/`ssrDefaults` FileOutputs by `componentName`
+  (always stamped by the compiler — see `compiler.ts`) rather than the
+  legacy CLI's own path-basename heuristic (which existed to paper over
+  esbuild's multi-physical-file output naming and has no equivalent
+  ambiguity under this plugin's own per-component-name output).
+
+Two legacy `ManifestEntry` fields are intentionally NOT reproduced —
+`stubDeps` (bookkeeping for the legacy CLI's esbuild-based stub-dependency
+resolution; Rollup's own module resolution makes it moot) and `clientJs`
+(a static path only meaningful when the CLI itself controlled the
+non-hashed output location; under Vite the real URL is content-hashed and
+mode-dependent, exactly what `scriptAssets` already resolves and bakes
+directly into the compiled template — no backend has ever read
+`manifest[name].clientJs`, confirmed by grepping the PHP/Python/Ruby
+runtimes).
+
+Written alongside, not instead of, the per-component files (dev re-emits
+of one changed component stay cheap; the combined file is rewritten whole
+every eager pass, which the full-discovery-every-pass design already
+implies). `@barefootjs/go-template/vite` and `@barefootjs/hono/vite` get
+the same manifest for free, even though neither adapter's own runtime
+reads it today (Go bakes `ssrDefaults` into generated source; Hono's
+`.tsx` inlines them as JS defaults) — confirmed by grepping both
+integrations' backend code for `manifest`/`ssrDefaults` reads: none exist.
+
+The seven integrations' manifest reads were reverted back to a single
+`json_decode`/`json.loads`/`JSON.parse` of `dist/templates/manifest.json` —
+byte-for-byte the pre-Vite-migration code, verified by diffing against
+each integration's pre-migration commit.

--- a/.changeset/vite-erb-vite-rails-sinatra-migration.md
+++ b/.changeset/vite-erb-vite-rails-sinatra-migration.md
@@ -41,10 +41,11 @@ preserved verbatim across the rewrite):
 
 - `ErbFilterEmitter`/`ErbTopLevelEmitter`'s constructors rewritten as plain
   field declarations + explicit assignment.
-- The Rails/Sinatra manifest reads reassemble `{ [component]: {
-  ssrDefaults } }` from the per-component `dist/templates/*.ssr-
-  defaults.json` files `@barefootjs/vite`'s core plugin writes, instead of
-  the legacy CLI's single combined `manifest.json`.
+- The Rails/Sinatra `BLOG_MANIFEST` reads the single combined
+  `dist/templates/manifest.json` `@barefootjs/vite`'s core plugin now
+  writes (see that package's own changeset in this PR), via the same
+  `symbolize_names: true` `slurp_json` helper both integrations already
+  had — byte-for-byte the pre-migration code.
 
 Third confirmation of the `@barefootjs/blade/vite` changeset's finding:
 writing the SAME `/vite` shape a third time, for a third template-string
@@ -52,11 +53,6 @@ adapter, was fully mechanical, and needed strictly less than Go's reference
 — not an equal amount reshaped.
 
 `integrations/rails` and `integrations/sinatra` both move onto this
-package's `/vite` in this PR (`config/initializers/example_app.rb`'s
-`BLOG_MANIFEST`/Rails, `app.rb`'s `BLOG_MANIFEST`/Sinatra — both
-`symbolize_names: true`, both reassembled from the per-component
-`dist/templates/*.ssr-defaults.json` files the same way as Laravel's/
-Django's PHP/Python read sides, just keyed by `Symbol` instead of
-`String` since every existing call site already does `entry[:ssrDefaults]`).
-Each integration's own 104-test Playwright E2E suite passes end-to-end
-against its migrated build, run twice for stability.
+package's `/vite` in this PR. Each integration's own 104-test Playwright
+E2E suite passes end-to-end against its migrated build, run twice for
+stability.

--- a/.changeset/vite-erb-vite-rails-sinatra-migration.md
+++ b/.changeset/vite-erb-vite-rails-sinatra-migration.md
@@ -1,0 +1,52 @@
+---
+"@barefootjs/erb": minor
+---
+
+Add `@barefootjs/erb/vite`, a composed Vite plugin for Ruby/ERB
+
+A new subpath exporting `barefoot` (named AND default, matching core's own
+`packages/vite/src/index.ts` shape, and `@barefootjs/go-template/vite`'s /
+`@barefootjs/hono/vite`'s / `@barefootjs/blade/vite`'s / `@barefootjs/jinja/
+vite`'s naming, exactly):
+
+```ts
+import { barefoot } from '@barefootjs/erb/vite'
+
+export default defineConfig({
+  base: '/integrations/rails/client/',
+  build: { outDir: 'dist/client' },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    templates: 'dist/templates',
+  }),
+})
+```
+
+No `adapter` option — this constructs `ErbAdapter` itself. Byte-for-byte
+the same shape as `@barefootjs/blade/vite`/`@barefootjs/jinja/vite` (see
+those changesets for the full design writeup): no `afterEmit`-driven type
+combination (`ErbAdapter.generate()` never produces a `types` section —
+`./build.ts`'s `createConfig` has no default `postBuild` either), no
+`adapterOptions` (`ErbAdapterOptions`'s two fields are dead once
+`scriptAssets` is always resolved), and `assets` ports over unchanged
+except the generated file is plain JSON (`dist/bf-assets.json`, gitignored,
+regenerated every build) — Ruby reads it at request time, nothing to
+commit.
+
+Also carries the same fixes the port needed to actually build, since
+`@barefootjs/erb/src/adapter/expr/emitters.ts` has the identical
+TS-constructor-parameter-property shape (plus one extra parameter,
+`renderParamAs`, whose default value reads an EARLIER parameter —
+preserved verbatim across the rewrite):
+
+- `ErbFilterEmitter`/`ErbTopLevelEmitter`'s constructors rewritten as plain
+  field declarations + explicit assignment.
+- The Rails/Sinatra manifest reads reassemble `{ [component]: {
+  ssrDefaults } }` from the per-component `dist/templates/*.ssr-
+  defaults.json` files `@barefootjs/vite`'s core plugin writes, instead of
+  the legacy CLI's single combined `manifest.json`.
+
+Third confirmation of the `@barefootjs/blade/vite` changeset's finding:
+writing the SAME `/vite` shape a third time, for a third template-string
+adapter, was fully mechanical, and needed strictly less than Go's reference
+— not an equal amount reshaped.

--- a/.changeset/vite-erb-vite-rails-sinatra-migration.md
+++ b/.changeset/vite-erb-vite-rails-sinatra-migration.md
@@ -2,16 +2,6 @@
 "@barefootjs/erb": minor
 ---
 
-`integrations/rails` and `integrations/sinatra` both move onto this
-package's `/vite` in this PR (`config/initializers/example_app.rb`'s
-`BLOG_MANIFEST`/Rails, `app.rb`'s `BLOG_MANIFEST`/Sinatra — both
-`symbolize_names: true`, both reassembled from the per-component
-`dist/templates/*.ssr-defaults.json` files the same way as Laravel's/
-Django's PHP/Python read sides, just keyed by `Symbol` instead of
-`String` since every existing call site already does `entry[:ssrDefaults]`).
-Each integration's own 104-test Playwright E2E suite passes end-to-end
-against its migrated build, run twice for stability.
-
 Add `@barefootjs/erb/vite`, a composed Vite plugin for Ruby/ERB
 
 A new subpath exporting `barefoot` (named AND default, matching core's own
@@ -60,3 +50,13 @@ Third confirmation of the `@barefootjs/blade/vite` changeset's finding:
 writing the SAME `/vite` shape a third time, for a third template-string
 adapter, was fully mechanical, and needed strictly less than Go's reference
 — not an equal amount reshaped.
+
+`integrations/rails` and `integrations/sinatra` both move onto this
+package's `/vite` in this PR (`config/initializers/example_app.rb`'s
+`BLOG_MANIFEST`/Rails, `app.rb`'s `BLOG_MANIFEST`/Sinatra — both
+`symbolize_names: true`, both reassembled from the per-component
+`dist/templates/*.ssr-defaults.json` files the same way as Laravel's/
+Django's PHP/Python read sides, just keyed by `Symbol` instead of
+`String` since every existing call site already does `entry[:ssrDefaults]`).
+Each integration's own 104-test Playwright E2E suite passes end-to-end
+against its migrated build, run twice for stability.

--- a/.changeset/vite-erb-vite-rails-sinatra-migration.md
+++ b/.changeset/vite-erb-vite-rails-sinatra-migration.md
@@ -2,6 +2,16 @@
 "@barefootjs/erb": minor
 ---
 
+`integrations/rails` and `integrations/sinatra` both move onto this
+package's `/vite` in this PR (`config/initializers/example_app.rb`'s
+`BLOG_MANIFEST`/Rails, `app.rb`'s `BLOG_MANIFEST`/Sinatra — both
+`symbolize_names: true`, both reassembled from the per-component
+`dist/templates/*.ssr-defaults.json` files the same way as Laravel's/
+Django's PHP/Python read sides, just keyed by `Symbol` instead of
+`String` since every existing call site already does `entry[:ssrDefaults]`).
+Each integration's own 104-test Playwright E2E suite passes end-to-end
+against its migrated build, run twice for stability.
+
 Add `@barefootjs/erb/vite`, a composed Vite plugin for Ruby/ERB
 
 A new subpath exporting `barefoot` (named AND default, matching core's own

--- a/.changeset/vite-jinja-vite-django-fastapi-flask-migration.md
+++ b/.changeset/vite-jinja-vite-django-fastapi-flask-migration.md
@@ -44,6 +44,15 @@ the identical TS-constructor-parameter-property shape:
   `@barefootjs/vite`'s core plugin writes, instead of the legacy CLI's
   single combined `manifest.json`.
 
+Ports `integrations/django` (the first of three integrations moving onto
+this adapter — `fastapi`/`flask` next) the same way `laravel` proved
+`@barefootjs/blade/vite`: `vite.config.ts` replaces `barefoot.config.ts`
+for `build`/`build:watch`, `build.outDir` scoped to `dist/client` (matching
+the existing `client_static`/`styles_static` Django views), and `app.py`'s
+`MANIFEST`/import map updated the same way as `ExampleApp.php`'s.
+`integrations/django`'s Playwright E2E suite (104 tests) passes end-to-end
+against the migrated build, run twice for stability.
+
 Confirms the `@barefootjs/blade/vite` changeset's finding a second time:
 writing the SAME `/vite` shape for a second template-string adapter was
 fully mechanical, and needed strictly less than Go's reference (no type

--- a/.changeset/vite-jinja-vite-django-fastapi-flask-migration.md
+++ b/.changeset/vite-jinja-vite-django-fastapi-flask-migration.md
@@ -1,0 +1,50 @@
+---
+"@barefootjs/jinja": minor
+---
+
+Add `@barefootjs/jinja/vite`, a composed Vite plugin for Python/Jinja2
+
+A new subpath exporting `barefoot` (named AND default, matching core's own
+`packages/vite/src/index.ts` shape, and `@barefootjs/go-template/vite`'s /
+`@barefootjs/hono/vite`'s / `@barefootjs/blade/vite`'s naming, exactly):
+
+```ts
+import { barefoot } from '@barefootjs/jinja/vite'
+
+export default defineConfig({
+  base: '/integrations/django/client/',
+  build: { outDir: 'dist/client' },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    templates: 'dist/templates',
+  }),
+})
+```
+
+No `adapter` option — this constructs `JinjaAdapter` itself. Byte-for-byte
+the same shape as `@barefootjs/blade/vite` (see that changeset for the full
+design writeup): no `afterEmit`-driven type combination
+(`JinjaAdapter.generate()` never produces a `types` section — `./build.ts`'s
+`createConfig` has no default `postBuild` either), no `adapterOptions`
+(`JinjaAdapterOptions`'s two fields are dead once `scriptAssets` is always
+resolved), and `assets` ports over unchanged except the generated file is
+plain JSON (`dist/bf-assets.json`, gitignored, regenerated every build) —
+Python reads it at request time, nothing to commit.
+
+Also carries the two `@barefootjs/blade/vite` fixes needed for the port to
+actually build, since `@barefootjs/jinja/src/adapter/expr/emitters.ts` has
+the identical TS-constructor-parameter-property shape:
+
+- `JinjaFilterEmitter`/`JinjaTopLevelEmitter`'s constructors rewritten as
+  plain field declarations + explicit assignment (Node's native TS
+  stripping, which Vite's `bundleConfigFile` externalization triggers for
+  this file, does not support parameter properties).
+- `app.py`'s manifest read reassembles `{ [component]: { ssrDefaults } }`
+  from the per-component `dist/templates/*.ssr-defaults.json` files
+  `@barefootjs/vite`'s core plugin writes, instead of the legacy CLI's
+  single combined `manifest.json`.
+
+Confirms the `@barefootjs/blade/vite` changeset's finding a second time:
+writing the SAME `/vite` shape for a second template-string adapter was
+fully mechanical, and needed strictly less than Go's reference (no type
+combining, no adapter options), not an equal amount reshaped.

--- a/.changeset/vite-jinja-vite-django-fastapi-flask-migration.md
+++ b/.changeset/vite-jinja-vite-django-fastapi-flask-migration.md
@@ -51,7 +51,11 @@ for `build`/`build:watch`, `build.outDir` scoped to `dist/client` (matching
 the existing `client_static`/`styles_static` Django views), and `app.py`'s
 `MANIFEST`/import map updated the same way as `ExampleApp.php`'s.
 `integrations/django`'s Playwright E2E suite (104 tests) passes end-to-end
-against the migrated build, run twice for stability.
+against the migrated build, run twice for stability. `integrations/fastapi`
+and `integrations/flask` follow the identical pattern (StaticFiles mount /
+Blueprint `url_prefix` instead of Django's `path()` dispatch, otherwise
+byte-for-byte the same `vite.config.ts` and `MANIFEST`/`ASSETS` reads);
+each also passes its own 104-test Playwright suite, run twice.
 
 Confirms the `@barefootjs/blade/vite` changeset's finding a second time:
 writing the SAME `/vite` shape for a second template-string adapter was

--- a/.changeset/vite-jinja-vite-django-fastapi-flask-migration.md
+++ b/.changeset/vite-jinja-vite-django-fastapi-flask-migration.md
@@ -39,17 +39,17 @@ the identical TS-constructor-parameter-property shape:
   plain field declarations + explicit assignment (Node's native TS
   stripping, which Vite's `bundleConfigFile` externalization triggers for
   this file, does not support parameter properties).
-- `app.py`'s manifest read reassembles `{ [component]: { ssrDefaults } }`
-  from the per-component `dist/templates/*.ssr-defaults.json` files
-  `@barefootjs/vite`'s core plugin writes, instead of the legacy CLI's
-  single combined `manifest.json`.
+- `app.py`'s `MANIFEST` reads the single combined `dist/templates/
+  manifest.json` `@barefootjs/vite`'s core plugin now writes (see that
+  package's own changeset in this PR) — byte-for-byte the pre-migration
+  code, unchanged from the legacy CLI's own manifest shape.
 
 Ports `integrations/django` (the first of three integrations moving onto
 this adapter — `fastapi`/`flask` next) the same way `laravel` proved
 `@barefootjs/blade/vite`: `vite.config.ts` replaces `barefoot.config.ts`
 for `build`/`build:watch`, `build.outDir` scoped to `dist/client` (matching
 the existing `client_static`/`styles_static` Django views), and `app.py`'s
-`MANIFEST`/import map updated the same way as `ExampleApp.php`'s.
+import map deleted the same way as `ExampleApp.php`'s.
 `integrations/django`'s Playwright E2E suite (104 tests) passes end-to-end
 against the migrated build, run twice for stability. `integrations/fastapi`
 and `integrations/flask` follow the identical pattern (StaticFiles mount /

--- a/integrations/blade/index.php
+++ b/integrations/blade/index.php
@@ -82,27 +82,16 @@ $backend = new BladeBackend([
     'cache_dir' => sys_get_temp_dir() . '/barefootjs-blade-cache',
 ]);
 
-// The build manifest -- reassembled from `dist/templates/*.ssr-defaults.json`
-// (one file per component, written by `@barefootjs/vite`'s core plugin --
-// see `packages/vite/src/emit.ts`'s `planEmits`), not a single combined
-// `manifest.json` the legacy CLI used to write. Each component's
-// `ssrDefaults` -- the set of signal/memo names an optional-prop-derived
-// initial value needs BOUND (to the real prop or to `null`) in the render
-// context -- lands in its own file; this glob-and-merge reassembles the
-// SAME `{ [component]: { ssrDefaults: {...} } }` shape every call site
-// below already expects. This integration's shared components aren't
-// manifest-registered under `ui/*` (see render_component's manual child
-// wiring below, mirroring app.py's comment), so root-level renders derive
-// the stash themselves via stash_from_ssr_defaults(), the same way app.py
-// does.
-$MANIFEST = [];
-foreach (glob($HERE . '/dist/templates/*.ssr-defaults.json') ?: [] as $path) {
-    $component = basename($path, '.ssr-defaults.json');
-    $defaults = json_decode(file_get_contents($path), true);
-    if (is_array($defaults)) {
-        $MANIFEST[$component] = ['ssrDefaults' => $defaults];
-    }
-}
+// The build manifest -- a plain build artifact (dist/templates/manifest.json),
+// not adapter internals -- lists each component's `ssrDefaults`: the set of
+// signal/memo names an optional-prop-derived initial value needs BOUND (to
+// the real prop or to `null`) in the render context. This integration's
+// shared components aren't manifest-registered under `ui/*` (see
+// render_component's manual child wiring below, mirroring app.py's comment),
+// so root-level renders derive the stash themselves via
+// stash_from_ssr_defaults(), the same way app.py does.
+$manifestPath = $HERE . '/dist/templates/manifest.json';
+$MANIFEST = is_file($manifestPath) ? (json_decode(file_get_contents($manifestPath), true) ?: []) : [];
 
 // The Vite-generated asset map (dist/bf-assets.json, written by
 // `@barefootjs/blade/vite`'s `afterEmit` hook) -- resolves a hand-written,

--- a/integrations/blade/index.php
+++ b/integrations/blade/index.php
@@ -82,16 +82,37 @@ $backend = new BladeBackend([
     'cache_dir' => sys_get_temp_dir() . '/barefootjs-blade-cache',
 ]);
 
-// The build manifest -- a plain build artifact (dist/templates/manifest.json),
-// not adapter internals -- lists each component's `ssrDefaults`: the set of
-// signal/memo names an optional-prop-derived initial value needs BOUND (to
-// the real prop or to `null`) in the render context. This integration's
-// shared components aren't manifest-registered under `ui/*` (see
-// render_component's manual child wiring below, mirroring app.py's comment),
-// so root-level renders derive the stash themselves via
-// stash_from_ssr_defaults(), the same way app.py does.
-$manifestPath = $HERE . '/dist/templates/manifest.json';
-$MANIFEST = is_file($manifestPath) ? (json_decode(file_get_contents($manifestPath), true) ?: []) : [];
+// The build manifest -- reassembled from `dist/templates/*.ssr-defaults.json`
+// (one file per component, written by `@barefootjs/vite`'s core plugin --
+// see `packages/vite/src/emit.ts`'s `planEmits`), not a single combined
+// `manifest.json` the legacy CLI used to write. Each component's
+// `ssrDefaults` -- the set of signal/memo names an optional-prop-derived
+// initial value needs BOUND (to the real prop or to `null`) in the render
+// context -- lands in its own file; this glob-and-merge reassembles the
+// SAME `{ [component]: { ssrDefaults: {...} } }` shape every call site
+// below already expects. This integration's shared components aren't
+// manifest-registered under `ui/*` (see render_component's manual child
+// wiring below, mirroring app.py's comment), so root-level renders derive
+// the stash themselves via stash_from_ssr_defaults(), the same way app.py
+// does.
+$MANIFEST = [];
+foreach (glob($HERE . '/dist/templates/*.ssr-defaults.json') ?: [] as $path) {
+    $component = basename($path, '.ssr-defaults.json');
+    $defaults = json_decode(file_get_contents($path), true);
+    if (is_array($defaults)) {
+        $MANIFEST[$component] = ['ssrDefaults' => $defaults];
+    }
+}
+
+// The Vite-generated asset map (dist/bf-assets.json, written by
+// `@barefootjs/blade/vite`'s `afterEmit` hook) -- resolves a hand-written,
+// non-component script entry's bundled URL (dev: Vite origin URL;
+// production: content-hashed manifest path). Read once at request time,
+// same rationale as $MANIFEST above: PHP has no compile step, so there is
+// nothing to commit -- a fresh copy lands under gitignored dist/ on every
+// build (dev AND production).
+$assetsPath = $HERE . '/dist/bf-assets.json';
+$ASSETS = is_file($assetsPath) ? (json_decode(file_get_contents($assetsPath), true) ?: []) : [];
 
 // The blog post corpus -- generated at build time by scripts/gen-blog-data.ts
 // from ../shared/blog/posts.ts (the single TS source of truth the JS adapters
@@ -472,9 +493,19 @@ HTML;
 // Mojolicious ports): a region-shell layout (header + ThemeToggle in the
 // shell, a hand-authored sidebar region `nav:0` + the compiled <PageShell>
 // nested content regions in the main column) whose islands are the shared
-// blog components in ../shared/blog, compiled by this integration's
-// `bf build`. The client router (client/router-entry.ts, bundled to
-// client/router-entry.js) swaps only the content region.
+// blog components in ../shared/blog, compiled by this integration's Vite
+// build (vite.config.ts). The client router (client/router-entry.ts,
+// its bundled URL resolved into $ASSETS['RouterEntry']) swaps only the
+// content region.
+//
+// No import map is needed (unlike the pre-Vite build): the router bundle's
+// `@barefootjs/client/runtime` import and every compiled island's own
+// `@barefootjs/client` import are ordinary ESM imports Rollup/Vite resolve
+// through their real module graph, collapsing into ONE shared chunk
+// (build) or ONE cached module (dev) automatically -- a single reactive
+// runtime instance without any hand-wired specifier redirection. That this
+// hand-written wiring could simply be deleted is the point of the
+// Vite-based design, not an incidental cleanup.
 //
 // There is no special server-side "partial navigation" endpoint: the router
 // (packages/router/src/router.ts) fetches a full HTML page for every
@@ -582,8 +613,7 @@ function blog_island(BarefootJS $root, string $component, array $props = [], arr
  * islands (and the shell islands rendered here) all share. */
 function blog_page(BarefootJS $root, string $title, string $base, string $contentHtml): string
 {
-    global $BASE;
-    $static = "{$BASE}/client";
+    global $BASE, $ASSETS;
     $theme = blog_island($root, 'ThemeToggle');
     $sidebar = blog_island($root, 'Sidebar');
     $shell = blog_island(
@@ -593,14 +623,8 @@ function blog_page(BarefootJS $root, string $title, string $base, string $conten
         ['children' => $root->backend->mark_raw($contentHtml)], // SSR-only: page content
         ['reader_toolbar' => 'ReaderToolbar'],
     );
-    $importMap = json_encode([
-        'imports' => [
-            '@barefootjs/client' => "{$static}/barefoot.js",
-            '@barefootjs/client/runtime' => "{$static}/barefoot.js",
-            '@barefootjs/client/reactive' => "{$static}/barefoot.js",
-        ],
-    ]);
     $scripts = $root->scripts();
+    $routerEntry = $ASSETS['RouterEntry'] ?? '';
     $escTitle = htmlspecialchars($title, ENT_QUOTES);
     return <<<HTML
 <!DOCTYPE html>
@@ -609,7 +633,6 @@ function blog_page(BarefootJS $root, string $title, string $base, string $conten
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{$escTitle}</title>
-<script type="importmap">{$importMap}</script>
 <link rel="stylesheet" href="{$BASE}/styles/blog.css">
 </head>
 <body>
@@ -622,7 +645,7 @@ function blog_page(BarefootJS $root, string $title, string $base, string $conten
 <main>{$shell}</main>
 </div>
 {$scripts}
-<script type="module" src="{$static}/router-entry.js"></script>
+<script type="module" src="{$routerEntry}"></script>
 </body>
 </html>
 HTML;

--- a/integrations/blade/package.json
+++ b/integrations/blade/package.json
@@ -2,9 +2,10 @@
   "name": "barefootjs-blade-example",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts && composer install --no-interaction --no-progress",
-    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "build": "vite build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts && composer install --no-interaction --no-progress",
+    "build:watch": "vite dev",
     "dev": "PHP_CLI_SERVER_WORKERS=8 BASE_PATH=/integrations/blade PORT=3015 php -S 0.0.0.0:3015 index.php",
     "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
@@ -18,10 +19,12 @@
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
     "@barefootjs/blade": "workspace:*",
+    "@barefootjs/vite": "workspace:*",
     "@cloudflare/containers": "^0.3.2",
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
+    "vite": "^6.0.0",
     "wrangler": "^4"
   }
 }

--- a/integrations/blade/vite.config.ts
+++ b/integrations/blade/vite.config.ts
@@ -1,0 +1,44 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { barefoot } from '@barefootjs/blade/vite'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const basePath = process.env.BASE_PATH ?? '/integrations/blade'
+const routerEntry = resolve(HERE, 'client/router-entry.ts')
+
+// This app's own Rollup entry: `client/router-entry.ts` (the
+// `@barefootjs/router` bootstrap for the blog) is a hand-written script,
+// not a `.tsx` component, so `barefoot()`'s own discovery never sees it —
+// per the design, bundling configuration is stock Vite config this plugin
+// never adds on the app's behalf. `assets.RouterEntry` below (Blade-
+// specific) only resolves the URL Vite bundles this to; THIS is what
+// requests the bundling.
+export default defineConfig({
+  base: `${basePath}/client/`,
+  build: {
+    // Scoped to `dist/client` (not the whole `dist`), matching the existing
+    // `serve_static_file($HERE . '/dist/client', ...)` route in index.php —
+    // the templates dir below is a SEPARATE, non-web-exposed directory PHP
+    // reads locally, never served over HTTP.
+    outDir: 'dist/client',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: { 'router-entry': routerEntry },
+    },
+  },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    // Matches the legacy CLI's output layout exactly (`outputLayout:
+    // { templates: 'templates', clientJs: 'client', runtime: 'client' }`
+    // under `outDir: 'dist'`) — `$backend` (BladeBackend) reads
+    // `dist/templates` directly; it is never served over HTTP.
+    templates: 'dist/templates',
+    // blog_page() no longer hand-writes `.../client/router-entry.js` (it's
+    // content-hashed under Vite) or a `barefoot.js` importmap entry (the
+    // runtime is a shared ESM chunk the browser follows on its own — see
+    // index.php's blog section docstring). `dist/bf-assets.json`'s
+    // `["RouterEntry"]` is what index.php's `assets()` reads instead.
+    assets: { RouterEntry: routerEntry },
+  }),
+})

--- a/integrations/django/app.py
+++ b/integrations/django/app.py
@@ -99,23 +99,18 @@ def jbool(v: Any) -> bool:
     return bool(v)
 
 
-# The build manifest -- reassembled from `dist/templates/*.ssr-defaults.json`
-# (one file per component, written by `@barefootjs/vite`'s core plugin --
-# see `packages/vite/src/emit.ts`'s `planEmits`), not the legacy CLI's
-# single combined `dist/templates/manifest.json`. Each component's
-# `ssrDefaults` -- the set of signal/memo names an optional-prop-derived
-# initial value needs BOUND (to the real prop or to `None`) in the render
-# context -- lands in its own file; this glob-and-merge reassembles the
-# SAME `{ [component]: { "ssrDefaults": {...} } }` shape every call site
-# below already expects. `register_child_renderer` via
-# `register_components_from_manifest` derives this automatically for
-# manifest-registered (`ui/*`) children; this integration's shared
-# components aren't manifest-registered (see render_component's manual
-# child wiring below), so root-level renders derive it themselves, the
-# same way.
-MANIFEST: dict[str, Any] = {}
-for _p in (HERE / "dist" / "templates").glob("*.ssr-defaults.json"):
-    MANIFEST[_p.name[: -len(".ssr-defaults.json")]] = {"ssrDefaults": _json.loads(_p.read_text())}
+# The build manifest -- a plain build artifact (dist/templates/manifest.json),
+# not adapter internals -- lists each component's `ssrDefaults`: the set of
+# signal/memo names an optional-prop-derived initial value needs BOUND (to
+# the real prop or to `None`) in the render context. `register_child_renderer`
+# via `register_components_from_manifest` derives this automatically for
+# manifest-registered (`ui/*`) children; this integration's shared components
+# aren't manifest-registered (see render_component's manual child wiring
+# below), so root-level renders derive it themselves, the same way.
+try:
+    MANIFEST: dict[str, Any] = _json.loads((HERE / "dist" / "templates" / "manifest.json").read_text())
+except FileNotFoundError:
+    MANIFEST = {}
 
 # The Vite-generated asset map (dist/bf-assets.json, written by
 # `@barefootjs/jinja/vite`'s `afterEmit` hook) -- resolves a hand-written,

--- a/integrations/django/app.py
+++ b/integrations/django/app.py
@@ -99,18 +99,35 @@ def jbool(v: Any) -> bool:
     return bool(v)
 
 
-# The build manifest -- a plain build artifact (dist/templates/manifest.json),
-# not adapter internals -- lists each component's `ssrDefaults`: the set of
-# signal/memo names an optional-prop-derived initial value needs BOUND (to
-# the real prop or to `None`) in the render context. `register_child_renderer`
-# via `register_components_from_manifest` derives this automatically for
-# manifest-registered (`ui/*`) children; this integration's shared components
-# aren't manifest-registered (see render_component's manual child wiring
-# below), so root-level renders derive it themselves, the same way.
+# The build manifest -- reassembled from `dist/templates/*.ssr-defaults.json`
+# (one file per component, written by `@barefootjs/vite`'s core plugin --
+# see `packages/vite/src/emit.ts`'s `planEmits`), not the legacy CLI's
+# single combined `dist/templates/manifest.json`. Each component's
+# `ssrDefaults` -- the set of signal/memo names an optional-prop-derived
+# initial value needs BOUND (to the real prop or to `None`) in the render
+# context -- lands in its own file; this glob-and-merge reassembles the
+# SAME `{ [component]: { "ssrDefaults": {...} } }` shape every call site
+# below already expects. `register_child_renderer` via
+# `register_components_from_manifest` derives this automatically for
+# manifest-registered (`ui/*`) children; this integration's shared
+# components aren't manifest-registered (see render_component's manual
+# child wiring below), so root-level renders derive it themselves, the
+# same way.
+MANIFEST: dict[str, Any] = {}
+for _p in (HERE / "dist" / "templates").glob("*.ssr-defaults.json"):
+    MANIFEST[_p.name[: -len(".ssr-defaults.json")]] = {"ssrDefaults": _json.loads(_p.read_text())}
+
+# The Vite-generated asset map (dist/bf-assets.json, written by
+# `@barefootjs/jinja/vite`'s `afterEmit` hook) -- resolves a hand-written,
+# non-component script entry's bundled URL (dev: Vite origin URL;
+# production: content-hashed manifest path). Read once at process start,
+# same rationale as MANIFEST above: Python has no compile step, so there is
+# nothing to commit -- a fresh copy lands under gitignored dist/ on every
+# build (dev AND production).
 try:
-    MANIFEST: dict[str, Any] = _json.loads((HERE / "dist" / "templates" / "manifest.json").read_text())
+    ASSETS: dict[str, str] = _json.loads((HERE / "dist" / "bf-assets.json").read_text())
 except FileNotFoundError:
-    MANIFEST = {}
+    ASSETS = {}
 
 # The blog post corpus -- generated at build time by scripts/gen-blog-data.ts
 # from ../shared/blog/posts.ts (the single TS source of truth the JS adapters
@@ -564,9 +581,18 @@ def styles_static(request, asset_path: str):
 # ports): a region-shell layout (header + ThemeToggle in the shell, a
 # hand-authored sidebar region `nav:0` + the compiled <PageShell> nested
 # content regions in the main column) whose islands are the shared blog
-# components in ../shared/blog, compiled by this integration's `bf build`.
-# The client router (client/router-entry.ts, bundled to
-# client/router-entry.js) swaps only the content region.
+# components in ../shared/blog, compiled by this integration's Vite build
+# (vite.config.ts). The client router (client/router-entry.ts, its bundled
+# URL resolved into ASSETS["RouterEntry"]) swaps only the content region.
+#
+# No import map is needed (unlike the pre-Vite build): the router bundle's
+# `@barefootjs/client/runtime` import and every compiled island's own
+# `@barefootjs/client` import are ordinary ESM imports Rollup/Vite resolve
+# through their real module graph, collapsing into ONE shared chunk (build)
+# or ONE cached module (dev) automatically -- a single reactive runtime
+# instance without any hand-wired specifier redirection. That this
+# hand-written wiring could simply be deleted is the point of the
+# Vite-based design, not an incidental cleanup.
 #
 # There is no special server-side "partial navigation" endpoint: the router
 # (packages/router/src/router.ts) fetches a full HTML page for every
@@ -676,7 +702,6 @@ def blog_page(root: BarefootJS, title: str, base: str, content_html: str) -> str
     """Assemble the region-shell page around already-rendered content HTML.
     `root` is the request-scoped runtime whose script collector the content
     islands (and the shell islands rendered here) all share."""
-    static = f"{BASE}/client"
     theme = blog_island(root, "ThemeToggle")
     sidebar = blog_island(root, "Sidebar")
     shell = blog_island(
@@ -685,14 +710,8 @@ def blog_page(root: BarefootJS, title: str, base: str, content_html: str) -> str
         {"children": backend.mark_raw(content_html)},     # SSR-only: page content
         {"reader_toolbar": "ReaderToolbar"},
     )
-    import_map = _json.dumps({
-        "imports": {
-            "@barefootjs/client": f"{static}/barefoot.js",
-            "@barefootjs/client/runtime": f"{static}/barefoot.js",
-            "@barefootjs/client/reactive": f"{static}/barefoot.js",
-        }
-    })
     scripts = root.scripts()
+    router_entry = ASSETS.get("RouterEntry", "")
     esc_title = title.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
     return f"""<!DOCTYPE html>
 <html lang="en" data-theme="dark">
@@ -700,7 +719,6 @@ def blog_page(root: BarefootJS, title: str, base: str, content_html: str) -> str
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{esc_title}</title>
-<script type="importmap">{import_map}</script>
 <link rel="stylesheet" href="{BASE}/styles/blog.css">
 </head>
 <body>
@@ -713,7 +731,7 @@ def blog_page(root: BarefootJS, title: str, base: str, content_html: str) -> str
 <main>{shell}</main>
 </div>
 {scripts}
-<script type="module" src="{static}/router-entry.js"></script>
+<script type="module" src="{router_entry}"></script>
 </body>
 </html>
 """

--- a/integrations/django/package.json
+++ b/integrations/django/package.json
@@ -2,9 +2,10 @@
   "name": "barefootjs-django-example",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts",
-    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "build": "vite build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts",
+    "build:watch": "vite dev",
     "dev": "PYTHONPATH=./lib BASE_PATH=/integrations/django DJANGO_DEBUG=1 PORT=3014 python3 app.py",
     "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
@@ -18,10 +19,12 @@
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
     "@barefootjs/jinja": "workspace:*",
+    "@barefootjs/vite": "workspace:*",
     "@cloudflare/containers": "^0.3.2",
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
+    "vite": "^6.0.0",
     "wrangler": "^4"
   }
 }

--- a/integrations/django/vite.config.ts
+++ b/integrations/django/vite.config.ts
@@ -1,0 +1,44 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { barefoot } from '@barefootjs/jinja/vite'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const basePath = process.env.BASE_PATH ?? '/integrations/django'
+const routerEntry = resolve(HERE, 'client/router-entry.ts')
+
+// This app's own Rollup entry: `client/router-entry.ts` (the
+// `@barefootjs/router` bootstrap for the blog) is a hand-written script,
+// not a `.tsx` component, so `barefoot()`'s own discovery never sees it —
+// per the design, bundling configuration is stock Vite config this plugin
+// never adds on the app's behalf. `assets.RouterEntry` below (Jinja-
+// specific) only resolves the URL Vite bundles this to; THIS is what
+// requests the bundling.
+export default defineConfig({
+  base: `${basePath}/client/`,
+  build: {
+    // Scoped to `dist/client` (not the whole `dist`), matching the existing
+    // `client_static`/`styles_static` Django views — the templates dir
+    // below is a SEPARATE, non-web-exposed directory Python reads locally,
+    // never served over HTTP.
+    outDir: 'dist/client',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: { 'router-entry': routerEntry },
+    },
+  },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    // Matches the legacy CLI's output layout exactly (`outputLayout:
+    // { templates: 'templates', clientJs: 'client', runtime: 'client' }`
+    // under `outDir: 'dist'`) — `backend` (JinjaBackend) reads
+    // `dist/templates` directly; it is never served over HTTP.
+    templates: 'dist/templates',
+    // blog_page() no longer hand-writes `.../client/router-entry.js` (it's
+    // content-hashed under Vite) or a `barefoot.js` importmap entry (the
+    // runtime is a shared ESM chunk the browser follows on its own — see
+    // app.py's blog section docstring). `dist/bf-assets.json`'s
+    // `["RouterEntry"]` is what app.py's `ASSETS` reads instead.
+    assets: { RouterEntry: routerEntry },
+  }),
+})

--- a/integrations/fastapi/app.py
+++ b/integrations/fastapi/app.py
@@ -69,18 +69,35 @@ def jbool(v: Any) -> bool:
     return bool(v)
 
 
-# The build manifest -- a plain build artifact (dist/templates/manifest.json),
-# not adapter internals -- lists each component's `ssrDefaults`: the set of
-# signal/memo names an optional-prop-derived initial value needs BOUND (to
-# the real prop or to `None`) in the render context. `register_child_renderer`
-# via `register_components_from_manifest` derives this automatically for
-# manifest-registered (`ui/*`) children; this integration's shared components
-# aren't manifest-registered (see render_component's manual child wiring
-# below), so root-level renders derive it themselves, the same way.
+# The build manifest -- reassembled from `dist/templates/*.ssr-defaults.json`
+# (one file per component, written by `@barefootjs/vite`'s core plugin --
+# see `packages/vite/src/emit.ts`'s `planEmits`), not the legacy CLI's
+# single combined `dist/templates/manifest.json`. Each component's
+# `ssrDefaults` -- the set of signal/memo names an optional-prop-derived
+# initial value needs BOUND (to the real prop or to `None`) in the render
+# context -- lands in its own file; this glob-and-merge reassembles the
+# SAME `{ [component]: { "ssrDefaults": {...} } }` shape every call site
+# below already expects. `register_child_renderer` via
+# `register_components_from_manifest` derives this automatically for
+# manifest-registered (`ui/*`) children; this integration's shared
+# components aren't manifest-registered (see render_component's manual
+# child wiring below), so root-level renders derive it themselves, the
+# same way.
+MANIFEST: dict[str, Any] = {}
+for _p in (HERE / "dist" / "templates").glob("*.ssr-defaults.json"):
+    MANIFEST[_p.name[: -len(".ssr-defaults.json")]] = {"ssrDefaults": _json.loads(_p.read_text())}
+
+# The Vite-generated asset map (dist/bf-assets.json, written by
+# `@barefootjs/jinja/vite`'s `afterEmit` hook) -- resolves a hand-written,
+# non-component script entry's bundled URL (dev: Vite origin URL;
+# production: content-hashed manifest path). Read once at process start,
+# same rationale as MANIFEST above: Python has no compile step, so there is
+# nothing to commit -- a fresh copy lands under gitignored dist/ on every
+# build (dev AND production).
 try:
-    MANIFEST: dict[str, Any] = _json.loads((HERE / "dist" / "templates" / "manifest.json").read_text())
+    ASSETS: dict[str, str] = _json.loads((HERE / "dist" / "bf-assets.json").read_text())
 except FileNotFoundError:
-    MANIFEST = {}
+    ASSETS = {}
 
 # The blog post corpus -- generated at build time by scripts/gen-blog-data.ts
 # from ../shared/blog/posts.ts (the single TS source of truth the JS adapters
@@ -519,6 +536,17 @@ async def ai_chat_stream() -> StreamingResponse:
 # table, structured section-by-section so the two files can be diffed side
 # by side; only the Flask/WSGI -> FastAPI/ASGI idiom differences change
 # (async view functions, `request.query_params` instead of `request.args`).
+# The client router (client/router-entry.ts, its bundled URL resolved into
+# ASSETS["RouterEntry"]) swaps only the content region.
+#
+# No import map is needed (unlike the pre-Vite build): the router bundle's
+# `@barefootjs/client/runtime` import and every compiled island's own
+# `@barefootjs/client` import are ordinary ESM imports Rollup/Vite resolve
+# through their real module graph, collapsing into ONE shared chunk (build)
+# or ONE cached module (dev) automatically -- a single reactive runtime
+# instance without any hand-wired specifier redirection. That this
+# hand-written wiring could simply be deleted is the point of the
+# Vite-based design, not an incidental cleanup.
 #
 # There is no special server-side "partial navigation" endpoint: the router
 # (packages/router/src/router.ts) fetches a full HTML page for every
@@ -628,7 +656,6 @@ def blog_page(root: BarefootJS, title: str, base: str, content_html: str) -> str
     """Assemble the region-shell page around already-rendered content HTML.
     `root` is the request-scoped runtime whose script collector the content
     islands (and the shell islands rendered here) all share."""
-    static = f"{BASE}/client"
     theme = blog_island(root, "ThemeToggle")
     sidebar = blog_island(root, "Sidebar")
     shell = blog_island(
@@ -637,14 +664,8 @@ def blog_page(root: BarefootJS, title: str, base: str, content_html: str) -> str
         {"children": backend.mark_raw(content_html)},     # SSR-only: page content
         {"reader_toolbar": "ReaderToolbar"},
     )
-    import_map = _json.dumps({
-        "imports": {
-            "@barefootjs/client": f"{static}/barefoot.js",
-            "@barefootjs/client/runtime": f"{static}/barefoot.js",
-            "@barefootjs/client/reactive": f"{static}/barefoot.js",
-        }
-    })
     scripts = root.scripts()
+    router_entry = ASSETS.get("RouterEntry", "")
     esc_title = title.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
     return f"""<!DOCTYPE html>
 <html lang="en" data-theme="dark">
@@ -652,7 +673,6 @@ def blog_page(root: BarefootJS, title: str, base: str, content_html: str) -> str
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{esc_title}</title>
-<script type="importmap">{import_map}</script>
 <link rel="stylesheet" href="{BASE}/styles/blog.css">
 </head>
 <body>
@@ -665,7 +685,7 @@ def blog_page(root: BarefootJS, title: str, base: str, content_html: str) -> str
 <main>{shell}</main>
 </div>
 {scripts}
-<script type="module" src="{static}/router-entry.js"></script>
+<script type="module" src="{router_entry}"></script>
 </body>
 </html>
 """

--- a/integrations/fastapi/app.py
+++ b/integrations/fastapi/app.py
@@ -69,23 +69,18 @@ def jbool(v: Any) -> bool:
     return bool(v)
 
 
-# The build manifest -- reassembled from `dist/templates/*.ssr-defaults.json`
-# (one file per component, written by `@barefootjs/vite`'s core plugin --
-# see `packages/vite/src/emit.ts`'s `planEmits`), not the legacy CLI's
-# single combined `dist/templates/manifest.json`. Each component's
-# `ssrDefaults` -- the set of signal/memo names an optional-prop-derived
-# initial value needs BOUND (to the real prop or to `None`) in the render
-# context -- lands in its own file; this glob-and-merge reassembles the
-# SAME `{ [component]: { "ssrDefaults": {...} } }` shape every call site
-# below already expects. `register_child_renderer` via
-# `register_components_from_manifest` derives this automatically for
-# manifest-registered (`ui/*`) children; this integration's shared
-# components aren't manifest-registered (see render_component's manual
-# child wiring below), so root-level renders derive it themselves, the
-# same way.
-MANIFEST: dict[str, Any] = {}
-for _p in (HERE / "dist" / "templates").glob("*.ssr-defaults.json"):
-    MANIFEST[_p.name[: -len(".ssr-defaults.json")]] = {"ssrDefaults": _json.loads(_p.read_text())}
+# The build manifest -- a plain build artifact (dist/templates/manifest.json),
+# not adapter internals -- lists each component's `ssrDefaults`: the set of
+# signal/memo names an optional-prop-derived initial value needs BOUND (to
+# the real prop or to `None`) in the render context. `register_child_renderer`
+# via `register_components_from_manifest` derives this automatically for
+# manifest-registered (`ui/*`) children; this integration's shared components
+# aren't manifest-registered (see render_component's manual child wiring
+# below), so root-level renders derive it themselves, the same way.
+try:
+    MANIFEST: dict[str, Any] = _json.loads((HERE / "dist" / "templates" / "manifest.json").read_text())
+except FileNotFoundError:
+    MANIFEST = {}
 
 # The Vite-generated asset map (dist/bf-assets.json, written by
 # `@barefootjs/jinja/vite`'s `afterEmit` hook) -- resolves a hand-written,

--- a/integrations/fastapi/package.json
+++ b/integrations/fastapi/package.json
@@ -2,9 +2,10 @@
   "name": "barefootjs-fastapi-example",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts",
-    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "build": "vite build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts",
+    "build:watch": "vite dev",
     "dev": "PYTHONPATH=./lib BASE_PATH=/integrations/fastapi FASTAPI_DEBUG=1 PORT=3009 python3 app.py",
     "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
@@ -18,10 +19,12 @@
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
     "@barefootjs/jinja": "workspace:*",
+    "@barefootjs/vite": "workspace:*",
     "@cloudflare/containers": "^0.3.2",
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
+    "vite": "^6.0.0",
     "wrangler": "^4"
   }
 }

--- a/integrations/fastapi/vite.config.ts
+++ b/integrations/fastapi/vite.config.ts
@@ -1,0 +1,44 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { barefoot } from '@barefootjs/jinja/vite'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const basePath = process.env.BASE_PATH ?? '/integrations/fastapi'
+const routerEntry = resolve(HERE, 'client/router-entry.ts')
+
+// This app's own Rollup entry: `client/router-entry.ts` (the
+// `@barefootjs/router` bootstrap for the blog) is a hand-written script,
+// not a `.tsx` component, so `barefoot()`'s own discovery never sees it —
+// per the design, bundling configuration is stock Vite config this plugin
+// never adds on the app's behalf. `assets.RouterEntry` below (Jinja-
+// specific) only resolves the URL Vite bundles this to; THIS is what
+// requests the bundling.
+export default defineConfig({
+  base: `${basePath}/client/`,
+  build: {
+    // Scoped to `dist/client` (not the whole `dist`), matching the existing
+    // `StaticFiles` mount at `${BASE}/client` -> `dist/client` — the
+    // templates dir below is a SEPARATE, non-web-exposed directory Python
+    // reads locally, never served over HTTP.
+    outDir: 'dist/client',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: { 'router-entry': routerEntry },
+    },
+  },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    // Matches the legacy CLI's output layout exactly (`outputLayout:
+    // { templates: 'templates', clientJs: 'client', runtime: 'client' }`
+    // under `outDir: 'dist'`) — `backend` (JinjaBackend) reads
+    // `dist/templates` directly; it is never served over HTTP.
+    templates: 'dist/templates',
+    // blog_page() no longer hand-writes `.../client/router-entry.js` (it's
+    // content-hashed under Vite) or a `barefoot.js` importmap entry (the
+    // runtime is a shared ESM chunk the browser follows on its own — see
+    // app.py's blog section docstring). `dist/bf-assets.json`'s
+    // `["RouterEntry"]` is what app.py's `ASSETS` reads instead.
+    assets: { RouterEntry: routerEntry },
+  }),
+})

--- a/integrations/flask/app.py
+++ b/integrations/flask/app.py
@@ -61,18 +61,35 @@ def jbool(v: Any) -> bool:
     return bool(v)
 
 
-# The build manifest -- a plain build artifact (dist/templates/manifest.json),
-# not adapter internals -- lists each component's `ssrDefaults`: the set of
-# signal/memo names an optional-prop-derived initial value needs BOUND (to
-# the real prop or to `None`) in the render context. `register_child_renderer`
-# via `register_components_from_manifest` derives this automatically for
-# manifest-registered (`ui/*`) children; this integration's shared components
-# aren't manifest-registered (see render_component's manual child wiring
-# below), so root-level renders derive it themselves, the same way.
+# The build manifest -- reassembled from `dist/templates/*.ssr-defaults.json`
+# (one file per component, written by `@barefootjs/vite`'s core plugin --
+# see `packages/vite/src/emit.ts`'s `planEmits`), not the legacy CLI's
+# single combined `dist/templates/manifest.json`. Each component's
+# `ssrDefaults` -- the set of signal/memo names an optional-prop-derived
+# initial value needs BOUND (to the real prop or to `None`) in the render
+# context -- lands in its own file; this glob-and-merge reassembles the
+# SAME `{ [component]: { "ssrDefaults": {...} } }` shape every call site
+# below already expects. `register_child_renderer` via
+# `register_components_from_manifest` derives this automatically for
+# manifest-registered (`ui/*`) children; this integration's shared
+# components aren't manifest-registered (see render_component's manual
+# child wiring below), so root-level renders derive it themselves, the
+# same way.
+MANIFEST: dict[str, Any] = {}
+for _p in (HERE / "dist" / "templates").glob("*.ssr-defaults.json"):
+    MANIFEST[_p.name[: -len(".ssr-defaults.json")]] = {"ssrDefaults": _json.loads(_p.read_text())}
+
+# The Vite-generated asset map (dist/bf-assets.json, written by
+# `@barefootjs/jinja/vite`'s `afterEmit` hook) -- resolves a hand-written,
+# non-component script entry's bundled URL (dev: Vite origin URL;
+# production: content-hashed manifest path). Read once at process start,
+# same rationale as MANIFEST above: Python has no compile step, so there is
+# nothing to commit -- a fresh copy lands under gitignored dist/ on every
+# build (dev AND production).
 try:
-    MANIFEST: dict[str, Any] = _json.loads((HERE / "dist" / "templates" / "manifest.json").read_text())
+    ASSETS: dict[str, str] = _json.loads((HERE / "dist" / "bf-assets.json").read_text())
 except FileNotFoundError:
-    MANIFEST = {}
+    ASSETS = {}
 
 # The blog post corpus -- generated at build time by scripts/gen-blog-data.ts
 # from ../shared/blog/posts.ts (the single TS source of truth the JS adapters
@@ -511,9 +528,18 @@ def styles_static(filename: str):
 # ports): a region-shell layout (header + ThemeToggle in the shell, a
 # hand-authored sidebar region `nav:0` + the compiled <PageShell> nested
 # content regions in the main column) whose islands are the shared blog
-# components in ../shared/blog, compiled by this integration's `bf build`.
-# The client router (client/router-entry.ts, bundled to
-# client/router-entry.js) swaps only the content region.
+# components in ../shared/blog, compiled by this integration's Vite build
+# (vite.config.ts). The client router (client/router-entry.ts, its bundled
+# URL resolved into ASSETS["RouterEntry"]) swaps only the content region.
+#
+# No import map is needed (unlike the pre-Vite build): the router bundle's
+# `@barefootjs/client/runtime` import and every compiled island's own
+# `@barefootjs/client` import are ordinary ESM imports Rollup/Vite resolve
+# through their real module graph, collapsing into ONE shared chunk (build)
+# or ONE cached module (dev) automatically -- a single reactive runtime
+# instance without any hand-wired specifier redirection. That this
+# hand-written wiring could simply be deleted is the point of the
+# Vite-based design, not an incidental cleanup.
 #
 # There is no special server-side "partial navigation" endpoint: the router
 # (packages/router/src/router.ts) fetches a full HTML page for every
@@ -623,7 +649,6 @@ def blog_page(root: BarefootJS, title: str, base: str, content_html: str) -> str
     """Assemble the region-shell page around already-rendered content HTML.
     `root` is the request-scoped runtime whose script collector the content
     islands (and the shell islands rendered here) all share."""
-    static = f"{BASE}/client"
     theme = blog_island(root, "ThemeToggle")
     sidebar = blog_island(root, "Sidebar")
     shell = blog_island(
@@ -632,14 +657,8 @@ def blog_page(root: BarefootJS, title: str, base: str, content_html: str) -> str
         {"children": backend.mark_raw(content_html)},     # SSR-only: page content
         {"reader_toolbar": "ReaderToolbar"},
     )
-    import_map = _json.dumps({
-        "imports": {
-            "@barefootjs/client": f"{static}/barefoot.js",
-            "@barefootjs/client/runtime": f"{static}/barefoot.js",
-            "@barefootjs/client/reactive": f"{static}/barefoot.js",
-        }
-    })
     scripts = root.scripts()
+    router_entry = ASSETS.get("RouterEntry", "")
     esc_title = title.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
     return f"""<!DOCTYPE html>
 <html lang="en" data-theme="dark">
@@ -647,7 +666,6 @@ def blog_page(root: BarefootJS, title: str, base: str, content_html: str) -> str
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{esc_title}</title>
-<script type="importmap">{import_map}</script>
 <link rel="stylesheet" href="{BASE}/styles/blog.css">
 </head>
 <body>
@@ -660,7 +678,7 @@ def blog_page(root: BarefootJS, title: str, base: str, content_html: str) -> str
 <main>{shell}</main>
 </div>
 {scripts}
-<script type="module" src="{static}/router-entry.js"></script>
+<script type="module" src="{router_entry}"></script>
 </body>
 </html>
 """

--- a/integrations/flask/app.py
+++ b/integrations/flask/app.py
@@ -61,23 +61,18 @@ def jbool(v: Any) -> bool:
     return bool(v)
 
 
-# The build manifest -- reassembled from `dist/templates/*.ssr-defaults.json`
-# (one file per component, written by `@barefootjs/vite`'s core plugin --
-# see `packages/vite/src/emit.ts`'s `planEmits`), not the legacy CLI's
-# single combined `dist/templates/manifest.json`. Each component's
-# `ssrDefaults` -- the set of signal/memo names an optional-prop-derived
-# initial value needs BOUND (to the real prop or to `None`) in the render
-# context -- lands in its own file; this glob-and-merge reassembles the
-# SAME `{ [component]: { "ssrDefaults": {...} } }` shape every call site
-# below already expects. `register_child_renderer` via
-# `register_components_from_manifest` derives this automatically for
-# manifest-registered (`ui/*`) children; this integration's shared
-# components aren't manifest-registered (see render_component's manual
-# child wiring below), so root-level renders derive it themselves, the
-# same way.
-MANIFEST: dict[str, Any] = {}
-for _p in (HERE / "dist" / "templates").glob("*.ssr-defaults.json"):
-    MANIFEST[_p.name[: -len(".ssr-defaults.json")]] = {"ssrDefaults": _json.loads(_p.read_text())}
+# The build manifest -- a plain build artifact (dist/templates/manifest.json),
+# not adapter internals -- lists each component's `ssrDefaults`: the set of
+# signal/memo names an optional-prop-derived initial value needs BOUND (to
+# the real prop or to `None`) in the render context. `register_child_renderer`
+# via `register_components_from_manifest` derives this automatically for
+# manifest-registered (`ui/*`) children; this integration's shared components
+# aren't manifest-registered (see render_component's manual child wiring
+# below), so root-level renders derive it themselves, the same way.
+try:
+    MANIFEST: dict[str, Any] = _json.loads((HERE / "dist" / "templates" / "manifest.json").read_text())
+except FileNotFoundError:
+    MANIFEST = {}
 
 # The Vite-generated asset map (dist/bf-assets.json, written by
 # `@barefootjs/jinja/vite`'s `afterEmit` hook) -- resolves a hand-written,

--- a/integrations/flask/package.json
+++ b/integrations/flask/package.json
@@ -2,9 +2,10 @@
   "name": "barefootjs-flask-example",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts",
-    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "build": "vite build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts",
+    "build:watch": "vite dev",
     "dev": "PYTHONPATH=./lib BASE_PATH=/integrations/flask FLASK_DEBUG=1 PORT=3008 python3 app.py",
     "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
@@ -18,10 +19,12 @@
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
     "@barefootjs/jinja": "workspace:*",
+    "@barefootjs/vite": "workspace:*",
     "@cloudflare/containers": "^0.3.2",
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
+    "vite": "^6.0.0",
     "wrangler": "^4"
   }
 }

--- a/integrations/flask/vite.config.ts
+++ b/integrations/flask/vite.config.ts
@@ -1,0 +1,44 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { barefoot } from '@barefootjs/jinja/vite'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const basePath = process.env.BASE_PATH ?? '/integrations/flask'
+const routerEntry = resolve(HERE, 'client/router-entry.ts')
+
+// This app's own Rollup entry: `client/router-entry.ts` (the
+// `@barefootjs/router` bootstrap for the blog) is a hand-written script,
+// not a `.tsx` component, so `barefoot()`'s own discovery never sees it —
+// per the design, bundling configuration is stock Vite config this plugin
+// never adds on the app's behalf. `assets.RouterEntry` below (Jinja-
+// specific) only resolves the URL Vite bundles this to; THIS is what
+// requests the bundling.
+export default defineConfig({
+  base: `${basePath}/client/`,
+  build: {
+    // Scoped to `dist/client` (not the whole `dist`), matching the existing
+    // `client_static`/`styles_static` Blueprint routes — the templates dir
+    // below is a SEPARATE, non-web-exposed directory Python reads locally,
+    // never served over HTTP.
+    outDir: 'dist/client',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: { 'router-entry': routerEntry },
+    },
+  },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    // Matches the legacy CLI's output layout exactly (`outputLayout:
+    // { templates: 'templates', clientJs: 'client', runtime: 'client' }`
+    // under `outDir: 'dist'`) — `backend` (JinjaBackend) reads
+    // `dist/templates` directly; it is never served over HTTP.
+    templates: 'dist/templates',
+    // blog_page() no longer hand-writes `.../client/router-entry.js` (it's
+    // content-hashed under Vite) or a `barefoot.js` importmap entry (the
+    // runtime is a shared ESM chunk the browser follows on its own — see
+    // app.py's blog section docstring). `dist/bf-assets.json`'s
+    // `["RouterEntry"]` is what app.py's `ASSETS` reads instead.
+    assets: { RouterEntry: routerEntry },
+  }),
+})

--- a/integrations/laravel/app/Support/ExampleApp.php
+++ b/integrations/laravel/app/Support/ExampleApp.php
@@ -54,14 +54,38 @@ final class ExampleApp
     }
 
     /**
-     * The build manifest -- a plain build artifact (dist/templates/manifest.json),
-     * not adapter internals -- lists each component's `ssrDefaults`: the set of
-     * signal/memo names an optional-prop-derived initial value needs BOUND (to
-     * the real prop or to `null`) in the render context. This integration's
-     * shared components aren't manifest-registered under `ui/*` (see
-     * BarefootHelper::renderComponent's manual child wiring, mirroring
-     * integrations/blade), so root-level renders derive the stash themselves
-     * via stashFromSsrDefaults().
+     * The Vite-generated asset map (dist/bf-assets.json, written by
+     * `@barefootjs/blade/vite`'s `afterEmit` hook) -- resolves a hand-written,
+     * non-component script entry's bundled URL (dev: Vite origin URL;
+     * production: content-hashed manifest path). Read at request time, same
+     * pattern as manifest() below: PHP has no compile step, so there is
+     * nothing to commit -- a fresh copy lands under gitignored dist/ on every
+     * build (dev AND production).
+     */
+    public static function assets(): array
+    {
+        static $assets = null;
+        if ($assets === null) {
+            $path = base_path('dist/bf-assets.json');
+            $assets = is_file($path) ? (json_decode((string) file_get_contents($path), true) ?: []) : [];
+        }
+        return $assets;
+    }
+
+    /**
+     * The build manifest -- reassembled from `dist/templates/*.ssr-defaults.json`
+     * (one file per component, written by `@barefootjs/vite`'s core plugin --
+     * see `packages/vite/src/emit.ts`'s `planEmits`), not a single combined
+     * `manifest.json` the legacy CLI used to write. Each component's
+     * `ssrDefaults` -- the set of signal/memo names an optional-prop-derived
+     * initial value needs BOUND (to the real prop or to `null`) in the render
+     * context -- lands in its own file; this glob-and-merge reassembles the
+     * SAME `{ [component]: { ssrDefaults: {...} } }` shape every call site
+     * below already expects, so stashFromSsrDefaults() and registerBlogChild()
+     * need no changes. This integration's shared components aren't manifest-
+     * registered under `ui/*` (see BarefootHelper::renderComponent's manual
+     * child wiring, mirroring integrations/blade), so root-level renders
+     * derive the stash themselves via stashFromSsrDefaults().
      *
      * PHP's cli-server resets statics per request, so this (and blogData) is
      * a per-request lazy read -- the same cost point as integrations/blade
@@ -71,8 +95,14 @@ final class ExampleApp
     {
         static $manifest = null;
         if ($manifest === null) {
-            $path = base_path('dist/templates/manifest.json');
-            $manifest = is_file($path) ? (json_decode((string) file_get_contents($path), true) ?: []) : [];
+            $manifest = [];
+            foreach (glob(base_path('dist/templates/*.ssr-defaults.json')) ?: [] as $path) {
+                $component = basename($path, '.ssr-defaults.json');
+                $defaults = json_decode((string) file_get_contents($path), true);
+                if (is_array($defaults)) {
+                    $manifest[$component] = ['ssrDefaults' => $defaults];
+                }
+            }
         }
         return $manifest;
     }
@@ -170,6 +200,15 @@ final class ExampleApp
     // Blog -- the @barefootjs/router showcase. Ports of integrations/blade's
     // register_blog_child / blog_island / blog_page; see that file's blog
     // section docstring for the searchParams() SSR seeding rationale.
+    //
+    // No import map is needed (unlike the pre-Vite build): the router
+    // bundle's `@barefootjs/client/runtime` import and every compiled
+    // island's own `@barefootjs/client` import are ordinary ESM imports
+    // Rollup/Vite resolve through their real module graph, collapsing into
+    // ONE shared chunk (build) or ONE cached module (dev) automatically --
+    // a single reactive runtime instance without any hand-wired specifier
+    // redirection. That this hand-written wiring could simply be deleted is
+    // the point of the Vite-based design, not an incidental cleanup.
     // -------------------------------------------------------------------
 
     /** Register a renderer for a flat (non-`ui/*`) child component from the
@@ -252,7 +291,6 @@ final class ExampleApp
     public static function blogPage(BarefootJS $root, string $title, string $base, string $contentHtml): string
     {
         $BASE = self::base();
-        $static = "{$BASE}/client";
         $theme = self::blogIsland($root, 'ThemeToggle');
         $sidebar = self::blogIsland($root, 'Sidebar');
         $shell = self::blogIsland(
@@ -262,14 +300,8 @@ final class ExampleApp
             ['children' => $root->backend->mark_raw($contentHtml)], // SSR-only: page content
             ['reader_toolbar' => 'ReaderToolbar'],
         );
-        $importMap = json_encode([
-            'imports' => [
-                '@barefootjs/client' => "{$static}/barefoot.js",
-                '@barefootjs/client/runtime' => "{$static}/barefoot.js",
-                '@barefootjs/client/reactive' => "{$static}/barefoot.js",
-            ],
-        ]);
         $scripts = $root->scripts();
+        $routerEntry = self::assets()['RouterEntry'] ?? '';
         $escTitle = htmlspecialchars($title, ENT_QUOTES);
         return <<<HTML
 <!DOCTYPE html>
@@ -278,7 +310,6 @@ final class ExampleApp
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{$escTitle}</title>
-<script type="importmap">{$importMap}</script>
 <link rel="stylesheet" href="{$BASE}/styles/blog.css">
 </head>
 <body>
@@ -291,7 +322,7 @@ final class ExampleApp
 <main>{$shell}</main>
 </div>
 {$scripts}
-<script type="module" src="{$static}/router-entry.js"></script>
+<script type="module" src="{$routerEntry}"></script>
 </body>
 </html>
 HTML;

--- a/integrations/laravel/app/Support/ExampleApp.php
+++ b/integrations/laravel/app/Support/ExampleApp.php
@@ -73,19 +73,14 @@ final class ExampleApp
     }
 
     /**
-     * The build manifest -- reassembled from `dist/templates/*.ssr-defaults.json`
-     * (one file per component, written by `@barefootjs/vite`'s core plugin --
-     * see `packages/vite/src/emit.ts`'s `planEmits`), not a single combined
-     * `manifest.json` the legacy CLI used to write. Each component's
-     * `ssrDefaults` -- the set of signal/memo names an optional-prop-derived
-     * initial value needs BOUND (to the real prop or to `null`) in the render
-     * context -- lands in its own file; this glob-and-merge reassembles the
-     * SAME `{ [component]: { ssrDefaults: {...} } }` shape every call site
-     * below already expects, so stashFromSsrDefaults() and registerBlogChild()
-     * need no changes. This integration's shared components aren't manifest-
-     * registered under `ui/*` (see BarefootHelper::renderComponent's manual
-     * child wiring, mirroring integrations/blade), so root-level renders
-     * derive the stash themselves via stashFromSsrDefaults().
+     * The build manifest -- a plain build artifact (dist/templates/manifest.json),
+     * not adapter internals -- lists each component's `ssrDefaults`: the set of
+     * signal/memo names an optional-prop-derived initial value needs BOUND (to
+     * the real prop or to `null`) in the render context. This integration's
+     * shared components aren't manifest-registered under `ui/*` (see
+     * BarefootHelper::renderComponent's manual child wiring, mirroring
+     * integrations/blade), so root-level renders derive the stash themselves
+     * via stashFromSsrDefaults().
      *
      * PHP's cli-server resets statics per request, so this (and blogData) is
      * a per-request lazy read -- the same cost point as integrations/blade
@@ -95,14 +90,8 @@ final class ExampleApp
     {
         static $manifest = null;
         if ($manifest === null) {
-            $manifest = [];
-            foreach (glob(base_path('dist/templates/*.ssr-defaults.json')) ?: [] as $path) {
-                $component = basename($path, '.ssr-defaults.json');
-                $defaults = json_decode((string) file_get_contents($path), true);
-                if (is_array($defaults)) {
-                    $manifest[$component] = ['ssrDefaults' => $defaults];
-                }
-            }
+            $path = base_path('dist/templates/manifest.json');
+            $manifest = is_file($path) ? (json_decode((string) file_get_contents($path), true) ?: []) : [];
         }
         return $manifest;
     }

--- a/integrations/laravel/package.json
+++ b/integrations/laravel/package.json
@@ -2,9 +2,10 @@
   "name": "barefootjs-laravel-example",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts && composer install --no-interaction --no-progress",
-    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "build": "vite build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts && composer install --no-interaction --no-progress",
+    "build:watch": "vite dev",
     "dev": "PHP_CLI_SERVER_WORKERS=8 BASE_PATH=/integrations/laravel php artisan serve --host=0.0.0.0 --port=3016",
     "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
@@ -18,10 +19,12 @@
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
     "@barefootjs/blade": "workspace:*",
+    "@barefootjs/vite": "workspace:*",
     "@cloudflare/containers": "^0.3.2",
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
+    "vite": "^6.0.0",
     "wrangler": "^4"
   }
 }

--- a/integrations/laravel/vite.config.ts
+++ b/integrations/laravel/vite.config.ts
@@ -1,0 +1,45 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { barefoot } from '@barefootjs/blade/vite'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const basePath = process.env.BASE_PATH ?? '/integrations/laravel'
+const routerEntry = resolve(HERE, 'client/router-entry.ts')
+
+// This app's own Rollup entry: `client/router-entry.ts` (the
+// `@barefootjs/router` bootstrap for the blog) is a hand-written script,
+// not a `.tsx` component, so `barefoot()`'s own discovery never sees it —
+// per the design, bundling configuration is stock Vite config this plugin
+// never adds on the app's behalf. `assets.RouterEntry` below (Blade-
+// specific) only resolves the URL Vite bundles this to; THIS is what
+// requests the bundling.
+export default defineConfig({
+  base: `${basePath}/client/`,
+  build: {
+    // Scoped to `dist/client` (not the whole `dist`), matching the existing
+    // `routes/web.php` static route (`client/{path}` -> `dist/client`) — the
+    // templates dir below is a SEPARATE, non-web-exposed directory PHP reads
+    // locally, never served over HTTP.
+    outDir: 'dist/client',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: { 'router-entry': routerEntry },
+    },
+  },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    // Matches the legacy CLI's output layout exactly (`outputLayout:
+    // { templates: 'templates', clientJs: 'client', runtime: 'client' }`
+    // under `outDir: 'dist'`) — `ExampleApp::backend()`'s `BladeBackend`
+    // reads `dist/templates` directly; it is never served over HTTP.
+    templates: 'dist/templates',
+    // ExampleApp::blogPage() no longer hand-writes `.../client/router-
+    // entry.js` (it's content-hashed under Vite) or a `barefoot.js`
+    // importmap entry (the runtime is a shared ESM chunk the browser
+    // follows on its own — see ExampleApp.php's header comment).
+    // `dist/bf-assets.json`'s `["RouterEntry"]` is what `ExampleApp::assets()`
+    // reads instead.
+    assets: { RouterEntry: routerEntry },
+  }),
+})

--- a/integrations/rails/config/initializers/example_app.rb
+++ b/integrations/rails/config/initializers/example_app.rb
@@ -89,6 +89,22 @@ module ExampleApp
     nil
   end
 
+  # Reassembles the SAME `{ component_sym => { ssrDefaults: {...} } }` shape
+  # `BLOG_MANIFEST` used to get from a single combined
+  # `dist/templates/manifest.json` (the legacy CLI's output), from
+  # `@barefootjs/vite`'s core plugin's ACTUAL per-component output instead:
+  # one `<Name>.ssr-defaults.json` file per component (see
+  # `packages/vite/src/emit.ts`'s `planEmits`). `slurp_json`'s
+  # `symbolize_names: true` already matches every downstream `entry[:ssrDefaults]`
+  # read below.
+  def load_blog_manifest
+    Dir.glob(Rails.root.join('dist/templates/*.ssr-defaults.json').to_s).each_with_object({}) do |path, acc|
+      component = File.basename(path, '.ssr-defaults.json').to_sym
+      defaults = slurp_json(path)
+      acc[component] = { ssrDefaults: defaults } if defaults
+    end
+  end
+
   # -------------------------------------------------------------------------
   # Blog — the @barefootjs/router showcase (ERB / Rails)
   #
@@ -158,20 +174,23 @@ module ExampleApp
   # Assemble the region-shell page around already-rendered content HTML. `root`
   # is the request-scoped runtime whose script collector the content islands
   # (and the shell islands rendered here) all share.
+  # No import map is needed (unlike the pre-Vite build): the router
+  # bundle's `@barefootjs/client/runtime` import and every compiled
+  # island's own `@barefootjs/client` import are ordinary ESM imports
+  # Rollup/Vite resolve through their real module graph, collapsing into
+  # ONE shared chunk (build) or ONE cached module (dev) automatically -- a
+  # single reactive runtime instance without any hand-wired specifier
+  # redirection. That this hand-written wiring could simply be deleted is
+  # the point of the Vite-based design, not an incidental cleanup.
   def blog_page(root, title, base, content_html)
-    static = "#{BASE}/client"
     theme = blog_island(root, 'ThemeToggle')
     sidebar = blog_island(root, 'Sidebar')
     shell = blog_island(root, 'PageShell',
                         {}, # no client props
                         { children: BACKEND.mark_raw(content_html) }, # SSR-only: page content
                         { 'reader_toolbar' => 'ReaderToolbar' })
-    importmap = JSON.generate({ imports: {
-      '@barefootjs/client' => "#{static}/barefoot.js",
-      '@barefootjs/client/runtime' => "#{static}/barefoot.js",
-      '@barefootjs/client/reactive' => "#{static}/barefoot.js",
-    } })
     scripts = root.scripts
+    router_entry = ASSETS['RouterEntry'] || ''
     esc_title = root.h(title)
     <<~HTML
       <!DOCTYPE html>
@@ -180,7 +199,6 @@ module ExampleApp
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>#{esc_title}</title>
-      <script type="importmap">#{importmap}</script>
       <link rel="stylesheet" href="#{BASE}/styles/blog.css">
       </head>
       <body>
@@ -193,12 +211,23 @@ module ExampleApp
       <main>#{shell}</main>
       </div>
       #{scripts}
-      <script type="module" src="#{static}/router-entry.js"></script>
+      <script type="module" src="#{router_entry}"></script>
       </body>
       </html>
     HTML
   end
 
-  BLOG_MANIFEST = slurp_json(Rails.root.join('dist/templates/manifest.json').to_s) || {}
+  BLOG_MANIFEST = load_blog_manifest
   BLOG_DATA = slurp_json(Rails.root.join('dist/blog-data.json').to_s) || { posts: [], listItems: [], allTags: [] }
+
+  # The Vite-generated asset map (dist/bf-assets.json, written by
+  # `@barefootjs/erb/vite`'s `afterEmit` hook) -- resolves a hand-written,
+  # non-component script entry's bundled URL (dev: Vite origin URL;
+  # production: content-hashed manifest path). String-keyed (NOT
+  # symbolize_names, unlike BLOG_MANIFEST above): a small flat map, not a
+  # per-component structure with downstream symbol-keyed reads. Ruby has no
+  # compile step, so there is nothing to commit -- a fresh copy lands under
+  # gitignored dist/ on every build (dev AND production).
+  assets_path = Rails.root.join('dist/bf-assets.json').to_s
+  ASSETS = File.file?(assets_path) ? (JSON.parse(File.read(assets_path, encoding: 'UTF-8')) rescue {}) : {}
 end

--- a/integrations/rails/config/initializers/example_app.rb
+++ b/integrations/rails/config/initializers/example_app.rb
@@ -89,22 +89,6 @@ module ExampleApp
     nil
   end
 
-  # Reassembles the SAME `{ component_sym => { ssrDefaults: {...} } }` shape
-  # `BLOG_MANIFEST` used to get from a single combined
-  # `dist/templates/manifest.json` (the legacy CLI's output), from
-  # `@barefootjs/vite`'s core plugin's ACTUAL per-component output instead:
-  # one `<Name>.ssr-defaults.json` file per component (see
-  # `packages/vite/src/emit.ts`'s `planEmits`). `slurp_json`'s
-  # `symbolize_names: true` already matches every downstream `entry[:ssrDefaults]`
-  # read below.
-  def load_blog_manifest
-    Dir.glob(Rails.root.join('dist/templates/*.ssr-defaults.json').to_s).each_with_object({}) do |path, acc|
-      component = File.basename(path, '.ssr-defaults.json').to_sym
-      defaults = slurp_json(path)
-      acc[component] = { ssrDefaults: defaults } if defaults
-    end
-  end
-
   # -------------------------------------------------------------------------
   # Blog — the @barefootjs/router showcase (ERB / Rails)
   #
@@ -217,7 +201,7 @@ module ExampleApp
     HTML
   end
 
-  BLOG_MANIFEST = load_blog_manifest
+  BLOG_MANIFEST = slurp_json(Rails.root.join('dist/templates/manifest.json').to_s) || {}
   BLOG_DATA = slurp_json(Rails.root.join('dist/blog-data.json').to_s) || { posts: [], listItems: [], allTags: [] }
 
   # The Vite-generated asset map (dist/bf-assets.json, written by

--- a/integrations/rails/package.json
+++ b/integrations/rails/package.json
@@ -2,9 +2,10 @@
   "name": "barefootjs-rails-example",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts",
-    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "build": "vite build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts",
+    "build:watch": "vite dev",
     "dev": "BASE_PATH=/integrations/rails bin/rails server -p 3011 -b 0.0.0.0",
     "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
@@ -17,10 +18,12 @@
   "devDependencies": {
     "@barefootjs/erb": "workspace:*",
     "@barefootjs/jsx": "workspace:*",
+    "@barefootjs/vite": "workspace:*",
     "@cloudflare/containers": "^0.3.2",
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
+    "vite": "^6.0.0",
     "wrangler": "^4"
   }
 }

--- a/integrations/rails/vite.config.ts
+++ b/integrations/rails/vite.config.ts
@@ -1,0 +1,45 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { barefoot } from '@barefootjs/erb/vite'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const basePath = process.env.BASE_PATH ?? '/integrations/rails'
+const routerEntry = resolve(HERE, 'client/router-entry.ts')
+
+// This app's own Rollup entry: `client/router-entry.ts` (the
+// `@barefootjs/router` bootstrap for the blog) is a hand-written script,
+// not a `.tsx` component, so `barefoot()`'s own discovery never sees it —
+// per the design, bundling configuration is stock Vite config this plugin
+// never adds on the app's behalf. `assets.RouterEntry` below (ERB-
+// specific) only resolves the URL Vite bundles this to; THIS is what
+// requests the bundling.
+export default defineConfig({
+  base: `${basePath}/client/`,
+  build: {
+    // Scoped to `dist/client` (not the whole `dist`), matching the existing
+    // `config.ru` Rack::Files mount (`${BASE}/client` -> `dist/client`) —
+    // the templates dir below is a SEPARATE, non-web-exposed directory
+    // Ruby reads locally, never served over HTTP.
+    outDir: 'dist/client',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: { 'router-entry': routerEntry },
+    },
+  },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    // Matches the legacy CLI's output layout exactly (`outputLayout:
+    // { templates: 'templates', clientJs: 'client', runtime: 'client' }`
+    // under `outDir: 'dist'`) — `BACKEND` (BarefootJS::Backend::Erb) reads
+    // `dist/templates` directly; it is never served over HTTP.
+    templates: 'dist/templates',
+    // ExampleApp.blog_page no longer hand-writes `.../client/router-
+    // entry.js` (it's content-hashed under Vite) or a `barefoot.js`
+    // importmap entry (the runtime is a shared ESM chunk the browser
+    // follows on its own — see example_app.rb's blog_page comment).
+    // `dist/bf-assets.json`'s `["RouterEntry"]` is what
+    // `ExampleApp::ASSETS` reads instead.
+    assets: { RouterEntry: routerEntry },
+  }),
+})

--- a/integrations/sinatra/app.rb
+++ b/integrations/sinatra/app.rb
@@ -103,8 +103,33 @@ rescue JSON::ParserError
   nil
 end
 
-BLOG_MANIFEST = slurp_json('dist/templates/manifest.json') || {}
+# Reassembles the SAME `{ component_sym => { ssrDefaults: {...} } }` shape a
+# single combined `dist/templates/manifest.json` (the legacy CLI's output)
+# used to provide, from `@barefootjs/vite`'s core plugin's ACTUAL
+# per-component output instead: one `<Name>.ssr-defaults.json` file per
+# component (see `packages/vite/src/emit.ts`'s `planEmits`). `slurp_json`'s
+# `symbolize_names: true` already matches every downstream
+# `entry[:ssrDefaults]` read below.
+def load_blog_manifest
+  Dir.glob('dist/templates/*.ssr-defaults.json').each_with_object({}) do |path, acc|
+    component = File.basename(path, '.ssr-defaults.json').to_sym
+    defaults = slurp_json(path)
+    acc[component] = { ssrDefaults: defaults } if defaults
+  end
+end
+
+BLOG_MANIFEST = load_blog_manifest
 BLOG_DATA = slurp_json('dist/blog-data.json') || { posts: [], listItems: [], allTags: [] }
+
+# The Vite-generated asset map (dist/bf-assets.json, written by
+# `@barefootjs/erb/vite`'s `afterEmit` hook) -- resolves a hand-written,
+# non-component script entry's bundled URL (dev: Vite origin URL;
+# production: content-hashed manifest path). String-keyed (NOT
+# symbolize_names, unlike BLOG_MANIFEST above): a small flat map, not a
+# per-component structure with downstream symbol-keyed reads. Ruby has no
+# compile step, so there is nothing to commit -- a fresh copy lands under
+# gitignored dist/ on every build (dev AND production).
+ASSETS = (File.file?('dist/bf-assets.json') ? (JSON.parse(File.read('dist/bf-assets.json', encoding: 'UTF-8')) rescue {}) : {})
 
 # NOTE on naming: `bf build`'s ERB output files are always named after the
 # PascalCase component/source-file name (e.g. `TodoItem.tsx` ->
@@ -181,20 +206,24 @@ end
 # Assemble the region-shell page around already-rendered content HTML. `root`
 # is the request-scoped runtime whose script collector the content islands
 # (and the shell islands rendered here) all share.
+#
+# No import map is needed (unlike the pre-Vite build): the router bundle's
+# `@barefootjs/client/runtime` import and every compiled island's own
+# `@barefootjs/client` import are ordinary ESM imports Rollup/Vite resolve
+# through their real module graph, collapsing into ONE shared chunk (build)
+# or ONE cached module (dev) automatically -- a single reactive runtime
+# instance without any hand-wired specifier redirection. That this
+# hand-written wiring could simply be deleted is the point of the
+# Vite-based design, not an incidental cleanup.
 def blog_page(root, title, base, content_html)
-  static = "#{BASE}/client"
   theme = blog_island(root, 'ThemeToggle')
   sidebar = blog_island(root, 'Sidebar')
   shell = blog_island(root, 'PageShell',
                        {}, # no client props
                        { children: BACKEND.mark_raw(content_html) }, # SSR-only: page content
                        { 'reader_toolbar' => 'ReaderToolbar' })
-  importmap = JSON.generate({ imports: {
-    '@barefootjs/client' => "#{static}/barefoot.js",
-    '@barefootjs/client/runtime' => "#{static}/barefoot.js",
-    '@barefootjs/client/reactive' => "#{static}/barefoot.js",
-  } })
   scripts = root.scripts
+  router_entry = ASSETS['RouterEntry'] || ''
   esc_title = root.h(title)
   <<~HTML
     <!DOCTYPE html>
@@ -203,7 +232,6 @@ def blog_page(root, title, base, content_html)
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>#{esc_title}</title>
-    <script type="importmap">#{importmap}</script>
     <link rel="stylesheet" href="#{BASE}/styles/blog.css">
     </head>
     <body>
@@ -216,7 +244,7 @@ def blog_page(root, title, base, content_html)
     <main>#{shell}</main>
     </div>
     #{scripts}
-    <script type="module" src="#{static}/router-entry.js"></script>
+    <script type="module" src="#{router_entry}"></script>
     </body>
     </html>
   HTML

--- a/integrations/sinatra/app.rb
+++ b/integrations/sinatra/app.rb
@@ -103,22 +103,7 @@ rescue JSON::ParserError
   nil
 end
 
-# Reassembles the SAME `{ component_sym => { ssrDefaults: {...} } }` shape a
-# single combined `dist/templates/manifest.json` (the legacy CLI's output)
-# used to provide, from `@barefootjs/vite`'s core plugin's ACTUAL
-# per-component output instead: one `<Name>.ssr-defaults.json` file per
-# component (see `packages/vite/src/emit.ts`'s `planEmits`). `slurp_json`'s
-# `symbolize_names: true` already matches every downstream
-# `entry[:ssrDefaults]` read below.
-def load_blog_manifest
-  Dir.glob('dist/templates/*.ssr-defaults.json').each_with_object({}) do |path, acc|
-    component = File.basename(path, '.ssr-defaults.json').to_sym
-    defaults = slurp_json(path)
-    acc[component] = { ssrDefaults: defaults } if defaults
-  end
-end
-
-BLOG_MANIFEST = load_blog_manifest
+BLOG_MANIFEST = slurp_json('dist/templates/manifest.json') || {}
 BLOG_DATA = slurp_json('dist/blog-data.json') || { posts: [], listItems: [], allTags: [] }
 
 # The Vite-generated asset map (dist/bf-assets.json, written by

--- a/integrations/sinatra/package.json
+++ b/integrations/sinatra/package.json
@@ -2,9 +2,10 @@
   "name": "barefootjs-sinatra-example",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts",
-    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "build": "vite build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts",
+    "build:watch": "vite dev",
     "dev": "BASE_PATH=/integrations/sinatra bundle exec rackup -s puma -p 3010 -o 0.0.0.0 config.ru",
     "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
@@ -17,10 +18,12 @@
   "devDependencies": {
     "@barefootjs/erb": "workspace:*",
     "@barefootjs/jsx": "workspace:*",
+    "@barefootjs/vite": "workspace:*",
     "@cloudflare/containers": "^0.3.2",
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
+    "vite": "^6.0.0",
     "wrangler": "^4"
   }
 }

--- a/integrations/sinatra/vite.config.ts
+++ b/integrations/sinatra/vite.config.ts
@@ -1,0 +1,44 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { barefoot } from '@barefootjs/erb/vite'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const basePath = process.env.BASE_PATH ?? '/integrations/sinatra'
+const routerEntry = resolve(HERE, 'client/router-entry.ts')
+
+// This app's own Rollup entry: `client/router-entry.ts` (the
+// `@barefootjs/router` bootstrap for the blog) is a hand-written script,
+// not a `.tsx` component, so `barefoot()`'s own discovery never sees it —
+// per the design, bundling configuration is stock Vite config this plugin
+// never adds on the app's behalf. `assets.RouterEntry` below (ERB-
+// specific) only resolves the URL Vite bundles this to; THIS is what
+// requests the bundling.
+export default defineConfig({
+  base: `${basePath}/client/`,
+  build: {
+    // Scoped to `dist/client` (not the whole `dist`), matching the existing
+    // `config.ru` Rack::Files mount (`${BASE}/client` -> `dist/client`) —
+    // the templates dir below is a SEPARATE, non-web-exposed directory
+    // Ruby reads locally, never served over HTTP.
+    outDir: 'dist/client',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: { 'router-entry': routerEntry },
+    },
+  },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    // Matches the legacy CLI's output layout exactly (`outputLayout:
+    // { templates: 'templates', clientJs: 'client', runtime: 'client' }`
+    // under `outDir: 'dist'`) — `BACKEND` (BarefootJS::Backend::Erb) reads
+    // `dist/templates` directly; it is never served over HTTP.
+    templates: 'dist/templates',
+    // blog_page no longer hand-writes `.../client/router-entry.js` (it's
+    // content-hashed under Vite) or a `barefoot.js` importmap entry (the
+    // runtime is a shared ESM chunk the browser follows on its own — see
+    // app.rb's blog_page comment). `dist/bf-assets.json`'s
+    // `["RouterEntry"]` is what app.rb's `ASSETS` reads instead.
+    assets: { RouterEntry: routerEntry },
+  }),
+})

--- a/packages/adapter-blade/e2e-fixture/client/bootstrap.ts
+++ b/packages/adapter-blade/e2e-fixture/client/bootstrap.ts
@@ -1,0 +1,8 @@
+/**
+ * A hand-written, non-component script entry — stands in for
+ * `integrations/laravel/client/router-entry.ts` in tests: not a `.tsx`
+ * component, so core's discovery/`scriptAssets` machinery never sees it,
+ * but its bundled URL still needs to reach the compiled PHP blog shell (the
+ * `assets`/`assetsOutputFile` option under test).
+ */
+export const bootstrapped = true

--- a/packages/adapter-blade/e2e-fixture/src/components/Counter.tsx
+++ b/packages/adapter-blade/e2e-fixture/src/components/Counter.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export interface CounterProps {
+  initial: number
+}
+
+export function Counter(props: CounterProps) {
+  const [count, setCount] = createSignal(props.initial)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}

--- a/packages/adapter-blade/package.json
+++ b/packages/adapter-blade/package.json
@@ -20,6 +20,10 @@
     "./build": {
       "types": "./src/build.ts",
       "import": "./src/build.ts"
+    },
+    "./vite": {
+      "types": "./src/vite.ts",
+      "import": "./src/vite.ts"
     }
   },
   "publishConfig": {
@@ -38,6 +42,10 @@
       "./build": {
         "types": "./dist/build.d.ts",
         "import": "./dist/build.js"
+      },
+      "./vite": {
+        "types": "./dist/vite.d.ts",
+        "import": "./dist/vite.js"
       }
     }
   },
@@ -51,7 +59,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",
@@ -76,11 +84,24 @@
     "@barefootjs/shared": "workspace:*"
   },
   "peerDependencies": {
-    "@barefootjs/jsx": ">=0.2.0"
+    "@barefootjs/jsx": ">=0.2.0",
+    "@barefootjs/vite": ">=0.2.0",
+    "vite": "^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@barefootjs/vite": {
+      "optional": true
+    },
+    "vite": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@barefootjs/adapter-tests": "workspace:*",
     "@barefootjs/jsx": "workspace:*",
-    "typescript": "^5.0.0"
+    "@barefootjs/vite": "workspace:*",
+    "@barefootjs/client": "workspace:*",
+    "typescript": "^5.0.0",
+    "vite": "^6.0.0"
   }
 }

--- a/packages/adapter-blade/src/__tests__/vite.test.ts
+++ b/packages/adapter-blade/src/__tests__/vite.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Coverage of `@barefootjs/blade/vite`'s `barefoot()`:
+ *
+ * - one real `vite build()` end to end (mirrors `@barefootjs/go-template/
+ *   vite` and `@barefootjs/hono/vite`'s own `vite.test.ts` rigor — a plugin
+ *   that only passes mocked unit tests hasn't been shown to work) against a
+ *   checked-in fixture (not a system tmpdir) so `@barefootjs/client`
+ *   resolves through the monorepo's real node_modules symlinks;
+ * - the `assets` → generated `bf-assets.json` behavior, exercised the same
+ *   way (a real build, since it needs the real manifest Vite writes).
+ *
+ * Unlike Go, there is no `afterEmit`-driven type-combination step to test
+ * here (see `vite.ts`'s module docstring) — `BladeAdapter.generate()` never
+ * produces a `types` section at all, so `barefoot()` always returns a
+ * single-element array unless `assets` is set.
+ */
+import { describe, test, expect } from 'bun:test'
+import { build } from 'vite'
+import { mkdtemp, rm, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { barefoot, barefoot as defaultBarefoot } from '../vite.ts'
+
+const FIXTURE_ROOT = resolve(import.meta.dirname, '../../e2e-fixture')
+
+describe('@barefootjs/blade/vite: real vite build', () => {
+  test('exports the same function as both named `barefoot` and default', () => {
+    expect(defaultBarefoot).toBe(barefoot)
+  })
+
+  test('returns a single-element plugin array when `assets` is omitted', () => {
+    const plugins = barefoot({ components: ['src/components'], templates: 'views' })
+    expect(plugins).toHaveLength(1)
+  })
+
+  test('writes a self-contained .blade.php template with scriptAssets baked in, same as core alone would do', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-blade-vite-dist-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-blade-vite-views-'))
+
+    try {
+      await build({
+        configFile: false,
+        root: FIXTURE_ROOT,
+        base: '/static/build/',
+        logLevel: 'warn',
+        build: { outDir, emptyOutDir: true },
+        plugins: barefoot({
+          components: ['src/components'],
+          templates: templatesDir,
+        }),
+      })
+
+      const template = await readFile(join(templatesDir, 'Counter.blade.php'), 'utf8')
+      expect(template).toContain("@php($bf->register_script(")
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  test('`assets` resolves a non-component entry\'s manifest-hashed URL into a generated JSON asset map', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-blade-vite-dist-assets-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-blade-vite-views-assets-'))
+    const assetsPath = join(FIXTURE_ROOT, 'dist/bf-assets.json')
+
+    try {
+      await build({
+        configFile: false,
+        root: FIXTURE_ROOT,
+        base: '/static/build/',
+        logLevel: 'warn',
+        build: {
+          outDir,
+          emptyOutDir: true,
+          // Registering the non-component entry is the CALLER's job (stock
+          // Vite config) — `assets` below only resolves the URL Vite
+          // already bundled it to, it doesn't request the bundling.
+          rollupOptions: { input: { bootstrap: resolve(FIXTURE_ROOT, 'client/bootstrap.ts') } },
+        },
+        plugins: barefoot({
+          components: ['src/components'],
+          templates: templatesDir,
+          assets: { Bootstrap: 'client/bootstrap.ts' },
+        }),
+      })
+
+      const manifest = JSON.parse(await readFile(join(outDir, '.vite/manifest.json'), 'utf8'))
+      const expectedUrl = `/static/build/${manifest['client/bootstrap.ts'].file}`
+
+      const content = JSON.parse(await readFile(assetsPath, 'utf8'))
+      expect(content).toEqual({ Bootstrap: expectedUrl })
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+      await rm(join(FIXTURE_ROOT, 'dist'), { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  test('`assets` throws an actionable error when the entry was never registered as a Rollup input', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-blade-vite-dist-assets-missing-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-blade-vite-views-assets-missing-'))
+
+    try {
+      await expect(
+        build({
+          configFile: false,
+          root: FIXTURE_ROOT,
+          base: '/static/build/',
+          logLevel: 'silent',
+          build: { outDir, emptyOutDir: true },
+          plugins: barefoot({
+            components: ['src/components'],
+            templates: templatesDir,
+            assets: { Bootstrap: 'client/bootstrap.ts' },
+          }),
+        }),
+      ).rejects.toThrow(/was not found in the build manifest/)
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+      await rm(join(FIXTURE_ROOT, 'dist'), { recursive: true, force: true })
+    }
+  }, 60_000)
+})

--- a/packages/adapter-blade/src/adapter/expr/emitters.ts
+++ b/packages/adapter-blade/src/adapter/expr/emitters.ts
@@ -152,15 +152,33 @@ export function truthyTest(node: ParsedExpr, rendered: string): string {
  * degrading to the callback's receiver.
  */
 export class BladeFilterEmitter implements ParsedExprEmitter {
+  // Plain field declarations + assignment, NOT TS constructor-parameter-
+  // property shorthand: Vite's `bundleConfigFile` externalizes any bare
+  // (non-relative) import when loading `vite.config.ts` (see
+  // `@barefootjs/blade/vite`'s docstring), so this file can be loaded
+  // directly by Node's OWN native TypeScript type-stripping (enabled by
+  // default since Node 22.18/23.6) rather than esbuild — and Node's
+  // strip-only mode does not support parameter properties (`SyntaxError
+  // [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]`), only plain type annotations.
+  private readonly param: string
+  private readonly localVarMap: Map<string, string>
+  private readonly isStringName: (n: string) => boolean
+  // Records a BF101 for predicate shapes this emitter can only degrade
+  // (#2038). Optional so emitter construction stays possible without an
+  // adapter; a missing hook keeps the old silent-degrade emit.
+  private readonly onUnsupported?: (message: string, reason?: string) => void
+
   constructor(
-    private readonly param: string,
-    private readonly localVarMap: Map<string, string>,
-    private readonly isStringName: (n: string) => boolean = () => false,
-    // Records a BF101 for predicate shapes this emitter can only degrade
-    // (#2038). Optional so emitter construction stays possible without an
-    // adapter; a missing hook keeps the old silent-degrade emit.
-    private readonly onUnsupported?: (message: string, reason?: string) => void,
-  ) {}
+    param: string,
+    localVarMap: Map<string, string>,
+    isStringName: (n: string) => boolean = () => false,
+    onUnsupported?: (message: string, reason?: string) => void,
+  ) {
+    this.param = param
+    this.localVarMap = localVarMap
+    this.isStringName = isStringName
+    this.onUnsupported = onUnsupported
+  }
 
   identifier(name: string): string {
     if (name === this.param) return bladeVar(this.param)
@@ -321,7 +339,13 @@ export class BladeFilterEmitter implements ParsedExprEmitter {
  *   - no lambda fallback exists (see the file header, divergence 9).
  */
 export class BladeTopLevelEmitter implements ParsedExprEmitter {
-  constructor(private readonly ctx: BladeEmitContext) {}
+  // Plain field + assignment, not a parameter property — see
+  // `BladeFilterEmitter`'s constructor comment above for why.
+  private readonly ctx: BladeEmitContext
+
+  constructor(ctx: BladeEmitContext) {
+    this.ctx = ctx
+  }
 
   identifier(name: string): string {
     // `undefined` / `null` nested inside a larger expression tree — PHP

--- a/packages/adapter-blade/src/vite.ts
+++ b/packages/adapter-blade/src/vite.ts
@@ -1,0 +1,216 @@
+/**
+ * `@barefootjs/blade/vite` — a Blade-specific COMPOSITION of core
+ * `@barefootjs/vite`'s `barefoot()`, mirroring `@barefootjs/go-template/
+ * vite`'s and `@barefootjs/hono/vite`'s shape and naming (`barefoot`, named
+ * AND default export; a user never passes `adapter`, this constructs
+ * `BladeAdapter` itself).
+ *
+ *   import { barefoot } from '@barefootjs/blade/vite'
+ *
+ *   export default defineConfig({
+ *     base: '/integrations/laravel/client/',
+ *     build: { outDir: 'dist/client' },
+ *     plugins: barefoot({
+ *       components: ['../shared/components', '../shared/blog'],
+ *       templates: 'dist/templates',
+ *     }),
+ *   })
+ *
+ * ## Why this needs no `afterEmit`-driven type-combination step (unlike Go)
+ *
+ * `@barefootjs/go-template/vite` exists mainly to combine every discovered
+ * file's `types` fragment into ONE compilable `components.go` — Go's
+ * per-file fragments assume a shared `randomID` helper and a single package
+ * header, so they are not independently valid Go source, and an unused
+ * import fails the build outright (see that module's docstring). `Blade
+ * Adapter.generate()` never produces a `types` section at all (PHP templates
+ * have no JS-style imports/types/exports to combine — see `blade-
+ * adapter.ts`'s `generate()`, whose `sections.types` is always `''`), so
+ * there is nothing across files to stitch together, and no unused-import
+ * failure mode to guard against either. Confirmed by reading `./build.ts`'s
+ * `createConfig`: unlike Go's, it has NO default `postBuild` of its own —
+ * it only forwards a caller-supplied one verbatim. So this composition's
+ * core job is just what core's `barefoot()` already does: construct
+ * `BladeAdapter` and hand it to core.
+ *
+ * ## No `adapterOptions` either — the other thing Go/Hono still need
+ *
+ * `BladeAdapterOptions` has exactly two fields, `clientJsBasePath` and
+ * `barefootJsPath` — and `BladeAdapter.generateScriptRegistrations` only
+ * falls back to them when `scriptAssets` is `undefined` (the legacy `bf
+ * build` path). Core's `barefoot()` plugin ALWAYS passes a resolved
+ * `scriptAssets` array (build: manifest-hashed; dev: origin-based — see
+ * `plugin.ts`), so that fallback is dead code on every Vite-driven build.
+ * Unlike Go (`packageName`, still real) or Hono (`clientJsFilename`, still
+ * real), Blade has no adapter option left with any effect once Vite drives
+ * the build — so this options interface simply omits the field rather than
+ * plumbing through two options that would always be ignored.
+ *
+ * ## `assets` — the one thing this DOES need, mirroring go-template/hono
+ *
+ * A hand-written, non-component client bootstrap (e.g. an integration's
+ * `client/router-entry.ts`, which boots `@barefootjs/router` for the blog)
+ * isn't a `.tsx` component, so core's own discovery/`scriptAssets` machinery
+ * never sees it — but the compiled blog shell still needs a `<script src>`
+ * for it, and that URL is only knowable after Vite bundles it (dev:
+ * origin-based; build: manifest-hashed). `assets` resolves exactly that,
+ * into a generated JSON file the PHP app reads at request time (the same
+ * `dist/templates/manifest.json` — read-a-JSON-file-at-runtime — idiom this
+ * PHP already uses for `ssrDefaults`; unlike Go/Hono there is no compile
+ * step on the PHP side, so plain JSON is enough — no generated Go/TS source
+ * needed). See `@barefootjs/go-template/vite`'s docstring for the full "why
+ * a companion config-capture plugin" rationale (`afterEmit`'s
+ * `AfterEmitContext` is deliberately narrow — no `ResolvedConfig`, no dev
+ * origin, no manifest — so a tiny second plugin captures those via its own
+ * `configResolved`/`configureServer` hooks for `afterEmit`, in the same
+ * closure, to read).
+ */
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
+import { barefoot as coreBarefoot } from '@barefootjs/vite'
+import type { AfterEmitContext } from '@barefootjs/vite'
+import { devModuleUrl, loadManifest, resolveDevOrigin, resolveScriptAssets, toPosixRelative } from '@barefootjs/vite'
+import { BladeAdapter } from './adapter/index.ts'
+
+export interface BladeViteOptions {
+  /** Source directories to scan for `.tsx` components, relative to the
+   * Vite project root (or absolute). */
+  components: string[]
+  /** Where compiled `.blade.php` templates and `ssrDefaults` land —
+   * relative to the Vite project root (or absolute). This is a backend
+   * source directory PHP reads, NOT `build.outDir` (Vite's client-asset
+   * output). */
+  templates: string
+  /**
+   * Extra, non-component script entries whose Vite-resolved URL (dev:
+   * origin-based; production: content-hashed manifest path) should be
+   * exposed to the PHP app as a generated JSON asset map — e.g. a
+   * hand-written client bootstrap script that isn't a `.tsx` component, so
+   * it never goes through core's discovery/`scriptAssets` machinery, but
+   * still needs a `<script src="...">` URL only knowable after bundling.
+   *
+   * Keyed by the identifier the resolved URL should appear under in the
+   * generated map; values are entry paths relative to the Vite project
+   * root. You must ALSO register the same path as a Rollup entry yourself
+   * via stock `build.rollupOptions.input` — this plugin never adds
+   * bundling configuration on your behalf; this option only resolves the
+   * URL Vite already bundled it to, it doesn't request the bundling.
+   */
+  assets?: Record<string, string>
+  /** Output path for the generated JSON asset map, relative to the Vite
+   * project root. Default: 'dist/bf-assets.json'. Ignored when `assets`
+   * is empty. Placed under `dist/` (already gitignored) rather than
+   * committed like Go's `bf_assets.go`: PHP reads this file at REQUEST
+   * time, so — unlike Go, which must compile a static map into the
+   * binary — there is nothing to commit; a fresh copy is generated on
+   * every build (dev AND production) and never checked in. */
+  assetsOutputFile?: string
+}
+
+/** write-if-changed: writes `content` to `absPath` only if it differs from
+ * what's already there, logging `label` when it actually wrote. Avoids
+ * touching mtime (and so falsely tripping a file watcher, e.g. PHP's own
+ * dev server) on a pass that produced byte-identical output. */
+async function writeIfChanged(absPath: string, content: string, label: string): Promise<void> {
+  const prev = await readFile(absPath, 'utf-8').catch(() => null)
+  if (prev === content) return
+  // Default `assetsOutputFile` lives under `dist/` — a directory `vite
+  // build` may not have created yet on a clean checkout — so ensure it
+  // exists before writing.
+  await mkdir(dirname(absPath), { recursive: true })
+  await writeFile(absPath, content)
+  console.log(`Generated: ${label}`)
+}
+
+/** Resolves ONE asset entry's URL for the current pass: manifest-hashed for
+ * `mode: 'build'`, dev-origin-based for `mode: 'dev'`. Throws with an
+ * actionable message when the entry isn't in the build manifest — almost
+ * always means the caller forgot to also add it to
+ * `build.rollupOptions.input`. */
+function resolveAssetUrl(
+  ctx: AfterEmitContext,
+  config: ResolvedConfig,
+  devServer: ViteDevServer | undefined,
+  entryRelPath: string,
+  manifest: Record<string, { file: string }> | undefined,
+): string {
+  const absPath = resolve(ctx.projectDir, entryRelPath)
+  if (ctx.mode === 'dev') {
+    if (!devServer) throw new Error(`[blade/vite] asset "${entryRelPath}": dev server not ready`)
+    return devModuleUrl(config, resolveDevOrigin(devServer), absPath)
+  }
+
+  const manifestKey = toPosixRelative(config.root, absPath)
+  const [url] = resolveScriptAssets(manifest ?? {}, manifestKey, config.base)
+  if (!url) {
+    throw new Error(
+      `[blade/vite] asset "${entryRelPath}" was not found in the build manifest. ` +
+        `Did you also add it to build.rollupOptions.input?`,
+    )
+  }
+  return url
+}
+
+/** Builds and write-if-changed's the generated JSON asset map. No-op when
+ * `assets` is empty. */
+async function writeAssetMap(
+  ctx: AfterEmitContext,
+  config: ResolvedConfig,
+  devServer: ViteDevServer | undefined,
+  assets: Record<string, string>,
+  assetsOutputFile: string,
+): Promise<void> {
+  const keys = Object.keys(assets)
+  if (keys.length === 0) return
+
+  const manifest = ctx.mode === 'build' ? await loadManifest(ctx.outDir, config.build.manifest) : undefined
+
+  const resolved: Record<string, string> = {}
+  for (const name of keys) {
+    resolved[name] = resolveAssetUrl(ctx, config, devServer, assets[name]!, manifest)
+  }
+
+  const content = `${JSON.stringify(resolved, null, 2)}\n`
+  await writeIfChanged(resolve(ctx.projectDir, assetsOutputFile), content, assetsOutputFile)
+}
+
+export function barefoot(options: BladeViteOptions): Plugin[] {
+  const assets = options.assets ?? {}
+  const assetsOutputFile = options.assetsOutputFile ?? 'dist/bf-assets.json'
+
+  // Populated by `bladeAssetsConfigCapture` below (only added to the
+  // returned array when `assets` is non-empty). Read by `afterEmit` — see
+  // `@barefootjs/go-template/vite`'s identical mechanism for the ordering
+  // guarantee (`configResolved`/`configureServer` always run before the
+  // eager pass that triggers `afterEmit`, for both build and dev).
+  let resolvedConfig: ResolvedConfig | undefined
+  let devServer: ViteDevServer | undefined
+
+  const core = coreBarefoot({
+    adapter: new BladeAdapter(),
+    components: options.components,
+    templates: options.templates,
+    async afterEmit(ctx) {
+      if (Object.keys(assets).length > 0 && resolvedConfig) {
+        await writeAssetMap(ctx, resolvedConfig, devServer, assets, assetsOutputFile)
+      }
+    },
+  })
+
+  if (Object.keys(assets).length === 0) return [core]
+
+  const bladeAssetsConfigCapture: Plugin = {
+    name: 'barefoot-blade-assets-config-capture',
+    configResolved(config) {
+      resolvedConfig = config
+    },
+    configureServer(server) {
+      devServer = server
+    },
+  }
+
+  return [core, bladeAssetsConfigCapture]
+}
+
+export { barefoot as default }

--- a/packages/adapter-erb/e2e-fixture/client/bootstrap.ts
+++ b/packages/adapter-erb/e2e-fixture/client/bootstrap.ts
@@ -1,0 +1,8 @@
+/**
+ * A hand-written, non-component script entry — stands in for
+ * `integrations/rails/client/router-entry.ts` (and sinatra's) in tests: not
+ * a `.tsx` component, so core's discovery/`scriptAssets` machinery never
+ * sees it, but its bundled URL still needs to reach the compiled Ruby blog
+ * shell (the `assets`/`assetsOutputFile` option under test).
+ */
+export const bootstrapped = true

--- a/packages/adapter-erb/e2e-fixture/src/components/Counter.tsx
+++ b/packages/adapter-erb/e2e-fixture/src/components/Counter.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export interface CounterProps {
+  initial: number
+}
+
+export function Counter(props: CounterProps) {
+  const [count, setCount] = createSignal(props.initial)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}

--- a/packages/adapter-erb/package.json
+++ b/packages/adapter-erb/package.json
@@ -20,6 +20,10 @@
     "./build": {
       "types": "./src/build.ts",
       "import": "./src/build.ts"
+    },
+    "./vite": {
+      "types": "./src/vite.ts",
+      "import": "./src/vite.ts"
     }
   },
   "publishConfig": {
@@ -38,6 +42,10 @@
       "./build": {
         "types": "./dist/build.d.ts",
         "import": "./dist/build.js"
+      },
+      "./vite": {
+        "types": "./dist/vite.d.ts",
+        "import": "./dist/vite.js"
       }
     }
   },
@@ -49,7 +57,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",
@@ -76,11 +84,24 @@
     "@barefootjs/shared": "workspace:*"
   },
   "peerDependencies": {
-    "@barefootjs/jsx": ">=0.2.0"
+    "@barefootjs/jsx": ">=0.2.0",
+    "@barefootjs/vite": ">=0.2.0",
+    "vite": "^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@barefootjs/vite": {
+      "optional": true
+    },
+    "vite": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@barefootjs/adapter-tests": "workspace:*",
     "@barefootjs/jsx": "workspace:*",
-    "typescript": "^5.0.0"
+    "@barefootjs/vite": "workspace:*",
+    "@barefootjs/client": "workspace:*",
+    "typescript": "^5.0.0",
+    "vite": "^6.0.0"
   }
 }

--- a/packages/adapter-erb/src/__tests__/vite.test.ts
+++ b/packages/adapter-erb/src/__tests__/vite.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Coverage of `@barefootjs/erb/vite`'s `barefoot()`:
+ *
+ * - one real `vite build()` end to end (mirrors `@barefootjs/go-template/
+ *   vite`, `@barefootjs/hono/vite`, `@barefootjs/blade/vite`, and
+ *   `@barefootjs/jinja/vite`'s own `vite.test.ts` rigor — a plugin that
+ *   only passes mocked unit tests hasn't been shown to work) against a
+ *   checked-in fixture (not a system tmpdir) so `@barefootjs/client`
+ *   resolves through the monorepo's real node_modules symlinks;
+ * - the `assets` → generated `bf-assets.json` behavior, exercised the same
+ *   way (a real build, since it needs the real manifest Vite writes).
+ *
+ * Unlike Go, there is no `afterEmit`-driven type-combination step to test
+ * here (see `vite.ts`'s module docstring) — `ErbAdapter.generate()` never
+ * produces a `types` section at all, so `barefoot()` always returns a
+ * single-element array unless `assets` is set.
+ */
+import { describe, test, expect } from 'bun:test'
+import { build } from 'vite'
+import { mkdtemp, rm, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { barefoot, barefoot as defaultBarefoot } from '../vite.ts'
+
+const FIXTURE_ROOT = resolve(import.meta.dirname, '../../e2e-fixture')
+
+describe('@barefootjs/erb/vite: real vite build', () => {
+  test('exports the same function as both named `barefoot` and default', () => {
+    expect(defaultBarefoot).toBe(barefoot)
+  })
+
+  test('returns a single-element plugin array when `assets` is omitted', () => {
+    const plugins = barefoot({ components: ['src/components'], templates: 'views' })
+    expect(plugins).toHaveLength(1)
+  })
+
+  test('writes a self-contained .erb template with scriptAssets baked in, same as core alone would do', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-erb-vite-dist-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-erb-vite-views-'))
+
+    try {
+      await build({
+        configFile: false,
+        root: FIXTURE_ROOT,
+        base: '/static/build/',
+        logLevel: 'warn',
+        build: { outDir, emptyOutDir: true },
+        plugins: barefoot({
+          components: ['src/components'],
+          templates: templatesDir,
+        }),
+      })
+
+      const template = await readFile(join(templatesDir, 'Counter.erb'), 'utf8')
+      expect(template).toContain("bf.register_script(")
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  test('`assets` resolves a non-component entry\'s manifest-hashed URL into a generated JSON asset map', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-erb-vite-dist-assets-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-erb-vite-views-assets-'))
+    const assetsPath = join(FIXTURE_ROOT, 'dist/bf-assets.json')
+
+    try {
+      await build({
+        configFile: false,
+        root: FIXTURE_ROOT,
+        base: '/static/build/',
+        logLevel: 'warn',
+        build: {
+          outDir,
+          emptyOutDir: true,
+          // Registering the non-component entry is the CALLER's job (stock
+          // Vite config) — `assets` below only resolves the URL Vite
+          // already bundled it to, it doesn't request the bundling.
+          rollupOptions: { input: { bootstrap: resolve(FIXTURE_ROOT, 'client/bootstrap.ts') } },
+        },
+        plugins: barefoot({
+          components: ['src/components'],
+          templates: templatesDir,
+          assets: { Bootstrap: 'client/bootstrap.ts' },
+        }),
+      })
+
+      const manifest = JSON.parse(await readFile(join(outDir, '.vite/manifest.json'), 'utf8'))
+      const expectedUrl = `/static/build/${manifest['client/bootstrap.ts'].file}`
+
+      const content = JSON.parse(await readFile(assetsPath, 'utf8'))
+      expect(content).toEqual({ Bootstrap: expectedUrl })
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+      await rm(join(FIXTURE_ROOT, 'dist'), { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  test('`assets` throws an actionable error when the entry was never registered as a Rollup input', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-erb-vite-dist-assets-missing-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-erb-vite-views-assets-missing-'))
+
+    try {
+      await expect(
+        build({
+          configFile: false,
+          root: FIXTURE_ROOT,
+          base: '/static/build/',
+          logLevel: 'silent',
+          build: { outDir, emptyOutDir: true },
+          plugins: barefoot({
+            components: ['src/components'],
+            templates: templatesDir,
+            assets: { Bootstrap: 'client/bootstrap.ts' },
+          }),
+        }),
+      ).rejects.toThrow(/was not found in the build manifest/)
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+      await rm(join(FIXTURE_ROOT, 'dist'), { recursive: true, force: true })
+    }
+  }, 60_000)
+})

--- a/packages/adapter-erb/src/adapter/expr/emitters.ts
+++ b/packages/adapter-erb/src/adapter/expr/emitters.ts
@@ -88,38 +88,60 @@ function unusedIsStringName(_n: string): boolean {
 }
 
 export class ErbFilterEmitter implements ParsedExprEmitter {
+  // Plain field declarations + assignment, NOT TS constructor-parameter-
+  // property shorthand: Vite's `bundleConfigFile` externalizes any bare
+  // (non-relative) import when loading `vite.config.ts` (see
+  // `@barefootjs/erb/vite`'s docstring), so this file can be loaded
+  // directly by Node's OWN native TypeScript type-stripping (enabled by
+  // default since Node 22.18/23.6) rather than esbuild — and Node's
+  // strip-only mode does not support parameter properties (`SyntaxError
+  // [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]`), only plain type annotations.
+  private readonly param: string
+  private readonly localVarMap: Map<string, string>
+  // Whether `name` currently names a bare Ruby local bound by an
+  // ENCLOSING loop/block (distinct from `this.param`, which is this
+  // predicate's own — possibly nested — loop param). See
+  // `ErbEmitContext.isLoopBoundName`'s docstring for why ERB needs this
+  // and EP does not.
+  private readonly isLoopBoundOuter: (n: string) => boolean
+  // Reports whether a getter/prop name is string-typed, for the Hash-vs-
+  // Array index-access split (#operand.ts). Defaults to "never" for
+  // callers that don't thread it through.
+  private readonly isStringName: (n: string) => boolean
+  // Records a BF101 for nested callback shapes this emitter can only
+  // degrade — `find*` and the non-predicate methods. Optional so emitter
+  // construction stays possible without an adapter; a missing hook keeps
+  // the old silent-degrade emit.
+  private readonly onUnsupported?: (message: string, reason?: string) => void
+  // The Ruby local to EMIT for a reference matching `this.param` — as
+  // opposed to `this.param` itself, which is only the name to MATCH.
+  // These two are the SAME value everywhere in this file except the
+  // `filter().map()` loop-gating `<if>` (erb-adapter.ts's `renderLoop`,
+  // #2245): `todos.filter(t => t.done).map(todo => ...)` parses the
+  // predicate against the filter callback's OWN param (`t`), but the
+  // Ruby local actually bound by the loop is the MAP callback's param
+  // (`todo`) — Ruby has no per-callback block scope there (unlike the
+  // real nested `.select { |t| ... }` block `callbackMethod` below
+  // builds, where match and render are naturally the same param).
+  // Defaults to `rubyLocal(param)`, i.e. every other construction site is
+  // unaffected.
+  private readonly renderParamAs: string
+
   constructor(
-    private readonly param: string,
-    private readonly localVarMap: Map<string, string>,
-    // Whether `name` currently names a bare Ruby local bound by an
-    // ENCLOSING loop/block (distinct from `this.param`, which is this
-    // predicate's own — possibly nested — loop param). See
-    // `ErbEmitContext.isLoopBoundName`'s docstring for why ERB needs this
-    // and EP does not.
-    private readonly isLoopBoundOuter: (n: string) => boolean = () => false,
-    // Reports whether a getter/prop name is string-typed, for the Hash-vs-
-    // Array index-access split (#operand.ts). Defaults to "never" for
-    // callers that don't thread it through.
-    private readonly isStringName: (n: string) => boolean = unusedIsStringName,
-    // Records a BF101 for nested callback shapes this emitter can only
-    // degrade — `find*` and the non-predicate methods. Optional so emitter
-    // construction stays possible without an adapter; a missing hook keeps
-    // the old silent-degrade emit.
-    private readonly onUnsupported?: (message: string, reason?: string) => void,
-    // The Ruby local to EMIT for a reference matching `this.param` — as
-    // opposed to `this.param` itself, which is only the name to MATCH.
-    // These two are the SAME value everywhere in this file except the
-    // `filter().map()` loop-gating `<if>` (erb-adapter.ts's `renderLoop`,
-    // #2245): `todos.filter(t => t.done).map(todo => ...)` parses the
-    // predicate against the filter callback's OWN param (`t`), but the
-    // Ruby local actually bound by the loop is the MAP callback's param
-    // (`todo`) — Ruby has no per-callback block scope there (unlike the
-    // real nested `.select { |t| ... }` block `callbackMethod` below
-    // builds, where match and render are naturally the same param).
-    // Defaults to `rubyLocal(this.param)`, i.e. every other construction
-    // site is unaffected.
-    private readonly renderParamAs: string = rubyLocal(param),
-  ) {}
+    param: string,
+    localVarMap: Map<string, string>,
+    isLoopBoundOuter: (n: string) => boolean = () => false,
+    isStringName: (n: string) => boolean = unusedIsStringName,
+    onUnsupported?: (message: string, reason?: string) => void,
+    renderParamAs: string = rubyLocal(param),
+  ) {
+    this.param = param
+    this.localVarMap = localVarMap
+    this.isLoopBoundOuter = isLoopBoundOuter
+    this.isStringName = isStringName
+    this.onUnsupported = onUnsupported
+    this.renderParamAs = renderParamAs
+  }
 
   identifier(name: string): string {
     if (name === this.param) return this.renderParamAs
@@ -315,7 +337,13 @@ export class ErbFilterEmitter implements ParsedExprEmitter {
  *   - the `unsupported` fallback returns the safe empty-string Ruby literal.
  */
 export class ErbTopLevelEmitter implements ParsedExprEmitter {
-  constructor(private readonly ctx: ErbEmitContext) {}
+  // Plain field + assignment, not a parameter property — see
+  // `ErbFilterEmitter`'s constructor comment above for why.
+  private readonly ctx: ErbEmitContext
+
+  constructor(ctx: ErbEmitContext) {
+    this.ctx = ctx
+  }
 
   identifier(name: string): string {
     // `undefined` / `null` nested inside a larger expression tree (e.g.

--- a/packages/adapter-erb/src/vite.ts
+++ b/packages/adapter-erb/src/vite.ts
@@ -1,0 +1,217 @@
+/**
+ * `@barefootjs/erb/vite` — an ERB-specific COMPOSITION of core
+ * `@barefootjs/vite`'s `barefoot()`, mirroring `@barefootjs/go-template/
+ * vite`'s, `@barefootjs/hono/vite`'s, `@barefootjs/blade/vite`'s, and
+ * `@barefootjs/jinja/vite`'s shape and naming (`barefoot`, named AND
+ * default export; a user never passes `adapter`, this constructs
+ * `ErbAdapter` itself).
+ *
+ *   import { barefoot } from '@barefootjs/erb/vite'
+ *
+ *   export default defineConfig({
+ *     base: '/integrations/rails/client/',
+ *     build: { outDir: 'dist/client' },
+ *     plugins: barefoot({
+ *       components: ['../shared/components', '../shared/blog'],
+ *       templates: 'dist/templates',
+ *     }),
+ *   })
+ *
+ * ## Why this needs no `afterEmit`-driven type-combination step (unlike Go)
+ *
+ * `@barefootjs/go-template/vite` exists mainly to combine every discovered
+ * file's `types` fragment into ONE compilable `components.go` — Go's
+ * per-file fragments assume a shared `randomID` helper and a single package
+ * header, so they are not independently valid Go source, and an unused
+ * import fails the build outright (see that module's docstring).
+ * `ErbAdapter.generate()` never produces a `types` section at all (ERB
+ * templates have no JS-style imports/types/exports to combine — see
+ * `erb-adapter.ts`'s `generate()`, whose `sections.types` is always `''`),
+ * so there is nothing across files to stitch together, and no
+ * unused-import failure mode to guard against either. Confirmed by reading
+ * `./build.ts`'s `createConfig`: unlike Go's, it has NO default `postBuild`
+ * of its own — it only forwards a caller-supplied one verbatim. So this
+ * composition's core job is just what core's `barefoot()` already does:
+ * construct `ErbAdapter` and hand it to core.
+ *
+ * ## No `adapterOptions` either — the other thing Go/Hono still need
+ *
+ * `ErbAdapterOptions` has exactly two fields, `clientJsBasePath` and
+ * `barefootJsPath` — and `ErbAdapter.generateScriptRegistrations` only
+ * falls back to them when `scriptAssets` is `undefined` (the legacy `bf
+ * build` path). Core's `barefoot()` plugin ALWAYS passes a resolved
+ * `scriptAssets` array (build: manifest-hashed; dev: origin-based — see
+ * `plugin.ts`), so that fallback is dead code on every Vite-driven build.
+ * Unlike Go (`packageName`, still real) or Hono (`clientJsFilename`, still
+ * real), ERB has no adapter option left with any effect once Vite drives
+ * the build — so this options interface simply omits the field rather than
+ * plumbing through two options that would always be ignored.
+ *
+ * ## `assets` — the one thing this DOES need, mirroring go-template/hono/blade/jinja
+ *
+ * A hand-written, non-component client bootstrap (e.g. an integration's
+ * `client/router-entry.ts`, which boots `@barefootjs/router` for the blog)
+ * isn't a `.tsx` component, so core's own discovery/`scriptAssets` machinery
+ * never sees it — but the compiled blog shell still needs a `<script src>`
+ * for it, and that URL is only knowable after Vite bundles it (dev:
+ * origin-based; build: manifest-hashed). `assets` resolves exactly that,
+ * into a generated JSON file the Ruby app reads at request time (the same
+ * `dist/templates/manifest.json` — read-a-JSON-file-at-runtime — idiom the
+ * Rails/Sinatra examples already use for `ssrDefaults`; unlike Go/Hono
+ * there is no compile step on the Ruby side, so plain JSON is enough — no
+ * generated Go/TS source needed). See `@barefootjs/go-template/vite`'s
+ * docstring for the full "why a companion config-capture plugin" rationale
+ * (`afterEmit`'s `AfterEmitContext` is deliberately narrow — no
+ * `ResolvedConfig`, no dev origin, no manifest — so a tiny second plugin
+ * captures those via its own `configResolved`/`configureServer` hooks for
+ * `afterEmit`, in the same closure, to read).
+ */
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
+import { barefoot as coreBarefoot } from '@barefootjs/vite'
+import type { AfterEmitContext } from '@barefootjs/vite'
+import { devModuleUrl, loadManifest, resolveDevOrigin, resolveScriptAssets, toPosixRelative } from '@barefootjs/vite'
+import { ErbAdapter } from './adapter/index.ts'
+
+export interface ErbViteOptions {
+  /** Source directories to scan for `.tsx` components, relative to the
+   * Vite project root (or absolute). */
+  components: string[]
+  /** Where compiled `.erb` templates and `ssrDefaults` land — relative to
+   * the Vite project root (or absolute). This is a backend source
+   * directory Ruby reads, NOT `build.outDir` (Vite's client-asset
+   * output). */
+  templates: string
+  /**
+   * Extra, non-component script entries whose Vite-resolved URL (dev:
+   * origin-based; production: content-hashed manifest path) should be
+   * exposed to the Ruby app as a generated JSON asset map — e.g. a
+   * hand-written client bootstrap script that isn't a `.tsx` component, so
+   * it never goes through core's discovery/`scriptAssets` machinery, but
+   * still needs a `<script src="...">` URL only knowable after bundling.
+   *
+   * Keyed by the identifier the resolved URL should appear under in the
+   * generated map; values are entry paths relative to the Vite project
+   * root. You must ALSO register the same path as a Rollup entry yourself
+   * via stock `build.rollupOptions.input` — this plugin never adds
+   * bundling configuration on your behalf; this option only resolves the
+   * URL Vite already bundled it to, it doesn't request the bundling.
+   */
+  assets?: Record<string, string>
+  /** Output path for the generated JSON asset map, relative to the Vite
+   * project root. Default: 'dist/bf-assets.json'. Ignored when `assets`
+   * is empty. Placed under `dist/` (already gitignored) rather than
+   * committed like Go's `bf_assets.go`: Ruby reads this file at REQUEST
+   * time, so — unlike Go, which must compile a static map into the
+   * binary — there is nothing to commit; a fresh copy is generated on
+   * every build (dev AND production) and never checked in. */
+  assetsOutputFile?: string
+}
+
+/** write-if-changed: writes `content` to `absPath` only if it differs from
+ * what's already there, logging `label` when it actually wrote. Avoids
+ * touching mtime (and so falsely tripping a file watcher, e.g. Ruby's own
+ * dev server) on a pass that produced byte-identical output. */
+async function writeIfChanged(absPath: string, content: string, label: string): Promise<void> {
+  const prev = await readFile(absPath, 'utf-8').catch(() => null)
+  if (prev === content) return
+  // Default `assetsOutputFile` lives under `dist/` — a directory `vite
+  // build` may not have created yet on a clean checkout — so ensure it
+  // exists before writing.
+  await mkdir(dirname(absPath), { recursive: true })
+  await writeFile(absPath, content)
+  console.log(`Generated: ${label}`)
+}
+
+/** Resolves ONE asset entry's URL for the current pass: manifest-hashed for
+ * `mode: 'build'`, dev-origin-based for `mode: 'dev'`. Throws with an
+ * actionable message when the entry isn't in the build manifest — almost
+ * always means the caller forgot to also add it to
+ * `build.rollupOptions.input`. */
+function resolveAssetUrl(
+  ctx: AfterEmitContext,
+  config: ResolvedConfig,
+  devServer: ViteDevServer | undefined,
+  entryRelPath: string,
+  manifest: Record<string, { file: string }> | undefined,
+): string {
+  const absPath = resolve(ctx.projectDir, entryRelPath)
+  if (ctx.mode === 'dev') {
+    if (!devServer) throw new Error(`[erb/vite] asset "${entryRelPath}": dev server not ready`)
+    return devModuleUrl(config, resolveDevOrigin(devServer), absPath)
+  }
+
+  const manifestKey = toPosixRelative(config.root, absPath)
+  const [url] = resolveScriptAssets(manifest ?? {}, manifestKey, config.base)
+  if (!url) {
+    throw new Error(
+      `[erb/vite] asset "${entryRelPath}" was not found in the build manifest. ` +
+        `Did you also add it to build.rollupOptions.input?`,
+    )
+  }
+  return url
+}
+
+/** Builds and write-if-changed's the generated JSON asset map. No-op when
+ * `assets` is empty. */
+async function writeAssetMap(
+  ctx: AfterEmitContext,
+  config: ResolvedConfig,
+  devServer: ViteDevServer | undefined,
+  assets: Record<string, string>,
+  assetsOutputFile: string,
+): Promise<void> {
+  const keys = Object.keys(assets)
+  if (keys.length === 0) return
+
+  const manifest = ctx.mode === 'build' ? await loadManifest(ctx.outDir, config.build.manifest) : undefined
+
+  const resolved: Record<string, string> = {}
+  for (const name of keys) {
+    resolved[name] = resolveAssetUrl(ctx, config, devServer, assets[name]!, manifest)
+  }
+
+  const content = `${JSON.stringify(resolved, null, 2)}\n`
+  await writeIfChanged(resolve(ctx.projectDir, assetsOutputFile), content, assetsOutputFile)
+}
+
+export function barefoot(options: ErbViteOptions): Plugin[] {
+  const assets = options.assets ?? {}
+  const assetsOutputFile = options.assetsOutputFile ?? 'dist/bf-assets.json'
+
+  // Populated by `erbAssetsConfigCapture` below (only added to the
+  // returned array when `assets` is non-empty). Read by `afterEmit` — see
+  // `@barefootjs/go-template/vite`'s identical mechanism for the ordering
+  // guarantee (`configResolved`/`configureServer` always run before the
+  // eager pass that triggers `afterEmit`, for both build and dev).
+  let resolvedConfig: ResolvedConfig | undefined
+  let devServer: ViteDevServer | undefined
+
+  const core = coreBarefoot({
+    adapter: new ErbAdapter(),
+    components: options.components,
+    templates: options.templates,
+    async afterEmit(ctx) {
+      if (Object.keys(assets).length > 0 && resolvedConfig) {
+        await writeAssetMap(ctx, resolvedConfig, devServer, assets, assetsOutputFile)
+      }
+    },
+  })
+
+  if (Object.keys(assets).length === 0) return [core]
+
+  const erbAssetsConfigCapture: Plugin = {
+    name: 'barefoot-erb-assets-config-capture',
+    configResolved(config) {
+      resolvedConfig = config
+    },
+    configureServer(server) {
+      devServer = server
+    },
+  }
+
+  return [core, erbAssetsConfigCapture]
+}
+
+export { barefoot as default }

--- a/packages/adapter-jinja/e2e-fixture/client/bootstrap.ts
+++ b/packages/adapter-jinja/e2e-fixture/client/bootstrap.ts
@@ -1,0 +1,9 @@
+/**
+ * A hand-written, non-component script entry — stands in for
+ * `integrations/django/client/router-entry.ts` (and fastapi's/flask's) in
+ * tests: not a `.tsx` component, so core's discovery/`scriptAssets`
+ * machinery never sees it, but its bundled URL still needs to reach the
+ * compiled Python blog shell (the `assets`/`assetsOutputFile` option under
+ * test).
+ */
+export const bootstrapped = true

--- a/packages/adapter-jinja/e2e-fixture/src/components/Counter.tsx
+++ b/packages/adapter-jinja/e2e-fixture/src/components/Counter.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export interface CounterProps {
+  initial: number
+}
+
+export function Counter(props: CounterProps) {
+  const [count, setCount] = createSignal(props.initial)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}

--- a/packages/adapter-jinja/package.json
+++ b/packages/adapter-jinja/package.json
@@ -20,6 +20,10 @@
     "./build": {
       "types": "./src/build.ts",
       "import": "./src/build.ts"
+    },
+    "./vite": {
+      "types": "./src/vite.ts",
+      "import": "./src/vite.ts"
     }
   },
   "publishConfig": {
@@ -38,6 +42,10 @@
       "./build": {
         "types": "./dist/build.d.ts",
         "import": "./dist/build.js"
+      },
+      "./vite": {
+        "types": "./dist/vite.d.ts",
+        "import": "./dist/vite.js"
       }
     }
   },
@@ -49,7 +57,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",
@@ -75,11 +83,24 @@
     "@barefootjs/shared": "workspace:*"
   },
   "peerDependencies": {
-    "@barefootjs/jsx": ">=0.2.0"
+    "@barefootjs/jsx": ">=0.2.0",
+    "@barefootjs/vite": ">=0.2.0",
+    "vite": "^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@barefootjs/vite": {
+      "optional": true
+    },
+    "vite": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@barefootjs/adapter-tests": "workspace:*",
     "@barefootjs/jsx": "workspace:*",
-    "typescript": "^5.0.0"
+    "@barefootjs/vite": "workspace:*",
+    "@barefootjs/client": "workspace:*",
+    "typescript": "^5.0.0",
+    "vite": "^6.0.0"
   }
 }

--- a/packages/adapter-jinja/src/__tests__/vite.test.ts
+++ b/packages/adapter-jinja/src/__tests__/vite.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Coverage of `@barefootjs/jinja/vite`'s `barefoot()`:
+ *
+ * - one real `vite build()` end to end (mirrors `@barefootjs/go-template/
+ *   vite`, `@barefootjs/hono/vite`, and `@barefootjs/blade/vite`'s own
+ *   `vite.test.ts` rigor — a plugin that only passes mocked unit tests
+ *   hasn't been shown to work) against a checked-in fixture (not a system
+ *   tmpdir) so `@barefootjs/client` resolves through the monorepo's real
+ *   node_modules symlinks;
+ * - the `assets` → generated `bf-assets.json` behavior, exercised the same
+ *   way (a real build, since it needs the real manifest Vite writes).
+ *
+ * Unlike Go, there is no `afterEmit`-driven type-combination step to test
+ * here (see `vite.ts`'s module docstring) — `JinjaAdapter.generate()` never
+ * produces a `types` section at all, so `barefoot()` always returns a
+ * single-element array unless `assets` is set.
+ */
+import { describe, test, expect } from 'bun:test'
+import { build } from 'vite'
+import { mkdtemp, rm, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { barefoot, barefoot as defaultBarefoot } from '../vite.ts'
+
+const FIXTURE_ROOT = resolve(import.meta.dirname, '../../e2e-fixture')
+
+describe('@barefootjs/jinja/vite: real vite build', () => {
+  test('exports the same function as both named `barefoot` and default', () => {
+    expect(defaultBarefoot).toBe(barefoot)
+  })
+
+  test('returns a single-element plugin array when `assets` is omitted', () => {
+    const plugins = barefoot({ components: ['src/components'], templates: 'views' })
+    expect(plugins).toHaveLength(1)
+  })
+
+  test('writes a self-contained .jinja template with scriptAssets baked in, same as core alone would do', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-jinja-vite-dist-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-jinja-vite-views-'))
+
+    try {
+      await build({
+        configFile: false,
+        root: FIXTURE_ROOT,
+        base: '/static/build/',
+        logLevel: 'warn',
+        build: { outDir, emptyOutDir: true },
+        plugins: barefoot({
+          components: ['src/components'],
+          templates: templatesDir,
+        }),
+      })
+
+      const template = await readFile(join(templatesDir, 'Counter.jinja'), 'utf8')
+      expect(template).toContain("bf.register_script(")
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  test('`assets` resolves a non-component entry\'s manifest-hashed URL into a generated JSON asset map', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-jinja-vite-dist-assets-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-jinja-vite-views-assets-'))
+    const assetsPath = join(FIXTURE_ROOT, 'dist/bf-assets.json')
+
+    try {
+      await build({
+        configFile: false,
+        root: FIXTURE_ROOT,
+        base: '/static/build/',
+        logLevel: 'warn',
+        build: {
+          outDir,
+          emptyOutDir: true,
+          // Registering the non-component entry is the CALLER's job (stock
+          // Vite config) — `assets` below only resolves the URL Vite
+          // already bundled it to, it doesn't request the bundling.
+          rollupOptions: { input: { bootstrap: resolve(FIXTURE_ROOT, 'client/bootstrap.ts') } },
+        },
+        plugins: barefoot({
+          components: ['src/components'],
+          templates: templatesDir,
+          assets: { Bootstrap: 'client/bootstrap.ts' },
+        }),
+      })
+
+      const manifest = JSON.parse(await readFile(join(outDir, '.vite/manifest.json'), 'utf8'))
+      const expectedUrl = `/static/build/${manifest['client/bootstrap.ts'].file}`
+
+      const content = JSON.parse(await readFile(assetsPath, 'utf8'))
+      expect(content).toEqual({ Bootstrap: expectedUrl })
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+      await rm(join(FIXTURE_ROOT, 'dist'), { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  test('`assets` throws an actionable error when the entry was never registered as a Rollup input', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-jinja-vite-dist-assets-missing-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-jinja-vite-views-assets-missing-'))
+
+    try {
+      await expect(
+        build({
+          configFile: false,
+          root: FIXTURE_ROOT,
+          base: '/static/build/',
+          logLevel: 'silent',
+          build: { outDir, emptyOutDir: true },
+          plugins: barefoot({
+            components: ['src/components'],
+            templates: templatesDir,
+            assets: { Bootstrap: 'client/bootstrap.ts' },
+          }),
+        }),
+      ).rejects.toThrow(/was not found in the build manifest/)
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+      await rm(join(FIXTURE_ROOT, 'dist'), { recursive: true, force: true })
+    }
+  }, 60_000)
+})

--- a/packages/adapter-jinja/src/adapter/expr/emitters.ts
+++ b/packages/adapter-jinja/src/adapter/expr/emitters.ts
@@ -117,15 +117,33 @@ export function truthyTest(node: ParsedExpr, rendered: string): string {
  * callback's receiver.
  */
 export class JinjaFilterEmitter implements ParsedExprEmitter {
+  // Plain field declarations + assignment, NOT TS constructor-parameter-
+  // property shorthand: Vite's `bundleConfigFile` externalizes any bare
+  // (non-relative) import when loading `vite.config.ts` (see
+  // `@barefootjs/jinja/vite`'s docstring), so this file can be loaded
+  // directly by Node's OWN native TypeScript type-stripping (enabled by
+  // default since Node 22.18/23.6) rather than esbuild — and Node's
+  // strip-only mode does not support parameter properties (`SyntaxError
+  // [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]`), only plain type annotations.
+  private readonly param: string
+  private readonly localVarMap: Map<string, string>
+  private readonly isStringName: (n: string) => boolean
+  // Records a BF101 for predicate shapes this emitter can only degrade
+  // (#2038). Optional so emitter construction stays possible without an
+  // adapter; a missing hook keeps the old silent-degrade emit.
+  private readonly onUnsupported?: (message: string, reason?: string) => void
+
   constructor(
-    private readonly param: string,
-    private readonly localVarMap: Map<string, string>,
-    private readonly isStringName: (n: string) => boolean = () => false,
-    // Records a BF101 for predicate shapes this emitter can only degrade
-    // (#2038). Optional so emitter construction stays possible without an
-    // adapter; a missing hook keeps the old silent-degrade emit.
-    private readonly onUnsupported?: (message: string, reason?: string) => void,
-  ) {}
+    param: string,
+    localVarMap: Map<string, string>,
+    isStringName: (n: string) => boolean = () => false,
+    onUnsupported?: (message: string, reason?: string) => void,
+  ) {
+    this.param = param
+    this.localVarMap = localVarMap
+    this.isStringName = isStringName
+    this.onUnsupported = onUnsupported
+  }
 
   identifier(name: string): string {
     if (name === this.param) return jinjaIdent(this.param)
@@ -296,7 +314,13 @@ export class JinjaFilterEmitter implements ParsedExprEmitter {
  *   - no lambda fallback exists (see the file header, divergence 2).
  */
 export class JinjaTopLevelEmitter implements ParsedExprEmitter {
-  constructor(private readonly ctx: JinjaEmitContext) {}
+  // Plain field + assignment, not a parameter property — see
+  // `JinjaFilterEmitter`'s constructor comment above for why.
+  private readonly ctx: JinjaEmitContext
+
+  constructor(ctx: JinjaEmitContext) {
+    this.ctx = ctx
+  }
 
   identifier(name: string): string {
     // `undefined` / `null` nested inside a larger expression tree — Jinja

--- a/packages/adapter-jinja/src/vite.ts
+++ b/packages/adapter-jinja/src/vite.ts
@@ -1,0 +1,216 @@
+/**
+ * `@barefootjs/jinja/vite` — a Jinja2-specific COMPOSITION of core
+ * `@barefootjs/vite`'s `barefoot()`, mirroring `@barefootjs/go-template/
+ * vite`'s, `@barefootjs/hono/vite`'s, and `@barefootjs/blade/vite`'s shape
+ * and naming (`barefoot`, named AND default export; a user never passes
+ * `adapter`, this constructs `JinjaAdapter` itself).
+ *
+ *   import { barefoot } from '@barefootjs/jinja/vite'
+ *
+ *   export default defineConfig({
+ *     base: '/integrations/django/client/',
+ *     build: { outDir: 'dist/client' },
+ *     plugins: barefoot({
+ *       components: ['../shared/components', '../shared/blog'],
+ *       templates: 'dist/templates',
+ *     }),
+ *   })
+ *
+ * ## Why this needs no `afterEmit`-driven type-combination step (unlike Go)
+ *
+ * `@barefootjs/go-template/vite` exists mainly to combine every discovered
+ * file's `types` fragment into ONE compilable `components.go` — Go's
+ * per-file fragments assume a shared `randomID` helper and a single package
+ * header, so they are not independently valid Go source, and an unused
+ * import fails the build outright (see that module's docstring).
+ * `JinjaAdapter.generate()` never produces a `types` section at all (Jinja2
+ * templates have no JS-style imports/types/exports to combine — see
+ * `jinja-adapter.ts`'s `generate()`, whose `sections.types` is always
+ * `''`), so there is nothing across files to stitch together, and no
+ * unused-import failure mode to guard against either. Confirmed by reading
+ * `./build.ts`'s `createConfig`: unlike Go's, it has NO default `postBuild`
+ * of its own — it only forwards a caller-supplied one verbatim. So this
+ * composition's core job is just what core's `barefoot()` already does:
+ * construct `JinjaAdapter` and hand it to core.
+ *
+ * ## No `adapterOptions` either — the other thing Go/Hono still need
+ *
+ * `JinjaAdapterOptions` has exactly two fields, `clientJsBasePath` and
+ * `barefootJsPath` — and `JinjaAdapter.generateScriptRegistrations` only
+ * falls back to them when `scriptAssets` is `undefined` (the legacy `bf
+ * build` path). Core's `barefoot()` plugin ALWAYS passes a resolved
+ * `scriptAssets` array (build: manifest-hashed; dev: origin-based — see
+ * `plugin.ts`), so that fallback is dead code on every Vite-driven build.
+ * Unlike Go (`packageName`, still real) or Hono (`clientJsFilename`, still
+ * real), Jinja has no adapter option left with any effect once Vite drives
+ * the build — so this options interface simply omits the field rather than
+ * plumbing through two options that would always be ignored.
+ *
+ * ## `assets` — the one thing this DOES need, mirroring go-template/hono/blade
+ *
+ * A hand-written, non-component client bootstrap (e.g. an integration's
+ * `client/router-entry.ts`, which boots `@barefootjs/router` for the blog)
+ * isn't a `.tsx` component, so core's own discovery/`scriptAssets` machinery
+ * never sees it — but the compiled blog shell still needs a `<script src>`
+ * for it, and that URL is only knowable after Vite bundles it (dev:
+ * origin-based; build: manifest-hashed). `assets` resolves exactly that,
+ * into a generated JSON file the Python app reads at request time (the same
+ * `dist/templates/manifest.json` — read-a-JSON-file-at-runtime — idiom
+ * app.py already uses for `ssrDefaults`; unlike Go/Hono there is no compile
+ * step on the Python side, so plain JSON is enough — no generated Go/TS
+ * source needed). See `@barefootjs/go-template/vite`'s docstring for the
+ * full "why a companion config-capture plugin" rationale (`afterEmit`'s
+ * `AfterEmitContext` is deliberately narrow — no `ResolvedConfig`, no dev
+ * origin, no manifest — so a tiny second plugin captures those via its own
+ * `configResolved`/`configureServer` hooks for `afterEmit`, in the same
+ * closure, to read).
+ */
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
+import { barefoot as coreBarefoot } from '@barefootjs/vite'
+import type { AfterEmitContext } from '@barefootjs/vite'
+import { devModuleUrl, loadManifest, resolveDevOrigin, resolveScriptAssets, toPosixRelative } from '@barefootjs/vite'
+import { JinjaAdapter } from './adapter/index.ts'
+
+export interface JinjaViteOptions {
+  /** Source directories to scan for `.tsx` components, relative to the
+   * Vite project root (or absolute). */
+  components: string[]
+  /** Where compiled `.jinja` templates and `ssrDefaults` land — relative to
+   * the Vite project root (or absolute). This is a backend source
+   * directory Python reads, NOT `build.outDir` (Vite's client-asset
+   * output). */
+  templates: string
+  /**
+   * Extra, non-component script entries whose Vite-resolved URL (dev:
+   * origin-based; production: content-hashed manifest path) should be
+   * exposed to the Python app as a generated JSON asset map — e.g. a
+   * hand-written client bootstrap script that isn't a `.tsx` component, so
+   * it never goes through core's discovery/`scriptAssets` machinery, but
+   * still needs a `<script src="...">` URL only knowable after bundling.
+   *
+   * Keyed by the identifier the resolved URL should appear under in the
+   * generated map; values are entry paths relative to the Vite project
+   * root. You must ALSO register the same path as a Rollup entry yourself
+   * via stock `build.rollupOptions.input` — this plugin never adds
+   * bundling configuration on your behalf; this option only resolves the
+   * URL Vite already bundled it to, it doesn't request the bundling.
+   */
+  assets?: Record<string, string>
+  /** Output path for the generated JSON asset map, relative to the Vite
+   * project root. Default: 'dist/bf-assets.json'. Ignored when `assets`
+   * is empty. Placed under `dist/` (already gitignored) rather than
+   * committed like Go's `bf_assets.go`: Python reads this file at REQUEST
+   * time, so — unlike Go, which must compile a static map into the
+   * binary — there is nothing to commit; a fresh copy is generated on
+   * every build (dev AND production) and never checked in. */
+  assetsOutputFile?: string
+}
+
+/** write-if-changed: writes `content` to `absPath` only if it differs from
+ * what's already there, logging `label` when it actually wrote. Avoids
+ * touching mtime (and so falsely tripping a file watcher, e.g. Python's own
+ * dev server) on a pass that produced byte-identical output. */
+async function writeIfChanged(absPath: string, content: string, label: string): Promise<void> {
+  const prev = await readFile(absPath, 'utf-8').catch(() => null)
+  if (prev === content) return
+  // Default `assetsOutputFile` lives under `dist/` — a directory `vite
+  // build` may not have created yet on a clean checkout — so ensure it
+  // exists before writing.
+  await mkdir(dirname(absPath), { recursive: true })
+  await writeFile(absPath, content)
+  console.log(`Generated: ${label}`)
+}
+
+/** Resolves ONE asset entry's URL for the current pass: manifest-hashed for
+ * `mode: 'build'`, dev-origin-based for `mode: 'dev'`. Throws with an
+ * actionable message when the entry isn't in the build manifest — almost
+ * always means the caller forgot to also add it to
+ * `build.rollupOptions.input`. */
+function resolveAssetUrl(
+  ctx: AfterEmitContext,
+  config: ResolvedConfig,
+  devServer: ViteDevServer | undefined,
+  entryRelPath: string,
+  manifest: Record<string, { file: string }> | undefined,
+): string {
+  const absPath = resolve(ctx.projectDir, entryRelPath)
+  if (ctx.mode === 'dev') {
+    if (!devServer) throw new Error(`[jinja/vite] asset "${entryRelPath}": dev server not ready`)
+    return devModuleUrl(config, resolveDevOrigin(devServer), absPath)
+  }
+
+  const manifestKey = toPosixRelative(config.root, absPath)
+  const [url] = resolveScriptAssets(manifest ?? {}, manifestKey, config.base)
+  if (!url) {
+    throw new Error(
+      `[jinja/vite] asset "${entryRelPath}" was not found in the build manifest. ` +
+        `Did you also add it to build.rollupOptions.input?`,
+    )
+  }
+  return url
+}
+
+/** Builds and write-if-changed's the generated JSON asset map. No-op when
+ * `assets` is empty. */
+async function writeAssetMap(
+  ctx: AfterEmitContext,
+  config: ResolvedConfig,
+  devServer: ViteDevServer | undefined,
+  assets: Record<string, string>,
+  assetsOutputFile: string,
+): Promise<void> {
+  const keys = Object.keys(assets)
+  if (keys.length === 0) return
+
+  const manifest = ctx.mode === 'build' ? await loadManifest(ctx.outDir, config.build.manifest) : undefined
+
+  const resolved: Record<string, string> = {}
+  for (const name of keys) {
+    resolved[name] = resolveAssetUrl(ctx, config, devServer, assets[name]!, manifest)
+  }
+
+  const content = `${JSON.stringify(resolved, null, 2)}\n`
+  await writeIfChanged(resolve(ctx.projectDir, assetsOutputFile), content, assetsOutputFile)
+}
+
+export function barefoot(options: JinjaViteOptions): Plugin[] {
+  const assets = options.assets ?? {}
+  const assetsOutputFile = options.assetsOutputFile ?? 'dist/bf-assets.json'
+
+  // Populated by `jinjaAssetsConfigCapture` below (only added to the
+  // returned array when `assets` is non-empty). Read by `afterEmit` — see
+  // `@barefootjs/go-template/vite`'s identical mechanism for the ordering
+  // guarantee (`configResolved`/`configureServer` always run before the
+  // eager pass that triggers `afterEmit`, for both build and dev).
+  let resolvedConfig: ResolvedConfig | undefined
+  let devServer: ViteDevServer | undefined
+
+  const core = coreBarefoot({
+    adapter: new JinjaAdapter(),
+    components: options.components,
+    templates: options.templates,
+    async afterEmit(ctx) {
+      if (Object.keys(assets).length > 0 && resolvedConfig) {
+        await writeAssetMap(ctx, resolvedConfig, devServer, assets, assetsOutputFile)
+      }
+    },
+  })
+
+  if (Object.keys(assets).length === 0) return [core]
+
+  const jinjaAssetsConfigCapture: Plugin = {
+    name: 'barefoot-jinja-assets-config-capture',
+    configResolved(config) {
+      resolvedConfig = config
+    },
+    configureServer(server) {
+      devServer = server
+    },
+  }
+
+  return [core, jinjaAssetsConfigCapture]
+}
+
+export { barefoot as default }

--- a/packages/vite/src/__tests__/component-manifest.test.ts
+++ b/packages/vite/src/__tests__/component-manifest.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Coverage of `buildManifestEntry` — the combined `manifest.json` row
+ * builder that reproduces `packages/cli/src/lib/build.ts`'s manifest shape
+ * (see `component-manifest.ts`'s header for the exact legacy fields this
+ * ports, and the two it deliberately doesn't).
+ */
+import { describe, test, expect } from 'bun:test'
+import type { CompileResult, TemplateAdapter } from '@barefootjs/jsx'
+import { buildManifestEntry } from '../component-manifest.ts'
+
+const fakeAdapter = { extension: '.tmpl', templatesPerComponent: false } as TemplateAdapter
+const perComponentAdapter = { extension: '.tmpl', templatesPerComponent: true } as TemplateAdapter
+
+describe('buildManifestEntry', () => {
+  test('single-component, non-templatesPerComponent, no ssrDefaults: absent key, no components map', () => {
+    const result: CompileResult = {
+      files: [{ path: '/x', content: '<button/>', type: 'markedTemplate', componentName: 'Counter' }],
+      errors: [],
+    }
+
+    const row = buildManifestEntry(result, '/src/components/Counter.tsx', ['/src/components'], fakeAdapter)
+
+    expect(row).not.toBeNull()
+    expect(row!.manifestKey).toBe('Counter')
+    expect(row!.entry).toEqual({ markedTemplate: 'Counter.tmpl' })
+    // The absent-key contract matters: a consumer checking
+    // `'ssrDefaults' in entry` (or PHP's `array_key_exists`) must see FALSE
+    // for a component with no SSR defaults, not an empty object — this is
+    // the exact legacy behavior (`...(ssrDefaults ? { ssrDefaults } : {})`).
+    expect('ssrDefaults' in row!.entry).toBe(false)
+    expect('components' in row!.entry).toBe(false)
+  })
+
+  test('single-component, non-templatesPerComponent, WITH ssrDefaults', () => {
+    const result: CompileResult = {
+      files: [
+        { path: '/x', content: '<button/>', type: 'markedTemplate', componentName: 'Counter' },
+        { path: '/x', content: '{"initial":{"propName":"initial","value":0}}', type: 'ssrDefaults', componentName: 'Counter' },
+      ],
+      errors: [],
+    }
+
+    const row = buildManifestEntry(result, '/src/components/Counter.tsx', ['/src/components'], fakeAdapter)
+
+    expect(row!.entry).toEqual({
+      markedTemplate: 'Counter.tmpl',
+      ssrDefaults: { initial: { propName: 'initial', value: 0 } },
+    })
+  })
+
+  test('templatesPerComponent adapter, single component: top-level fields mirror the components sub-map', () => {
+    const result: CompileResult = {
+      files: [
+        { path: '/x', content: 'body', type: 'markedTemplate', componentName: 'Counter' },
+        { path: '/x', content: '{"initial":{"value":0}}', type: 'ssrDefaults', componentName: 'Counter' },
+      ],
+      errors: [],
+    }
+
+    const row = buildManifestEntry(result, '/src/components/Counter.tsx', ['/src/components'], perComponentAdapter)
+
+    expect(row!.manifestKey).toBe('Counter')
+    expect(row!.entry).toEqual({
+      markedTemplate: 'Counter.tmpl',
+      ssrDefaults: { initial: { value: 0 } },
+      components: {
+        Counter: { markedTemplate: 'Counter.tmpl', ssrDefaults: { initial: { value: 0 } } },
+      },
+    })
+  })
+
+  test('templatesPerComponent adapter, multi-export file: one manifestKey, per-component rows, partial ssrDefaults', () => {
+    const result: CompileResult = {
+      files: [
+        { path: '/x', content: 'toast body', type: 'markedTemplate', componentName: 'Toast' },
+        { path: '/x', content: 'toaster body', type: 'markedTemplate', componentName: 'Toaster' },
+        { path: '/x', content: '{"open":{"value":false}}', type: 'ssrDefaults', componentName: 'Toast' },
+        // Toaster has no ssrDefaults file at all.
+      ],
+      errors: [],
+    }
+
+    const row = buildManifestEntry(
+      result,
+      '/src/components/ui/toast/index.tsx',
+      ['/src/components'],
+      perComponentAdapter,
+    )
+
+    // Neither exported component's name is 'index' (the file's own
+    // basename) — mirrors the legacy CLI falling through to
+    // `markedTemplates[0]` for a multi-export file (see this module's
+    // "Primary (top-level) template" comment).
+    expect(row!.manifestKey).toBe('ui/toast/index')
+    expect(row!.entry.markedTemplate).toBe('ui/toast/Toast.tmpl')
+    expect(row!.entry.ssrDefaults).toEqual({ open: { value: false } })
+    expect(row!.entry.components).toEqual({
+      Toast: { markedTemplate: 'ui/toast/Toast.tmpl', ssrDefaults: { open: { value: false } } },
+      Toaster: { markedTemplate: 'ui/toast/Toaster.tmpl' },
+    })
+    expect('ssrDefaults' in row!.entry.components!.Toaster!).toBe(false)
+  })
+
+  test('returns null for a state-only compile with no markedTemplate output', () => {
+    const result: CompileResult = {
+      files: [{ path: '/x', content: 'export const x = 1', type: 'clientJs' }],
+      errors: [],
+    }
+    expect(buildManifestEntry(result, '/src/components/state.tsx', ['/src/components'], fakeAdapter)).toBeNull()
+  })
+
+  test('drops malformed ssrDefaults content instead of throwing', () => {
+    const result: CompileResult = {
+      files: [
+        { path: '/x', content: 'body', type: 'markedTemplate', componentName: 'Counter' },
+        { path: '/x', content: 'not json', type: 'ssrDefaults', componentName: 'Counter' },
+      ],
+      errors: [],
+    }
+
+    const row = buildManifestEntry(result, '/src/components/Counter.tsx', ['/src/components'], fakeAdapter)
+    expect('ssrDefaults' in row!.entry).toBe(false)
+  })
+})

--- a/packages/vite/src/__tests__/e2e-vite-build.test.ts
+++ b/packages/vite/src/__tests__/e2e-vite-build.test.ts
@@ -162,4 +162,25 @@ describe('e2e: vite build', () => {
     expect(files).toContain('SharedCounter.tmpl')
     expect(files).toContain('Greeting.tmpl')
   })
+
+  test('writes a combined manifest.json alongside the per-component templates, matching the legacy CLI\'s shape (#2494 review)', async () => {
+    const manifest = JSON.parse(await readFile(resolve(templatesDir, 'manifest.json'), 'utf8'))
+
+    // Keyed by component name (GoTemplateAdapter isn't `templatesPerComponent`,
+    // so no `components` sub-map is expected — see `component-manifest.ts`).
+    // Counter's own `count` signal seeds a literal SSR default even with no
+    // backing prop (`ssrDefaults` covers every signal needing an in-template
+    // seed, not only optional-prop-derived ones); Greeting's required `name`
+    // prop reference seeds a `{ propName, value: null }` row the same way.
+    expect(manifest.Counter).toEqual({ markedTemplate: 'Counter.tmpl', ssrDefaults: { count: { value: 0 } } })
+    expect(manifest.Greeting).toEqual({
+      markedTemplate: 'Greeting.tmpl',
+      ssrDefaults: { name: { propName: 'name', value: null } },
+    })
+    expect('components' in manifest.Counter).toBe(false)
+    // The absent-key contract itself (no entry carries `ssrDefaults: {}`)
+    // is covered precisely, on fabricated input, by
+    // `component-manifest.test.ts` — this test's job is just proving the
+    // combined file actually lands on disk from a REAL build.
+  })
 })

--- a/packages/vite/src/component-manifest.ts
+++ b/packages/vite/src/component-manifest.ts
@@ -1,0 +1,154 @@
+/**
+ * Reassembles ONE source file's row for the combined `manifest.json` this
+ * plugin writes to `templatesDir` alongside the per-component
+ * `<Name>.ssr-defaults.json` files `emit.ts`'s `planEmits` already produces
+ * — matching `packages/cli/src/lib/build-cache.ts`'s `ManifestEntry` /
+ * `ManifestComponentEntry` shape and `packages/cli/src/lib/build.ts`'s
+ * manifest-building block (search that file for `manifestKey = baseNameNoExt`)
+ * EXACTLY, verified by reading both, not inferred from any consumer.
+ *
+ * WHY THIS EXISTS (not just the per-component files): every PHP/Python/Ruby
+ * backend driving a `templatesPerComponent` adapter (Blade/Jinja2/ERB) reads
+ * `ssrDefaults` — an optional-prop-derived signal's SSR seed value — from
+ * disk at REQUEST time (there is no compile step to bake it into source the
+ * way Go's generated `NewXxxProps` constructor or Hono's self-contained
+ * `.tsx` file can). The legacy CLI wrote that as one combined
+ * `dist/templates/manifest.json`; without this, every one of those backends
+ * would have to glob-and-reassemble the identical `{ [component]: {
+ * ssrDefaults } }` shape from the per-component files themselves — seven
+ * copies of the same reconstruction logic across three languages, and a
+ * capability the pipeline used to just hand over silently regressing the
+ * moment nobody's looking (stack 7 deletes the legacy CLI entirely). One
+ * place in core beats three `/vite` packages reimplementing it, and
+ * `@barefootjs/go-template/vite` / `@barefootjs/hono/vite` get the same
+ * manifest for free even though neither adapter's own backend currently
+ * reads it (Go bakes `ssrDefaults` into generated source; Hono's `.tsx`
+ * inlines them as JS defaults) — see this module's own callers for the
+ * confirmation that neither reads a manifest today.
+ *
+ * Ported (not imported) from `@barefootjs/cli`'s types, per this package's
+ * existing precedent — see `paths.ts`'s header comment: `@barefootjs/cli`'s
+ * only published entry point pulls in its whole esbuild-based build
+ * pipeline as an import side effect, which this plugin exists to replace.
+ *
+ * Two legacy `ManifestEntry` fields are intentionally NOT reproduced:
+ *
+ * - `stubDeps` — bookkeeping for the legacy CLI's esbuild-based stub-
+ *   dependency resolution (`resolveRelativeImports`). Rollup's own module
+ *   graph resolution makes the concept moot; no consumer reads it.
+ * - `clientJs` — the legacy CLI wrote a STATIC (non-hashed) relative path
+ *   because it controlled the client JS output location directly. Under
+ *   Vite the real URL is content-hashed and mode-dependent (dev-origin vs.
+ *   build-manifest-resolved) — exactly what `scriptAssets` already resolves
+ *   and bakes directly into the compiled template's own script-registration
+ *   call, so no backend has ever read `manifest[name].clientJs` (grep the
+ *   PHP/Python/Ruby runtimes: zero hits) and there is no single static path
+ *   left to put there that wouldn't be actively misleading.
+ */
+import type { CompileResult, TemplateAdapter } from '@barefootjs/jsx'
+import { perComponentRelPath, relativeUnderComponentDir, withExtension } from './paths.ts'
+
+/** One exported component's row inside a multi-export source file's
+ * `components` map (`templatesPerComponent` adapters only) — matches
+ * `@barefootjs/cli`'s `ManifestComponentEntry`. */
+export interface ManifestComponentEntry {
+  markedTemplate: string
+  ssrDefaults?: Record<string, unknown>
+}
+
+/** One SOURCE FILE's row in the combined manifest — matches
+ * `@barefootjs/cli`'s `ManifestEntry` (minus `stubDeps`/`clientJs`; see this
+ * module's header). */
+export interface ManifestEntry {
+  markedTemplate: string
+  ssrDefaults?: Record<string, unknown>
+  /** Per-exported-component rows for `templatesPerComponent` adapters
+   * (piconic-ai/barefootjs#2132) — present even for a single-component file,
+   * matching the legacy CLI's own unconditional-when-`templatesPerComponent`
+   * behavior. */
+  components?: Record<string, ManifestComponentEntry>
+}
+
+/**
+ * Builds one source file's `{ manifestKey, entry }` pair from its
+ * already-compiled `CompileResult`. Returns `null` when the compile
+ * produced no `markedTemplate` at all (nothing to register) — mirrors the
+ * legacy CLI's own `markedTemplates.length > 0` guard.
+ */
+export function buildManifestEntry(
+  result: CompileResult,
+  absPath: string,
+  componentDirs: readonly string[],
+  adapter: TemplateAdapter,
+): { manifestKey: string; entry: ManifestEntry } | null {
+  const markedTemplates = result.files.filter(f => f.type === 'markedTemplate')
+  if (markedTemplates.length === 0) return null
+
+  const relUnderComponentDir = relativeUnderComponentDir(absPath, componentDirs)
+  // Source file's path relative to its `components` dir, extension
+  // stripped (e.g. `Counter`, or `ui/toast/index` for a multi-export
+  // file) — matches the legacy CLI's `effectiveNamesFor`'s `baseNameNoExt`
+  // (this plugin's `relativeUnderComponentDir` is the SAME "position under
+  // whichever configured componentDirs entry contains it" computation,
+  // just WITH the extension still on; `withExtension(..., '')` strips it).
+  const manifestKey = withExtension(relUnderComponentDir, '')
+
+  const ssrDefaultsByComponent = new Map<string, Record<string, unknown>>()
+  for (const f of result.files) {
+    if (f.type !== 'ssrDefaults' || !f.componentName) continue
+    try {
+      ssrDefaultsByComponent.set(f.componentName, JSON.parse(f.content) as Record<string, unknown>)
+    } catch {
+      // Malformed ssrDefaults content is dropped — matches the legacy
+      // CLI's own `try { JSON.parse(...) } catch { return undefined }`.
+    }
+  }
+
+  // Every `markedTemplate`/`ssrDefaults` FileOutput is unconditionally
+  // stamped with `componentName` (see `packages/jsx/src/compiler.ts`,
+  // both the single- and multi-component-per-file code paths) — pairing on
+  // it directly is exact and adapter-agnostic, unlike the legacy CLI's own
+  // path-basename heuristic (`ssrDefaultsForTemplate`), which existed to
+  // paper over esbuild's own multi-physical-file output naming and has no
+  // equivalent ambiguity here.
+  const relPathFor = (componentName: string | undefined): string =>
+    adapter.templatesPerComponent && componentName
+      ? perComponentRelPath(relUnderComponentDir, componentName, adapter.extension)
+      : withExtension(relUnderComponentDir, adapter.extension)
+
+  let componentsMap: Record<string, ManifestComponentEntry> | undefined
+  if (adapter.templatesPerComponent) {
+    componentsMap = {}
+    for (const tpl of markedTemplates) {
+      if (!tpl.componentName) continue
+      const ssrDefaults = ssrDefaultsByComponent.get(tpl.componentName)
+      componentsMap[tpl.componentName] = {
+        markedTemplate: relPathFor(tpl.componentName),
+        ...(ssrDefaults ? { ssrDefaults } : {}),
+      }
+    }
+    if (Object.keys(componentsMap).length === 0) componentsMap = undefined
+  }
+
+  // Primary (top-level) template: the legacy CLI picks whichever template's
+  // OWN output filename starts with the source file's basename — a
+  // heuristic that, for a `templatesPerComponent` adapter, only matches
+  // when the sole/first component's name equals the source file's own
+  // basename (the case every real component in this repo hits: `Counter.tsx`
+  // exports `Counter`) and falls through to `markedTemplates[0]` for every
+  // other case (a multi-export file, where NO per-component name equals the
+  // file's own basename, e.g. `ui/toast/index.tsx`). So `markedTemplates[0]`
+  // alone reproduces its result exactly, for both per-component and
+  // combined-file adapters, without re-deriving esbuild-era filename
+  // conventions this plugin's own output doesn't share.
+  const primary = markedTemplates[0]!
+  const primarySsrDefaults = primary.componentName ? ssrDefaultsByComponent.get(primary.componentName) : undefined
+
+  const entry: ManifestEntry = {
+    markedTemplate: relPathFor(primary.componentName),
+    ...(primarySsrDefaults ? { ssrDefaults: primarySsrDefaults } : {}),
+    ...(componentsMap ? { components: componentsMap } : {}),
+  }
+
+  return { manifestKey, entry }
+}

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -62,7 +62,7 @@
  * not just the build one, because e.g. Go's `components.go` has to exist
  * for `go run .` to compile even in dev.
  */
-import { readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
 import {
@@ -78,6 +78,7 @@ import { resolveClientJsSpecifier } from './resolve-client-js.ts'
 import { buildRelativeImportRewriter, relativeUnderComponentDir, safeRollupEntryName, toPosixRelative } from './paths.ts'
 import { loadManifest, resolveScriptAssets } from './manifest.ts'
 import { planEmits, writeEmits, type EmitTarget } from './emit.ts'
+import { buildManifestEntry, type ManifestEntry } from './component-manifest.ts'
 import {
   DEFAULT_DEV_CORS_ORIGIN,
   DEV_ARTIFACT_MARKER_CONTENT,
@@ -217,6 +218,11 @@ export function barefoot(options: BarefootViteOptions): Plugin {
     resolveScriptAssetsFor: (component: DiscoveredComponent) => string[],
   ): Promise<Map<string, string>> {
     const types = new Map<string, string>()
+    // Combined `manifest.json` row per source file — see
+    // `component-manifest.ts`'s header for why this is written alongside
+    // (not instead of) the per-component `.ssr-defaults.json` files
+    // `writeEmits` already produces.
+    const manifestEntries: Record<string, ManifestEntry> = {}
     for (const component of discovered) {
       const content = await readFile(component.absPath, 'utf8')
       const canonical = compileCanonical(component.absPath, content)
@@ -245,7 +251,22 @@ export function barefoot(options: BarefootViteOptions): Plugin {
       for (const file of result.files) {
         if (file.type === 'types') types.set(component.absPath, file.content)
       }
+
+      const manifestRow = buildManifestEntry(result, component.absPath, componentDirs, options.adapter)
+      if (manifestRow) manifestEntries[manifestRow.manifestKey] = manifestRow.entry
     }
+
+    // Written unconditionally every pass (matching `writeEmits`'s own
+    // no-diffing convention for this eager pass, and the legacy CLI's own
+    // always-write-unless-clientOnly behavior) — `discovered` is always the
+    // FULL current set (see this module's docstring on why this plugin
+    // never does a partial/diffed re-run), so this naturally drops a
+    // deleted component's row without any separate cleanup step. `mkdir`
+    // first: an empty `discovered` set means `writeEmits` never ran (no
+    // targets to create `templatesDir` for), so it may not exist yet.
+    await mkdir(templatesDir, { recursive: true })
+    await writeFile(resolve(templatesDir, 'manifest.json'), JSON.stringify(manifestEntries, null, 2))
+
     return types
   }
 


### PR DESCRIPTION
**Stack 6b/7** — targets #2512. Three new `/vite` subpaths (`@barefootjs/blade`, `@barefootjs/jinja`, `@barefootjs/erb`) and the seven integrations on them.

| Integration | Adapter | E2E |
|---|---|---|
| laravel | blade | 104/104 |
| blade | blade | 104/104 |
| django | jinja | 104/104 |
| fastapi | jinja | 104/104 |
| flask | jinja | 104/104 |
| rails | erb | 104/104 |
| sinatra | erb | 104/104 |

## The second and third `/vite` were *more* mechanical, not less

This batch was chosen to test whether `@barefootjs/go-template/vite` had been shaped around Go. It had — but cleanly, in two separable places that blade/jinja/erb simply shed:

- **No `afterEmit` type-combining at all.** None of these three adapters produce a `types` section (confirmed by reading each `createConfig`, which has no default `postBuild`, unlike Go's). Go needs `randomID` injected, imports merged and duplicate types removed because it fails to compile otherwise; PHP, Python and Ruby have no unused-import error and no such helper. The `afterEmit` bodies are correspondingly near-empty rather than transcriptions of Go's.
- **No `adapterOptions`.** Each of these adapters' only two options — `clientJsBasePath` / `barefootJsPath` — are dead code once Vite always resolves `scriptAssets`. Go's `packageName` and Hono's `clientJsFilename` remain real.

The `assets` mechanism ported over unchanged in shape, emitting plain JSON rather than generated source, since these backends read it at request time and nothing needs committing (unlike Go's tracked `bf_assets.go`).

Import maps deleted in all seven, bringing the running total to **fourteen backends** across five languages where that hand-wiring removed itself.

## Core change: emit the combined component manifest

The first cut of this batch absorbed a pipeline regression on the read side, and that got sent back.

`@barefootjs/vite` writes `ssrDefaults` per component as `<Name>.ssr-defaults.json`; the legacy CLI wrote one combined `dist/templates/manifest.json`. Every `templatesPerComponent` backend reads `ssrDefaults` at request time — there is no compile step to bake it into source the way Go's generated props constructor or Hono's self-contained `.tsx` can. The initial fix globbed and reassembled that shape in each integration's server entrypoint: **seven copies of identical reconstruction logic across three languages**, for an artifact the pipeline used to just hand over. With five more integrations coming in 6c and the legacy CLI deleted in stack 7, it would have become a silent capability regression with nothing left to diff against.

Now emitted from core, alongside the per-component files rather than replacing them — the per-component writes keep dev re-emits cheap, and the combined file is rewritten whole each pass, which the full eager pass already implies. Core rather than the three `/vite` packages because `ssrDefaults` is core-emitted and the shape is backend-neutral; go-template and hono get it for free.

The shape matches `build-cache.ts`'s `ManifestEntry` and `build.ts`'s manifest-building block, verified by reading both rather than inferring from a consumer. Two fields are deliberately not reproduced, and the module says why: `stubDeps` (bookkeeping for the legacy esbuild stub resolution, moot under Rollup's module graph) and `clientJs` (a static non-hashed path superseded by `scriptAssets`, which bakes the real mode-dependent URL into the template's own registration call — grepping the PHP/Python/Ruby runtimes for reads of it returns zero hits).

## One adapter-source change worth a look

Node's native TypeScript type-stripping — on by default since 22.18/23.6 — cannot handle constructor parameter-property shorthand, and Vite's config loader externalizes bare `@barefootjs/*/vite` imports, so `expr/emitters.ts` gets loaded by Node rather than esbuild. Rewritten to explicit field declarations plus assignment in all three adapters, behaviour-preserving, with a comment at the site explaining why it must stay that way. Without that comment someone would tidy it back and break config loading in a way no unit test would catch.

## Testing

E2E per the table, each run twice by the implementing agent. `blade` (PHP) and `flask` (Python) were additionally re-run independently — 104 passed each.

Note for anyone reproducing these locally: unlike hono and h3, these integrations' `playwright.config.ts` starts the server **without** building first, deliberately (production-shaped server, template cache on). Run `bun run build` before `bunx playwright test` or you get `View [...] not found` / `TemplateNotFound`, which looks exactly like a real regression and is not one.

`packages/vite` 116 pass. adapter-blade and adapter-jinja 1260 pass each. adapter-erb has pre-existing local-only failures from a missing `tzinfo` gem and a non-UTF-8 locale for the Ruby subprocess; verified environmental by reproducing them with the change reverted.

## Out of scope

`twig`, `rust`, `mojolicious`, `xslate`, `client` `/vite` and their five integrations (6c). Deleting `createConfig` / `./build` / `barefoot.config.ts` (7).

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ)_