### PR TITLE
feat(twig,rust,mojolicious,xslate): add /vite subpaths and migrate their integrations

### DIFF
--- a/.changeset/vite-mojolicious-vite-mojolicious-migration.md
+++ b/.changeset/vite-mojolicious-vite-mojolicious-migration.md
@@ -1,0 +1,49 @@
+---
+"@barefootjs/mojolicious": minor
+---
+
+Add `@barefootjs/mojolicious/vite`, a composed Vite plugin for Perl/Mojolicious
+
+A new subpath exporting `barefoot` (named AND default, matching core's own
+`packages/vite/src/index.ts` shape, and this PR's other template-string
+adapters' naming, exactly):
+
+```ts
+import { barefoot } from '@barefootjs/mojolicious/vite'
+
+export default defineConfig({
+  base: '/integrations/mojolicious/client/',
+  build: { outDir: 'dist/client' },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    templates: 'dist/templates',
+  }),
+})
+```
+
+No `adapter` option — this constructs `MojoAdapter` itself. Byte-for-byte
+the same shape as `@barefootjs/blade/vite`/`@barefootjs/jinja/vite`/
+`@barefootjs/erb/vite`/`@barefootjs/twig/vite`: no `afterEmit`-driven type
+combination (`MojoAdapter.generate()` never produces a `types` section —
+`./build.ts`'s `createConfig` has no default `postBuild` either), no
+`adapterOptions` (`MojoAdapterOptions`'s two fields are dead once
+`scriptAssets` is always resolved), and `assets` ports over unchanged
+except the generated file is plain JSON (`dist/bf-assets.json`, gitignored,
+regenerated every build) — Perl reads it at request time, nothing to
+commit.
+
+Also carries the same fix the port needed to actually build: `@barefootjs/
+mojolicious/src/adapter/expr/emitters.ts` has the identical TS-constructor-
+parameter-property shape — `MojoFilterEmitter`/`MojoTopLevelEmitter`'s
+constructors rewritten as plain field declarations + explicit assignment.
+
+Mojolicious was not preinstalled in this environment; installed via
+`cpanm --notest Mojolicious` to get a real E2E run rather than an assumed
+one. That real run surfaced a pre-existing, unrelated bug in
+`integrations/mojolicious/app.pl`'s `/blog` route (a missing `root` seed —
+see that migration's own commit), never exercised before because `bun
+test` always skips Mojo rendering when Mojolicious isn't installed.
+
+`integrations/mojolicious` moves onto this package's `/vite` in this PR.
+Its 104-test Playwright E2E suite passes end-to-end against the migrated
+build.

--- a/.changeset/vite-rust-vite-axum-migration.md
+++ b/.changeset/vite-rust-vite-axum-migration.md
@@ -1,0 +1,49 @@
+---
+"@barefootjs/rust": minor
+---
+
+Add `@barefootjs/rust/vite`, a composed Vite plugin for Rust/minijinja
+
+A new subpath exporting `barefoot` (named AND default, matching core's own
+`packages/vite/src/index.ts` shape, and this PR's other template-string
+adapters' naming, exactly):
+
+```ts
+import { barefoot } from '@barefootjs/rust/vite'
+
+export default defineConfig({
+  base: '/integrations/axum/client/',
+  build: { outDir: 'dist/client' },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    templates: 'dist/templates',
+  }),
+})
+```
+
+No `adapter` option — this constructs `MinijinjaAdapter` itself. Byte-for-
+byte the same shape as `@barefootjs/blade/vite`/`@barefootjs/jinja/vite`/
+`@barefootjs/erb/vite`/`@barefootjs/twig/vite`: no `afterEmit`-driven type
+combination (`MinijinjaAdapter.generate()` never produces a `types`
+section — `./build.ts`'s `createConfig` has no default `postBuild`
+either), no `adapterOptions` (`MinijinjaAdapterOptions`'s two fields are
+dead once `scriptAssets` is always resolved), and `assets` ports over
+unchanged except the generated file is plain JSON (`dist/bf-assets.json`,
+gitignored, regenerated every build) — the Rust binary reads it once at
+startup, nothing to commit.
+
+Also carries the same fix the port needed to actually build: `@barefootjs/
+rust/src/adapter/expr/emitters.ts` has the identical TS-constructor-
+parameter-property shape (its own emitter classes are named
+`JinjaFilterEmitter`/`JinjaTopLevelEmitter`, not renamed, since minijinja
+is Jinja2-compatible — pre-existing naming, untouched here) — rewritten as
+plain field declarations + explicit assignment.
+
+Unlike the other four template-string adapters in this stack, this one
+needed a real toolchain check first: `cargo`/`rustc` 1.94.1 were confirmed
+present before planning around `integrations/axum`'s build, so this PR's
+E2E claim for it is a real, not assumed, pass.
+
+`integrations/axum` moves onto this package's `/vite` in this PR. Its
+104-test Playwright E2E suite passes end-to-end against the migrated
+build (verified with a real `cargo build`/`cargo run`).

--- a/.changeset/vite-twig-vite-php-migration.md
+++ b/.changeset/vite-twig-vite-php-migration.md
@@ -1,0 +1,48 @@
+---
+"@barefootjs/twig": minor
+---
+
+Add `@barefootjs/twig/vite`, a composed Vite plugin for PHP/Twig
+
+A new subpath exporting `barefoot` (named AND default, matching core's own
+`packages/vite/src/index.ts` shape, and `@barefootjs/go-template/vite`'s /
+`@barefootjs/hono/vite`'s / `@barefootjs/blade/vite`'s / `@barefootjs/jinja/
+vite`'s / `@barefootjs/erb/vite`'s naming, exactly):
+
+```ts
+import { barefoot } from '@barefootjs/twig/vite'
+
+export default defineConfig({
+  base: '/integrations/php/client/',
+  build: { outDir: 'dist/client' },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    templates: 'dist/templates',
+  }),
+})
+```
+
+No `adapter` option — this constructs `TwigAdapter` itself. Byte-for-byte
+the same shape as `@barefootjs/blade/vite`/`@barefootjs/jinja/vite`/
+`@barefootjs/erb/vite` (see those changesets for the full design writeup):
+no `afterEmit`-driven type combination (`TwigAdapter.generate()` never
+produces a `types` section — `./build.ts`'s `createConfig` has no default
+`postBuild` either), no `adapterOptions` (`TwigAdapterOptions`'s two fields
+are dead once `scriptAssets` is always resolved), and `assets` ports over
+unchanged except the generated file is plain JSON (`dist/bf-assets.json`,
+gitignored, regenerated every build) — PHP reads it at request time,
+nothing to commit.
+
+Also carries the same fix the port needed to actually build: `@barefootjs/
+twig/src/adapter/expr/emitters.ts` has the identical TS-constructor-
+parameter-property shape — `TwigFilterEmitter`/`TwigTopLevelEmitter`'s
+constructors rewritten as plain field declarations + explicit assignment.
+
+Fourth confirmation of the `@barefootjs/blade/vite` changeset's finding:
+writing the SAME `/vite` shape a fourth time, for a fourth template-string
+adapter, was fully mechanical, and needed strictly less than Go's reference
+— not an equal amount reshaped.
+
+`integrations/php` moves onto this package's `/vite` in this PR. Its
+104-test Playwright E2E suite passes end-to-end against the migrated
+build.

--- a/.changeset/vite-xslate-vite-xslate-migration.md
+++ b/.changeset/vite-xslate-vite-xslate-migration.md
@@ -1,0 +1,52 @@
+---
+"@barefootjs/xslate": minor
+---
+
+Add `@barefootjs/xslate/vite`, a composed Vite plugin for Perl/Text::Xslate
+
+A new subpath exporting `barefoot` (named AND default, matching core's own
+`packages/vite/src/index.ts` shape, and this PR's other template-string
+adapters' naming, exactly):
+
+```ts
+import { barefoot } from '@barefootjs/xslate/vite'
+
+export default defineConfig({
+  base: '/integrations/xslate/client/',
+  build: { outDir: 'dist/client' },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    templates: 'dist/templates',
+  }),
+})
+```
+
+No `adapter` option — this constructs `XslateAdapter` itself. Byte-for-byte
+the same shape as `@barefootjs/blade/vite`/`@barefootjs/jinja/vite`/
+`@barefootjs/erb/vite`/`@barefootjs/twig/vite`/`@barefootjs/mojolicious/
+vite`: no `afterEmit`-driven type combination (`XslateAdapter.generate()`
+never produces a `types` section — `./build.ts`'s `createConfig` has no
+default `postBuild` either), no `adapterOptions` (`XslateAdapterOptions`'s
+two fields are dead once `scriptAssets` is always resolved), and `assets`
+ports over unchanged except the generated file is plain JSON
+(`dist/bf-assets.json`, gitignored, regenerated every build) — Perl reads
+it at request time, nothing to commit.
+
+Also carries the same fix the port needed to actually build: `@barefootjs/
+xslate/src/adapter/expr/emitters.ts` has the identical TS-constructor-
+parameter-property shape — `XslateFilterEmitter`/`XslateTopLevelEmitter`'s
+constructors rewritten as plain field declarations + explicit assignment.
+
+Text::Xslate, Plack, and Starman were not preinstalled in this environment;
+installed via `cpanm --notest Text::Xslate Plack Starman JSON::PP` to get a
+real E2E run rather than an assumed one. That real run surfaced two
+pre-existing, unrelated bugs in `integrations/xslate/app.psgi` (a missing
+`root` seed on the `/blog` route's PostList, and a strict-arity Perl
+signature on the generic `render_component` helper's child renderer that
+crashed on the framework's real two-argument renderer contract — see that
+migration's own commit), never exercised before because `bun test` always
+skips Xslate rendering when Text::Xslate isn't installed.
+
+`integrations/xslate` moves onto this package's `/vite` in this PR. Its
+104-test Playwright E2E suite passes end-to-end against the migrated build,
+with both fixes applied.

--- a/integrations/axum/Cargo.lock
+++ b/integrations/axum/Cargo.lock
@@ -31,6 +31,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +92,8 @@ dependencies = [
 name = "barefootjs"
 version = "0.1.0"
 dependencies = [
+ "chrono",
+ "chrono-tz",
  "minijinja",
  "serde",
  "serde_json",
@@ -118,6 +126,25 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
 
 [[package]]
 name = "errno"
@@ -337,6 +364,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +383,24 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -453,6 +507,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/integrations/axum/package.json
+++ b/integrations/axum/package.json
@@ -2,9 +2,10 @@
   "name": "barefootjs-axum-example",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/copy-shared.ts",
-    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "build": "vite build && bun run scripts/gen-blog-data.ts && bun run scripts/copy-shared.ts",
+    "build:watch": "vite dev",
     "dev": "BASE_PATH=/integrations/axum APP_ENV=development PORT=3012 cargo run",
     "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
@@ -18,10 +19,12 @@
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
     "@barefootjs/rust": "workspace:*",
+    "@barefootjs/vite": "workspace:*",
     "@cloudflare/containers": "^0.3.2",
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
+    "vite": "^6.0.0",
     "wrangler": "^4"
   }
 }

--- a/integrations/axum/src/blog.rs
+++ b/integrations/axum/src/blog.rs
@@ -3,13 +3,20 @@
 //! region-shell layout (header + ThemeToggle in the shell, a hand-authored
 //! sidebar region `nav:0` + the compiled `<PageShell>` nested content
 //! region in the main column) whose islands are the shared blog components
-//! in `../shared/blog`, compiled by this integration's `bf build`.
+//! in `../shared/blog`, compiled by this integration's Vite build
+//! (`vite.config.ts`). The client router (`client/router-entry.ts`, its
+//! bundled URL resolved into `state.assets["RouterEntry"]`) fetches a full
+//! HTML page for every navigation and diffs `[bf-region]` boundaries
+//! client-side, so every route below just returns a normal HTML document.
 //!
-//! There is no special server-side "partial navigation" endpoint: the
-//! client router (`client/router-entry.ts`, bundled to `client/router-
-//! entry.js`) fetches a full HTML page for every navigation and diffs
-//! `[bf-region]` boundaries client-side, so every route below just returns
-//! a normal HTML document.
+//! No import map is needed (unlike the pre-Vite build): the router
+//! bundle's `@barefootjs/client/runtime` import and every compiled
+//! island's own `@barefootjs/client` import are ordinary ESM imports
+//! Rollup/Vite resolve through their real module graph, collapsing into
+//! ONE shared chunk (build) or ONE cached module (dev) automatically -- a
+//! single reactive runtime instance without any hand-wired specifier
+//! redirection. That this hand-written wiring could simply be deleted is
+//! the point of the Vite-based design, not an incidental cleanup.
 //!
 //! `PostList`'s own `params` memo returns an OBJECT built through a helper
 //! function, and `sortClass`/`tagClass` are plain functions called with
@@ -151,15 +158,6 @@ fn blog_base(state: &AppState) -> String {
     format!("{}/blog", state.base)
 }
 
-fn import_map(state: &AppState) -> String {
-    let bjs = format!("{}/client/barefoot.js", state.base);
-    let json = format!(
-        r#"{{"imports":{{"@barefootjs/client":{b:?},"@barefootjs/client/runtime":{b:?},"@barefootjs/client/reactive":{b:?}}}}}"#,
-        b = bjs
-    );
-    json.replace('<', "\\u003c")
-}
-
 fn esc(s: &str) -> String {
     s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
 }
@@ -173,7 +171,7 @@ fn blog_page(state: &AppState, session: &std::sync::Arc<barefootjs::RenderSessio
     let sidebar = render_island(state, session, "Sidebar", empty_obj(), empty_obj())?;
     let (shell, _) = render_component_with_raw_children(state, session, "PageShell", empty_obj(), empty_obj(), content_html)?;
     let scripts = scripts_html(session);
-    let static_base = format!("{}/client", state.base);
+    let router_entry = state.assets.get("RouterEntry").cloned().unwrap_or_default();
 
     Ok(format!(
         r#"<!DOCTYPE html>
@@ -182,7 +180,6 @@ fn blog_page(state: &AppState, session: &std::sync::Arc<barefootjs::RenderSessio
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{title}</title>
-<script type="importmap">{import_map}</script>
 <link rel="stylesheet" href="{base_styles}/styles/blog.css">
 </head>
 <body>
@@ -195,19 +192,18 @@ fn blog_page(state: &AppState, session: &std::sync::Arc<barefootjs::RenderSessio
 <main>{shell}</main>
 </div>
 {scripts}
-<script type="module" src="{static_base}/router-entry.js"></script>
+<script type="module" src="{router_entry}"></script>
 </body>
 </html>
 "#,
         title = esc(title),
-        import_map = import_map(state),
         base_styles = state.base,
         base = base,
         theme = theme,
         sidebar = sidebar,
         shell = shell,
         scripts = scripts,
-        static_base = static_base,
+        router_entry = router_entry,
     ))
 }
 

--- a/integrations/axum/src/main.rs
+++ b/integrations/axum/src/main.rs
@@ -22,6 +22,7 @@ use barefootjs::backend_minijinja;
 use barefootjs::JsValue;
 use minijinja::Environment;
 use render::{empty_obj, jb, jobj, js, jn, new_session, render_component};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tower_http::services::ServeDir;
@@ -36,6 +37,15 @@ pub struct AppState {
     /// request in dev instead).
     pub env: Arc<Environment<'static>>,
     pub manifest: Arc<JsValue>,
+    /// The Vite-generated asset map (`dist/bf-assets.json`, written by
+    /// `@barefootjs/rust/vite`'s `afterEmit` hook) -- resolves a
+    /// hand-written, non-component script entry's bundled URL (dev: Vite
+    /// origin URL; production: content-hashed manifest path). Read once at
+    /// startup, same rationale as `manifest` above: there is no compile
+    /// step needing the URL baked in ahead of time -- a fresh copy lands
+    /// under gitignored `dist/` on every build (dev AND production). See
+    /// `blog.rs`'s use for `RouterEntry`.
+    pub assets: Arc<HashMap<String, String>>,
     pub blog: Arc<blog::BlogData>,
     pub sessions: Arc<session::SessionStore>,
 }
@@ -46,6 +56,19 @@ fn base_path() -> String {
 
 fn is_dev() -> bool {
     std::env::var("APP_ENV").map(|v| v == "development").unwrap_or(false)
+}
+
+/// Read `dist/bf-assets.json` (see `AppState.assets`'s docstring) into a
+/// flat `name -> url` map, degrading to empty on a missing/unparsable file
+/// (a fresh build always regenerates it; a missing file just means
+/// `bun run build` hasn't run yet, same fallback as `load_manifest`'s
+/// caller above).
+fn load_assets(path: &PathBuf) -> HashMap<String, String> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(_) => return HashMap::new(),
+    };
+    serde_json::from_str(&text).unwrap_or_default()
 }
 
 #[tokio::main]
@@ -64,6 +87,7 @@ async fn main() {
     };
     let env = backend_minijinja::build_environment(&templates_dir);
     let blog_data = blog::load_blog_data(&PathBuf::from("dist/blog-data.json"));
+    let assets = load_assets(&PathBuf::from("dist/bf-assets.json"));
 
     let state = AppState {
         base: Arc::new(base.clone()),
@@ -71,6 +95,7 @@ async fn main() {
         templates_dir: Arc::new(templates_dir),
         env: Arc::new(env),
         manifest: Arc::new(manifest),
+        assets: Arc::new(assets),
         blog: Arc::new(blog_data),
         sessions: Arc::new(session::SessionStore::new()),
     };

--- a/integrations/axum/vite.config.ts
+++ b/integrations/axum/vite.config.ts
@@ -1,0 +1,44 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { barefoot } from '@barefootjs/rust/vite'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const basePath = process.env.BASE_PATH ?? '/integrations/axum'
+const routerEntry = resolve(HERE, 'client/router-entry.ts')
+
+// This app's own Rollup entry: `client/router-entry.ts` (the
+// `@barefootjs/router` bootstrap for the blog) is a hand-written script,
+// not a `.tsx` component, so `barefoot()`'s own discovery never sees it —
+// per the design, bundling configuration is stock Vite config this plugin
+// never adds on the app's behalf. `assets.RouterEntry` below (Rust-
+// specific) only resolves the URL Vite bundles this to; THIS is what
+// requests the bundling.
+export default defineConfig({
+  base: `${basePath}/client/`,
+  build: {
+    // Scoped to `dist/client` (not the whole `dist`), matching the existing
+    // `.nest_service("/client", ServeDir::new("dist/client"))` route in
+    // main.rs -- the templates dir below is a SEPARATE, non-web-exposed
+    // directory the Rust binary reads locally, never served over HTTP.
+    outDir: 'dist/client',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: { 'router-entry': routerEntry },
+    },
+  },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    // Matches the legacy CLI's output layout exactly (`outputLayout:
+    // { templates: 'templates', clientJs: 'client', runtime: 'client' }`
+    // under `outDir: 'dist'`) -- `main.rs` reads `dist/templates` and
+    // `dist/templates/manifest.json` directly; neither is served over HTTP.
+    templates: 'dist/templates',
+    // blog_page() no longer hand-writes `.../client/router-entry.js` (it's
+    // content-hashed under Vite) or a `barefoot.js` importmap entry (the
+    // runtime is a shared ESM chunk the browser follows on its own — see
+    // blog.rs's module docstring). `dist/bf-assets.json`'s `["RouterEntry"]`
+    // is what `AppState.assets` reads instead.
+    assets: { RouterEntry: routerEntry },
+  }),
+})

--- a/integrations/mojolicious/app.pl
+++ b/integrations/mojolicious/app.pl
@@ -426,8 +426,18 @@ $r->post('/api/todos/reset' => sub ($c) {
 # ThemeToggle in the shell, a hand-authored sidebar region `nav:0` + the
 # compiled <PageShell> nested content regions in the main column) whose islands
 # are the shared blog components in ../shared/blog, compiled by this
-# integration's `bf build`. The client router (client/router-entry.ts, bundled
-# to client/router-entry.js) swaps only the content region on navigation.
+# integration's Vite build (vite.config.ts). The client router
+# (client/router-entry.ts, its bundled URL resolved into
+# $BLOG_ASSETS->{RouterEntry}) swaps only the content region on navigation.
+#
+# No import map is needed (unlike the pre-Vite build): the router bundle's
+# @barefootjs/client/runtime import and every compiled island's own
+# @barefootjs/client import are ordinary ESM imports Rollup/Vite resolve
+# through their real module graph, collapsing into ONE shared chunk (build)
+# or ONE cached module (dev) automatically — a single reactive runtime
+# instance without any hand-wired specifier redirection. That this
+# hand-written wiring could simply be deleted is the point of the
+# Vite-based design, not an incidental cleanup.
 #
 # Unlike Hono — where the whole page is one JSX tree — there is no server JSX
 # here: the page is composed in Perl from individually-rendered island
@@ -444,6 +454,17 @@ $r->post('/api/todos/reset' => sub ($c) {
 
 my $BLOG_MANIFEST = do {
     my $f = app->home->child('dist/templates/manifest.json');
+    -r $f ? decode_json($f->slurp) : {};
+};
+# The Vite-generated asset map (dist/bf-assets.json, written by
+# `@barefootjs/mojolicious/vite`'s `afterEmit` hook) — resolves a
+# hand-written, non-component script entry's bundled URL (dev: Vite origin
+# URL; production: content-hashed manifest path). Read once at startup,
+# same rationale as $BLOG_MANIFEST above: there is no compile step needing
+# the URL baked in ahead of time — a fresh copy lands under gitignored
+# dist/ on every build (dev AND production).
+my $BLOG_ASSETS = do {
+    my $f = app->home->child('dist/bf-assets.json');
     -r $f ? decode_json($f->slurp) : {};
 };
 my $BLOG_DATA = do {
@@ -525,7 +546,6 @@ helper blog_island => sub ($c, $component, $props = {}, $extra = {}, $children =
 
 # Assemble the full region-shell page around already-rendered content HTML.
 sub _blog_page ($c, $title, $base, $content_html) {
-    my $static = "$BASE_PATH/client";
     my $theme   = $c->blog_island('ThemeToggle');
     my $sidebar = $c->blog_island('Sidebar');
     my $shell   = $c->blog_island(
@@ -534,15 +554,7 @@ sub _blog_page ($c, $title, $base, $content_html) {
         { children => b($content_html) },         # SSR-only: the page content
         { reader_toolbar => 'ReaderToolbar' },
     );
-    # `searchParams()` lives in the single physical `@barefootjs/client/reactive`
-    # module re-exported by every `@barefootjs/client*` entry, so the islands and
-    # the router bootstrap share ONE signal instance by resolving the bare
-    # specifiers to the same `barefoot.js`.
-    my $importmap = encode_json({ imports => {
-        '@barefootjs/client'         => "$static/barefoot.js",
-        '@barefootjs/client/runtime' => "$static/barefoot.js",
-        '@barefootjs/client/reactive'=> "$static/barefoot.js",
-    } });
+    my $router_entry = $BLOG_ASSETS->{RouterEntry} // '';
     my $scripts = $c->bf->scripts;
     my $esc_title = xml_escape($title);
     return <<"HTML";
@@ -552,7 +564,6 @@ sub _blog_page ($c, $title, $base, $content_html) {
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>$esc_title</title>
-<script type="importmap">$importmap</script>
 <link rel="stylesheet" href="$BASE_PATH/styles/blog.css">
 </head>
 <body>
@@ -565,7 +576,7 @@ sub _blog_page ($c, $title, $base, $content_html) {
 <main>$shell</main>
 </div>
 $scripts
-<script type="module" src="$static/router-entry.js"></script>
+<script type="module" src="$router_entry"></script>
 </body>
 </html>
 HTML
@@ -600,6 +611,15 @@ $r_blog->get('/blog' => sub ($c) {
             sortHref  => $base,
             tagClass  => 'tag',
             tagHref   => $base,
+            # `bf->query($root, ...)`'s first arg is the plain base-URL STRING
+            # every per-link sort/tag href builds against (see
+            # BarefootJS.pm's `query`, and integrations/php's/integrations/
+            # flask's identical `'root' => $base` seed) -- unrelated to the
+            # Vite migration, but was missing here, so every PostList render
+            # died with "Global symbol '$root' requires explicit package
+            # name" the first time this route was exercised against a real
+            # perl/Mojolicious (previously always skipped in `bun test`).
+            root      => $base,
         },
         { post_list_item => 'PostListItem' },
     );

--- a/integrations/mojolicious/package.json
+++ b/integrations/mojolicious/package.json
@@ -2,9 +2,10 @@
   "name": "barefootjs-mojolicious-example",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts",
-    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "build": "vite build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts",
+    "build:watch": "vite dev",
     "dev": "BASE_PATH=/integrations/mojolicious perl app.pl daemon -l 'http://*:3004'",
     "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
@@ -17,10 +18,12 @@
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
     "@barefootjs/mojolicious": "workspace:*",
+    "@barefootjs/vite": "workspace:*",
     "@cloudflare/containers": "^0.3.2",
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
+    "vite": "^6.0.0",
     "wrangler": "^4"
   }
 }

--- a/integrations/mojolicious/vite.config.ts
+++ b/integrations/mojolicious/vite.config.ts
@@ -1,0 +1,45 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { barefoot } from '@barefootjs/mojolicious/vite'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const basePath = process.env.BASE_PATH ?? '/integrations/mojolicious'
+const routerEntry = resolve(HERE, 'client/router-entry.ts')
+
+// This app's own Rollup entry: `client/router-entry.ts` (the
+// `@barefootjs/router` bootstrap for the blog) is a hand-written script,
+// not a `.tsx` component, so `barefoot()`'s own discovery never sees it —
+// per the design, bundling configuration is stock Vite config this plugin
+// never adds on the app's behalf. `assets.RouterEntry` below (Mojolicious-
+// specific) only resolves the URL Vite bundles this to; THIS is what
+// requests the bundling.
+export default defineConfig({
+  base: `${basePath}/client/`,
+  build: {
+    // Scoped to `dist/client` (not the whole `dist`), matching the existing
+    // static-path proxy in app.pl (`/$BASE_PATH/client/*` -> `reply->static
+    // ('client/...')` against `app->static->paths->[0]` = `dist`) — the
+    // templates dir below is a SEPARATE, non-web-exposed directory Perl
+    // reads locally, never served over HTTP.
+    outDir: 'dist/client',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: { 'router-entry': routerEntry },
+    },
+  },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    // Matches the legacy CLI's output layout exactly (`outputLayout:
+    // { templates: 'templates', clientJs: 'client', runtime: 'client' }`
+    // under `outDir: 'dist'`) — app.pl reads `dist/templates` directly; it
+    // is never served over HTTP.
+    templates: 'dist/templates',
+    // _blog_page() no longer hand-writes `.../client/router-entry.js`
+    // (it's content-hashed under Vite) or a `barefoot.js` importmap entry
+    // (the runtime is a shared ESM chunk the browser follows on its own —
+    // see app.pl's blog section docstring). `dist/bf-assets.json`'s
+    // `["RouterEntry"]` is what app.pl's `$BLOG_ASSETS` reads instead.
+    assets: { RouterEntry: routerEntry },
+  }),
+})

--- a/integrations/php/index.php
+++ b/integrations/php/index.php
@@ -92,6 +92,16 @@ $backend = new TwigBackend([
 $manifestPath = $HERE . '/dist/templates/manifest.json';
 $MANIFEST = is_file($manifestPath) ? (json_decode(file_get_contents($manifestPath), true) ?: []) : [];
 
+// The Vite-generated asset map (dist/bf-assets.json, written by
+// `@barefootjs/twig/vite`'s `afterEmit` hook) -- resolves a hand-written,
+// non-component script entry's bundled URL (dev: Vite origin URL;
+// production: content-hashed manifest path). Read once at request time,
+// same rationale as $MANIFEST above: PHP has no compile step, so there is
+// nothing to commit -- a fresh copy lands under gitignored dist/ on every
+// build (dev AND production).
+$assetsPath = $HERE . '/dist/bf-assets.json';
+$ASSETS = is_file($assetsPath) ? (json_decode(file_get_contents($assetsPath), true) ?: []) : [];
+
 // The blog post corpus -- generated at build time by scripts/gen-blog-data.ts
 // from ../shared/blog/posts.ts (the single TS source of truth the JS adapters
 // import directly; this PHP server reads the JSON mirror instead). See
@@ -470,9 +480,19 @@ HTML;
 // Mojolicious ports): a region-shell layout (header + ThemeToggle in the
 // shell, a hand-authored sidebar region `nav:0` + the compiled <PageShell>
 // nested content regions in the main column) whose islands are the shared
-// blog components in ../shared/blog, compiled by this integration's
-// `bf build`. The client router (client/router-entry.ts, bundled to
-// client/router-entry.js) swaps only the content region.
+// blog components in ../shared/blog, compiled by this integration's Vite
+// build (vite.config.ts). The client router (client/router-entry.ts,
+// its bundled URL resolved into $ASSETS['RouterEntry']) swaps only the
+// content region.
+//
+// No import map is needed (unlike the pre-Vite build): the router bundle's
+// `@barefootjs/client/runtime` import and every compiled island's own
+// `@barefootjs/client` import are ordinary ESM imports Rollup/Vite resolve
+// through their real module graph, collapsing into ONE shared chunk
+// (build) or ONE cached module (dev) automatically -- a single reactive
+// runtime instance without any hand-wired specifier redirection. That this
+// hand-written wiring could simply be deleted is the point of the
+// Vite-based design, not an incidental cleanup.
 //
 // There is no special server-side "partial navigation" endpoint: the router
 // (packages/router/src/router.ts) fetches a full HTML page for every
@@ -580,8 +600,7 @@ function blog_island(BarefootJS $root, string $component, array $props = [], arr
  * islands (and the shell islands rendered here) all share. */
 function blog_page(BarefootJS $root, string $title, string $base, string $contentHtml): string
 {
-    global $BASE;
-    $static = "{$BASE}/client";
+    global $BASE, $ASSETS;
     $theme = blog_island($root, 'ThemeToggle');
     $sidebar = blog_island($root, 'Sidebar');
     $shell = blog_island(
@@ -591,14 +610,8 @@ function blog_page(BarefootJS $root, string $title, string $base, string $conten
         ['children' => $root->backend->mark_raw($contentHtml)], // SSR-only: page content
         ['reader_toolbar' => 'ReaderToolbar'],
     );
-    $importMap = json_encode([
-        'imports' => [
-            '@barefootjs/client' => "{$static}/barefoot.js",
-            '@barefootjs/client/runtime' => "{$static}/barefoot.js",
-            '@barefootjs/client/reactive' => "{$static}/barefoot.js",
-        ],
-    ]);
     $scripts = $root->scripts();
+    $routerEntry = $ASSETS['RouterEntry'] ?? '';
     $escTitle = htmlspecialchars($title, ENT_QUOTES);
     return <<<HTML
 <!DOCTYPE html>
@@ -607,7 +620,6 @@ function blog_page(BarefootJS $root, string $title, string $base, string $conten
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{$escTitle}</title>
-<script type="importmap">{$importMap}</script>
 <link rel="stylesheet" href="{$BASE}/styles/blog.css">
 </head>
 <body>
@@ -620,7 +632,7 @@ function blog_page(BarefootJS $root, string $title, string $base, string $conten
 <main>{$shell}</main>
 </div>
 {$scripts}
-<script type="module" src="{$static}/router-entry.js"></script>
+<script type="module" src="{$routerEntry}"></script>
 </body>
 </html>
 HTML;

--- a/integrations/php/package.json
+++ b/integrations/php/package.json
@@ -2,9 +2,10 @@
   "name": "barefootjs-php-example",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts && composer install --no-interaction --no-progress",
-    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "build": "vite build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts && composer install --no-interaction --no-progress",
+    "build:watch": "vite dev",
     "dev": "PHP_CLI_SERVER_WORKERS=8 BASE_PATH=/integrations/php PORT=3013 php -S 0.0.0.0:3013 index.php",
     "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
@@ -18,10 +19,12 @@
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
     "@barefootjs/twig": "workspace:*",
+    "@barefootjs/vite": "workspace:*",
     "@cloudflare/containers": "^0.3.2",
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
+    "vite": "^6.0.0",
     "wrangler": "^4"
   }
 }

--- a/integrations/php/vite.config.ts
+++ b/integrations/php/vite.config.ts
@@ -1,0 +1,44 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { barefoot } from '@barefootjs/twig/vite'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const basePath = process.env.BASE_PATH ?? '/integrations/php'
+const routerEntry = resolve(HERE, 'client/router-entry.ts')
+
+// This app's own Rollup entry: `client/router-entry.ts` (the
+// `@barefootjs/router` bootstrap for the blog) is a hand-written script,
+// not a `.tsx` component, so `barefoot()`'s own discovery never sees it —
+// per the design, bundling configuration is stock Vite config this plugin
+// never adds on the app's behalf. `assets.RouterEntry` below (Twig-
+// specific) only resolves the URL Vite bundles this to; THIS is what
+// requests the bundling.
+export default defineConfig({
+  base: `${basePath}/client/`,
+  build: {
+    // Scoped to `dist/client` (not the whole `dist`), matching the existing
+    // `serve_static_file($HERE . '/dist/client', ...)` route in index.php —
+    // the templates dir below is a SEPARATE, non-web-exposed directory PHP
+    // reads locally, never served over HTTP.
+    outDir: 'dist/client',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: { 'router-entry': routerEntry },
+    },
+  },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    // Matches the legacy CLI's output layout exactly (`outputLayout:
+    // { templates: 'templates', clientJs: 'client', runtime: 'client' }`
+    // under `outDir: 'dist'`) — `$backend` (TwigBackend) reads
+    // `dist/templates` directly; it is never served over HTTP.
+    templates: 'dist/templates',
+    // blog_page() no longer hand-writes `.../client/router-entry.js` (it's
+    // content-hashed under Vite) or a `barefoot.js` importmap entry (the
+    // runtime is a shared ESM chunk the browser follows on its own — see
+    // index.php's blog section docstring). `dist/bf-assets.json`'s
+    // `["RouterEntry"]` is what index.php's `assets()` reads instead.
+    assets: { RouterEntry: routerEntry },
+  }),
+})

--- a/integrations/xslate/app.psgi
+++ b/integrations/xslate/app.psgi
@@ -108,7 +108,17 @@ sub render_component ($component, %opts) {
     for my $child_name (keys %$children) {
         my $child_template = $children->{$child_name};
         my $child_init     = $signal_init->{$child_name};
-        $bf->register_child_renderer($child_name, sub ($props) {
+        # `$props, $caller` (renderer contract #1897 -- see BarefootJS.pm's
+        # `render_child`): a renderer is always invoked with the INVOKING
+        # instance too, since a renderer registered on the root may be
+        # called from a nested child render. `$caller` isn't needed for a
+        # top-level flat child of a standalone component page (unlike the
+        # blog's `_register_blog_child`, which chains off it) -- but this
+        # sub's signature must still ACCEPT it, or a two-arg call fails
+        # arity checking outright (was `sub ($props)`, unrelated to the
+        # Vite migration; surfaced once real perl/Text::Xslate first ran
+        # this route end to end).
+        $bf->register_child_renderer($child_name, sub ($props, $caller = undef) {
             my $child_bf = BarefootJS->new(undef, { backend => $backend });
             # Loop children carry no _bf_slot; fall back to template + suffix so
             # each instance gets a distinct scope id (client JS finds children
@@ -329,8 +339,18 @@ sub api_todos_reset ($req) {
 # layout (header + ThemeToggle in the shell, a hand-authored sidebar region
 # `nav:0` + the compiled <PageShell> nested content regions in the main column)
 # whose islands are the shared blog components in ../shared/blog, compiled by
-# this integration's `bf build`. The client router (client/router-entry.ts,
-# bundled to client/router-entry.js) swaps only the content region.
+# this integration's Vite build (vite.config.ts). The client router
+# (client/router-entry.ts, its bundled URL resolved into
+# $BLOG_ASSETS->{RouterEntry}) swaps only the content region.
+#
+# No import map is needed (unlike the pre-Vite build): the router bundle's
+# @barefootjs/client/runtime import and every compiled island's own
+# @barefootjs/client import are ordinary ESM imports Rollup/Vite resolve
+# through their real module graph, collapsing into ONE shared chunk (build)
+# or ONE cached module (dev) automatically — a single reactive runtime
+# instance without any hand-wired specifier redirection. That this
+# hand-written wiring could simply be deleted is the point of the
+# Vite-based design, not an incidental cleanup.
 #
 # There is no server JSX here: the page is composed in Perl from individually-
 # rendered island templates (`blog_island`), each sharing one request-scoped
@@ -351,6 +371,14 @@ sub _slurp_json ($path) {
     return eval { $J->decode($content) };
 }
 my $BLOG_MANIFEST = _slurp_json('dist/templates/manifest.json') // {};
+# The Vite-generated asset map (dist/bf-assets.json, written by
+# `@barefootjs/xslate/vite`'s `afterEmit` hook) — resolves a hand-written,
+# non-component script entry's bundled URL (dev: Vite origin URL;
+# production: content-hashed manifest path). Read once at startup, same
+# rationale as $BLOG_MANIFEST above: there is no compile step needing the
+# URL baked in ahead of time — a fresh copy lands under gitignored dist/ on
+# every build (dev AND production).
+my $BLOG_ASSETS = _slurp_json('dist/bf-assets.json') // {};
 my $BLOG_DATA = _slurp_json('dist/blog-data.json')
     // { posts => [], listItems => [], allTags => [] };
 
@@ -414,18 +442,13 @@ sub blog_island ($root, $component, $props = {}, $extra = {}, $children = {}) {
 # is the request-scoped runtime whose script collector the content islands (and
 # the shell islands rendered here) all share.
 sub blog_page ($root, $title, $base, $content_html) {
-    my $static    = "$BASE/client";
     my $theme     = blog_island($root, 'ThemeToggle');
     my $sidebar   = blog_island($root, 'Sidebar');
     my $shell     = blog_island($root, 'PageShell',
         {},                                                # no client props
         { children => $backend->mark_raw($content_html) }, # SSR-only: page content
         { reader_toolbar => 'ReaderToolbar' });
-    my $importmap = $J->encode({ imports => {
-        '@barefootjs/client'          => "$static/barefoot.js",
-        '@barefootjs/client/runtime'  => "$static/barefoot.js",
-        '@barefootjs/client/reactive' => "$static/barefoot.js",
-    } });
+    my $router_entry = $BLOG_ASSETS->{RouterEntry} // '';
     my $scripts   = $root->scripts;
     my $esc_title = _esc($title);
     return <<"HTML";
@@ -435,7 +458,6 @@ sub blog_page ($root, $title, $base, $content_html) {
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>$esc_title</title>
-<script type="importmap">$importmap</script>
 <link rel="stylesheet" href="$BASE/styles/blog.css">
 </head>
 <body>
@@ -448,7 +470,7 @@ sub blog_page ($root, $title, $base, $content_html) {
 <main>$shell</main>
 </div>
 $scripts
-<script type="module" src="$static/router-entry.js"></script>
+<script type="module" src="$router_entry"></script>
 </body>
 </html>
 HTML
@@ -477,6 +499,15 @@ sub blog_index_route ($req) {
             sortHref  => $base,
             tagClass  => 'tag',
             tagHref   => $base,
+            # `bf.query($root, ...)`'s first arg is the plain base-URL STRING
+            # every per-link sort/tag href builds against (see
+            # BarefootJS.pm's `query`, and integrations/php's/integrations/
+            # flask's identical `'root' => $base` seed) -- unrelated to the
+            # Vite migration, but was missing here, so every PostList render
+            # died with "Global symbol '$root' requires explicit package
+            # name" the first time this route was exercised against a real
+            # perl/Text::Xslate (previously always skipped in `bun test`).
+            root      => $base,
         },
         { post_list_item => 'PostListItem' });
     my $now = blog_island($root, 'NowPlaying', {}, { Math => { min => 0 } });

--- a/integrations/xslate/package.json
+++ b/integrations/xslate/package.json
@@ -2,9 +2,10 @@
   "name": "barefootjs-xslate-example",
   "version": "0.1.4",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts",
-    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "build": "vite build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts",
+    "build:watch": "vite dev",
     "dev": "BASE_PATH=/integrations/xslate plackup -s Starman --workers 5 -p 3007 app.psgi",
     "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
@@ -17,10 +18,12 @@
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
     "@barefootjs/xslate": "workspace:*",
+    "@barefootjs/vite": "workspace:*",
     "@cloudflare/containers": "^0.3.2",
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
+    "vite": "^6.0.0",
     "wrangler": "^4"
   }
 }

--- a/integrations/xslate/vite.config.ts
+++ b/integrations/xslate/vite.config.ts
@@ -1,0 +1,44 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { barefoot } from '@barefootjs/xslate/vite'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const basePath = process.env.BASE_PATH ?? '/integrations/xslate'
+const routerEntry = resolve(HERE, 'client/router-entry.ts')
+
+// This app's own Rollup entry: `client/router-entry.ts` (the
+// `@barefootjs/router` bootstrap for the blog) is a hand-written script,
+// not a `.tsx` component, so `barefoot()`'s own discovery never sees it —
+// per the design, bundling configuration is stock Vite config this plugin
+// never adds on the app's behalf. `assets.RouterEntry` below (Xslate-
+// specific) only resolves the URL Vite bundles this to; THIS is what
+// requests the bundling.
+export default defineConfig({
+  base: `${basePath}/client/`,
+  build: {
+    // Scoped to `dist/client` (not the whole `dist`), matching the existing
+    // `Plack::App::File->new(root => 'dist/client')` mount in app.psgi —
+    // the templates dir below is a SEPARATE, non-web-exposed directory
+    // Perl reads locally, never served over HTTP.
+    outDir: 'dist/client',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: { 'router-entry': routerEntry },
+    },
+  },
+  plugins: barefoot({
+    components: ['../shared/components', '../shared/blog'],
+    // Matches the legacy CLI's output layout exactly (`outputLayout:
+    // { templates: 'templates', clientJs: 'client', runtime: 'client' }`
+    // under `outDir: 'dist'`) — app.psgi reads `dist/templates` directly;
+    // it is never served over HTTP.
+    templates: 'dist/templates',
+    // blog_page() no longer hand-writes `.../client/router-entry.js` (it's
+    // content-hashed under Vite) or a `barefoot.js` importmap entry (the
+    // runtime is a shared ESM chunk the browser follows on its own — see
+    // app.psgi's blog section docstring). `dist/bf-assets.json`'s
+    // `["RouterEntry"]` is what app.psgi's `$BLOG_ASSETS` reads instead.
+    assets: { RouterEntry: routerEntry },
+  }),
+})

--- a/packages/adapter-mojolicious/e2e-fixture/client/bootstrap.ts
+++ b/packages/adapter-mojolicious/e2e-fixture/client/bootstrap.ts
@@ -1,0 +1,8 @@
+/**
+ * A hand-written, non-component script entry — stands in for
+ * `integrations/mojolicious/client/router-entry.ts` in tests: not a `.tsx`
+ * component, so core's discovery/`scriptAssets` machinery never sees it,
+ * but its bundled URL still needs to reach the compiled Perl blog shell
+ * (the `assets`/`assetsOutputFile` option under test).
+ */
+export const bootstrapped = true

--- a/packages/adapter-mojolicious/e2e-fixture/src/components/Counter.tsx
+++ b/packages/adapter-mojolicious/e2e-fixture/src/components/Counter.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export interface CounterProps {
+  initial: number
+}
+
+export function Counter(props: CounterProps) {
+  const [count, setCount] = createSignal(props.initial)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}

--- a/packages/adapter-mojolicious/package.json
+++ b/packages/adapter-mojolicious/package.json
@@ -20,6 +20,10 @@
     "./build": {
       "types": "./src/build.ts",
       "import": "./src/build.ts"
+    },
+    "./vite": {
+      "types": "./src/vite.ts",
+      "import": "./src/vite.ts"
     }
   },
   "publishConfig": {
@@ -38,6 +42,10 @@
       "./build": {
         "types": "./dist/build.d.ts",
         "import": "./dist/build.js"
+      },
+      "./vite": {
+        "types": "./dist/vite.d.ts",
+        "import": "./dist/vite.js"
       }
     }
   },
@@ -48,7 +56,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external typescript",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external typescript --external @barefootjs/vite --external vite",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",
@@ -75,10 +83,23 @@
   },
   "peerDependencies": {
     "@barefootjs/jsx": ">=0.2.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "@barefootjs/vite": ">=0.2.0",
+    "vite": "^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@barefootjs/vite": {
+      "optional": true
+    },
+    "vite": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@barefootjs/adapter-tests": "workspace:*",
-    "@barefootjs/jsx": "workspace:*"
+    "@barefootjs/jsx": "workspace:*",
+    "@barefootjs/vite": "workspace:*",
+    "@barefootjs/client": "workspace:*",
+    "vite": "^6.0.0"
   }
 }

--- a/packages/adapter-mojolicious/src/__tests__/vite.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/vite.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Coverage of `@barefootjs/mojolicious/vite`'s `barefoot()`:
+ *
+ * - one real `vite build()` end to end (mirrors `@barefootjs/go-template/
+ *   vite`, `@barefootjs/hono/vite`, `@barefootjs/blade/vite`'s,
+ *   `@barefootjs/jinja/vite`'s, and `@barefootjs/erb/vite`'s own
+ *   `vite.test.ts` rigor — a plugin that only passes mocked unit tests
+ *   hasn't been shown to work) against a checked-in fixture (not a system
+ *   tmpdir) so `@barefootjs/client` resolves through the monorepo's real
+ *   node_modules symlinks;
+ * - the `assets` → generated `bf-assets.json` behavior, exercised the same
+ *   way (a real build, since it needs the real manifest Vite writes).
+ *
+ * Unlike Go, there is no `afterEmit`-driven type-combination step to test
+ * here (see `vite.ts`'s module docstring) — `MojoAdapter.generate()` never
+ * produces a `types` section at all, so `barefoot()` always returns a
+ * single-element array unless `assets` is set.
+ */
+import { describe, test, expect } from 'bun:test'
+import { build } from 'vite'
+import { mkdtemp, rm, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { barefoot, barefoot as defaultBarefoot } from '../vite.ts'
+
+const FIXTURE_ROOT = resolve(import.meta.dirname, '../../e2e-fixture')
+
+describe('@barefootjs/mojolicious/vite: real vite build', () => {
+  test('exports the same function as both named `barefoot` and default', () => {
+    expect(defaultBarefoot).toBe(barefoot)
+  })
+
+  test('returns a single-element plugin array when `assets` is omitted', () => {
+    const plugins = barefoot({ components: ['src/components'], templates: 'views' })
+    expect(plugins).toHaveLength(1)
+  })
+
+  test('writes a self-contained .html.ep template with scriptAssets baked in, same as core alone would do', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-mojolicious-vite-dist-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-mojolicious-vite-views-'))
+
+    try {
+      await build({
+        configFile: false,
+        root: FIXTURE_ROOT,
+        base: '/static/build/',
+        logLevel: 'warn',
+        build: { outDir, emptyOutDir: true },
+        plugins: barefoot({
+          components: ['src/components'],
+          templates: templatesDir,
+        }),
+      })
+
+      const template = await readFile(join(templatesDir, 'Counter.html.ep'), 'utf8')
+      expect(template).toContain("bf->register_script(")
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  test('`assets` resolves a non-component entry\'s manifest-hashed URL into a generated JSON asset map', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-mojolicious-vite-dist-assets-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-mojolicious-vite-views-assets-'))
+    const assetsPath = join(FIXTURE_ROOT, 'dist/bf-assets.json')
+
+    try {
+      await build({
+        configFile: false,
+        root: FIXTURE_ROOT,
+        base: '/static/build/',
+        logLevel: 'warn',
+        build: {
+          outDir,
+          emptyOutDir: true,
+          // Registering the non-component entry is the CALLER's job (stock
+          // Vite config) — `assets` below only resolves the URL Vite
+          // already bundled it to, it doesn't request the bundling.
+          rollupOptions: { input: { bootstrap: resolve(FIXTURE_ROOT, 'client/bootstrap.ts') } },
+        },
+        plugins: barefoot({
+          components: ['src/components'],
+          templates: templatesDir,
+          assets: { Bootstrap: 'client/bootstrap.ts' },
+        }),
+      })
+
+      const manifest = JSON.parse(await readFile(join(outDir, '.vite/manifest.json'), 'utf8'))
+      const expectedUrl = `/static/build/${manifest['client/bootstrap.ts'].file}`
+
+      const content = JSON.parse(await readFile(assetsPath, 'utf8'))
+      expect(content).toEqual({ Bootstrap: expectedUrl })
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+      await rm(join(FIXTURE_ROOT, 'dist'), { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  test('`assets` throws an actionable error when the entry was never registered as a Rollup input', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-mojolicious-vite-dist-assets-missing-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-mojolicious-vite-views-assets-missing-'))
+
+    try {
+      await expect(
+        build({
+          configFile: false,
+          root: FIXTURE_ROOT,
+          base: '/static/build/',
+          logLevel: 'silent',
+          build: { outDir, emptyOutDir: true },
+          plugins: barefoot({
+            components: ['src/components'],
+            templates: templatesDir,
+            assets: { Bootstrap: 'client/bootstrap.ts' },
+          }),
+        }),
+      ).rejects.toThrow(/was not found in the build manifest/)
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+      await rm(join(FIXTURE_ROOT, 'dist'), { recursive: true, force: true })
+    }
+  }, 60_000)
+})

--- a/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
@@ -77,19 +77,37 @@ const PREDICATE_METHODS: ReadonlySet<string> = new Set([
 ])
 
 export class MojoFilterEmitter implements ParsedExprEmitter {
+  // Plain field declarations + assignment, NOT TS constructor-parameter-
+  // property shorthand: Vite's `bundleConfigFile` externalizes any bare
+  // (non-relative) import when loading `vite.config.ts` (see
+  // `@barefootjs/mojolicious/vite`'s docstring), so this file can be loaded
+  // directly by Node's OWN native TypeScript type-stripping (enabled by
+  // default since Node 22.18/23.6) rather than esbuild — and Node's
+  // strip-only mode does not support parameter properties (`SyntaxError
+  // [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]`), only plain type annotations.
+  private readonly param: string
+  private readonly localVarMap: Map<string, string>
+  // Reports whether a getter/prop name is string-typed, so `===`/`!==`
+  // against it lowers to `eq`/`ne` (#1672). Defaults to "never" for callers
+  // that don't thread it through.
+  private readonly isStringName: (n: string) => boolean
+  // Records a BF101 for nested callback shapes this emitter can only
+  // degrade — `find*` and the non-predicate methods (#2038). Optional so
+  // emitter construction stays possible without an adapter; a missing hook
+  // keeps the old silent-degrade emit.
+  private readonly onUnsupported?: (message: string, reason?: string) => void
+
   constructor(
-    private readonly param: string,
-    private readonly localVarMap: Map<string, string>,
-    // Reports whether a getter/prop name is string-typed, so `===`/`!==`
-    // against it lowers to `eq`/`ne` (#1672). Defaults to "never" for callers
-    // that don't thread it through.
-    private readonly isStringName: (n: string) => boolean = () => false,
-    // Records a BF101 for nested callback shapes this emitter can only
-    // degrade — `find*` and the non-predicate methods (#2038). Optional so
-    // emitter construction stays possible without an adapter; a missing hook
-    // keeps the old silent-degrade emit.
-    private readonly onUnsupported?: (message: string, reason?: string) => void,
-  ) {}
+    param: string,
+    localVarMap: Map<string, string>,
+    isStringName: (n: string) => boolean = () => false,
+    onUnsupported?: (message: string, reason?: string) => void,
+  ) {
+    this.param = param
+    this.localVarMap = localVarMap
+    this.isStringName = isStringName
+    this.onUnsupported = onUnsupported
+  }
 
   identifier(name: string): string {
     if (name === this.param) return `$${this.param}`
@@ -296,7 +314,13 @@ export class MojoFilterEmitter implements ParsedExprEmitter {
  *     shapes the AST can't classify still emit something coherent.
  */
 export class MojoTopLevelEmitter implements ParsedExprEmitter {
-  constructor(private readonly ctx: MojoEmitContext) {}
+  // Plain field + assignment, not a parameter property — see
+  // `MojoFilterEmitter`'s constructor comment above for why.
+  private readonly ctx: MojoEmitContext
+
+  constructor(ctx: MojoEmitContext) {
+    this.ctx = ctx
+  }
 
   identifier(name: string): string {
     // `undefined` / `null` nested inside a larger expression tree

--- a/packages/adapter-mojolicious/src/vite.ts
+++ b/packages/adapter-mojolicious/src/vite.ts
@@ -1,0 +1,217 @@
+/**
+ * `@barefootjs/mojolicious/vite` — a Mojolicious-specific COMPOSITION of
+ * core `@barefootjs/vite`'s `barefoot()`, mirroring `@barefootjs/go-
+ * template/vite`'s, `@barefootjs/hono/vite`'s, `@barefootjs/blade/vite`'s,
+ * `@barefootjs/jinja/vite`'s, and `@barefootjs/erb/vite`'s shape and naming
+ * (`barefoot`, named AND default export; a user never passes `adapter`,
+ * this constructs `MojoAdapter` itself).
+ *
+ *   import { barefoot } from '@barefootjs/mojolicious/vite'
+ *
+ *   export default defineConfig({
+ *     base: '/integrations/mojolicious/client/',
+ *     build: { outDir: 'dist/client' },
+ *     plugins: barefoot({
+ *       components: ['../shared/components', '../shared/blog'],
+ *       templates: 'dist/templates',
+ *     }),
+ *   })
+ *
+ * ## Why this needs no `afterEmit`-driven type-combination step (unlike Go)
+ *
+ * `@barefootjs/go-template/vite` exists mainly to combine every discovered
+ * file's `types` fragment into ONE compilable `components.go` — Go's
+ * per-file fragments assume a shared `randomID` helper and a single package
+ * header, so they are not independently valid Go source, and an unused
+ * import fails the build outright (see that module's docstring).
+ * `MojoAdapter.generate()` never produces a `types` section at all
+ * (Mojolicious EP templates have no JS-style imports/types/exports to
+ * combine — see `mojo-adapter.ts`'s `generate()`, whose `sections.types`
+ * is always `''`), so there is nothing across files to stitch together,
+ * and no unused-import failure mode to guard against either. Confirmed by
+ * reading `./build.ts`'s `createConfig`: unlike Go's, it has NO default
+ * `postBuild` of its own — it only forwards a caller-supplied one
+ * verbatim. So this composition's core job is just what core's
+ * `barefoot()` already does: construct `MojoAdapter` and hand it to core.
+ *
+ * ## No `adapterOptions` either — the other thing Go/Hono still need
+ *
+ * `MojoAdapterOptions` has exactly two fields, `clientJsBasePath` and
+ * `barefootJsPath` — and `MojoAdapter.generateScriptRegistrations` only
+ * falls back to them when `scriptAssets` is `undefined` (the legacy `bf
+ * build` path). Core's `barefoot()` plugin ALWAYS passes a resolved
+ * `scriptAssets` array (build: manifest-hashed; dev: origin-based — see
+ * `plugin.ts`), so that fallback is dead code on every Vite-driven build.
+ * Unlike Go (`packageName`, still real) or Hono (`clientJsFilename`, still
+ * real), Mojolicious has no adapter option left with any effect once Vite
+ * drives the build — so this options interface simply omits the field
+ * rather than plumbing through two options that would always be ignored.
+ *
+ * ## `assets` — the one thing this DOES need, mirroring go-template/hono/blade
+ *
+ * A hand-written, non-component client bootstrap (e.g. an integration's
+ * `client/router-entry.ts`, which boots `@barefootjs/router` for the blog)
+ * isn't a `.tsx` component, so core's own discovery/`scriptAssets` machinery
+ * never sees it — but the compiled blog shell still needs a `<script src>`
+ * for it, and that URL is only knowable after Vite bundles it (dev:
+ * origin-based; build: manifest-hashed). `assets` resolves exactly that,
+ * into a generated JSON file the Perl app reads at request time (the same
+ * `dist/templates/manifest.json` — read-a-JSON-file-at-runtime — idiom this
+ * Perl app already uses for `ssrDefaults`; unlike Go/Hono there is no
+ * compile step on the Perl side, so plain JSON is enough — no generated
+ * Go/TS source needed). See `@barefootjs/go-template/vite`'s docstring for
+ * the full "why a companion config-capture plugin" rationale (`afterEmit`'s
+ * `AfterEmitContext` is deliberately narrow — no `ResolvedConfig`, no dev
+ * origin, no manifest — so a tiny second plugin captures those via its own
+ * `configResolved`/`configureServer` hooks for `afterEmit`, in the same
+ * closure, to read).
+ */
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
+import { barefoot as coreBarefoot } from '@barefootjs/vite'
+import type { AfterEmitContext } from '@barefootjs/vite'
+import { devModuleUrl, loadManifest, resolveDevOrigin, resolveScriptAssets, toPosixRelative } from '@barefootjs/vite'
+import { MojoAdapter } from './adapter/index.ts'
+
+export interface MojoliciousViteOptions {
+  /** Source directories to scan for `.tsx` components, relative to the
+   * Vite project root (or absolute). */
+  components: string[]
+  /** Where compiled `.html.ep` templates and `ssrDefaults` land — relative
+   * to the Vite project root (or absolute). This is a backend source
+   * directory Perl reads, NOT `build.outDir` (Vite's client-asset
+   * output). */
+  templates: string
+  /**
+   * Extra, non-component script entries whose Vite-resolved URL (dev:
+   * origin-based; production: content-hashed manifest path) should be
+   * exposed to the Perl app as a generated JSON asset map — e.g. a
+   * hand-written client bootstrap script that isn't a `.tsx` component, so
+   * it never goes through core's discovery/`scriptAssets` machinery, but
+   * still needs a `<script src="...">` URL only knowable after bundling.
+   *
+   * Keyed by the identifier the resolved URL should appear under in the
+   * generated map; values are entry paths relative to the Vite project
+   * root. You must ALSO register the same path as a Rollup entry yourself
+   * via stock `build.rollupOptions.input` — this plugin never adds
+   * bundling configuration on your behalf; this option only resolves the
+   * URL Vite already bundled it to, it doesn't request the bundling.
+   */
+  assets?: Record<string, string>
+  /** Output path for the generated JSON asset map, relative to the Vite
+   * project root. Default: 'dist/bf-assets.json'. Ignored when `assets`
+   * is empty. Placed under `dist/` (already gitignored) rather than
+   * committed like Go's `bf_assets.go`: Perl reads this file at REQUEST
+   * time, so — unlike Go, which must compile a static map into the
+   * binary — there is nothing to commit; a fresh copy is generated on
+   * every build (dev AND production) and never checked in. */
+  assetsOutputFile?: string
+}
+
+/** write-if-changed: writes `content` to `absPath` only if it differs from
+ * what's already there, logging `label` when it actually wrote. Avoids
+ * touching mtime (and so falsely tripping a file watcher, e.g. Perl's own
+ * dev server) on a pass that produced byte-identical output. */
+async function writeIfChanged(absPath: string, content: string, label: string): Promise<void> {
+  const prev = await readFile(absPath, 'utf-8').catch(() => null)
+  if (prev === content) return
+  // Default `assetsOutputFile` lives under `dist/` — a directory `vite
+  // build` may not have created yet on a clean checkout — so ensure it
+  // exists before writing.
+  await mkdir(dirname(absPath), { recursive: true })
+  await writeFile(absPath, content)
+  console.log(`Generated: ${label}`)
+}
+
+/** Resolves ONE asset entry's URL for the current pass: manifest-hashed for
+ * `mode: 'build'`, dev-origin-based for `mode: 'dev'`. Throws with an
+ * actionable message when the entry isn't in the build manifest — almost
+ * always means the caller forgot to also add it to
+ * `build.rollupOptions.input`. */
+function resolveAssetUrl(
+  ctx: AfterEmitContext,
+  config: ResolvedConfig,
+  devServer: ViteDevServer | undefined,
+  entryRelPath: string,
+  manifest: Record<string, { file: string }> | undefined,
+): string {
+  const absPath = resolve(ctx.projectDir, entryRelPath)
+  if (ctx.mode === 'dev') {
+    if (!devServer) throw new Error(`[mojolicious/vite] asset "${entryRelPath}": dev server not ready`)
+    return devModuleUrl(config, resolveDevOrigin(devServer), absPath)
+  }
+
+  const manifestKey = toPosixRelative(config.root, absPath)
+  const [url] = resolveScriptAssets(manifest ?? {}, manifestKey, config.base)
+  if (!url) {
+    throw new Error(
+      `[mojolicious/vite] asset "${entryRelPath}" was not found in the build manifest. ` +
+        `Did you also add it to build.rollupOptions.input?`,
+    )
+  }
+  return url
+}
+
+/** Builds and write-if-changed's the generated JSON asset map. No-op when
+ * `assets` is empty. */
+async function writeAssetMap(
+  ctx: AfterEmitContext,
+  config: ResolvedConfig,
+  devServer: ViteDevServer | undefined,
+  assets: Record<string, string>,
+  assetsOutputFile: string,
+): Promise<void> {
+  const keys = Object.keys(assets)
+  if (keys.length === 0) return
+
+  const manifest = ctx.mode === 'build' ? await loadManifest(ctx.outDir, config.build.manifest) : undefined
+
+  const resolved: Record<string, string> = {}
+  for (const name of keys) {
+    resolved[name] = resolveAssetUrl(ctx, config, devServer, assets[name]!, manifest)
+  }
+
+  const content = `${JSON.stringify(resolved, null, 2)}\n`
+  await writeIfChanged(resolve(ctx.projectDir, assetsOutputFile), content, assetsOutputFile)
+}
+
+export function barefoot(options: MojoliciousViteOptions): Plugin[] {
+  const assets = options.assets ?? {}
+  const assetsOutputFile = options.assetsOutputFile ?? 'dist/bf-assets.json'
+
+  // Populated by `mojoliciousAssetsConfigCapture` below (only added to the
+  // returned array when `assets` is non-empty). Read by `afterEmit` — see
+  // `@barefootjs/go-template/vite`'s identical mechanism for the ordering
+  // guarantee (`configResolved`/`configureServer` always run before the
+  // eager pass that triggers `afterEmit`, for both build and dev).
+  let resolvedConfig: ResolvedConfig | undefined
+  let devServer: ViteDevServer | undefined
+
+  const core = coreBarefoot({
+    adapter: new MojoAdapter(),
+    components: options.components,
+    templates: options.templates,
+    async afterEmit(ctx) {
+      if (Object.keys(assets).length > 0 && resolvedConfig) {
+        await writeAssetMap(ctx, resolvedConfig, devServer, assets, assetsOutputFile)
+      }
+    },
+  })
+
+  if (Object.keys(assets).length === 0) return [core]
+
+  const mojoliciousAssetsConfigCapture: Plugin = {
+    name: 'barefoot-mojolicious-assets-config-capture',
+    configResolved(config) {
+      resolvedConfig = config
+    },
+    configureServer(server) {
+      devServer = server
+    },
+  }
+
+  return [core, mojoliciousAssetsConfigCapture]
+}
+
+export { barefoot as default }

--- a/packages/adapter-rust/e2e-fixture/client/bootstrap.ts
+++ b/packages/adapter-rust/e2e-fixture/client/bootstrap.ts
@@ -1,0 +1,8 @@
+/**
+ * A hand-written, non-component script entry — stands in for
+ * `integrations/axum/client/router-entry.ts` in tests: not a `.tsx`
+ * component, so core's discovery/`scriptAssets` machinery never sees it,
+ * but its bundled URL still needs to reach the compiled Rust blog shell
+ * (the `assets`/`assetsOutputFile` option under test).
+ */
+export const bootstrapped = true

--- a/packages/adapter-rust/e2e-fixture/src/components/Counter.tsx
+++ b/packages/adapter-rust/e2e-fixture/src/components/Counter.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export interface CounterProps {
+  initial: number
+}
+
+export function Counter(props: CounterProps) {
+  const [count, setCount] = createSignal(props.initial)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}

--- a/packages/adapter-rust/package.json
+++ b/packages/adapter-rust/package.json
@@ -20,6 +20,10 @@
     "./build": {
       "types": "./src/build.ts",
       "import": "./src/build.ts"
+    },
+    "./vite": {
+      "types": "./src/vite.ts",
+      "import": "./src/vite.ts"
     }
   },
   "publishConfig": {
@@ -38,6 +42,10 @@
       "./build": {
         "types": "./dist/build.d.ts",
         "import": "./dist/build.js"
+      },
+      "./vite": {
+        "types": "./dist/vite.d.ts",
+        "import": "./dist/vite.js"
       }
     }
   },
@@ -49,7 +57,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",
@@ -76,11 +84,24 @@
     "@barefootjs/shared": "workspace:*"
   },
   "peerDependencies": {
-    "@barefootjs/jsx": ">=0.2.0"
+    "@barefootjs/jsx": ">=0.2.0",
+    "@barefootjs/vite": ">=0.2.0",
+    "vite": "^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@barefootjs/vite": {
+      "optional": true
+    },
+    "vite": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@barefootjs/adapter-tests": "workspace:*",
     "@barefootjs/jsx": "workspace:*",
-    "typescript": "^5.0.0"
+    "@barefootjs/vite": "workspace:*",
+    "@barefootjs/client": "workspace:*",
+    "typescript": "^5.0.0",
+    "vite": "^6.0.0"
   }
 }

--- a/packages/adapter-rust/src/__tests__/vite.test.ts
+++ b/packages/adapter-rust/src/__tests__/vite.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Coverage of `@barefootjs/rust/vite`'s `barefoot()`:
+ *
+ * - one real `vite build()` end to end (mirrors `@barefootjs/go-template/
+ *   vite`, `@barefootjs/hono/vite`, `@barefootjs/blade/vite`'s,
+ *   `@barefootjs/jinja/vite`'s, and `@barefootjs/erb/vite`'s own
+ *   `vite.test.ts` rigor — a plugin that only passes mocked unit tests
+ *   hasn't been shown to work) against a checked-in fixture (not a system
+ *   tmpdir) so `@barefootjs/client` resolves through the monorepo's real
+ *   node_modules symlinks;
+ * - the `assets` → generated `bf-assets.json` behavior, exercised the same
+ *   way (a real build, since it needs the real manifest Vite writes).
+ *
+ * Unlike Go, there is no `afterEmit`-driven type-combination step to test
+ * here (see `vite.ts`'s module docstring) — `MinijinjaAdapter.generate()`
+ * never produces a `types` section at all, so `barefoot()` always returns a
+ * single-element array unless `assets` is set.
+ */
+import { describe, test, expect } from 'bun:test'
+import { build } from 'vite'
+import { mkdtemp, rm, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { barefoot, barefoot as defaultBarefoot } from '../vite.ts'
+
+const FIXTURE_ROOT = resolve(import.meta.dirname, '../../e2e-fixture')
+
+describe('@barefootjs/rust/vite: real vite build', () => {
+  test('exports the same function as both named `barefoot` and default', () => {
+    expect(defaultBarefoot).toBe(barefoot)
+  })
+
+  test('returns a single-element plugin array when `assets` is omitted', () => {
+    const plugins = barefoot({ components: ['src/components'], templates: 'views' })
+    expect(plugins).toHaveLength(1)
+  })
+
+  test('writes a self-contained .j2 template with scriptAssets baked in, same as core alone would do', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-rust-vite-dist-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-rust-vite-views-'))
+
+    try {
+      await build({
+        configFile: false,
+        root: FIXTURE_ROOT,
+        base: '/static/build/',
+        logLevel: 'warn',
+        build: { outDir, emptyOutDir: true },
+        plugins: barefoot({
+          components: ['src/components'],
+          templates: templatesDir,
+        }),
+      })
+
+      const template = await readFile(join(templatesDir, 'Counter.j2'), 'utf8')
+      expect(template).toContain("bf.register_script(")
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  test('`assets` resolves a non-component entry\'s manifest-hashed URL into a generated JSON asset map', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-rust-vite-dist-assets-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-rust-vite-views-assets-'))
+    const assetsPath = join(FIXTURE_ROOT, 'dist/bf-assets.json')
+
+    try {
+      await build({
+        configFile: false,
+        root: FIXTURE_ROOT,
+        base: '/static/build/',
+        logLevel: 'warn',
+        build: {
+          outDir,
+          emptyOutDir: true,
+          // Registering the non-component entry is the CALLER's job (stock
+          // Vite config) — `assets` below only resolves the URL Vite
+          // already bundled it to, it doesn't request the bundling.
+          rollupOptions: { input: { bootstrap: resolve(FIXTURE_ROOT, 'client/bootstrap.ts') } },
+        },
+        plugins: barefoot({
+          components: ['src/components'],
+          templates: templatesDir,
+          assets: { Bootstrap: 'client/bootstrap.ts' },
+        }),
+      })
+
+      const manifest = JSON.parse(await readFile(join(outDir, '.vite/manifest.json'), 'utf8'))
+      const expectedUrl = `/static/build/${manifest['client/bootstrap.ts'].file}`
+
+      const content = JSON.parse(await readFile(assetsPath, 'utf8'))
+      expect(content).toEqual({ Bootstrap: expectedUrl })
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+      await rm(join(FIXTURE_ROOT, 'dist'), { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  test('`assets` throws an actionable error when the entry was never registered as a Rollup input', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-rust-vite-dist-assets-missing-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-rust-vite-views-assets-missing-'))
+
+    try {
+      await expect(
+        build({
+          configFile: false,
+          root: FIXTURE_ROOT,
+          base: '/static/build/',
+          logLevel: 'silent',
+          build: { outDir, emptyOutDir: true },
+          plugins: barefoot({
+            components: ['src/components'],
+            templates: templatesDir,
+            assets: { Bootstrap: 'client/bootstrap.ts' },
+          }),
+        }),
+      ).rejects.toThrow(/was not found in the build manifest/)
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+      await rm(join(FIXTURE_ROOT, 'dist'), { recursive: true, force: true })
+    }
+  }, 60_000)
+})

--- a/packages/adapter-rust/src/adapter/expr/emitters.ts
+++ b/packages/adapter-rust/src/adapter/expr/emitters.ts
@@ -117,15 +117,33 @@ export function truthyTest(node: ParsedExpr, rendered: string): string {
  * callback's receiver.
  */
 export class JinjaFilterEmitter implements ParsedExprEmitter {
+  // Plain field declarations + assignment, NOT TS constructor-parameter-
+  // property shorthand: Vite's `bundleConfigFile` externalizes any bare
+  // (non-relative) import when loading `vite.config.ts` (see
+  // `@barefootjs/rust/vite`'s docstring), so this file can be loaded
+  // directly by Node's OWN native TypeScript type-stripping (enabled by
+  // default since Node 22.18/23.6) rather than esbuild — and Node's
+  // strip-only mode does not support parameter properties (`SyntaxError
+  // [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]`), only plain type annotations.
+  private readonly param: string
+  private readonly localVarMap: Map<string, string>
+  private readonly isStringName: (n: string) => boolean
+  // Records a BF101 for predicate shapes this emitter can only degrade
+  // (#2038). Optional so emitter construction stays possible without an
+  // adapter; a missing hook keeps the old silent-degrade emit.
+  private readonly onUnsupported?: (message: string, reason?: string) => void
+
   constructor(
-    private readonly param: string,
-    private readonly localVarMap: Map<string, string>,
-    private readonly isStringName: (n: string) => boolean = () => false,
-    // Records a BF101 for predicate shapes this emitter can only degrade
-    // (#2038). Optional so emitter construction stays possible without an
-    // adapter; a missing hook keeps the old silent-degrade emit.
-    private readonly onUnsupported?: (message: string, reason?: string) => void,
-  ) {}
+    param: string,
+    localVarMap: Map<string, string>,
+    isStringName: (n: string) => boolean = () => false,
+    onUnsupported?: (message: string, reason?: string) => void,
+  ) {
+    this.param = param
+    this.localVarMap = localVarMap
+    this.isStringName = isStringName
+    this.onUnsupported = onUnsupported
+  }
 
   identifier(name: string): string {
     if (name === this.param) return minijinjaIdent(this.param)
@@ -288,7 +306,13 @@ export class JinjaFilterEmitter implements ParsedExprEmitter {
  *   - no lambda fallback exists (see the file header, divergence 2).
  */
 export class JinjaTopLevelEmitter implements ParsedExprEmitter {
-  constructor(private readonly ctx: JinjaEmitContext) {}
+  // Plain field + assignment, not a parameter property — see
+  // `JinjaFilterEmitter`'s constructor comment above for why.
+  private readonly ctx: JinjaEmitContext
+
+  constructor(ctx: JinjaEmitContext) {
+    this.ctx = ctx
+  }
 
   identifier(name: string): string {
     // `undefined` / `null` nested inside a larger expression tree — Jinja

--- a/packages/adapter-rust/src/vite.ts
+++ b/packages/adapter-rust/src/vite.ts
@@ -1,0 +1,218 @@
+/**
+ * `@barefootjs/rust/vite` — a minijinja(Rust)-specific COMPOSITION of core
+ * `@barefootjs/vite`'s `barefoot()`, mirroring `@barefootjs/go-template/
+ * vite`'s, `@barefootjs/hono/vite`'s, `@barefootjs/blade/vite`'s,
+ * `@barefootjs/jinja/vite`'s, and `@barefootjs/erb/vite`'s shape and naming
+ * (`barefoot`, named AND default export; a user never passes `adapter`,
+ * this constructs `MinijinjaAdapter` itself).
+ *
+ *   import { barefoot } from '@barefootjs/rust/vite'
+ *
+ *   export default defineConfig({
+ *     base: '/integrations/axum/client/',
+ *     build: { outDir: 'dist/client' },
+ *     plugins: barefoot({
+ *       components: ['../shared/components', '../shared/blog'],
+ *       templates: 'dist/templates',
+ *     }),
+ *   })
+ *
+ * ## Why this needs no `afterEmit`-driven type-combination step (unlike Go)
+ *
+ * `@barefootjs/go-template/vite` exists mainly to combine every discovered
+ * file's `types` fragment into ONE compilable `components.go` — Go's
+ * per-file fragments assume a shared `randomID` helper and a single package
+ * header, so they are not independently valid Go source, and an unused
+ * import fails the build outright (see that module's docstring).
+ * `MinijinjaAdapter.generate()` never produces a `types` section at all
+ * (minijinja templates have no JS-style imports/types/exports to combine —
+ * see `minijinja-adapter.ts`'s `generate()`, whose `sections.types` is
+ * always `''`), so there is nothing across files to stitch together, and no
+ * unused-import failure mode to guard against either. Confirmed by reading
+ * `./build.ts`'s `createConfig`: unlike Go's, it has NO default `postBuild`
+ * of its own — it only forwards a caller-supplied one verbatim. So this
+ * composition's core job is just what core's `barefoot()` already does:
+ * construct `MinijinjaAdapter` and hand it to core.
+ *
+ * ## No `adapterOptions` either — the other thing Go/Hono still need
+ *
+ * `MinijinjaAdapterOptions` has exactly two fields, `clientJsBasePath` and
+ * `barefootJsPath` — and `MinijinjaAdapter.generateScriptRegistrations`
+ * only falls back to them when `scriptAssets` is `undefined` (the legacy
+ * `bf build` path). Core's `barefoot()` plugin ALWAYS passes a resolved
+ * `scriptAssets` array (build: manifest-hashed; dev: origin-based — see
+ * `plugin.ts`), so that fallback is dead code on every Vite-driven build.
+ * Unlike Go (`packageName`, still real) or Hono (`clientJsFilename`, still
+ * real), minijinja has no adapter option left with any effect once Vite
+ * drives the build — so this options interface simply omits the field
+ * rather than plumbing through two options that would always be ignored.
+ *
+ * ## `assets` — the one thing this DOES need, mirroring go-template/hono/blade
+ *
+ * A hand-written, non-component client bootstrap (e.g. an integration's
+ * `client/router-entry.ts`, which boots `@barefootjs/router` for the blog)
+ * isn't a `.tsx` component, so core's own discovery/`scriptAssets` machinery
+ * never sees it — but the compiled blog shell still needs a `<script src>`
+ * for it, and that URL is only knowable after Vite bundles it (dev:
+ * origin-based; build: manifest-hashed). `assets` resolves exactly that,
+ * into a generated JSON file the Rust app reads at request time (the same
+ * `dist/templates/manifest.json` — read-a-JSON-file-at-runtime — idiom this
+ * Rust binary already uses for `ssrDefaults`; unlike Go/Hono there is no
+ * compile step on the Rust side that needs the URL baked in ahead of time
+ * — a plain JSON file read at startup is enough — no generated Go/TS
+ * source needed). See `@barefootjs/go-template/vite`'s docstring for the
+ * full "why a companion config-capture plugin" rationale (`afterEmit`'s
+ * `AfterEmitContext` is deliberately narrow — no `ResolvedConfig`, no dev
+ * origin, no manifest — so a tiny second plugin captures those via its own
+ * `configResolved`/`configureServer` hooks for `afterEmit`, in the same
+ * closure, to read).
+ */
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
+import { barefoot as coreBarefoot } from '@barefootjs/vite'
+import type { AfterEmitContext } from '@barefootjs/vite'
+import { devModuleUrl, loadManifest, resolveDevOrigin, resolveScriptAssets, toPosixRelative } from '@barefootjs/vite'
+import { MinijinjaAdapter } from './adapter/index.ts'
+
+export interface RustViteOptions {
+  /** Source directories to scan for `.tsx` components, relative to the
+   * Vite project root (or absolute). */
+  components: string[]
+  /** Where compiled `.j2` templates and `ssrDefaults` land — relative to
+   * the Vite project root (or absolute). This is a backend source
+   * directory the Rust binary reads, NOT `build.outDir` (Vite's
+   * client-asset output). */
+  templates: string
+  /**
+   * Extra, non-component script entries whose Vite-resolved URL (dev:
+   * origin-based; production: content-hashed manifest path) should be
+   * exposed to the Rust app as a generated JSON asset map — e.g. a
+   * hand-written client bootstrap script that isn't a `.tsx` component, so
+   * it never goes through core's discovery/`scriptAssets` machinery, but
+   * still needs a `<script src="...">` URL only knowable after bundling.
+   *
+   * Keyed by the identifier the resolved URL should appear under in the
+   * generated map; values are entry paths relative to the Vite project
+   * root. You must ALSO register the same path as a Rollup entry yourself
+   * via stock `build.rollupOptions.input` — this plugin never adds
+   * bundling configuration on your behalf; this option only resolves the
+   * URL Vite already bundled it to, it doesn't request the bundling.
+   */
+  assets?: Record<string, string>
+  /** Output path for the generated JSON asset map, relative to the Vite
+   * project root. Default: 'dist/bf-assets.json'. Ignored when `assets`
+   * is empty. Placed under `dist/` (already gitignored) rather than
+   * committed like Go's `bf_assets.go`: the Rust app reads this file at
+   * STARTUP, so — unlike Go, which must compile a static map into the
+   * binary — there is nothing to commit; a fresh copy is generated on
+   * every build (dev AND production) and never checked in. */
+  assetsOutputFile?: string
+}
+
+/** write-if-changed: writes `content` to `absPath` only if it differs from
+ * what's already there, logging `label` when it actually wrote. Avoids
+ * touching mtime (and so falsely tripping a file watcher) on a pass that
+ * produced byte-identical output. */
+async function writeIfChanged(absPath: string, content: string, label: string): Promise<void> {
+  const prev = await readFile(absPath, 'utf-8').catch(() => null)
+  if (prev === content) return
+  // Default `assetsOutputFile` lives under `dist/` — a directory `vite
+  // build` may not have created yet on a clean checkout — so ensure it
+  // exists before writing.
+  await mkdir(dirname(absPath), { recursive: true })
+  await writeFile(absPath, content)
+  console.log(`Generated: ${label}`)
+}
+
+/** Resolves ONE asset entry's URL for the current pass: manifest-hashed for
+ * `mode: 'build'`, dev-origin-based for `mode: 'dev'`. Throws with an
+ * actionable message when the entry isn't in the build manifest — almost
+ * always means the caller forgot to also add it to
+ * `build.rollupOptions.input`. */
+function resolveAssetUrl(
+  ctx: AfterEmitContext,
+  config: ResolvedConfig,
+  devServer: ViteDevServer | undefined,
+  entryRelPath: string,
+  manifest: Record<string, { file: string }> | undefined,
+): string {
+  const absPath = resolve(ctx.projectDir, entryRelPath)
+  if (ctx.mode === 'dev') {
+    if (!devServer) throw new Error(`[rust/vite] asset "${entryRelPath}": dev server not ready`)
+    return devModuleUrl(config, resolveDevOrigin(devServer), absPath)
+  }
+
+  const manifestKey = toPosixRelative(config.root, absPath)
+  const [url] = resolveScriptAssets(manifest ?? {}, manifestKey, config.base)
+  if (!url) {
+    throw new Error(
+      `[rust/vite] asset "${entryRelPath}" was not found in the build manifest. ` +
+        `Did you also add it to build.rollupOptions.input?`,
+    )
+  }
+  return url
+}
+
+/** Builds and write-if-changed's the generated JSON asset map. No-op when
+ * `assets` is empty. */
+async function writeAssetMap(
+  ctx: AfterEmitContext,
+  config: ResolvedConfig,
+  devServer: ViteDevServer | undefined,
+  assets: Record<string, string>,
+  assetsOutputFile: string,
+): Promise<void> {
+  const keys = Object.keys(assets)
+  if (keys.length === 0) return
+
+  const manifest = ctx.mode === 'build' ? await loadManifest(ctx.outDir, config.build.manifest) : undefined
+
+  const resolved: Record<string, string> = {}
+  for (const name of keys) {
+    resolved[name] = resolveAssetUrl(ctx, config, devServer, assets[name]!, manifest)
+  }
+
+  const content = `${JSON.stringify(resolved, null, 2)}\n`
+  await writeIfChanged(resolve(ctx.projectDir, assetsOutputFile), content, assetsOutputFile)
+}
+
+export function barefoot(options: RustViteOptions): Plugin[] {
+  const assets = options.assets ?? {}
+  const assetsOutputFile = options.assetsOutputFile ?? 'dist/bf-assets.json'
+
+  // Populated by `rustAssetsConfigCapture` below (only added to the
+  // returned array when `assets` is non-empty). Read by `afterEmit` — see
+  // `@barefootjs/go-template/vite`'s identical mechanism for the ordering
+  // guarantee (`configResolved`/`configureServer` always run before the
+  // eager pass that triggers `afterEmit`, for both build and dev).
+  let resolvedConfig: ResolvedConfig | undefined
+  let devServer: ViteDevServer | undefined
+
+  const core = coreBarefoot({
+    adapter: new MinijinjaAdapter(),
+    components: options.components,
+    templates: options.templates,
+    async afterEmit(ctx) {
+      if (Object.keys(assets).length > 0 && resolvedConfig) {
+        await writeAssetMap(ctx, resolvedConfig, devServer, assets, assetsOutputFile)
+      }
+    },
+  })
+
+  if (Object.keys(assets).length === 0) return [core]
+
+  const rustAssetsConfigCapture: Plugin = {
+    name: 'barefoot-rust-assets-config-capture',
+    configResolved(config) {
+      resolvedConfig = config
+    },
+    configureServer(server) {
+      devServer = server
+    },
+  }
+
+  return [core, rustAssetsConfigCapture]
+}
+
+export { barefoot as default }

--- a/packages/adapter-twig/e2e-fixture/client/bootstrap.ts
+++ b/packages/adapter-twig/e2e-fixture/client/bootstrap.ts
@@ -1,0 +1,8 @@
+/**
+ * A hand-written, non-component script entry — stands in for
+ * `integrations/php/client/router-entry.ts` (and laravel's) in tests: not a
+ * `.tsx` component, so core's discovery/`scriptAssets` machinery never sees
+ * it, but its bundled URL still needs to reach the compiled PHP blog shell
+ * (the `assets`/`assetsOutputFile` option under test).
+ */
+export const bootstrapped = true

--- a/packages/adapter-twig/e2e-fixture/src/components/Counter.tsx
+++ b/packages/adapter-twig/e2e-fixture/src/components/Counter.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export interface CounterProps {
+  initial: number
+}
+
+export function Counter(props: CounterProps) {
+  const [count, setCount] = createSignal(props.initial)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}

--- a/packages/adapter-twig/package.json
+++ b/packages/adapter-twig/package.json
@@ -20,6 +20,10 @@
     "./build": {
       "types": "./src/build.ts",
       "import": "./src/build.ts"
+    },
+    "./vite": {
+      "types": "./src/vite.ts",
+      "import": "./src/vite.ts"
     }
   },
   "publishConfig": {
@@ -38,6 +42,10 @@
       "./build": {
         "types": "./dist/build.d.ts",
         "import": "./dist/build.js"
+      },
+      "./vite": {
+        "types": "./dist/vite.d.ts",
+        "import": "./dist/vite.js"
       }
     }
   },
@@ -51,7 +59,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",
@@ -76,11 +84,24 @@
     "@barefootjs/shared": "workspace:*"
   },
   "peerDependencies": {
-    "@barefootjs/jsx": ">=0.2.0"
+    "@barefootjs/jsx": ">=0.2.0",
+    "@barefootjs/vite": ">=0.2.0",
+    "vite": "^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@barefootjs/vite": {
+      "optional": true
+    },
+    "vite": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@barefootjs/adapter-tests": "workspace:*",
     "@barefootjs/jsx": "workspace:*",
-    "typescript": "^5.0.0"
+    "@barefootjs/vite": "workspace:*",
+    "@barefootjs/client": "workspace:*",
+    "typescript": "^5.0.0",
+    "vite": "^6.0.0"
   }
 }

--- a/packages/adapter-twig/src/__tests__/vite.test.ts
+++ b/packages/adapter-twig/src/__tests__/vite.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Coverage of `@barefootjs/twig/vite`'s `barefoot()`:
+ *
+ * - one real `vite build()` end to end (mirrors `@barefootjs/go-template/
+ *   vite`, `@barefootjs/hono/vite`, `@barefootjs/blade/vite`'s,
+ *   `@barefootjs/jinja/vite`'s, and `@barefootjs/erb/vite`'s own
+ *   `vite.test.ts` rigor — a plugin that only passes mocked unit tests
+ *   hasn't been shown to work) against a checked-in fixture (not a system
+ *   tmpdir) so `@barefootjs/client` resolves through the monorepo's real
+ *   node_modules symlinks;
+ * - the `assets` → generated `bf-assets.json` behavior, exercised the same
+ *   way (a real build, since it needs the real manifest Vite writes).
+ *
+ * Unlike Go, there is no `afterEmit`-driven type-combination step to test
+ * here (see `vite.ts`'s module docstring) — `TwigAdapter.generate()` never
+ * produces a `types` section at all, so `barefoot()` always returns a
+ * single-element array unless `assets` is set.
+ */
+import { describe, test, expect } from 'bun:test'
+import { build } from 'vite'
+import { mkdtemp, rm, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { barefoot, barefoot as defaultBarefoot } from '../vite.ts'
+
+const FIXTURE_ROOT = resolve(import.meta.dirname, '../../e2e-fixture')
+
+describe('@barefootjs/twig/vite: real vite build', () => {
+  test('exports the same function as both named `barefoot` and default', () => {
+    expect(defaultBarefoot).toBe(barefoot)
+  })
+
+  test('returns a single-element plugin array when `assets` is omitted', () => {
+    const plugins = barefoot({ components: ['src/components'], templates: 'views' })
+    expect(plugins).toHaveLength(1)
+  })
+
+  test('writes a self-contained .twig template with scriptAssets baked in, same as core alone would do', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-twig-vite-dist-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-twig-vite-views-'))
+
+    try {
+      await build({
+        configFile: false,
+        root: FIXTURE_ROOT,
+        base: '/static/build/',
+        logLevel: 'warn',
+        build: { outDir, emptyOutDir: true },
+        plugins: barefoot({
+          components: ['src/components'],
+          templates: templatesDir,
+        }),
+      })
+
+      const template = await readFile(join(templatesDir, 'Counter.twig'), 'utf8')
+      expect(template).toContain("bf.register_script(")
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  test('`assets` resolves a non-component entry\'s manifest-hashed URL into a generated JSON asset map', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-twig-vite-dist-assets-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-twig-vite-views-assets-'))
+    const assetsPath = join(FIXTURE_ROOT, 'dist/bf-assets.json')
+
+    try {
+      await build({
+        configFile: false,
+        root: FIXTURE_ROOT,
+        base: '/static/build/',
+        logLevel: 'warn',
+        build: {
+          outDir,
+          emptyOutDir: true,
+          // Registering the non-component entry is the CALLER's job (stock
+          // Vite config) — `assets` below only resolves the URL Vite
+          // already bundled it to, it doesn't request the bundling.
+          rollupOptions: { input: { bootstrap: resolve(FIXTURE_ROOT, 'client/bootstrap.ts') } },
+        },
+        plugins: barefoot({
+          components: ['src/components'],
+          templates: templatesDir,
+          assets: { Bootstrap: 'client/bootstrap.ts' },
+        }),
+      })
+
+      const manifest = JSON.parse(await readFile(join(outDir, '.vite/manifest.json'), 'utf8'))
+      const expectedUrl = `/static/build/${manifest['client/bootstrap.ts'].file}`
+
+      const content = JSON.parse(await readFile(assetsPath, 'utf8'))
+      expect(content).toEqual({ Bootstrap: expectedUrl })
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+      await rm(join(FIXTURE_ROOT, 'dist'), { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  test('`assets` throws an actionable error when the entry was never registered as a Rollup input', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-twig-vite-dist-assets-missing-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-twig-vite-views-assets-missing-'))
+
+    try {
+      await expect(
+        build({
+          configFile: false,
+          root: FIXTURE_ROOT,
+          base: '/static/build/',
+          logLevel: 'silent',
+          build: { outDir, emptyOutDir: true },
+          plugins: barefoot({
+            components: ['src/components'],
+            templates: templatesDir,
+            assets: { Bootstrap: 'client/bootstrap.ts' },
+          }),
+        }),
+      ).rejects.toThrow(/was not found in the build manifest/)
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+      await rm(join(FIXTURE_ROOT, 'dist'), { recursive: true, force: true })
+    }
+  }, 60_000)
+})

--- a/packages/adapter-twig/src/adapter/expr/emitters.ts
+++ b/packages/adapter-twig/src/adapter/expr/emitters.ts
@@ -129,15 +129,33 @@ export function truthyTest(node: ParsedExpr, rendered: string): string {
  * callback's receiver.
  */
 export class TwigFilterEmitter implements ParsedExprEmitter {
+  // Plain field declarations + assignment, NOT TS constructor-parameter-
+  // property shorthand: Vite's `bundleConfigFile` externalizes any bare
+  // (non-relative) import when loading `vite.config.ts` (see
+  // `@barefootjs/twig/vite`'s docstring), so this file can be loaded
+  // directly by Node's OWN native TypeScript type-stripping (enabled by
+  // default since Node 22.18/23.6) rather than esbuild — and Node's
+  // strip-only mode does not support parameter properties (`SyntaxError
+  // [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]`), only plain type annotations.
+  private readonly param: string
+  private readonly localVarMap: Map<string, string>
+  private readonly isStringName: (n: string) => boolean
+  // Records a BF101 for predicate shapes this emitter can only degrade
+  // (#2038). Optional so emitter construction stays possible without an
+  // adapter; a missing hook keeps the old silent-degrade emit.
+  private readonly onUnsupported?: (message: string, reason?: string) => void
+
   constructor(
-    private readonly param: string,
-    private readonly localVarMap: Map<string, string>,
-    private readonly isStringName: (n: string) => boolean = () => false,
-    // Records a BF101 for predicate shapes this emitter can only degrade
-    // (#2038). Optional so emitter construction stays possible without an
-    // adapter; a missing hook keeps the old silent-degrade emit.
-    private readonly onUnsupported?: (message: string, reason?: string) => void,
-  ) {}
+    param: string,
+    localVarMap: Map<string, string>,
+    isStringName: (n: string) => boolean = () => false,
+    onUnsupported?: (message: string, reason?: string) => void,
+  ) {
+    this.param = param
+    this.localVarMap = localVarMap
+    this.isStringName = isStringName
+    this.onUnsupported = onUnsupported
+  }
 
   identifier(name: string): string {
     if (name === this.param) return twigIdent(this.param)
@@ -301,7 +319,13 @@ export class TwigFilterEmitter implements ParsedExprEmitter {
  *   - no lambda fallback exists (see the file header, divergence 5).
  */
 export class TwigTopLevelEmitter implements ParsedExprEmitter {
-  constructor(private readonly ctx: TwigEmitContext) {}
+  // Plain field + assignment, not a parameter property — see
+  // `TwigFilterEmitter`'s constructor comment above for why.
+  private readonly ctx: TwigEmitContext
+
+  constructor(ctx: TwigEmitContext) {
+    this.ctx = ctx
+  }
 
   identifier(name: string): string {
     // `undefined` / `null` nested inside a larger expression tree — Twig

--- a/packages/adapter-twig/src/vite.ts
+++ b/packages/adapter-twig/src/vite.ts
@@ -1,0 +1,217 @@
+/**
+ * `@barefootjs/twig/vite` — a Twig-specific COMPOSITION of core
+ * `@barefootjs/vite`'s `barefoot()`, mirroring `@barefootjs/go-template/
+ * vite`'s, `@barefootjs/hono/vite`'s, `@barefootjs/blade/vite`'s,
+ * `@barefootjs/jinja/vite`'s, and `@barefootjs/erb/vite`'s shape and naming
+ * (`barefoot`, named AND default export; a user never passes `adapter`,
+ * this constructs `TwigAdapter` itself).
+ *
+ *   import { barefoot } from '@barefootjs/twig/vite'
+ *
+ *   export default defineConfig({
+ *     base: '/integrations/php/client/',
+ *     build: { outDir: 'dist/client' },
+ *     plugins: barefoot({
+ *       components: ['../shared/components', '../shared/blog'],
+ *       templates: 'dist/templates',
+ *     }),
+ *   })
+ *
+ * ## Why this needs no `afterEmit`-driven type-combination step (unlike Go)
+ *
+ * `@barefootjs/go-template/vite` exists mainly to combine every discovered
+ * file's `types` fragment into ONE compilable `components.go` — Go's
+ * per-file fragments assume a shared `randomID` helper and a single package
+ * header, so they are not independently valid Go source, and an unused
+ * import fails the build outright (see that module's docstring).
+ * `TwigAdapter.generate()` never produces a `types` section at all (PHP
+ * templates have no JS-style imports/types/exports to combine — see
+ * `twig-adapter.ts`'s `generate()`, whose `sections.types` is always `''`),
+ * so there is nothing across files to stitch together, and no unused-import
+ * failure mode to guard against either. Confirmed by reading `./build.ts`'s
+ * `createConfig`: unlike Go's, it has NO default `postBuild` of its own —
+ * it only forwards a caller-supplied one verbatim. So this composition's
+ * core job is just what core's `barefoot()` already does: construct
+ * `TwigAdapter` and hand it to core.
+ *
+ * ## No `adapterOptions` either — the other thing Go/Hono still need
+ *
+ * `TwigAdapterOptions` has exactly two fields, `clientJsBasePath` and
+ * `barefootJsPath` — and `TwigAdapter.generateScriptRegistrations` only
+ * falls back to them when `scriptAssets` is `undefined` (the legacy `bf
+ * build` path). Core's `barefoot()` plugin ALWAYS passes a resolved
+ * `scriptAssets` array (build: manifest-hashed; dev: origin-based — see
+ * `plugin.ts`), so that fallback is dead code on every Vite-driven build.
+ * Unlike Go (`packageName`, still real) or Hono (`clientJsFilename`, still
+ * real), Twig has no adapter option left with any effect once Vite drives
+ * the build — so this options interface simply omits the field rather than
+ * plumbing through two options that would always be ignored.
+ *
+ * ## `assets` — the one thing this DOES need, mirroring go-template/hono/blade
+ *
+ * A hand-written, non-component client bootstrap (e.g. an integration's
+ * `client/router-entry.ts`, which boots `@barefootjs/router` for the blog)
+ * isn't a `.tsx` component, so core's own discovery/`scriptAssets` machinery
+ * never sees it — but the compiled blog shell still needs a `<script src>`
+ * for it, and that URL is only knowable after Vite bundles it (dev:
+ * origin-based; build: manifest-hashed). `assets` resolves exactly that,
+ * into a generated JSON file the PHP app reads at request time (the same
+ * `dist/templates/manifest.json` — read-a-JSON-file-at-runtime — idiom this
+ * PHP already uses for `ssrDefaults`; unlike Go/Hono there is no compile
+ * step on the PHP side, so plain JSON is enough — no generated Go/TS source
+ * needed). See `@barefootjs/go-template/vite`'s docstring for the full "why
+ * a companion config-capture plugin" rationale (`afterEmit`'s
+ * `AfterEmitContext` is deliberately narrow — no `ResolvedConfig`, no dev
+ * origin, no manifest — so a tiny second plugin captures those via its own
+ * `configResolved`/`configureServer` hooks for `afterEmit`, in the same
+ * closure, to read).
+ */
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
+import { barefoot as coreBarefoot } from '@barefootjs/vite'
+import type { AfterEmitContext } from '@barefootjs/vite'
+import { devModuleUrl, loadManifest, resolveDevOrigin, resolveScriptAssets, toPosixRelative } from '@barefootjs/vite'
+import { TwigAdapter } from './adapter/index.ts'
+
+export interface TwigViteOptions {
+  /** Source directories to scan for `.tsx` components, relative to the
+   * Vite project root (or absolute). */
+  components: string[]
+  /** Where compiled `.twig` templates and `ssrDefaults` land — relative to
+   * the Vite project root (or absolute). This is a backend source
+   * directory PHP reads, NOT `build.outDir` (Vite's client-asset
+   * output). */
+  templates: string
+  /**
+   * Extra, non-component script entries whose Vite-resolved URL (dev:
+   * origin-based; production: content-hashed manifest path) should be
+   * exposed to the PHP app as a generated JSON asset map — e.g. a
+   * hand-written client bootstrap script that isn't a `.tsx` component, so
+   * it never goes through core's discovery/`scriptAssets` machinery, but
+   * still needs a `<script src="...">` URL only knowable after bundling.
+   *
+   * Keyed by the identifier the resolved URL should appear under in the
+   * generated map; values are entry paths relative to the Vite project
+   * root. You must ALSO register the same path as a Rollup entry yourself
+   * via stock `build.rollupOptions.input` — this plugin never adds
+   * bundling configuration on your behalf; this option only resolves the
+   * URL Vite already bundled it to, it doesn't request the bundling.
+   */
+  assets?: Record<string, string>
+  /** Output path for the generated JSON asset map, relative to the Vite
+   * project root. Default: 'dist/bf-assets.json'. Ignored when `assets`
+   * is empty. Placed under `dist/` (already gitignored) rather than
+   * committed like Go's `bf_assets.go`: PHP reads this file at REQUEST
+   * time, so — unlike Go, which must compile a static map into the
+   * binary — there is nothing to commit; a fresh copy is generated on
+   * every build (dev AND production) and never checked in. */
+  assetsOutputFile?: string
+}
+
+/** write-if-changed: writes `content` to `absPath` only if it differs from
+ * what's already there, logging `label` when it actually wrote. Avoids
+ * touching mtime (and so falsely tripping a file watcher, e.g. PHP's own
+ * dev server) on a pass that produced byte-identical output. */
+async function writeIfChanged(absPath: string, content: string, label: string): Promise<void> {
+  const prev = await readFile(absPath, 'utf-8').catch(() => null)
+  if (prev === content) return
+  // Default `assetsOutputFile` lives under `dist/` — a directory `vite
+  // build` may not have created yet on a clean checkout — so ensure it
+  // exists before writing.
+  await mkdir(dirname(absPath), { recursive: true })
+  await writeFile(absPath, content)
+  console.log(`Generated: ${label}`)
+}
+
+/** Resolves ONE asset entry's URL for the current pass: manifest-hashed for
+ * `mode: 'build'`, dev-origin-based for `mode: 'dev'`. Throws with an
+ * actionable message when the entry isn't in the build manifest — almost
+ * always means the caller forgot to also add it to
+ * `build.rollupOptions.input`. */
+function resolveAssetUrl(
+  ctx: AfterEmitContext,
+  config: ResolvedConfig,
+  devServer: ViteDevServer | undefined,
+  entryRelPath: string,
+  manifest: Record<string, { file: string }> | undefined,
+): string {
+  const absPath = resolve(ctx.projectDir, entryRelPath)
+  if (ctx.mode === 'dev') {
+    if (!devServer) throw new Error(`[twig/vite] asset "${entryRelPath}": dev server not ready`)
+    return devModuleUrl(config, resolveDevOrigin(devServer), absPath)
+  }
+
+  const manifestKey = toPosixRelative(config.root, absPath)
+  const [url] = resolveScriptAssets(manifest ?? {}, manifestKey, config.base)
+  if (!url) {
+    throw new Error(
+      `[twig/vite] asset "${entryRelPath}" was not found in the build manifest. ` +
+        `Did you also add it to build.rollupOptions.input?`,
+    )
+  }
+  return url
+}
+
+/** Builds and write-if-changed's the generated JSON asset map. No-op when
+ * `assets` is empty. */
+async function writeAssetMap(
+  ctx: AfterEmitContext,
+  config: ResolvedConfig,
+  devServer: ViteDevServer | undefined,
+  assets: Record<string, string>,
+  assetsOutputFile: string,
+): Promise<void> {
+  const keys = Object.keys(assets)
+  if (keys.length === 0) return
+
+  const manifest = ctx.mode === 'build' ? await loadManifest(ctx.outDir, config.build.manifest) : undefined
+
+  const resolved: Record<string, string> = {}
+  for (const name of keys) {
+    resolved[name] = resolveAssetUrl(ctx, config, devServer, assets[name]!, manifest)
+  }
+
+  const content = `${JSON.stringify(resolved, null, 2)}\n`
+  await writeIfChanged(resolve(ctx.projectDir, assetsOutputFile), content, assetsOutputFile)
+}
+
+export function barefoot(options: TwigViteOptions): Plugin[] {
+  const assets = options.assets ?? {}
+  const assetsOutputFile = options.assetsOutputFile ?? 'dist/bf-assets.json'
+
+  // Populated by `twigAssetsConfigCapture` below (only added to the
+  // returned array when `assets` is non-empty). Read by `afterEmit` — see
+  // `@barefootjs/go-template/vite`'s identical mechanism for the ordering
+  // guarantee (`configResolved`/`configureServer` always run before the
+  // eager pass that triggers `afterEmit`, for both build and dev).
+  let resolvedConfig: ResolvedConfig | undefined
+  let devServer: ViteDevServer | undefined
+
+  const core = coreBarefoot({
+    adapter: new TwigAdapter(),
+    components: options.components,
+    templates: options.templates,
+    async afterEmit(ctx) {
+      if (Object.keys(assets).length > 0 && resolvedConfig) {
+        await writeAssetMap(ctx, resolvedConfig, devServer, assets, assetsOutputFile)
+      }
+    },
+  })
+
+  if (Object.keys(assets).length === 0) return [core]
+
+  const twigAssetsConfigCapture: Plugin = {
+    name: 'barefoot-twig-assets-config-capture',
+    configResolved(config) {
+      resolvedConfig = config
+    },
+    configureServer(server) {
+      devServer = server
+    },
+  }
+
+  return [core, twigAssetsConfigCapture]
+}
+
+export { barefoot as default }

--- a/packages/adapter-xslate/e2e-fixture/client/bootstrap.ts
+++ b/packages/adapter-xslate/e2e-fixture/client/bootstrap.ts
@@ -1,0 +1,8 @@
+/**
+ * A hand-written, non-component script entry — stands in for
+ * `integrations/xslate/client/router-entry.ts` in tests: not a `.tsx`
+ * component, so core's discovery/`scriptAssets` machinery never sees it,
+ * but its bundled URL still needs to reach the compiled Perl blog shell
+ * (the `assets`/`assetsOutputFile` option under test).
+ */
+export const bootstrapped = true

--- a/packages/adapter-xslate/e2e-fixture/src/components/Counter.tsx
+++ b/packages/adapter-xslate/e2e-fixture/src/components/Counter.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export interface CounterProps {
+  initial: number
+}
+
+export function Counter(props: CounterProps) {
+  const [count, setCount] = createSignal(props.initial)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}

--- a/packages/adapter-xslate/package.json
+++ b/packages/adapter-xslate/package.json
@@ -20,6 +20,10 @@
     "./build": {
       "types": "./src/build.ts",
       "import": "./src/build.ts"
+    },
+    "./vite": {
+      "types": "./src/vite.ts",
+      "import": "./src/vite.ts"
     }
   },
   "publishConfig": {
@@ -38,6 +42,10 @@
       "./build": {
         "types": "./dist/build.d.ts",
         "import": "./dist/build.js"
+      },
+      "./vite": {
+        "types": "./dist/vite.d.ts",
+        "import": "./dist/vite.js"
       }
     }
   },
@@ -49,7 +57,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",
@@ -77,11 +85,24 @@
     "@barefootjs/shared": "workspace:*"
   },
   "peerDependencies": {
-    "@barefootjs/jsx": ">=0.2.0"
+    "@barefootjs/jsx": ">=0.2.0",
+    "@barefootjs/vite": ">=0.2.0",
+    "vite": "^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@barefootjs/vite": {
+      "optional": true
+    },
+    "vite": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@barefootjs/adapter-tests": "workspace:*",
     "@barefootjs/jsx": "workspace:*",
-    "typescript": "^5.0.0"
+    "@barefootjs/vite": "workspace:*",
+    "@barefootjs/client": "workspace:*",
+    "typescript": "^5.0.0",
+    "vite": "^6.0.0"
   }
 }

--- a/packages/adapter-xslate/src/__tests__/vite.test.ts
+++ b/packages/adapter-xslate/src/__tests__/vite.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Coverage of `@barefootjs/xslate/vite`'s `barefoot()`:
+ *
+ * - one real `vite build()` end to end (mirrors `@barefootjs/go-template/
+ *   vite`, `@barefootjs/hono/vite`, `@barefootjs/blade/vite`'s,
+ *   `@barefootjs/jinja/vite`'s, and `@barefootjs/erb/vite`'s own
+ *   `vite.test.ts` rigor — a plugin that only passes mocked unit tests
+ *   hasn't been shown to work) against a checked-in fixture (not a system
+ *   tmpdir) so `@barefootjs/client` resolves through the monorepo's real
+ *   node_modules symlinks;
+ * - the `assets` → generated `bf-assets.json` behavior, exercised the same
+ *   way (a real build, since it needs the real manifest Vite writes).
+ *
+ * Unlike Go, there is no `afterEmit`-driven type-combination step to test
+ * here (see `vite.ts`'s module docstring) — `XslateAdapter.generate()` never
+ * produces a `types` section at all, so `barefoot()` always returns a
+ * single-element array unless `assets` is set.
+ */
+import { describe, test, expect } from 'bun:test'
+import { build } from 'vite'
+import { mkdtemp, rm, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { barefoot, barefoot as defaultBarefoot } from '../vite.ts'
+
+const FIXTURE_ROOT = resolve(import.meta.dirname, '../../e2e-fixture')
+
+describe('@barefootjs/xslate/vite: real vite build', () => {
+  test('exports the same function as both named `barefoot` and default', () => {
+    expect(defaultBarefoot).toBe(barefoot)
+  })
+
+  test('returns a single-element plugin array when `assets` is omitted', () => {
+    const plugins = barefoot({ components: ['src/components'], templates: 'views' })
+    expect(plugins).toHaveLength(1)
+  })
+
+  test('writes a self-contained .tx template with scriptAssets baked in, same as core alone would do', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-xslate-vite-dist-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-xslate-vite-views-'))
+
+    try {
+      await build({
+        configFile: false,
+        root: FIXTURE_ROOT,
+        base: '/static/build/',
+        logLevel: 'warn',
+        build: { outDir, emptyOutDir: true },
+        plugins: barefoot({
+          components: ['src/components'],
+          templates: templatesDir,
+        }),
+      })
+
+      const template = await readFile(join(templatesDir, 'Counter.tx'), 'utf8')
+      expect(template).toContain("bf.register_script(")
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  test('`assets` resolves a non-component entry\'s manifest-hashed URL into a generated JSON asset map', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-xslate-vite-dist-assets-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-xslate-vite-views-assets-'))
+    const assetsPath = join(FIXTURE_ROOT, 'dist/bf-assets.json')
+
+    try {
+      await build({
+        configFile: false,
+        root: FIXTURE_ROOT,
+        base: '/static/build/',
+        logLevel: 'warn',
+        build: {
+          outDir,
+          emptyOutDir: true,
+          // Registering the non-component entry is the CALLER's job (stock
+          // Vite config) — `assets` below only resolves the URL Vite
+          // already bundled it to, it doesn't request the bundling.
+          rollupOptions: { input: { bootstrap: resolve(FIXTURE_ROOT, 'client/bootstrap.ts') } },
+        },
+        plugins: barefoot({
+          components: ['src/components'],
+          templates: templatesDir,
+          assets: { Bootstrap: 'client/bootstrap.ts' },
+        }),
+      })
+
+      const manifest = JSON.parse(await readFile(join(outDir, '.vite/manifest.json'), 'utf8'))
+      const expectedUrl = `/static/build/${manifest['client/bootstrap.ts'].file}`
+
+      const content = JSON.parse(await readFile(assetsPath, 'utf8'))
+      expect(content).toEqual({ Bootstrap: expectedUrl })
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+      await rm(join(FIXTURE_ROOT, 'dist'), { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  test('`assets` throws an actionable error when the entry was never registered as a Rollup input', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'barefoot-xslate-vite-dist-assets-missing-'))
+    const templatesDir = await mkdtemp(join(tmpdir(), 'barefoot-xslate-vite-views-assets-missing-'))
+
+    try {
+      await expect(
+        build({
+          configFile: false,
+          root: FIXTURE_ROOT,
+          base: '/static/build/',
+          logLevel: 'silent',
+          build: { outDir, emptyOutDir: true },
+          plugins: barefoot({
+            components: ['src/components'],
+            templates: templatesDir,
+            assets: { Bootstrap: 'client/bootstrap.ts' },
+          }),
+        }),
+      ).rejects.toThrow(/was not found in the build manifest/)
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+      await rm(templatesDir, { recursive: true, force: true })
+      await rm(join(FIXTURE_ROOT, 'dist'), { recursive: true, force: true })
+    }
+  }, 60_000)
+})

--- a/packages/adapter-xslate/src/adapter/expr/emitters.ts
+++ b/packages/adapter-xslate/src/adapter/expr/emitters.ts
@@ -70,15 +70,33 @@ const PREDICATE_METHODS = new Set<HigherOrderMethod>([
  * (#2038) instead of silently degrading to the callback's receiver.
  */
 export class XslateFilterEmitter implements ParsedExprEmitter {
+  // Plain field declarations + assignment, NOT TS constructor-parameter-
+  // property shorthand: Vite's `bundleConfigFile` externalizes any bare
+  // (non-relative) import when loading `vite.config.ts` (see
+  // `@barefootjs/xslate/vite`'s docstring), so this file can be loaded
+  // directly by Node's OWN native TypeScript type-stripping (enabled by
+  // default since Node 22.18/23.6) rather than esbuild — and Node's
+  // strip-only mode does not support parameter properties (`SyntaxError
+  // [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]`), only plain type annotations.
+  private readonly param: string
+  private readonly localVarMap: Map<string, string>
+  private readonly isStringName: (n: string) => boolean
+  // Records a BF101 for predicate shapes this emitter can only degrade
+  // (#2038). Optional so emitter construction stays possible without an
+  // adapter; a missing hook keeps the old silent-degrade emit.
+  private readonly onUnsupported?: (message: string, reason?: string) => void
+
   constructor(
-    private readonly param: string,
-    private readonly localVarMap: Map<string, string>,
-    private readonly isStringName: (n: string) => boolean = () => false,
-    // Records a BF101 for predicate shapes this emitter can only degrade
-    // (#2038). Optional so emitter construction stays possible without an
-    // adapter; a missing hook keeps the old silent-degrade emit.
-    private readonly onUnsupported?: (message: string, reason?: string) => void,
-  ) {}
+    param: string,
+    localVarMap: Map<string, string>,
+    isStringName: (n: string) => boolean = () => false,
+    onUnsupported?: (message: string, reason?: string) => void,
+  ) {
+    this.param = param
+    this.localVarMap = localVarMap
+    this.isStringName = isStringName
+    this.onUnsupported = onUnsupported
+  }
 
   identifier(name: string): string {
     if (name === this.param) return `$${this.param}`
@@ -239,7 +257,13 @@ export class XslateFilterEmitter implements ParsedExprEmitter {
  *   - higher-order methods route through `$bf` array helpers.
  */
 export class XslateTopLevelEmitter implements ParsedExprEmitter {
-  constructor(private readonly ctx: XslateEmitContext) {}
+  // Plain field + assignment, not a parameter property — see
+  // `XslateFilterEmitter`'s constructor comment above for why.
+  private readonly ctx: XslateEmitContext
+
+  constructor(ctx: XslateEmitContext) {
+    this.ctx = ctx
+  }
 
   identifier(name: string): string {
     // `undefined` / `null` nested inside a larger expression tree —

--- a/packages/adapter-xslate/src/vite.ts
+++ b/packages/adapter-xslate/src/vite.ts
@@ -1,0 +1,217 @@
+/**
+ * `@barefootjs/xslate/vite` — a Text::Xslate(Kolon)-specific COMPOSITION of
+ * core `@barefootjs/vite`'s `barefoot()`, mirroring `@barefootjs/go-
+ * template/vite`'s, `@barefootjs/hono/vite`'s, `@barefootjs/blade/vite`'s,
+ * `@barefootjs/jinja/vite`'s, and `@barefootjs/erb/vite`'s shape and naming
+ * (`barefoot`, named AND default export; a user never passes `adapter`,
+ * this constructs `XslateAdapter` itself).
+ *
+ *   import { barefoot } from '@barefootjs/xslate/vite'
+ *
+ *   export default defineConfig({
+ *     base: '/integrations/xslate/client/',
+ *     build: { outDir: 'dist/client' },
+ *     plugins: barefoot({
+ *       components: ['../shared/components', '../shared/blog'],
+ *       templates: 'dist/templates',
+ *     }),
+ *   })
+ *
+ * ## Why this needs no `afterEmit`-driven type-combination step (unlike Go)
+ *
+ * `@barefootjs/go-template/vite` exists mainly to combine every discovered
+ * file's `types` fragment into ONE compilable `components.go` — Go's
+ * per-file fragments assume a shared `randomID` helper and a single package
+ * header, so they are not independently valid Go source, and an unused
+ * import fails the build outright (see that module's docstring).
+ * `XslateAdapter.generate()` never produces a `types` section at all
+ * (Kolon templates have no JS-style imports/types/exports to combine — see
+ * `xslate-adapter.ts`'s `generate()`, whose `sections.types` is always
+ * `''`), so there is nothing across files to stitch together, and no
+ * unused-import failure mode to guard against either. Confirmed by reading
+ * `./build.ts`'s `createConfig`: unlike Go's, it has NO default `postBuild`
+ * of its own — it only forwards a caller-supplied one verbatim. So this
+ * composition's core job is just what core's `barefoot()` already does:
+ * construct `XslateAdapter` and hand it to core.
+ *
+ * ## No `adapterOptions` either — the other thing Go/Hono still need
+ *
+ * `XslateAdapterOptions` has exactly two fields, `clientJsBasePath` and
+ * `barefootJsPath` — and `XslateAdapter.generateScriptRegistrations` only
+ * falls back to them when `scriptAssets` is `undefined` (the legacy `bf
+ * build` path). Core's `barefoot()` plugin ALWAYS passes a resolved
+ * `scriptAssets` array (build: manifest-hashed; dev: origin-based — see
+ * `plugin.ts`), so that fallback is dead code on every Vite-driven build.
+ * Unlike Go (`packageName`, still real) or Hono (`clientJsFilename`, still
+ * real), Xslate has no adapter option left with any effect once Vite drives
+ * the build — so this options interface simply omits the field rather than
+ * plumbing through two options that would always be ignored.
+ *
+ * ## `assets` — the one thing this DOES need, mirroring go-template/hono/blade
+ *
+ * A hand-written, non-component client bootstrap (e.g. an integration's
+ * `client/router-entry.ts`, which boots `@barefootjs/router` for the blog)
+ * isn't a `.tsx` component, so core's own discovery/`scriptAssets` machinery
+ * never sees it — but the compiled blog shell still needs a `<script src>`
+ * for it, and that URL is only knowable after Vite bundles it (dev:
+ * origin-based; build: manifest-hashed). `assets` resolves exactly that,
+ * into a generated JSON file the Perl app reads at request time (the same
+ * `dist/templates/manifest.json` — read-a-JSON-file-at-runtime — idiom this
+ * Perl app already uses for `ssrDefaults`; unlike Go/Hono there is no
+ * compile step on the Perl side, so plain JSON is enough — no generated
+ * Go/TS source needed). See `@barefootjs/go-template/vite`'s docstring for
+ * the full "why a companion config-capture plugin" rationale (`afterEmit`'s
+ * `AfterEmitContext` is deliberately narrow — no `ResolvedConfig`, no dev
+ * origin, no manifest — so a tiny second plugin captures those via its own
+ * `configResolved`/`configureServer` hooks for `afterEmit`, in the same
+ * closure, to read).
+ */
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
+import { barefoot as coreBarefoot } from '@barefootjs/vite'
+import type { AfterEmitContext } from '@barefootjs/vite'
+import { devModuleUrl, loadManifest, resolveDevOrigin, resolveScriptAssets, toPosixRelative } from '@barefootjs/vite'
+import { XslateAdapter } from './adapter/index.ts'
+
+export interface XslateViteOptions {
+  /** Source directories to scan for `.tsx` components, relative to the
+   * Vite project root (or absolute). */
+  components: string[]
+  /** Where compiled `.tx` templates and `ssrDefaults` land — relative to
+   * the Vite project root (or absolute). This is a backend source
+   * directory Perl reads, NOT `build.outDir` (Vite's client-asset
+   * output). */
+  templates: string
+  /**
+   * Extra, non-component script entries whose Vite-resolved URL (dev:
+   * origin-based; production: content-hashed manifest path) should be
+   * exposed to the Perl app as a generated JSON asset map — e.g. a
+   * hand-written client bootstrap script that isn't a `.tsx` component, so
+   * it never goes through core's discovery/`scriptAssets` machinery, but
+   * still needs a `<script src="...">` URL only knowable after bundling.
+   *
+   * Keyed by the identifier the resolved URL should appear under in the
+   * generated map; values are entry paths relative to the Vite project
+   * root. You must ALSO register the same path as a Rollup entry yourself
+   * via stock `build.rollupOptions.input` — this plugin never adds
+   * bundling configuration on your behalf; this option only resolves the
+   * URL Vite already bundled it to, it doesn't request the bundling.
+   */
+  assets?: Record<string, string>
+  /** Output path for the generated JSON asset map, relative to the Vite
+   * project root. Default: 'dist/bf-assets.json'. Ignored when `assets`
+   * is empty. Placed under `dist/` (already gitignored) rather than
+   * committed like Go's `bf_assets.go`: Perl reads this file at REQUEST
+   * time, so — unlike Go, which must compile a static map into the
+   * binary — there is nothing to commit; a fresh copy is generated on
+   * every build (dev AND production) and never checked in. */
+  assetsOutputFile?: string
+}
+
+/** write-if-changed: writes `content` to `absPath` only if it differs from
+ * what's already there, logging `label` when it actually wrote. Avoids
+ * touching mtime (and so falsely tripping a file watcher, e.g. Perl's own
+ * dev server) on a pass that produced byte-identical output. */
+async function writeIfChanged(absPath: string, content: string, label: string): Promise<void> {
+  const prev = await readFile(absPath, 'utf-8').catch(() => null)
+  if (prev === content) return
+  // Default `assetsOutputFile` lives under `dist/` — a directory `vite
+  // build` may not have created yet on a clean checkout — so ensure it
+  // exists before writing.
+  await mkdir(dirname(absPath), { recursive: true })
+  await writeFile(absPath, content)
+  console.log(`Generated: ${label}`)
+}
+
+/** Resolves ONE asset entry's URL for the current pass: manifest-hashed for
+ * `mode: 'build'`, dev-origin-based for `mode: 'dev'`. Throws with an
+ * actionable message when the entry isn't in the build manifest — almost
+ * always means the caller forgot to also add it to
+ * `build.rollupOptions.input`. */
+function resolveAssetUrl(
+  ctx: AfterEmitContext,
+  config: ResolvedConfig,
+  devServer: ViteDevServer | undefined,
+  entryRelPath: string,
+  manifest: Record<string, { file: string }> | undefined,
+): string {
+  const absPath = resolve(ctx.projectDir, entryRelPath)
+  if (ctx.mode === 'dev') {
+    if (!devServer) throw new Error(`[xslate/vite] asset "${entryRelPath}": dev server not ready`)
+    return devModuleUrl(config, resolveDevOrigin(devServer), absPath)
+  }
+
+  const manifestKey = toPosixRelative(config.root, absPath)
+  const [url] = resolveScriptAssets(manifest ?? {}, manifestKey, config.base)
+  if (!url) {
+    throw new Error(
+      `[xslate/vite] asset "${entryRelPath}" was not found in the build manifest. ` +
+        `Did you also add it to build.rollupOptions.input?`,
+    )
+  }
+  return url
+}
+
+/** Builds and write-if-changed's the generated JSON asset map. No-op when
+ * `assets` is empty. */
+async function writeAssetMap(
+  ctx: AfterEmitContext,
+  config: ResolvedConfig,
+  devServer: ViteDevServer | undefined,
+  assets: Record<string, string>,
+  assetsOutputFile: string,
+): Promise<void> {
+  const keys = Object.keys(assets)
+  if (keys.length === 0) return
+
+  const manifest = ctx.mode === 'build' ? await loadManifest(ctx.outDir, config.build.manifest) : undefined
+
+  const resolved: Record<string, string> = {}
+  for (const name of keys) {
+    resolved[name] = resolveAssetUrl(ctx, config, devServer, assets[name]!, manifest)
+  }
+
+  const content = `${JSON.stringify(resolved, null, 2)}\n`
+  await writeIfChanged(resolve(ctx.projectDir, assetsOutputFile), content, assetsOutputFile)
+}
+
+export function barefoot(options: XslateViteOptions): Plugin[] {
+  const assets = options.assets ?? {}
+  const assetsOutputFile = options.assetsOutputFile ?? 'dist/bf-assets.json'
+
+  // Populated by `xslateAssetsConfigCapture` below (only added to the
+  // returned array when `assets` is non-empty). Read by `afterEmit` — see
+  // `@barefootjs/go-template/vite`'s identical mechanism for the ordering
+  // guarantee (`configResolved`/`configureServer` always run before the
+  // eager pass that triggers `afterEmit`, for both build and dev).
+  let resolvedConfig: ResolvedConfig | undefined
+  let devServer: ViteDevServer | undefined
+
+  const core = coreBarefoot({
+    adapter: new XslateAdapter(),
+    components: options.components,
+    templates: options.templates,
+    async afterEmit(ctx) {
+      if (Object.keys(assets).length > 0 && resolvedConfig) {
+        await writeAssetMap(ctx, resolvedConfig, devServer, assets, assetsOutputFile)
+      }
+    },
+  })
+
+  if (Object.keys(assets).length === 0) return [core]
+
+  const xslateAssetsConfigCapture: Plugin = {
+    name: 'barefoot-xslate-assets-config-capture',
+    configResolved(config) {
+      resolvedConfig = config
+    },
+    configureServer(server) {
+      devServer = server
+    },
+  }
+
+  return [core, xslateAssetsConfigCapture]
+}
+
+export { barefoot as default }


### PR DESCRIPTION
**Stack 6c/7** — targets #2515. Four more `/vite` subpaths and their integrations. With this, **eighteen of the nineteen integrations are migrated**; `csr` is carved out below.

| Integration | Adapter | E2E |
|---|---|---|
| php | twig | 104/104 — verified independently |
| axum | rust (minijinja) | 104/104 — verified independently |
| mojolicious | mojolicious | see verification note |
| xslate | xslate | see verification note |

## Verification, stated plainly

`php` and `axum` were built and re-run independently of the implementing agent: 104 passed each.

**`mojolicious` and `xslate` are unverified locally.** Perl is not installed in this sandbox, and the implementing agent's final report was lost to a tooling failure before it reported their counts. The code is committed and the adapters' own suites are in the diff, but CI is the first real check these two get. Please don't read the table above as claiming otherwise — if CI goes red on either, that is genuinely new information rather than a flake.

## `csr` is not here

`integrations/csr` is the one integration that is structurally unlike the other eighteen: it uses `@barefootjs/client/build`, emits no templates, and does no SSR. It was pre-authorised to be carved out if it fought the batch shape, and it did not get done.

It is small — its whole config is three options — but it carries a real design question this stack has not had to answer yet: whether `@barefootjs/client` needs a `/vite` package at all or plain `@barefootjs/vite` covers it, and what `templates` means when there is nothing to emit. That question has to be settled before stack 7 can delete `@barefootjs/client/build`'s `createConfig`, so it becomes its own PR rather than being rushed in here.

## Shape

The four adapters matched blade/jinja/erb rather than go-template, as expected from #2515: no `types` output, so near-empty `afterEmit` bodies rather than transcriptions of Go's `randomID`-injecting, import-merging combiner; `clientJsBasePath` / `barefootJsPath` dead once Vite always resolves `scriptAssets`.

Import maps deleted in all four, bringing the total to **eighteen backends across seven languages** where that hand-wiring removed itself once Rollup resolves `@barefootjs/client` through the real module graph.

## Reproducing the E2E locally

Two things cost review cycles earlier in this stack and are worth knowing:

- Integrations differ in whether `playwright.config.ts` builds before starting the server. hono and h3 run `bun run build && …` in `webServer.command`; php, blade and flask start the server only, deliberately (production-shaped, template cache on). Forgetting the build produces `View [...] not found` / `TemplateNotFound`, which looks exactly like a real regression.
- This sandbox's Chromium is revision 1194 while `@playwright/test` pins another, with CDN egress blocked. The configs carry a `PW_EXECUTABLE_PATH` hook; no config file was modified.

## Out of scope

`csr` (its own PR). Deleting `createConfig` / `./build` / `barefoot.config.ts` / `addScriptCollection` / `packages/cli/src/lib/build.ts` (stack 7).

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ)_