### PR TITLE
revert(ci): remove the fallback publish — it released the pending Version PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,8 @@ jobs:
     # default 6h, blocking every queued release run behind it.
     timeout-minutes: 30
     outputs:
-      published: ${{ steps.changesets.outputs.published == 'true' && 'true' || steps.fallback.outputs.published }}
-      publishedPackages: ${{ steps.changesets.outputs.published == 'true' && steps.changesets.outputs.publishedPackages || steps.fallback.outputs.publishedPackages }}
+      published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -81,58 +81,6 @@ jobs:
           publish: bun run release:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Whether a release happens must not depend on what else merged.
-      #
-      # changesets/action decides between "open a Version PR" and "publish"
-      # from whether `.changeset/` is empty — global state any PR can change.
-      # A changeset landing on main between the Version PR being refreshed and
-      # merged turns that merge into another version PR, and the run goes green
-      # having released nothing (0.30.1: #2500 merged 29s before #2495).
-      #
-      # So decide from what is actually on npm instead. release:publish is
-      # idempotent and version-driven — it compares each package.json against
-      # the registry and skips what is already there — so this is a no-op in
-      # the ordinary case and a release in the case above. Guarded by the
-      # verify script so the ordinary case costs 22 small HTTP requests rather
-      # than a full build; exit 2 (could not reach a registry) deliberately
-      # does not trigger a publish.
-      - name: Publish anything main has that npm does not
-        id: fallback
-        if: steps.changesets.outputs.published != 'true'
-        run: |
-          # pipefail matters below: `bun run release:publish | tee` reports
-          # tee's status without it, so a failed publish would fall through to
-          # the parsing step and mark a partial release as a successful one —
-          # the exact silent-failure shape this whole step exists to remove.
-          set -o pipefail
-          set +e
-          bun scripts/verify-released.ts --npm
-          drift=$?
-          set -e
-          if [ "$drift" -eq 0 ]; then
-            echo "main matches npm — nothing to publish"
-            exit 0
-          fi
-          if [ "$drift" -ne 1 ]; then
-            echo "::error::could not determine what is published; not publishing"
-            exit 1
-          fi
-
-          echo "::warning::main is ahead of npm — publishing (changesets took the version path)"
-          bun run release:publish | tee publish.log
-
-          # Rebuild the shape changesets/action would have emitted, so
-          # cpan-release and every sibling native-registry job still fire.
-          # changeset-publish.ts prints one "New tag: <name>@<version>" per
-          # package it published — the same line the action itself parses.
-          entries=$(sed -n 's/^New tag: \(.*\)@\([^@]*\)$/{"name":"\1","version":"\2"}/p' publish.log | paste -sd, -)
-          if [ -z "$entries" ]; then
-            echo "::error::main was ahead of npm but nothing published — check the log above"
-            exit 1
-          fi
-          echo "published=true" >> "$GITHUB_OUTPUT"
-          echo "publishedPackages=[$entries]" >> "$GITHUB_OUTPUT"
 
   # Mirror whatever Changesets just published to npm onto JSR. Delegates to
   # the reusable jsr-publish.yml so the release-driven path and the manual


### PR DESCRIPTION
**Merge this before anything else lands on main.** The bug fires on every push to main that carries a changeset, which is the normal state between releases.

## What happened

The fallback I added in #2507 published **0.30.3 off the merge of #2507 itself** — [run 30800053812](https://github.com/piconic-ai/barefootjs/actions/runs/30800053812), `Done: 22 published, 0 skipped`.

The step reads `package.json` from the job's working tree. By the time it runs, `changesets/action` has already rewritten that tree: taking the version path means running `bunx changeset version` **in place** to produce the Version PR's contents. So the step compared the *pending* 0.30.3 against npm's 0.30.2, correctly concluded "main is ahead of npm", and published.

```
publish  @barefootjs/rust@0.30.3 (0.30.2 → 0.30.3)
...
Done: 22 published, 0 skipped
```

Every changeset landing on main would have immediately released the next version. The Version PR workflow was bypassed entirely. Note `git log main` still has no "Version Packages" commit for 0.30.3 — main is at 0.30.2 with a pending Version PR.

## Actual damage: npm only

Verified against every registry:

| registry | state | note |
| --- | --- | --- |
| **npm** | **0.30.3** ×22 | the only contamination |
| JSR | 0.30.2 | job "succeeded" — no-op, its script self-skips live versions |
| Packagist twig / blade / php | v0.30.2 | twig+php "succeeded" — no-op, they tag `v$version` from their own checkout |
| PyPI | 0.30.2 | job failed |
| crates.io | 0.30.2 | job failed |
| CPAN | 0.30.2 | job failed |
| RubyGems | **0.25.0** | job failed — **and this one predates today**, see below |

The five failures are the same confusion seen from the other side: every native job does its own `actions/checkout`, so they saw main's **real** state — 0.30.2, already published — and tried to re-publish it. npm got a version main has never contained; the native registries got asked to re-publish one they already had. Harmless, but noisy.

## Separately: RubyGems has been failing for a while

`barefoot_js` is on **0.25.0** while `@barefootjs/erb` is on 0.30.x. `rubygems-release` also failed in the previous, entirely legitimate 0.30.2 release ([run 30782330121](https://github.com/piconic-ai/barefootjs/actions/runs/30782330121)) — the only failing job in an otherwise green release.

This is not caused by this PR's bug, and it is worth recording because it refutes the reasoning I used in #2507 to leave PyPI/RubyGems/crates.io out of `verify-released.ts`: I argued a failed publish is already red, so no check is needed. It has been red, repeatedly, and the gap still grew to five minor versions. Red is evidently not the same as noticed.

## This PR

Removes the fallback step and restores the `release` job's outputs. `.github/workflows/release.yml` is now **byte-identical to its pre-#2507 state** — `git diff e13937b -- .github/workflows/release.yml` is empty.

`scripts/verify-released.ts` stays. Nothing calls it automatically, so it is inert, and it is the tool for seeing where things actually stand:

```
bun scripts/verify-released.ts
```

## Why revert rather than repair

The one-line version of the fix is to read committed state instead of the working tree. But this shipped having been tested only against a tree nobody had touched — the version path, the one that breaks, was never exercised. Repairing that under fire and merging it straight back into the same pipeline is how the second mistake happens.

The underlying idea still holds: whether a release happens should be decided by what is on the registry, not by whether `.changeset/` happens to be empty at merge time. It needs its own change, with the version path simulated before it merges.

## Cleanup this does not do

npm is at 0.30.3 for all 22 packages, with nothing else at 0.30.3 anywhere. Choosing between yanking those and rolling forward to a real 0.30.3 is yours — happy to do either, but it should not be bundled into a revert that needs to merge now.