### PR TITLE
feat(csr): migrate integrations/csr onto @barefootjs/vite, completing all nineteen

### DIFF
--- a/.changeset/vite-csr-migration.md
+++ b/.changeset/vite-csr-migration.md
@@ -1,0 +1,78 @@
+---
+"@barefootjs/vite": minor
+---
+
+Make `templates` optional, and migrate `integrations/csr` — the last of the nineteen
+
+`integrations/csr` is unlike the other eighteen: it emits no templates and
+does no SSR, so it needed no answer to "does `@barefootjs/client` need its
+own `/vite` package?" — it doesn't. Plain `@barefootjs/vite`'s `barefoot()`
+with `new CSRAdapter()` (`@barefootjs/client/build`'s existing sentinel
+adapter — `generate()` always returns empty output) covers it exactly.
+`CSRAdapter` is still required, not skippable: the compiler's analyzer
+consults `TemplateAdapter.acceptsTemplateCall` when deciding template- vs.
+init-scope placement for a call expression, so CSR still needs *an* adapter
+— just one whose output is thrown away.
+
+## The one thing core needed: the degenerate "no real template" case
+
+The eager pass previously wrote one `markedTemplate` file per discovered
+component unconditionally — for CSR that's a directory of empty `.tsx`
+files, exactly what the legacy CLI's `clientOnly` gate always avoided.
+`BarefootViteOptions.templates` is now optional; when omitted, the eager
+pass still compiles every discovered component (the graph pass needs the
+same canonical compile regardless of `templates`) but writes nothing on
+its behalf — no per-component template/`ssrDefaults`/types files, no
+`manifest.json`, no dev-artifact marker, no `afterEmit` call.
+
+Omitting `templates` is a claim this plugin verifies, not trusts:
+`assertNoRealTemplateOutput` refuses loudly if any discovered component's
+`markedTemplate` output turns out non-empty anyway, rather than silently
+dropping it — CLAUDE.md's sound-or-loud idiom, applied here. The check is
+scoped to `markedTemplate` content specifically, not any adapter output:
+`ssrDefaults` is derived from IR metadata independent of the adapter, and
+IS real even under `CSRAdapter` (a `Counter`'s signal default produces a
+non-empty `ssrDefaults` file regardless of what `generate()` returns) —
+treating it as loudness-worthy would make `templates` impossible to omit
+for the one adapter this option exists to accommodate. This matches the
+legacy CLI's own `clientOnly` gate exactly, which drops `ssrDefaults`
+alongside the template rather than failing over it.
+
+## What CSR revealed the other eighteen couldn't
+
+CSR's `pages/*.html` are a genuinely different shape: static, hand-written
+HTML files with an inline `<script type="module">`, not a per-request
+server-rendered template. Each one hand-imported a fixed, un-hashed path
+(`/static/components/Counter.client.js`, matching the legacy CLI's
+un-bundled output layout) and carried a hand-written `@barefootjs/client*`
+import map (`{"@barefootjs/client/runtime": "/static/components/
+barefoot.js"}`) so the browser's native module loader could resolve the
+bare specifier its own inline script used — CSR's answer to the "hand-
+written import map" every other integration has already deleted, just for
+a different reason (there being no SSR shell to embed it in) than the
+usual "Vite bundling already resolves this" one.
+
+Fixed by routing every `pages/*.html` through Vite's own multi-page build
+(`build.rollupOptions.input`, merged with `barefoot()`'s own component-
+derived entries) instead of serving them as static passthrough files:
+Vite rewrites each page's inline script into a real, hashed, bundled
+entry, resolving both the dynamic `import()` of the component `.tsx` file
+(now a plain relative import, e.g. `../../shared/components/Counter.tsx`)
+and the `@barefootjs/client/runtime` bare specifier — no import map
+needed. `server.ts` now serves the built `dist/pages/*.html`, not the
+`pages/` source directory.
+
+One CSR-specific consequence for `build:watch`: every other migrated
+integration maps it to `vite dev`, pairing a backend dev script that reads
+`templates` at request time and renders a `<script src>` pointing at
+Vite's own dev-server origin. CSR has no such backend step to bake a
+dev-origin URL into — its pages are the shell. `build:watch` instead runs
+`vite build --watch`, preserving CSR's actual prior dev loop (rebuild to
+`dist/` on save, reload the browser) rather than wiring up a cross-origin
+split that would silently never take effect.
+
+`barefoot.config.ts` stays, unused, until a later PR removes the legacy
+CLI outright. `integrations/csr`'s 79-test Playwright E2E suite passes
+against the migrated build with the same single pre-existing, unrelated
+failure (`ToggleItem` scope-ID format) reproduced identically against the
+legacy build — not a regression from this migration.

--- a/integrations/csr/package.json
+++ b/integrations/csr/package.json
@@ -2,19 +2,21 @@
   "name": "barefootjs-csr-example",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build",
-    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "build": "vite build",
+    "build:watch": "vite build --watch",
     "dev": "bun run server.ts",
     "test:e2e": "bunx playwright test",
     "test:e2e:ui": "bunx playwright test --ui"
   },
   "dependencies": {
-    "@barefootjs/client": "workspace:*",
-    "@barefootjs/hono": "workspace:*"
+    "@barefootjs/client": "workspace:*"
   },
   "devDependencies": {
-    "@barefootjs/hono": "workspace:*",
-    "bun-types": "^1.1.0"
+    "@barefootjs/jsx": "workspace:*",
+    "@barefootjs/vite": "workspace:*",
+    "bun-types": "^1.1.0",
+    "vite": "^6.0.0"
   }
 }

--- a/integrations/csr/pages/conditional-return-link.html
+++ b/integrations/csr/pages/conditional-return-link.html
@@ -3,9 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>Conditional Return (Link) - CSR</title>
-  <script type="importmap">
-    { "imports": { "@barefootjs/client/runtime": "/static/components/barefoot.js" } }
-  </script>
   <link rel="stylesheet" href="/shared/styles/components.css">
 </head>
 <body>
@@ -16,7 +13,7 @@
   </div>
   <script type="module">
     import { render } from '@barefootjs/client/runtime'
-    await import('/static/components/ConditionalReturn.client.js')
+    await import('../../shared/components/ConditionalReturn.tsx')
     render(document.getElementById('app'), 'ConditionalReturn', { variant: 'link' })
   </script>
 </body>

--- a/integrations/csr/pages/conditional-return.html
+++ b/integrations/csr/pages/conditional-return.html
@@ -3,9 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>Conditional Return - CSR</title>
-  <script type="importmap">
-    { "imports": { "@barefootjs/client/runtime": "/static/components/barefoot.js" } }
-  </script>
   <link rel="stylesheet" href="/shared/styles/components.css">
 </head>
 <body>
@@ -16,7 +13,7 @@
   </div>
   <script type="module">
     import { render } from '@barefootjs/client/runtime'
-    await import('/static/components/ConditionalReturn.client.js')
+    await import('../../shared/components/ConditionalReturn.tsx')
     render(document.getElementById('app'), 'ConditionalReturn')
   </script>
 </body>

--- a/integrations/csr/pages/counter.html
+++ b/integrations/csr/pages/counter.html
@@ -3,9 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>Counter - CSR</title>
-  <script type="importmap">
-    { "imports": { "@barefootjs/client/runtime": "/static/components/barefoot.js" } }
-  </script>
   <link rel="stylesheet" href="/shared/styles/components.css">
 </head>
 <body>
@@ -16,7 +13,7 @@
   </div>
   <script type="module">
     import { render } from '@barefootjs/client/runtime'
-    await import('/static/components/Counter.client.js')
+    await import('../../shared/components/Counter.tsx')
     render(document.getElementById('app'), 'Counter')
   </script>
 </body>

--- a/integrations/csr/pages/form.html
+++ b/integrations/csr/pages/form.html
@@ -3,9 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>Form - CSR</title>
-  <script type="importmap">
-    { "imports": { "@barefootjs/client/runtime": "/static/components/barefoot.js" } }
-  </script>
   <link rel="stylesheet" href="/shared/styles/components.css">
 </head>
 <body>
@@ -16,7 +13,7 @@
   </div>
   <script type="module">
     import { render } from '@barefootjs/client/runtime'
-    await import('/static/components/Form.client.js')
+    await import('../../shared/components/Form.tsx')
     render(document.getElementById('app'), 'Form')
   </script>
 </body>

--- a/integrations/csr/pages/portal.html
+++ b/integrations/csr/pages/portal.html
@@ -3,9 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>Portal - CSR</title>
-  <script type="importmap">
-    { "imports": { "@barefootjs/client/runtime": "/static/components/barefoot.js" } }
-  </script>
   <link rel="stylesheet" href="/shared/styles/components.css">
 </head>
 <body>
@@ -16,7 +13,7 @@
   </div>
   <script type="module">
     import { render } from '@barefootjs/client/runtime'
-    await import('/static/components/PortalExample.client.js')
+    await import('../../shared/components/PortalExample.tsx')
     render(document.getElementById('app'), 'PortalExample')
   </script>
 </body>

--- a/integrations/csr/pages/props-reactivity.html
+++ b/integrations/csr/pages/props-reactivity.html
@@ -3,9 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>Props Reactivity Comparison - CSR</title>
-  <script type="importmap">
-    { "imports": { "@barefootjs/client/runtime": "/static/components/barefoot.js" } }
-  </script>
   <link rel="stylesheet" href="/shared/styles/components.css">
 </head>
 <body>
@@ -16,7 +13,7 @@
   </div>
   <script type="module">
     import { render } from '@barefootjs/client/runtime'
-    await import('/static/components/ReactiveProps.client.js')
+    await import('../../shared/components/ReactiveProps.tsx')
     render(document.getElementById('app'), 'PropsReactivityComparison')
   </script>
 </body>

--- a/integrations/csr/pages/reactive-props.html
+++ b/integrations/csr/pages/reactive-props.html
@@ -3,9 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>Reactive Props - CSR</title>
-  <script type="importmap">
-    { "imports": { "@barefootjs/client/runtime": "/static/components/barefoot.js" } }
-  </script>
   <link rel="stylesheet" href="/shared/styles/components.css">
 </head>
 <body>
@@ -16,7 +13,7 @@
   </div>
   <script type="module">
     import { render } from '@barefootjs/client/runtime'
-    await import('/static/components/ReactiveProps.client.js')
+    await import('../../shared/components/ReactiveProps.tsx')
     render(document.getElementById('app'), 'ReactiveProps')
   </script>
 </body>

--- a/integrations/csr/pages/todos.html
+++ b/integrations/csr/pages/todos.html
@@ -3,9 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>Todo App - CSR</title>
-  <script type="importmap">
-    { "imports": { "@barefootjs/client/runtime": "/static/components/barefoot.js" } }
-  </script>
   <link rel="stylesheet" href="/shared/styles/components.css">
   <link rel="stylesheet" href="/shared/styles/todo-app.css">
 </head>
@@ -13,7 +10,7 @@
   <div id="app"></div>
   <script type="module">
     import { render } from '@barefootjs/client/runtime'
-    await import('/static/components/TodoApp.client.js')
+    await import('../../shared/components/TodoApp.tsx')
 
     // Fetch initial todos from API
     const response = await fetch('/api/todos')

--- a/integrations/csr/pages/toggle.html
+++ b/integrations/csr/pages/toggle.html
@@ -3,9 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>Toggle - CSR</title>
-  <script type="importmap">
-    { "imports": { "@barefootjs/client/runtime": "/static/components/barefoot.js" } }
-  </script>
   <link rel="stylesheet" href="/shared/styles/components.css">
 </head>
 <body>
@@ -16,7 +13,7 @@
   </div>
   <script type="module">
     import { render } from '@barefootjs/client/runtime'
-    await import('/static/components/Toggle.client.js')
+    await import('../../shared/components/Toggle.tsx')
     const toggleItems = [
       { label: 'Setting 1', defaultOn: true },
       { label: 'Setting 2', defaultOn: false },

--- a/integrations/csr/playwright.config.ts
+++ b/integrations/csr/playwright.config.ts
@@ -20,9 +20,18 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'bun run build.ts && bun run server.ts',
+    // `bun run build`, not `bun run build.ts` — there has never been a
+    // `build.ts` in this directory, so this command could only ever have
+    // worked when a server was already listening on 3002 and
+    // `reuseExistingServer` skipped it. Nothing caught that: unlike the
+    // other integrations, csr has no e2e job in `.github/workflows`.
+    command: 'bun run build && bun run server.ts',
     url: 'http://localhost:3002',
     reuseExistingServer: !process.env.CI,
-    timeout: 15000,
+    // 30s, matching every other integration whose command builds first. The
+    // old 15s only ever had to cover `server.ts` starting, because the build
+    // half of the command failed instantly on a missing file. A cold
+    // `vite build` here measures ~17s.
+    timeout: 30000,
   },
 })

--- a/integrations/csr/server.ts
+++ b/integrations/csr/server.ts
@@ -1,15 +1,22 @@
 /**
  * BarefootJS CSR example server
  *
- * Serves static HTML pages + compiled client JS.
+ * Serves Vite-built HTML pages + compiled client JS.
  * Each page contains an empty mount point where components render via CSR.
+ *
+ * Pages live in `dist/pages/` (Vite build output), NOT the `pages/` source
+ * dir: each source page's inline `<script type="module">` imports a
+ * component `.tsx` file directly and `@barefootjs/client/runtime` by bare
+ * specifier — both need `vite build`'s own HTML processing to become real,
+ * resolvable, hashed asset references before a plain static file server
+ * like this one can serve them (see `vite.config.ts`).
  */
 
 import { resolve, dirname } from 'node:path'
 
 const ROOT_DIR = dirname(import.meta.path)
-const PAGES_DIR = resolve(ROOT_DIR, 'pages')
 const DIST_DIR = resolve(ROOT_DIR, 'dist')
+const PAGES_DIR = resolve(DIST_DIR, 'pages')
 const SHARED_DIR = resolve(ROOT_DIR, '../shared')
 
 // In-memory todo storage (same as Hono server)

--- a/integrations/csr/vite.config.ts
+++ b/integrations/csr/vite.config.ts
@@ -1,0 +1,75 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { barefoot } from '@barefootjs/vite'
+import { CSRAdapter } from '@barefootjs/client/build'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+
+// Every `pages/*.html` file is a genuine Vite entry (not a static passthrough
+// asset): each one's inline `<script type="module">` imports a component
+// `.tsx` file directly (e.g. `../../shared/components/Counter.tsx`) and
+// `@barefootjs/client/runtime`'s `render()`. Both need real module
+// resolution/bundling — the FIRST because `barefoot()`'s own `transform`
+// hook only ever sees a `.tsx` file if something reaches it as a module (an
+// unprocessed static HTML file never would), the SECOND because a plain
+// static file server (`server.ts`) can't resolve a bare `@barefootjs/
+// client/runtime` specifier a browser would otherwise need an import map
+// for. Routing pages through Vite's own multi-page build lets it rewrite
+// both into real, hashed asset URLs — no hand-written import map, no
+// hardcoded `/static/components/Foo.client.js` guess at what the legacy
+// CLI's un-bundled output layout used to be.
+const pages = [
+  'index',
+  'counter',
+  'toggle',
+  'todos',
+  'form',
+  'portal',
+  'reactive-props',
+  'props-reactivity',
+  'conditional-return',
+  'conditional-return-link',
+]
+
+// `package.json`'s `build:watch` runs `vite build --watch` here, NOT
+// `vite dev` (the convention every other migrated integration uses). Those
+// integrations pair `vite dev` with a BACKEND dev script that reads
+// `templates` at request time and renders a `<script src>` pointing at
+// Vite's own dev-server origin (see `@barefootjs/vite`'s `devScriptAssets`)
+// — a cross-origin split that needs a template-rendering step in the
+// middle. CSR has no such step: its pages are the shell, served verbatim by
+// `server.ts` from `dist/pages/`, so there is nothing to bake a dev-origin
+// URL INTO. `vite build --watch` keeps CSR's actual dev loop (rebuild to
+// `dist/` on save, then reload the browser) working exactly as it did under
+// the legacy CLI's own `--watch`, without a half-working dev-server split
+// that would silently never take effect.
+
+export default defineConfig({
+  base: '/static/',
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    // Several pages' inline module scripts use top-level `await import(...)`
+    // (fetching data before rendering, e.g. `todos.html`) — Vite/esbuild's
+    // default target predates top-level await support.
+    target: 'esnext',
+    rollupOptions: {
+      // Merged with `barefoot()`'s own component-derived entries — see
+      // `@barefootjs/hono/vite`'s `router-entry` for the same
+      // user-config-supplies-extra-entries pattern.
+      input: Object.fromEntries(pages.map(name => [`pages/${name}`, resolve(HERE, `pages/${name}.html`)])),
+    },
+  },
+  plugins: [
+    barefoot({
+      // CSRAdapter's `generate()` always returns empty output — CSR has no
+      // template-language backend, no SSR shell, nothing for a `templates`
+      // dir to hold. `templates` stays unset; `@barefootjs/vite` verifies
+      // that claim itself rather than trusting it (see its
+      // `assertNoRealTemplateOutput`).
+      adapter: new CSRAdapter(),
+      components: ['../shared/components'],
+    }),
+  ],
+})

--- a/packages/vite/src/__tests__/templates-optional.test.ts
+++ b/packages/vite/src/__tests__/templates-optional.test.ts
@@ -1,0 +1,139 @@
+/**
+ * `templates` is optional on `BarefootViteOptions` for an adapter whose
+ * `generate()` output is ALWAYS empty (CSR — see `@barefootjs/client`'s
+ * `CSRAdapter`). These tests pin both halves of that contract directly
+ * against `plugin.ts`'s hooks (no real Vite build — see
+ * `e2e-vite-build.test.ts` for that):
+ *
+ *   - a CSR-shaped project (CSRAdapter, `templates` omitted) builds clean:
+ *     no template files, no manifest.json, no thrown error — even for a
+ *     component whose `ssrDefaults` output IS real (proving the guard is
+ *     scoped to `markedTemplate` content specifically, not any adapter
+ *     output — see `plugin.ts`'s `assertNoRealTemplateOutput` docstring).
+ *   - a non-CSR adapter (one that actually emits template text) with
+ *     `templates` omitted refuses loudly instead of silently dropping that
+ *     output.
+ */
+import { describe, test, expect, afterEach } from 'bun:test'
+import { mkdtemp, rm, mkdir, writeFile, access } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { testAdapter } from '@barefootjs/jsx'
+import { CSRAdapter } from '@barefootjs/client/build'
+import { barefoot } from '../plugin.ts'
+
+// biome-ignore lint: hooks are called directly, bypassing Vite's own
+// dispatch/typing — casting to `any` is the standard way to unit-test a
+// Vite plugin's hooks in isolation.
+type AnyPlugin = any
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe('templates: optional for an adapter with always-empty output (CSR)', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  test('builds clean with no template files, no manifest.json, and no error — including a component with real ssrDefaults', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-plugin-templates-optional-csr-'))
+    await mkdir(join(dir, 'src/components'), { recursive: true })
+    // A signal with a literal initializer produces non-empty `ssrDefaults`
+    // regardless of adapter (that computation reads IR metadata, not
+    // `generate()`'s output) — this is the case that would wrongly trip an
+    // over-broad guard checking ANY adapter output, not just the template.
+    await writeFile(
+      join(dir, 'src/components/Counter.tsx'),
+      '\'use client\'\nimport { createSignal } from \'@barefootjs/client\'\nexport function Counter() {\n  const [count, setCount] = createSignal(0)\n  return <button onClick={() => setCount(count() + 1)}>{count()}</button>\n}\n',
+    )
+
+    const plugin: AnyPlugin = barefoot({
+      adapter: new CSRAdapter(),
+      components: ['src/components'],
+    })
+    await plugin.config({ root: dir }, { command: 'build', mode: 'production' })
+    plugin.configResolved({ root: dir, base: '/', build: { outDir: 'dist', manifest: true } })
+    await mkdir(join(dir, 'dist/.vite'), { recursive: true })
+    await writeFile(
+      join(dir, 'dist/.vite/manifest.json'),
+      JSON.stringify({ 'src/components/Counter.tsx': { file: 'assets/Counter-abc123.js', isEntry: true } }),
+    )
+
+    await expect(plugin.writeBundle()).resolves.toBeUndefined()
+
+    // No `templates` option was given, so there is no directory this
+    // plugin could have written a template/manifest into in the first
+    // place — the absence of a stray output directory anywhere under the
+    // project root is the observable half of "no template files".
+    expect(await pathExists(join(dir, 'manifest.json'))).toBe(false)
+  })
+
+  test('dev pass also builds clean with `templates` omitted', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-plugin-templates-optional-csr-dev-'))
+    await mkdir(join(dir, 'src/components'), { recursive: true })
+    await writeFile(join(dir, 'src/components/Greeting.tsx'), 'export function Greeting() { return <p>Hi</p> }')
+
+    const plugin: AnyPlugin = barefoot({
+      adapter: new CSRAdapter(),
+      components: ['src/components'],
+    })
+    await plugin.config({ root: dir }, { command: 'serve', mode: 'development' })
+    plugin.configResolved({ root: dir, base: '/', build: { outDir: 'dist', manifest: true } })
+
+    // Drive `configureServer`'s middleware-mode path (no `httpServer`)
+    // directly, matching how `e2e-vite-dev.test.ts` exercises this without
+    // a real listening server.
+    const watchedDirs: string[] = []
+    const listeners: Record<string, (arg: string) => void> = {}
+    plugin.configureServer({
+      httpServer: null,
+      config: { logger: { error: () => {} } },
+      watcher: {
+        add: (d: string) => watchedDirs.push(d),
+        on: (event: string, cb: (arg: string) => void) => { listeners[event] = cb },
+      },
+      ws: { send: () => {} },
+    })
+
+    // The initial pass runs asynchronously (middleware-mode branch) —
+    // give it a tick to complete and surface any thrown error.
+    await new Promise(r => setTimeout(r, 50))
+    expect(watchedDirs).toContain(join(dir, 'src/components'))
+  })
+})
+
+describe('templates: refuses loudly when omitted but the adapter produces a real template', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  test('writeBundle throws a clear error naming the offending file', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-plugin-templates-optional-refuse-'))
+    await mkdir(join(dir, 'src/components'), { recursive: true })
+    // `testAdapter` (unlike CSRAdapter) emits a REAL, non-empty template —
+    // exactly the output that would be silently dropped without this guard.
+    await writeFile(join(dir, 'src/components/Greeting.tsx'), 'export function Greeting() { return <p>Hi</p> }')
+
+    const plugin: AnyPlugin = barefoot({
+      adapter: testAdapter,
+      components: ['src/components'],
+    })
+    await plugin.config({ root: dir }, { command: 'build', mode: 'production' })
+    plugin.configResolved({ root: dir, base: '/', build: { outDir: 'dist', manifest: true } })
+    await mkdir(join(dir, 'dist/.vite'), { recursive: true })
+    await writeFile(join(dir, 'dist/.vite/manifest.json'), '{}')
+
+    await expect(plugin.writeBundle()).rejects.toThrow(/templates/)
+    await expect(plugin.writeBundle()).rejects.toThrow(/Greeting\.tsx/)
+  })
+})

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -120,7 +120,12 @@ export function barefoot(options: BarefootViteOptions): Plugin {
   // be set; then again in `configResolved` with Vite's authoritative
   // `root`, which is what `resolveId` / `transform` / `writeBundle` use.
   let componentDirs: string[] = []
-  let templatesDir = ''
+  // `undefined` exactly when `options.templates` was never set — the CSR
+  // degenerate case. Every write path below (`writeEmits`, `manifest.json`,
+  // the dev-artifact marker, `afterEmit`) is gated on this being defined;
+  // `assertNoRealTemplateOutput` is what makes skipping those writes safe
+  // rather than a silent drop.
+  let templatesDir: string | undefined
   let resolvedConfig: ResolvedConfig | undefined
 
   // Name → absolute-path index for resolving `@bf-child:<Name>` markers
@@ -153,8 +158,41 @@ export function barefoot(options: BarefootViteOptions): Plugin {
   // (Hono-shaped JS-runtime adapters; Go/Mojo/etc. templates have no
   // imports and never call this at all).
   function rewriterFor(absPath: string): (importPath: string) => string {
+    // No `templates` dir configured (the CSR degenerate case) — there is
+    // nowhere for a rewritten import to point, but that's harmless: a
+    // relative import only reaches emitted template text (never client
+    // JS), and `assertNoRealTemplateOutput` refuses loudly the moment any
+    // component's template output turns out non-empty. Identity is a safe
+    // placeholder for output that can never survive to be read.
+    if (templatesDir === undefined) return importPath => importPath
     const outputPathGuess = resolve(templatesDir, relativeUnderComponentDir(absPath, componentDirs))
     return buildRelativeImportRewriter(absPath, outputPathGuess, componentDirs, templatesDir)
+  }
+
+  /**
+   * Refuses loudly when `options.templates` is omitted but `result` (a
+   * specific discovered component's compile) produced a REAL `markedTemplate`
+   * — non-empty content that would otherwise be silently dropped by the
+   * `templatesDir === undefined` skip below. `ssrDefaults`/`types` output is
+   * deliberately NOT checked here: the legacy CLI's own `clientOnly` gate
+   * (`packages/cli/src/lib/build.ts`) drops those unconditionally alongside
+   * the template even for an adapter whose components carry real signal
+   * defaults (a CSR `Counter` DOES produce non-empty `ssrDefaults` — proven
+   * by inspection — precisely because that computation reads IR metadata,
+   * not the adapter's `generate()` output), so treating them as
+   * loudness-worthy here would make `templates` impossible to omit for the
+   * one adapter (`CSRAdapter`) this option exists to accommodate.
+   */
+  function assertNoRealTemplateOutput(result: CompileResult, absPath: string): void {
+    const real = result.files.find(f => f.type === 'markedTemplate' && f.content.trim() !== '')
+    if (!real) return
+    throw new Error(
+      `[${PLUGIN_NAME}] adapter "${options.adapter.name}" produced a real template for ` +
+      `"${absPath}", but no \`templates\` option is configured on barefoot() — that output ` +
+      `would be silently dropped. Set \`templates: '<dir>'\`, or use an adapter whose ` +
+      `generate() output is always empty (e.g. CSRAdapter) if this project truly emits no ` +
+      `templates.`,
+    )
   }
 
   function compileCanonical(absPath: string, content: string): CompileResult {
@@ -211,6 +249,13 @@ export function barefoot(options: BarefootViteOptions): Plugin {
    * `AfterEmitContext`). Collected here (not read back off disk) since
    * `planEmits`/`writeEmits` already have the compiled `CompileResult` in
    * hand; no adapter-specific knowledge is needed to harvest it.
+   *
+   * When `options.templates` is omitted (`templatesDir === undefined`),
+   * this still compiles every discovered component — the graph pass
+   * (`transform`) needs the same canonical compile anyway, and
+   * `assertNoRealTemplateOutput` needs a real `CompileResult` to check —
+   * but writes nothing to disk on any component's behalf and returns an
+   * empty `types` map. See `types.ts`'s docstring on `templates`.
    */
   async function emitTemplatesFor(
     discovered: DiscoveredComponent[],
@@ -221,7 +266,8 @@ export function barefoot(options: BarefootViteOptions): Plugin {
     // Combined `manifest.json` row per source file — see
     // `component-manifest.ts`'s header for why this is written alongside
     // (not instead of) the per-component `.ssr-defaults.json` files
-    // `writeEmits` already produces.
+    // `writeEmits` already produces. Stays empty (and unwritten) when
+    // `templatesDir` is undefined.
     const manifestEntries: Record<string, ManifestEntry> = {}
     for (const component of discovered) {
       const content = await readFile(component.absPath, 'utf8')
@@ -244,6 +290,11 @@ export function barefoot(options: BarefootViteOptions): Plugin {
         }
       }
 
+      if (templatesDir === undefined) {
+        assertNoRealTemplateOutput(result, component.absPath)
+        continue
+      }
+
       const targets = planEmits(result, component.absPath, componentDirs, options.adapter)
       lastEmitsByAbsPath.set(component.absPath, targets)
       await writeEmits(templatesDir, targets)
@@ -255,6 +306,8 @@ export function barefoot(options: BarefootViteOptions): Plugin {
       const manifestRow = buildManifestEntry(result, component.absPath, componentDirs, options.adapter)
       if (manifestRow) manifestEntries[manifestRow.manifestKey] = manifestRow.entry
     }
+
+    if (templatesDir === undefined) return types
 
     // Written unconditionally every pass (matching `writeEmits`'s own
     // no-diffing convention for this eager pass, and the legacy CLI's own
@@ -283,7 +336,12 @@ export function barefoot(options: BarefootViteOptions): Plugin {
       const targets = lastEmitsByAbsPath.get(absPath)
       lastEmitsByAbsPath.delete(absPath)
       cache.delete(absPath)
-      if (!targets) continue
+      // `lastEmitsByAbsPath` is only ever populated inside `emitTemplatesFor`
+      // when `templatesDir` is defined (see its `continue` for the CSR
+      // degenerate case), so `targets` is never non-empty here without
+      // `templatesDir` also being defined — this check is for the type
+      // checker, not a real runtime possibility.
+      if (!targets || templatesDir === undefined) continue
       for (const target of targets) {
         await rm(resolve(templatesDir, target.relPath), { force: true })
       }
@@ -310,6 +368,11 @@ export function barefoot(options: BarefootViteOptions): Plugin {
     const types = await emitTemplatesFor(discovered, config.root, component =>
       devScriptAssets(config, devOrigin, component.absPath),
     )
+
+    // Both the marker and `afterEmit` exist to annotate/post-process
+    // `templatesDir` — neither has anything to do when there isn't one
+    // (the CSR degenerate case).
+    if (templatesDir === undefined) return
 
     await writeFile(resolve(templatesDir, DEV_ARTIFACT_MARKER_FILENAME), DEV_ARTIFACT_MARKER_CONTENT)
 
@@ -390,7 +453,7 @@ export function barefoot(options: BarefootViteOptions): Plugin {
     async configResolved(config) {
       resolvedConfig = config
       componentDirs = options.components.map(d => resolve(config.root, d))
-      templatesDir = resolve(config.root, options.templates)
+      templatesDir = options.templates !== undefined ? resolve(config.root, options.templates) : undefined
       const discovered = await discoverComponents(componentDirs, absPath => readFile(absPath, 'utf8'))
       childNameIndex = buildChildNameIndex(discovered)
     },
@@ -453,6 +516,11 @@ export function barefoot(options: BarefootViteOptions): Plugin {
         const manifestKey = toPosixRelative(config.root, component.absPath)
         return resolveScriptAssets(manifest, manifestKey, config.base)
       })
+
+      // No `templates` dir configured (the CSR degenerate case) — nothing
+      // was written for `emitTemplatesFor` to have staled, and `afterEmit`
+      // exists to post-process `templatesDir`, which doesn't exist here.
+      if (templatesDir === undefined) return
 
       // A prior `vite dev` run may have left the dev-artifact marker (and
       // dev-origin URLs) behind — this pass just overwrote every template

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -60,11 +60,24 @@ export interface BarefootViteOptions {
   /** Source directories to scan for `.tsx` components, relative to the
    * Vite project root (or absolute). */
   components: string[]
-  /** Where compiled templates, `ssrDefaults`, and adapter-generated types
+  /**
+   * Where compiled templates, `ssrDefaults`, and adapter-generated types
    * land — relative to the Vite project root (or absolute). This is a
    * backend source directory the server-side app reads, NOT
-   * `build.outDir` (which is Vite's client-asset output). */
-  templates: string
+   * `build.outDir` (which is Vite's client-asset output).
+   *
+   * Optional for an adapter whose `generate()` output is ALWAYS empty
+   * (e.g. `CSRAdapter` — CSR has no template-language backend to point a
+   * `templates` dir at). When omitted, the eager pass still compiles every
+   * discovered component (client JS generation is unaffected) but writes
+   * nothing to disk on its behalf — no per-component template/ssrDefaults/
+   * types files, no `manifest.json`. If some discovered component turns
+   * out to produce a REAL (non-empty) template anyway, the eager pass
+   * refuses loudly instead of silently dropping it: omitting `templates`
+   * is a claim about the adapter's output that this plugin verifies rather
+   * than trusts. See `plugin.ts`'s `assertNoRealTemplateOutput`.
+   */
+  templates?: string
   /**
    * Optional escape hatch called once per eager pass (build AND dev), after
    * templates are written, with a narrow `AfterEmitContext`. NOT a


### PR DESCRIPTION
**Stack 6d/7** — targets #2516. The last integration. **All nineteen are now migrated.**

## `@barefootjs/client` does not need a `/vite` package

CSR still needs *an* adapter — the compiler consults `acceptsTemplateCall` when deciding template-scope vs init-scope placement — but not one whose output is kept. `CSRAdapter` already exists and its `generate()` returns an empty `AdapterOutput`; the legacy CLI discarded the result at its `clientOnly` gate. So `integrations/csr/vite.config.ts` calls plain `barefoot()` with `new CSRAdapter()`, and no new package appears.

## Core: `templates` becomes optional

With `CSRAdapter`, the eager pass would otherwise write a directory of empty template files. `BarefootViteOptions.templates` is now optional; when omitted the pass still compiles every component (the graph pass needs that regardless) but skips writing templates, `ssrDefaults`, types, `manifest.json`, the dev-artifact marker, and the `afterEmit` call.

Optionality creates a silent-drop risk — omit `templates` against an adapter that *does* produce templates and the output vanishes. So `assertNoRealTemplateOutput` refuses loudly instead, which is the sound-or-loud idiom CLAUDE.md's map-body rule describes.

The guard is scoped to `markedTemplate` content **only, not `ssrDefaults`**, and that distinction is load-bearing: `ssrDefaults` derives from IR metadata independently of the adapter, so it is non-empty even under `CSRAdapter` (verified by running `compileJSX` over `Counter.tsx`). Treating it as loudness-worthy would have made `templates` impossible to omit for CSR at all — and the legacy `clientOnly` gate drops `ssrDefaults` alongside the template for the same reason.

## What CSR revealed that eighteen SSR backends could not

`integrations/csr/pages/*.html` are hand-written static files, not per-request templates — and they carried the same hand-written `@barefootjs/client*` import map and hardcoded `/static/components/Foo.client.js` paths every other integration has now shed, but for a different reason: there was no SSR shell to put them in, rather than "bundling already resolves this."

They now go through Vite's multi-page HTML build. The inline scripts `import()` component `.tsx` files by relative path and `@barefootjs/client/runtime` normally; Vite rewrites both to hashed asset URLs. `server.ts` serves `dist/pages/*.html` instead of the source dir.

`build:watch` uses `vite build --watch`, not `vite dev` like the other eighteen. CSR has no backend render step to bake a dev-origin URL into, so `vite dev`'s cross-origin split would do nothing observable; `vite build --watch` preserves CSR's actual "rebuild to disk, reload" loop.

## Two pre-existing config defects, fixed

Running this suite end to end for the first time exposed both:

`webServer.command` was `bun run build.ts && bun run server.ts`, and **`build.ts` has never existed** in that directory — it appears nowhere in git history. With `reuseExistingServer: !process.env.CI`, a server already listening on 3002 made Playwright skip the command entirely, so the suite tested whatever happened to be running rather than a clean build.

Fixing that exposed a second defect it had been hiding: the 15s `webServer.timeout` only had to cover `server.ts` starting, because the build half failed instantly. A cold `vite build` here measures ~17s, so it moves to 30s — the value every other build-first integration already uses.

Neither is migration fallout. Both went unnoticed because **`integrations/csr` is the only integration with no `e2e-<name>` job in `.github/workflows`.**

## Testing

Cold run from a deleted `dist`, `CI=1` so `reuseExistingServer` is off: **78 passed, 1 failed**.

The one failure is pre-existing and filed as #2518. CSR registers components under a content-hash-suffixed name, so `bf-s` is `ToggleItem__<hash>_<rand>` where the shared spec expects `ToggleItem_<rand>`. Verified independently against **both** pipelines rather than taken on trust:

| Build | Received |
|---|---|
| Vite (this PR) | `ToggleItem__9225e5b2_fs08lm` |
| Legacy CLI (#2516's branch) | `ToggleItem__30dd705c_1hk7uz` |

Same shape, different per-build hash. Not caused by this migration.

`packages/vite`: 119 pass.

## Recommendation

**Add an `e2e-csr` job to CI.** The config fixes make the suite runnable from clean, and the client-only path is now the one path with no second implementation to diff against once stack 7 deletes the legacy pipeline. Tracked in #2518.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ)_