### PR TITLE
chore: burn 0.30.3 so the pending changesets release as 0.30.4

### DIFF
--- a/packages/adapter-blade/package.json
+++ b/packages/adapter-blade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/blade",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Laravel Blade (PHP) adapter for BarefootJS — compiles IR to .blade.php templates and ships the PHP BarefootJS rendering runtime on illuminate/view standalone",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-erb/package.json
+++ b/packages/adapter-erb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/erb",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "ERB (Embedded Ruby) adapter for BarefootJS — compiles IR to .erb templates and ships the Ruby rendering backend; runs under any Rack app (Sinatra, Rails)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-go-template/package.json
+++ b/packages/adapter-go-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/go-template",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Go html/template adapter for BarefootJS - generates Go template files from IR",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-hono/package.json
+++ b/packages/adapter-hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/hono",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Hono integration for BarefootJS",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/adapter-jinja/package.json
+++ b/packages/adapter-jinja/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/jinja",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Jinja2 adapter for BarefootJS — compiles IR to .jinja templates and ships the Python BarefootJS rendering runtime; runs under any Python web framework (Flask, etc.)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-mojolicious/package.json
+++ b/packages/adapter-mojolicious/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/mojolicious",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Mojolicious EP template adapter for BarefootJS - generates .html.ep files from IR",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-perl/package.json
+++ b/packages/adapter-perl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/perl",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "BarefootJS engine-agnostic Perl runtime (BarefootJS.pm) — pluggable rendering backend; the shared basis for Mojolicious and other Perl framework integrations",
   "type": "module",
   "files": [

--- a/packages/adapter-php/package.json
+++ b/packages/adapter-php/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/php",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "BarefootJS engine-agnostic PHP runtime -- pluggable rendering backend; the shared basis for Twig, Blade and other PHP engine integrations",
   "type": "module",
   "files": [

--- a/packages/adapter-rust/package.json
+++ b/packages/adapter-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/rust",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "minijinja (Rust) adapter for BarefootJS — compiles IR to .j2 templates and ships a Rust rendering runtime (packages/adapter-rust/runtime/); runs under any Rust web framework (axum, etc.)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-twig/package.json
+++ b/packages/adapter-twig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/twig",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Twig (PHP) adapter for BarefootJS — compiles IR to .twig templates and ships the PHP BarefootJS rendering runtime; runs under any PHP web app (Slim, plain PHP, etc.)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-xslate/package.json
+++ b/packages/adapter-xslate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/xslate",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Text::Xslate (Kolon) adapter for BarefootJS — compiles IR to .tx templates and ships the Xslate rendering backend; runs under any PSGI/Plack app",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/chart",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "SVG chart components for BarefootJS with signal-based reactivity",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/cli",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "CLI for agent-driven UI component discovery and scaffolding",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/client",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "BarefootJS client package: reactive primitives (SSR-safe) plus browser runtime under the `/runtime` subpath (compiler target)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/create-barefootjs/package.json
+++ b/packages/create-barefootjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-barefootjs",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Scaffold a new BarefootJS app — `npm create barefootjs@latest <dir>`",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/form",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Signal-based form management for BarefootJS",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/jsx",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "JSX compiler for BarefootJS - transforms JSX to server HTML + client JS",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/router",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Backend-agnostic partial-navigation client router for BarefootJS — swaps only the page region and re-hydrates the islands inside it",
   "type": "module",
   "main": "./src/index.ts",
@@ -58,7 +58,7 @@
     }
   },
   "devDependencies": {
-    "@barefootjs/client": "^0.30.2",
+    "@barefootjs/client": "^0.30.3",
     "@happy-dom/global-registrator": "^20.0.11",
     "typescript": "^5.0.0"
   }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/shared",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Shared constants for BarefootJS compiler and runtime",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/streaming/package.json
+++ b/packages/streaming/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/streaming",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Backend-agnostic SSR streaming helpers for BarefootJS",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/test",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Test utilities for BarefootJS - IR-based component testing without a browser",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/xyflow/package.json
+++ b/packages/xyflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/xyflow",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Signal-based xyflow wrapper for BarefootJS",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Follow-up to #2517. Bumps main to 0.30.3 **without publishing it**, so the next release is 0.30.4.

> **Correction (added after review):** an earlier version of this description, and the commit message, said npm's orphaned 0.30.3 is "functionally identical to 0.30.2 — same source". **That is wrong.** See [What npm's 0.30.3 actually contains](#user-content-what-0303-contains) below. The rest of the reasoning is unaffected.

## Why skip rather than adopt

0.30.3 is on npm for all 22 packages and nowhere else — my fallback published it off the *pending* Version PR's contents. main has never contained 0.30.3.

The tempting move is to adopt it: merge the Version PR that is sitting at 0.30.3 and let git catch up to npm. That does not work, and the reason matters — **the two pending changesets are adapter fixes from #2503 and #2504, which touch the Perl, Rust and PHP adapters**:

```
.changeset/go-loop-scope-condition-and-nesting.md
.changeset/loop-bound-name-position-accurate.md
```

Merging a 0.30.3 Version PR would publish nothing. `release:publish` is version-driven, so it would skip all 22 as already on npm, emit no `New tag:` lines, and `published` would come out **false** — which is the gate every native-registry job hangs off. Those adapter fixes would reach npm alone, with their changesets consumed and no way left to trigger a CPAN / crates.io / Packagist release for them.

Skipping the number costs nothing. Registries do not need contiguous versions, and 0.30.4 then carries both changesets to every registry at once.

<a id="what-0303-contains"></a>
## What npm's 0.30.3 actually contains

Not a copy of 0.30.2 — **a preview of 0.30.4**. This follows from the mechanism: the fallback published main's source with only `package.json` rewritten, and main already carried #2503 and #2504. Confirmed by diffing the published tarballs:

```
$ diff -rq 0.30.2/package/src 0.30.3/package/src
Files ... src/adapter/go-template-adapter.ts ... differ
Files ... src/render-divergences.ts ... differ
```

So npm's `latest` is currently serving the loop-scope fixes that **no native registry has**. It is internally consistent on npm and not broken; the skew is cross-registry, and it closes when 0.30.4 ships. That is an argument for landing 0.30.4 promptly, not for changing this PR.

## What this does

Ran `changeset version` and reverted everything except the `version` fields, so the bump is exactly what changesets would have written:

```
22 files changed, 23 insertions(+), 23 deletions(-)
   package.json only
```

The 23rd line is `packages/router`'s pinned `"@barefootjs/client": "^0.30.2"` → `^0.30.3` — the one internal dependency not on `workspace:*`, which is precisely why this was generated rather than hand-edited.

**CHANGELOGs are deliberately untouched.** 0.30.3 was never released from this repo and should not appear in them; the entries for these two changesets belong under 0.30.4.

Verified locally that a second `changeset version` on this tree yields **0.30.4**.

## What happens after merge

1. This merges → release.yml runs → changesets sees pending changesets → refreshes the Version PR, now at **0.30.4**. Nothing publishes.
2. Merge that Version PR → full release of 0.30.4 to npm, JSR, CPAN, PyPI, crates.io and Packagist.

With the fallback gone (#2517), step 1 cannot publish anything on its own.

## Not done here

Deprecating npm's 0.30.3 once 0.30.4 is out. Note that `npm deprecate '@barefootjs/<pkg>@0.30.3' …` would **miss `create-barefootjs`** — it is unscoped, it is one of the 22, and it is currently `latest`. Enumerate the set instead of pattern-matching the scope. It also needs an interactive `npm login`: publishing here is OIDC trusted publishing, so there is no token to reuse.