### PR TITLE
fix(ci): resolve the Ruby runtime's gems from its gemspec so it can publish

### DIFF
--- a/.github/workflows/ci-erb.yml
+++ b/.github/workflows/ci-erb.yml
@@ -63,16 +63,19 @@ jobs:
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/erb' build
 
-      # tzinfo (#2344): the one runtime gem — named-IANA-zone resolution in
-      # `format_date` (loaded lazily; every other helper stays stdlib-only).
-      - name: Install runtime gems
-        run: gem install tzinfo --no-document
+      # Dependencies come from barefoot_js.gemspec via the Gemfile, so adding
+      # a gem needs no change here or in release.yml. Bundler installs into
+      # the default gem home, which keeps them reachable from the bare `ruby`
+      # the conformance suite below spawns.
+      - name: Install gem dependencies
+        working-directory: packages/adapter-erb
+        run: bundle install
 
       - name: Run Ruby minitest suite
+        working-directory: packages/adapter-erb
         run: |
-          cd packages/adapter-erb
           for f in test/*_test.rb; do
-            ruby -Ilib -Itest "$f" || exit 1
+            bundle exec ruby -Ilib -Itest "$f" || exit 1
           done
 
       # The bun conformance suite compiles fixtures to ERB and renders them

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,21 +229,22 @@ jobs:
         # GEM_HOST_API_KEY for the `gem push` below.
         uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
 
-      # tzinfo (#2344): the one runtime gem — named-IANA-zone resolution in
-      # `format_date` (loaded lazily; every other helper stays stdlib-only).
-      # The gemspec declares it, but `bundler-cache: false` means nothing
-      # installs it, and the suite below `require`s it for real. ci-erb.yml
-      # has had this step all along; only this job was missing it, so the
-      # tests failed here on every release and `gem push` was never reached.
-      - name: Install runtime gems
-        run: gem install tzinfo --no-document
+      # Nothing installed the gemspec's dependencies here, so the suite below
+      # died on `require 'tzinfo'` and `gem push` was never reached — on every
+      # release since 0.25.0. ci-erb.yml installed them by hand and this job
+      # did not, which is exactly the drift that hid it. Both now install from
+      # barefoot_js.gemspec via the Gemfile, so a new dependency is declared
+      # once and neither workflow has to learn about it.
+      - name: Install gem dependencies
+        working-directory: packages/adapter-erb
+        run: bundle install
 
       - name: Build, test, and publish Ruby runtime to RubyGems
         working-directory: packages/adapter-erb
         run: |
           gemspec=$(find . -maxdepth 1 -name '*.gemspec' -print -quit)
           test -n "$gemspec"
-          ruby -Ilib -Itest -e 'Dir["test/**/*_test.rb"].sort.each { |f| require_relative f }'
+          bundle exec ruby -Ilib -Itest -e 'Dir["test/**/*_test.rb"].sort.each { |f| require_relative f }'
           gem build "$gemspec"
           gem push ./*.gem
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,15 @@ jobs:
         # GEM_HOST_API_KEY for the `gem push` below.
         uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
 
+      # tzinfo (#2344): the one runtime gem — named-IANA-zone resolution in
+      # `format_date` (loaded lazily; every other helper stays stdlib-only).
+      # The gemspec declares it, but `bundler-cache: false` means nothing
+      # installs it, and the suite below `require`s it for real. ci-erb.yml
+      # has had this step all along; only this job was missing it, so the
+      # tests failed here on every release and `gem push` was never reached.
+      - name: Install runtime gems
+        run: gem install tzinfo --no-document
+
       - name: Build, test, and publish Ruby runtime to RubyGems
         working-directory: packages/adapter-erb
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,11 @@ __pycache__/
 vendor/
 composer.lock
 
+# Ruby (Bundler) — barefoot_js is a library, so the lockfile is not committed;
+# dependencies resolve from barefoot_js.gemspec on every run.
+Gemfile.lock
+.bundle/
+
 # Benchmarks: generated output (runner/build.ts, babel transform temp, results)
 benchmarks/results/
 benchmarks/**/.babel-out*/

--- a/packages/adapter-erb/Gemfile
+++ b/packages/adapter-erb/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# The gemspec is the single source of truth for this runtime's dependencies —
+# `gemspec` pulls in both its runtime and development requirements. Adding a
+# gem means editing barefoot_js.gemspec and nothing else; no workflow has to
+# learn about it. That matters here specifically: release.yml's
+# rubygems-release and ci-erb.yml each installed gems by hand, drifted apart,
+# and the gem sat unpublished at 0.25.0 for eleven releases as a result.
+source 'https://rubygems.org'
+
+gemspec

--- a/packages/adapter-erb/barefoot_js.gemspec
+++ b/packages/adapter-erb/barefoot_js.gemspec
@@ -24,6 +24,12 @@ Gem::Specification.new do |s|
   # installed). Loaded lazily — every other helper stays stdlib-only.
   s.add_dependency 'tzinfo', '~> 2.0'
 
+  # Test-only. Declared here rather than in the Gemfile so the gemspec stays
+  # the one place dependencies are listed. minitest ships with Ruby but is a
+  # bundled gem, not a default one, so it is not on the load path under
+  # `bundle exec` unless the bundle asks for it.
+  s.add_development_dependency 'minitest', '~> 5.0'
+
   s.metadata['documentation_uri'] = 'https://barefootjs.dev'
   s.metadata['source_code_uri'] = 'https://github.com/piconic-ai/barefootjs/tree/main/packages/adapter-erb'
   s.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION
`barefoot_js` has been stuck at **0.25.0** since 2026-07-20 while `@barefootjs/erb` reached 0.30.4 — **eleven releases** where the gem never shipped. `rubygems-release` failed every one of them, including today's 0.30.4 run and the entirely legitimate 0.30.2 before it.

## Cause

`barefoot_js.gemspec` declares `add_dependency 'tzinfo', '~> 2.0'`, and `format_date` requires it for real when resolving a named IANA zone. The job runs `ruby/setup-ruby` with `bundler-cache: false`, and nothing else installed it — so the suite died before `gem build`, and `gem push` was never reached:

```
540 runs, 1412 assertions, 10 failures, 1 errors, 0 skips
format_date: IANA timeZone "America/New_York" requires the tzinfo gem (~> 2.0)
```

`ci-erb.yml` had `gem install tzinfo --no-document` since #2344. `release.yml` did not. That is why ordinary CI stayed green while the release job did not — the two workflows disagreed about the environment for eleven releases and nothing reconciled them.

## Why this doesn't just copy that line across

The first commit here did exactly that, and it was the wrong shape: it unblocks the publish while reproducing the cause. Two workflows each naming the dependency by hand are free to drift apart again the moment a second gem is added — you would have to remember to edit both.

The gemspec already says what the runtime needs. So both workflows now read from it:

```ruby
# packages/adapter-erb/Gemfile
source 'https://rubygems.org'
gemspec
```

Adding a dependency is now a one-line gemspec edit. Neither workflow has to learn about it.

`minitest` moves into the gemspec as a development dependency. It ships with Ruby, but as a *bundled* gem rather than a default one, so it is off the load path under `bundle exec` unless the bundle asks for it — declaring it there keeps the gemspec the single list rather than splitting deps between two files.

## The part worth checking

`ci-erb.yml`'s conformance suite renders fixtures through a **bare `ruby` subprocess**, not through the bundle. If `bundle install` vendored gems into the package, that path would silently lose `tzinfo` — trading one broken thing for another.

It does not, and this was verified rather than assumed:

```
$ bundle info tzinfo --path
/opt/rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/tzinfo-2.0.6
$ gem environment gemdir
/opt/rbenv/versions/3.3.6/lib/ruby/gems/3.3.0          # same tree
$ ruby -e "require 'tzinfo'"                            # outside the bundle
                                                        # → ok
```

`Gemfile.lock` is not committed, matching how `composer.lock` is treated for the PHP runtime: these are libraries, so each run should resolve against current dependencies rather than a frozen set.

## Verification

`release.yml`'s exact sequence, locally on ruby 3.3.6:

```
bundle install                       ok
bundle exec <full suite>             540 runs, 1423 assertions, 0 failures, 0 errors
gem build barefoot_js.gemspec        barefoot_js-0.30.4.gem
```

And the failure reproduces without it — 10 failures / 1 error, matching the CI log including the count.

Note that CI here cannot exercise the fix: the release job only runs on a push to main, and `ci-erb.yml` is path-filtered to `packages/adapter-erb/**`. The local run above is the evidence; the real proof is the next release.

## Note on how this went unnoticed

Worth recording, because it contradicts an argument I made in #2507: I left PyPI, RubyGems and crates.io out of `scripts/verify-released.ts` on the grounds that their uploads are synchronous, so a failure is a failed step and therefore already loud.

It was loud. The job went red on every release for two weeks. **Red was not the same as noticed.** That argues for extending the verify script to the synchronous registries too — separate change, happy to do it if you want it.

## What happens next

The gem jumps 0.25.0 → whatever ships next. Registries do not require contiguous versions, and everything in between is present in the current source, so the next release is a complete gem rather than a catch-up sequence.