### PR TITLE
fix: make every /vite entry loadable by Node, not just by a new-enough one

### DIFF
--- a/.changeset/vite-entry-node-loadable.md
+++ b/.changeset/vite-entry-node-loadable.md
@@ -1,0 +1,94 @@
+---
+"@barefootjs/vite": patch
+"@barefootjs/client": patch
+"@barefootjs/blade": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+"@barefootjs/hono": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/rust": patch
+"@barefootjs/twig": patch
+"@barefootjs/xslate": patch
+---
+
+Fix `./vite` entry points crashing on Node versions without native TypeScript stripping
+
+Every adapter's `./vite` subpath (and `@barefootjs/vite`'s own `.` entry)
+pointed at `.ts` source, e.g. `{"types": "./src/vite.ts", "import":
+"./src/vite.ts"}`. That copied the shape of `./build` — which is only ever
+loaded by `bf build` running under bun, a runtime that reads `.ts`
+natively — but Vite's own config loader is a different kind of consumer:
+it externalizes bare imports like `import { barefoot } from
+'@barefootjs/hono/vite'` and lets **Node**, not bun, resolve and load them.
+This only ever worked in a container whose Node happens to have native
+type-stripping on by default (22.18+); on any older Node it fails with
+`TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"` the
+moment a downstream app's `vite.config.ts` does `import { barefoot } from
+'@barefootjs/<adapter>/vite'`.
+
+Fix, per package:
+
+- Every `./vite` subpath (`@barefootjs/blade`, `@barefootjs/erb`,
+  `@barefootjs/go-template`, `@barefootjs/hono`, `@barefootjs/jinja`,
+  `@barefootjs/mojolicious`, `@barefootjs/rust`, `@barefootjs/twig`,
+  `@barefootjs/xslate`) now points at built JS (`dist/vite.js` +
+  `dist/vite.d.ts`) unconditionally — no publishConfig src→dist swap,
+  matching `@barefootjs/client`'s existing "always dist" treatment for
+  entries a non-bun runtime must load directly.
+- `@barefootjs/vite`'s own `.` entry gets the same unconditional
+  dist-only treatment (previously src-in-dev, dist-at-pack like most
+  other entries).
+- Each adapter's `build:js` now bundles `src/vite.ts` in its own `bun
+  build` invocation, separate from the `index.ts`/`adapter/index.ts`/
+  `build.ts` invocation those subpaths keep sharing. The `./vite` build
+  does NOT externalize `@barefootjs/jsx` / `@barefootjs/shared` — Node
+  would otherwise hit the exact same `.ts`-extension failure one hop
+  later, resolving `@barefootjs/jsx`'s own (still src-pointing, unchanged)
+  `.` export. `@barefootjs/vite`'s own build drops the same two externals
+  for the same reason. Both keep `typescript` external (a real npm
+  package, already Node-loadable) to avoid bundling the whole TS compiler
+  into every adapter's `./vite` output.
+- `--target node` on both of the above: bun's default bundle target is
+  `browser`, which polyfills `node:fs/promises` et al. into browser stubs
+  — silently turning every `readFile`/`writeFile`/`mkdir` call into
+  `undefined` at runtime (`TypeError: readFile is not a function`) instead
+  of failing to build. Only surfaces once something (Vite's config loader)
+  actually calls the plugin's manifest-reading code, so it hid behind the
+  same "nothing loads dist under Node" gap as the `.ts`-extension bug.
+- `@barefootjs/client`'s `./build` entry (already dist-only) had the
+  identical latent bug one level removed: `CSRAdapter` (`csr-adapter.ts`)
+  imports `BaseAdapter` from `@barefootjs/jsx` as a real value, and
+  `build:js` externalized it — so `integrations/csr`'s `vite.config.ts`
+  (`import { CSRAdapter } from '@barefootjs/client/build'`) hit the same
+  crash one hop further down the chain. Fixed the same way: stop
+  externalizing `@barefootjs/jsx`, add `--target node`.
+- Root `build` script: `@barefootjs/vite` now builds before the
+  `@barefootjs/hono` / `@barefootjs/go-template` / `@barefootjs/mojolicious`
+  early-build trio, whose `build:types` step type-checks their `./vite`
+  entry's `import type { AfterEmitContext } from '@barefootjs/vite'`
+  against `@barefootjs/vite`'s (now dist-only) `.d.ts` — a real
+  dependency edge the previous ordering didn't account for.
+- `packages/vite/tsconfig.json` gains `DOM`/`DOM.Iterable` lib entries
+  (every sibling adapter tsconfig already had them) — needed once
+  `bun run build:types` for this package actually has to succeed instead
+  of emitting into a `dist/` nobody read.
+
+**DX cost**: every one of these packages now needs `bun run build` before
+its `./vite` (or `@barefootjs/vite`'s `.`) entry resolves to anything
+runnable — previously the workspace/dev resolution pointed straight at
+`.ts` source with nothing to build. Running `vite dev` / `vite build` in
+any integration (`hono`, `gin`, `csr`, …) without building the workspace
+packages first now fails the same `ERR_UNKNOWN_FILE_EXTENSION` /
+`Cannot find module` way it always would have on a stricter Node — the
+fix removes the accidental "works because dist happens to already exist
+from an unrelated build" case, it doesn't add a new requirement so much as
+make the existing one enforced everywhere instead of hidden by this
+container's Node version.
+
+Backstop: `__tests__/vite-entry-node-loadable.test.ts` reads every
+workspace package's manifest and fails if any `./vite` (or
+`@barefootjs/vite`'s `.`) export's `types`/`import` resolves to raw `.ts`
+source (a `.d.ts` declaration file is fine) — a future adapter that copies
+the old `./build`-shaped entry fails loudly here instead of silently
+depending on a new-enough Node.

--- a/.changeset/vite-entry-node-loadable.md
+++ b/.changeset/vite-entry-node-loadable.md
@@ -32,13 +32,20 @@ Fix, per package:
 - Every `./vite` subpath (`@barefootjs/blade`, `@barefootjs/erb`,
   `@barefootjs/go-template`, `@barefootjs/hono`, `@barefootjs/jinja`,
   `@barefootjs/mojolicious`, `@barefootjs/rust`, `@barefootjs/twig`,
-  `@barefootjs/xslate`) now points at built JS (`dist/vite.js` +
-  `dist/vite.d.ts`) unconditionally — no publishConfig src→dist swap,
-  matching `@barefootjs/client`'s existing "always dist" treatment for
-  entries a non-bun runtime must load directly.
-- `@barefootjs/vite`'s own `.` entry gets the same unconditional
-  dist-only treatment (previously src-in-dev, dist-at-pack like most
-  other entries).
+  `@barefootjs/xslate`) now SPLITS its two conditions instead of pointing
+  both at the same file: `{"types": "./src/vite.ts", "import":
+  "./dist/vite.js"}`. TypeScript reads `types`, Node reads `import` — they
+  never had to be the same file, and keeping `types` on real source means
+  every consumer that only ever needed to *type-check* against this entry
+  (an adapter's own `build:types`, a downstream app's `tsc`) keeps doing so
+  straight from source, with nothing built, exactly as before. Only the
+  condition Node's ESM loader actually resolves (`import`) needs to be
+  built JS. `publishConfig` is untouched — it already swapped both
+  conditions to `dist` at pack time, which is correct: nothing outside
+  this workspace should type-check against source.
+- `@barefootjs/vite`'s own `.` entry gets the same split (top-level `types`
+  → `./src/index.ts`, `import` → `./dist/index.js`; `publishConfig` keeps
+  swapping both to dist at pack time, restored to its original shape).
 - Each adapter's `build:js` now bundles `src/vite.ts` in its own `bun
   build` invocation, separate from the `index.ts`/`adapter/index.ts`/
   `build.ts` invocation those subpaths keep sharing. The `./vite` build
@@ -56,39 +63,57 @@ Fix, per package:
   of failing to build. Only surfaces once something (Vite's config loader)
   actually calls the plugin's manifest-reading code, so it hid behind the
   same "nothing loads dist under Node" gap as the `.ts`-extension bug.
-- `@barefootjs/client`'s `./build` entry (already dist-only) had the
-  identical latent bug one level removed: `CSRAdapter` (`csr-adapter.ts`)
-  imports `BaseAdapter` from `@barefootjs/jsx` as a real value, and
-  `build:js` externalized it — so `integrations/csr`'s `vite.config.ts`
-  (`import { CSRAdapter } from '@barefootjs/client/build'`) hit the same
-  crash one hop further down the chain. Fixed the same way: stop
-  externalizing `@barefootjs/jsx`, add `--target node`.
-- Root `build` script: `@barefootjs/vite` now builds before the
-  `@barefootjs/hono` / `@barefootjs/go-template` / `@barefootjs/mojolicious`
-  early-build trio, whose `build:types` step type-checks their `./vite`
-  entry's `import type { AfterEmitContext } from '@barefootjs/vite'`
-  against `@barefootjs/vite`'s (now dist-only) `.d.ts` — a real
-  dependency edge the previous ordering didn't account for.
+- `@barefootjs/client`'s `./build` entry (already dist-only on both
+  conditions, unchanged by this PR — its consumers always needed it
+  built) had the identical latent runtime bug one level removed:
+  `CSRAdapter` (`csr-adapter.ts`) imports `BaseAdapter` from
+  `@barefootjs/jsx` as a real value, and `build:js` externalized it — so
+  `integrations/csr`'s `vite.config.ts` (`import { CSRAdapter } from
+  '@barefootjs/client/build'`) hit the same crash one hop further down the
+  chain. Fixed the same way: stop externalizing `@barefootjs/jsx`, add
+  `--target node`.
+- Root `build` script keeps `@barefootjs/vite` as an explicit early build
+  step, before the `@barefootjs/hono` / `@barefootjs/go-template` /
+  `@barefootjs/mojolicious` trio and the rest of `--filter '*'`. This is
+  NOT for type resolution (the `types`/`import` split above already
+  decouples that from build order — a scoped `build:types` run, e.g. `cd
+  packages/blade && bun run build`, never needs `@barefootjs/vite` built).
+  It's for the RUNTIME resolution real `vite build`/`vite dev` invocations
+  need: `--filter '*'` does not reliably build `@barefootjs/vite` before
+  workspace packages whose OWN build step actually executes a Vite config
+  that imports it (`integrations/nethttp`, `integrations/chi`, and any
+  other integration whose `build` script runs `vite build` for real, not
+  just type-checks) — confirmed by dropping this step and watching a
+  clean `bun run build` fail with `ERR_MODULE_NOT_FOUND` resolving
+  `@barefootjs/vite/dist/index.js` from `adapter-go-template/dist/vite.js`
+  partway through `--filter '*'`.
 - `packages/vite/tsconfig.json` gains `DOM`/`DOM.Iterable` lib entries
-  (every sibling adapter tsconfig already had them) — needed once
-  `bun run build:types` for this package actually has to succeed instead
-  of emitting into a `dist/` nobody read.
+  (every sibling adapter tsconfig already had them) — still needed
+  independent of the above: `packages/vite`'s OWN `build:types` walks real
+  (non-type-only) imports from `@barefootjs/jsx`, whose `html-types.ts`
+  needs DOM lib to resolve `HTMLButtonElement` and friends. Confirmed by
+  reverting just this file and rebuilding — `tsgo` fails the same way
+  whether or not the root build ordering or the `types`/`import` split are
+  in place.
 
-**DX cost**: every one of these packages now needs `bun run build` before
-its `./vite` (or `@barefootjs/vite`'s `.`) entry resolves to anything
-runnable — previously the workspace/dev resolution pointed straight at
-`.ts` source with nothing to build. Running `vite dev` / `vite build` in
-any integration (`hono`, `gin`, `csr`, …) without building the workspace
-packages first now fails the same `ERR_UNKNOWN_FILE_EXTENSION` /
-`Cannot find module` way it always would have on a stricter Node — the
-fix removes the accidental "works because dist happens to already exist
-from an unrelated build" case, it doesn't add a new requirement so much as
-make the existing one enforced everywhere instead of hidden by this
-container's Node version.
+**DX cost**: every one of these packages' `./vite` (or `@barefootjs/vite`'s
+`.`) entry now needs `bun run build` before `vite dev` / `vite build` can
+actually load and run it — the `import` condition was always meant to be a
+build artifact, this just stops it accidentally working off raw source.
+Type-checking (`tsc`/`tsgo` against the `types` condition) needs no build
+step at all, in any of these packages, scoped or full — that's the whole
+point of the split. Running an integration's `vite dev`/`vite build`
+without building workspace packages first fails the same
+`ERR_UNKNOWN_FILE_EXTENSION` / `ERR_MODULE_NOT_FOUND` way it always would
+have on a stricter Node; the fix removes the accidental "works because
+dist happens to already exist from an unrelated build" case rather than
+adding a new requirement.
 
 Backstop: `__tests__/vite-entry-node-loadable.test.ts` reads every
 workspace package's manifest and fails if any `./vite` (or
-`@barefootjs/vite`'s `.`) export's `types`/`import` resolves to raw `.ts`
-source (a `.d.ts` declaration file is fine) — a future adapter that copies
-the old `./build`-shaped entry fails loudly here instead of silently
-depending on a new-enough Node.
+`@barefootjs/vite`'s `.`) export's `import`/`default` condition — the ones
+Node's ESM loader itself resolves — points at raw `.ts` source. `types` is
+deliberately exempt (see above); a `.d.ts` declaration file is fine on
+either condition. A future adapter that copies the old fully-`.ts`-pointing
+shape, or that regresses `import` back onto source, fails loudly here
+instead of silently depending on a new-enough Node.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,6 +51,7 @@ jobs:
           bun run --filter '@barefootjs/shared' build
           bun run --filter '@barefootjs/streaming' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
 
       - name: Build benchmark apps

--- a/.github/workflows/ci-blade.yml
+++ b/.github/workflows/ci-blade.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/blade' build
 
@@ -106,6 +107,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/blade' build
 
@@ -159,6 +161,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/blade' build
 

--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
 
       - name: Embed adapter runtime sources

--- a/.github/workflows/ci-compat.yml
+++ b/.github/workflows/ci-compat.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           # packages/compat (the compat engine + `bun run compat:lock`)
           # imports every workspace adapter. These 8 have `main`/`exports`

--- a/.github/workflows/ci-elysia.yml
+++ b/.github/workflows/ci-elysia.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/hono' build
 

--- a/.github/workflows/ci-erb.yml
+++ b/.github/workflows/ci-erb.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/erb' build
 

--- a/.github/workflows/ci-form.yml
+++ b/.github/workflows/ci-form.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Build dependencies
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
 
       - name: Type check

--- a/.github/workflows/ci-go-template.yml
+++ b/.github/workflows/ci-go-template.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/go-template' build
 
@@ -98,6 +99,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/go-template' build
 

--- a/.github/workflows/ci-h3.yml
+++ b/.github/workflows/ci-h3.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/hono' build
 

--- a/.github/workflows/ci-hono.yml
+++ b/.github/workflows/ci-hono.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/hono' build
 
@@ -88,6 +89,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/hono' build
 

--- a/.github/workflows/ci-mojolicious.yml
+++ b/.github/workflows/ci-mojolicious.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/mojolicious' build
 

--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -84,6 +84,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/twig' build
 
@@ -111,6 +112,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/twig' build
 

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jinja' build
 
@@ -110,6 +111,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jinja' build
 
@@ -165,6 +167,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jinja' build
 
@@ -220,6 +223,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jinja' build
 

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/rust' build
 
@@ -125,6 +126,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/rust' build
 

--- a/.github/workflows/ci-xslate.yml
+++ b/.github/workflows/ci-xslate.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/xslate' build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
 
       - name: Run unit tests
@@ -109,6 +110,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
 
       - name: Run UI component IR tests
@@ -134,6 +136,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/form' build
           bun run --filter '@barefootjs/chart' build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
 
       - name: Build site
@@ -112,6 +113,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/hono' build
           bun run --filter '@barefootjs/form' build
@@ -157,6 +159,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/hono' build
 
@@ -194,6 +197,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/hono' build
 
@@ -231,6 +235,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/hono' build
 
@@ -268,6 +273,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/go-template' build
 
@@ -308,6 +314,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/go-template' build
 
@@ -348,6 +355,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/go-template' build
 
@@ -388,6 +396,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/go-template' build
 
@@ -428,6 +437,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/mojolicious' build
 
@@ -468,6 +478,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/xslate' build
 
@@ -508,6 +519,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jinja' build
 
@@ -548,6 +560,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jinja' build
 
@@ -588,6 +601,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/erb' build
 
@@ -628,6 +642,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/erb' build
 
@@ -668,6 +683,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/rust' build
 
@@ -708,6 +724,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/twig' build
 
@@ -748,6 +765,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jinja' build
 
@@ -788,6 +806,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/blade' build
 
@@ -828,6 +847,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/blade' build
 

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -44,6 +44,7 @@ jobs:
           bun run --filter '@barefootjs/shared' build
           bun run --filter '@barefootjs/streaming' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/form' build
           bun run --filter '@barefootjs/chart' build

--- a/.github/workflows/update-doc-snapshots.yml
+++ b/.github/workflows/update-doc-snapshots.yml
@@ -56,6 +56,7 @@ jobs:
         # from the same compiler artefacts.
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
 
       - name: Regenerate doc-examples snapshots

--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Build packages
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/hono' build
 

--- a/.github/workflows/update-meta.yml
+++ b/.github/workflows/update-meta.yml
@@ -51,6 +51,7 @@ jobs:
         # resolved by the CLI entrypoint.
         run: |
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/vite' build
           bun run --filter '@barefootjs/client' build
 
       - name: Extract component metadata

--- a/__tests__/vite-entry-node-loadable.test.ts
+++ b/__tests__/vite-entry-node-loadable.test.ts
@@ -1,0 +1,122 @@
+// Guards the packaging invariant behind the fix in
+// https://github.com/piconic-ai/barefootjs (Vite migration entry
+// packaging): Vite's own config loader externalizes bare imports like
+// `@barefootjs/hono/vite`, so Node — NOT bun — is the one that resolves
+// and loads them. Node has no built-in TypeScript support unless the
+// running version happens to have type-stripping on by default (22.18+):
+// pointing a `./vite` export (or `@barefootjs/vite`'s own `.` export) at
+// `.ts` source works only by accident of the dev container's Node
+// version, and breaks with
+// `TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"`
+// on any older Node.
+//
+// This test reads every workspace package's manifest and asserts that
+// none of these Node-loaded entry points resolve to a `.ts` file — a
+// tenth adapter (or a new @barefootjs/vite export) that copies the
+// `.ts`-pointing shape must fail loudly here rather than silently
+// depending on a new-enough Node.
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, test } from 'bun:test'
+
+const REPO_ROOT = resolve(import.meta.dir, '..')
+const PACKAGES_DIR = resolve(REPO_ROOT, 'packages')
+
+interface ExportTarget {
+  types?: string
+  import?: string
+  bun?: string
+}
+
+interface PackageManifest {
+  name: string
+  exports?: Record<string, ExportTarget | string>
+  publishConfig?: { exports?: Record<string, ExportTarget | string> }
+}
+
+function loadManifest(dir: string): PackageManifest | null {
+  const pkgPath = resolve(dir, 'package.json')
+  try {
+    if (!statSync(pkgPath).isFile()) return null
+  } catch {
+    return null
+  }
+  return JSON.parse(readFileSync(pkgPath, 'utf-8')) as PackageManifest
+}
+
+/** Every workspace package directory under `packages/` that has a
+ * `package.json` — mirrors the `packages/*` workspace glob in the root
+ * manifest. */
+const packageDirs = readdirSync(PACKAGES_DIR, { withFileTypes: true })
+  .filter(entry => entry.isDirectory())
+  .map(entry => resolve(PACKAGES_DIR, entry.name))
+
+/** Node-loaded export keys, per package name: the `./vite` subpath every
+ * adapter ships (loaded by Vite's own Node-based config loader when a
+ * downstream app's `vite.config.ts` imports `<adapter>/vite`), plus
+ * `@barefootjs/vite`'s own `.` entry (loaded directly by `vite.config.ts`
+ * files that use core `barefoot()`, and transitively by every adapter's
+ * `./vite`). A tenth adapter's `./vite` export is covered automatically —
+ * this list only needs the one special case (core's `.`).
+ */
+function nodeLoadedKeysFor(pkgName: string): string[] {
+  const keys = ['./vite']
+  if (pkgName === '@barefootjs/vite') keys.push('.')
+  return keys
+}
+
+function targetsToCheck(target: ExportTarget | string | undefined): string[] {
+  if (!target) return []
+  if (typeof target === 'string') return [target]
+  return [target.types, target.import].filter((v): v is string => typeof v === 'string')
+}
+
+/** True for raw TypeScript SOURCE Node's ESM loader would choke on
+ * (`ERR_UNKNOWN_FILE_EXTENSION`) — but not for a `.d.ts` DECLARATION file,
+ * which is never executed and is exactly what a `types` field should
+ * point at once an entry is built. */
+function isRawTsSource(path: string): boolean {
+  return path.endsWith('.ts') && !path.endsWith('.d.ts')
+}
+
+describe('Node-loaded package exports never point at .ts source', () => {
+  const manifests = packageDirs
+    .map(dir => ({ dir, manifest: loadManifest(dir) }))
+    .filter((entry): entry is { dir: string; manifest: PackageManifest } => entry.manifest !== null)
+
+  // Sanity check on the test itself: fail loudly if the workspace scan
+  // came up empty (a broken path would otherwise make every case below
+  // vacuously pass).
+  test('found workspace packages to check', () => {
+    expect(manifests.length).toBeGreaterThan(0)
+  })
+
+  for (const { dir, manifest } of manifests) {
+    for (const key of nodeLoadedKeysFor(manifest.name)) {
+      const topLevel = manifest.exports?.[key]
+      const published = manifest.publishConfig?.exports?.[key]
+      if (topLevel === undefined && published === undefined) continue
+
+      test(`${manifest.name}${key === '.' ? '' : key} does not resolve to .ts source`, () => {
+        // The workspace (dev/bun) resolution — this is the one Vite's
+        // Node config loader actually walks when a sibling package's
+        // `vite.config.ts` imports this specifier, so it is the entry
+        // that must never point at `.ts`.
+        for (const path of targetsToCheck(topLevel)) {
+          expect(isRawTsSource(path)).toBe(false)
+        }
+        // The published-tarball resolution (after swap-publish-config.mjs
+        // merges `publishConfig` in at pack time) — checked too so a
+        // future edit can't silently regress just the published shape
+        // while leaving the workspace shape fixed.
+        for (const path of targetsToCheck(published)) {
+          expect(isRawTsSource(path)).toBe(false)
+        }
+        // `dir` is asserted on implicitly above (loadManifest read from
+        // it) — kept in scope for a clearer failure message via `test`'s
+        // own title rather than repeated here.
+        void dir
+      })
+    }
+  }
+})

--- a/__tests__/vite-entry-node-loadable.test.ts
+++ b/__tests__/vite-entry-node-loadable.test.ts
@@ -4,17 +4,27 @@
 // `@barefootjs/hono/vite`, so Node — NOT bun — is the one that resolves
 // and loads them. Node has no built-in TypeScript support unless the
 // running version happens to have type-stripping on by default (22.18+):
-// pointing a `./vite` export (or `@barefootjs/vite`'s own `.` export) at
-// `.ts` source works only by accident of the dev container's Node
-// version, and breaks with
+// pointing a `./vite` export's RUNTIME condition (`import` — the one
+// Node's ESM loader actually reads) at `.ts` source works only by
+// accident of the dev container's Node version, and breaks with
 // `TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"`
 // on any older Node.
 //
-// This test reads every workspace package's manifest and asserts that
-// none of these Node-loaded entry points resolve to a `.ts` file — a
-// tenth adapter (or a new @barefootjs/vite export) that copies the
-// `.ts`-pointing shape must fail loudly here rather than silently
-// depending on a new-enough Node.
+// `types` is a DIFFERENT condition — TypeScript reads it, Node never
+// does — so it is deliberately exempt here: `./vite`'s `types` points at
+// real `.ts` source on purpose (so `tsgo`/`tsc` type-check straight from
+// source with nothing built, decoupling type resolution from build
+// order — see the `vite-entry-node-loadable` changeset). Only `import`
+// (and `default`, on the rare export shape that carries one) is what
+// Node ever loads, so those are the conditions this test holds to "must
+// already be built JS, never raw TypeScript". `.d.ts` declaration files
+// are unaffected either way — Node never loads those, TypeScript does.
+//
+// This test reads every workspace package's manifest and asserts that no
+// Node-loaded entry point's `import`/`default` condition resolves to a
+// `.ts` file — a tenth adapter (or a new `@barefootjs/vite` export) that
+// copies the old fully-`.ts`-pointing shape must fail loudly here rather
+// than silently depending on a new-enough Node.
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, test } from 'bun:test'
@@ -25,6 +35,7 @@ const PACKAGES_DIR = resolve(REPO_ROOT, 'packages')
 interface ExportTarget {
   types?: string
   import?: string
+  default?: string
   bun?: string
 }
 
@@ -65,21 +76,25 @@ function nodeLoadedKeysFor(pkgName: string): string[] {
   return keys
 }
 
-function targetsToCheck(target: ExportTarget | string | undefined): string[] {
+/** Only the conditions Node's ESM loader itself ever resolves — NOT
+ * `types` (TypeScript-only, allowed to point at source; see file header)
+ * and NOT `bun` (a separate condition bun's own runtime picks, exempt for
+ * the same reason `types` is). */
+function runtimeTargetsToCheck(target: ExportTarget | string | undefined): string[] {
   if (!target) return []
   if (typeof target === 'string') return [target]
-  return [target.types, target.import].filter((v): v is string => typeof v === 'string')
+  return [target.import, target.default].filter((v): v is string => typeof v === 'string')
 }
 
 /** True for raw TypeScript SOURCE Node's ESM loader would choke on
  * (`ERR_UNKNOWN_FILE_EXTENSION`) — but not for a `.d.ts` DECLARATION file,
- * which is never executed and is exactly what a `types` field should
- * point at once an entry is built. */
+ * which is never executed (and never appears on `import`/`default`
+ * anyway; kept for robustness against a manifest typo). */
 function isRawTsSource(path: string): boolean {
   return path.endsWith('.ts') && !path.endsWith('.d.ts')
 }
 
-describe('Node-loaded package exports never point at .ts source', () => {
+describe('Node-loaded package exports never resolve import/default to .ts source', () => {
   const manifests = packageDirs
     .map(dir => ({ dir, manifest: loadManifest(dir) }))
     .filter((entry): entry is { dir: string; manifest: PackageManifest } => entry.manifest !== null)
@@ -97,19 +112,20 @@ describe('Node-loaded package exports never point at .ts source', () => {
       const published = manifest.publishConfig?.exports?.[key]
       if (topLevel === undefined && published === undefined) continue
 
-      test(`${manifest.name}${key === '.' ? '' : key} does not resolve to .ts source`, () => {
+      test(`${manifest.name}${key === '.' ? '' : key}'s import/default condition does not resolve to .ts source`, () => {
         // The workspace (dev/bun) resolution — this is the one Vite's
         // Node config loader actually walks when a sibling package's
-        // `vite.config.ts` imports this specifier, so it is the entry
-        // that must never point at `.ts`.
-        for (const path of targetsToCheck(topLevel)) {
+        // `vite.config.ts` imports this specifier, so its `import`
+        // condition is the one that must never point at `.ts`. `types`
+        // is deliberately NOT checked — see file header.
+        for (const path of runtimeTargetsToCheck(topLevel)) {
           expect(isRawTsSource(path)).toBe(false)
         }
         // The published-tarball resolution (after swap-publish-config.mjs
         // merges `publishConfig` in at pack time) — checked too so a
         // future edit can't silently regress just the published shape
         // while leaving the workspace shape fixed.
-        for (const path of targetsToCheck(published)) {
+        for (const path of runtimeTargetsToCheck(published)) {
           expect(isRawTsSource(path)).toBe(false)
         }
         // `dir` is asserted on implicitly above (loadManifest read from

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "setup": "bun install && bun run --filter 'barefootjs-echo-example' setup",
-    "build": "bun run --filter '@barefootjs/shared' build && bun run --filter '@barefootjs/streaming' build && bun run --filter '@barefootjs/jsx' build && bun run --filter '@barefootjs/client' build && bun run --filter '@barefootjs/hono' --filter '@barefootjs/go-template' --filter '@barefootjs/mojolicious' build && bun run --filter '*' build",
+    "build": "bun run --filter '@barefootjs/shared' build && bun run --filter '@barefootjs/streaming' build && bun run --filter '@barefootjs/jsx' build && bun run --filter '@barefootjs/client' build && bun run --filter '@barefootjs/vite' build && bun run --filter '@barefootjs/hono' --filter '@barefootjs/go-template' --filter '@barefootjs/mojolicious' build && bun run --filter '*' build",
     "test": "bun test --cwd . __tests__",
     "test:e2e": "bun run --filter '*' test:e2e",
     "clean": "bun run --filter '*' clean",

--- a/packages/adapter-blade/package.json
+++ b/packages/adapter-blade/package.json
@@ -22,8 +22,8 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./src/vite.ts",
-      "import": "./src/vite.ts"
+      "types": "./dist/vite.d.ts",
+      "import": "./dist/vite.js"
     }
   },
   "publishConfig": {
@@ -59,7 +59,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite && bun build ./src/vite.ts --outfile ./dist/vite.js --format esm --target node --external @barefootjs/vite --external vite --external typescript",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",

--- a/packages/adapter-blade/package.json
+++ b/packages/adapter-blade/package.json
@@ -22,7 +22,7 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./dist/vite.d.ts",
+      "types": "./src/vite.ts",
       "import": "./dist/vite.js"
     }
   },

--- a/packages/adapter-erb/package.json
+++ b/packages/adapter-erb/package.json
@@ -22,8 +22,8 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./src/vite.ts",
-      "import": "./src/vite.ts"
+      "types": "./dist/vite.d.ts",
+      "import": "./dist/vite.js"
     }
   },
   "publishConfig": {
@@ -57,7 +57,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite && bun build ./src/vite.ts --outfile ./dist/vite.js --format esm --target node --external @barefootjs/vite --external vite --external typescript",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",

--- a/packages/adapter-erb/package.json
+++ b/packages/adapter-erb/package.json
@@ -22,7 +22,7 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./dist/vite.d.ts",
+      "types": "./src/vite.ts",
       "import": "./dist/vite.js"
     }
   },

--- a/packages/adapter-go-template/package.json
+++ b/packages/adapter-go-template/package.json
@@ -22,8 +22,8 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./src/vite.ts",
-      "import": "./src/vite.ts"
+      "types": "./dist/vite.d.ts",
+      "import": "./dist/vite.js"
     }
   },
   "publishConfig": {
@@ -55,7 +55,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite --external typescript",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite --external typescript && bun build ./src/vite.ts --outfile ./dist/vite.js --format esm --target node --external @barefootjs/vite --external vite --external typescript",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",

--- a/packages/adapter-go-template/package.json
+++ b/packages/adapter-go-template/package.json
@@ -22,7 +22,7 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./dist/vite.d.ts",
+      "types": "./src/vite.ts",
       "import": "./dist/vite.js"
     }
   },

--- a/packages/adapter-hono/package.json
+++ b/packages/adapter-hono/package.json
@@ -70,8 +70,8 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./src/vite.ts",
-      "import": "./src/vite.ts"
+      "types": "./dist/vite.d.ts",
+      "import": "./dist/vite.js"
     },
     "./app": {
       "types": "./src/app.ts",
@@ -178,7 +178,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/scripts.tsx ./src/portals.tsx ./src/portal-ssr.tsx ./src/dialog-context.tsx ./src/client-shim.ts ./src/preload.tsx ./src/dev.tsx ./src/dev-worker.ts ./src/jsx/jsx-runtime/index.ts ./src/jsx/jsx-dev-runtime/index.ts ./src/async.tsx ./src/utils.ts ./src/build.ts ./src/vite.ts ./src/app.ts ./src/render.ts ./src/request-env.ts --root ./src --outdir ./dist --format esm --external hono --external @barefootjs/client --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/scripts.tsx ./src/portals.tsx ./src/portal-ssr.tsx ./src/dialog-context.tsx ./src/client-shim.ts ./src/preload.tsx ./src/dev.tsx ./src/dev-worker.ts ./src/jsx/jsx-runtime/index.ts ./src/jsx/jsx-dev-runtime/index.ts ./src/async.tsx ./src/utils.ts ./src/build.ts ./src/app.ts ./src/render.ts ./src/request-env.ts --root ./src --outdir ./dist --format esm --external hono --external @barefootjs/client --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite && bun build ./src/vite.ts --outfile ./dist/vite.js --format esm --target node --external @barefootjs/vite --external vite --external typescript",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",

--- a/packages/adapter-hono/package.json
+++ b/packages/adapter-hono/package.json
@@ -70,7 +70,7 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./dist/vite.d.ts",
+      "types": "./src/vite.ts",
       "import": "./dist/vite.js"
     },
     "./app": {

--- a/packages/adapter-jinja/package.json
+++ b/packages/adapter-jinja/package.json
@@ -22,8 +22,8 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./src/vite.ts",
-      "import": "./src/vite.ts"
+      "types": "./dist/vite.d.ts",
+      "import": "./dist/vite.js"
     }
   },
   "publishConfig": {
@@ -57,7 +57,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite && bun build ./src/vite.ts --outfile ./dist/vite.js --format esm --target node --external @barefootjs/vite --external vite --external typescript",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",

--- a/packages/adapter-jinja/package.json
+++ b/packages/adapter-jinja/package.json
@@ -22,7 +22,7 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./dist/vite.d.ts",
+      "types": "./src/vite.ts",
       "import": "./dist/vite.js"
     }
   },

--- a/packages/adapter-mojolicious/package.json
+++ b/packages/adapter-mojolicious/package.json
@@ -22,8 +22,8 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./src/vite.ts",
-      "import": "./src/vite.ts"
+      "types": "./dist/vite.d.ts",
+      "import": "./dist/vite.js"
     }
   },
   "publishConfig": {
@@ -56,7 +56,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external typescript --external @barefootjs/vite --external vite",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external typescript --external @barefootjs/vite --external vite && bun build ./src/vite.ts --outfile ./dist/vite.js --format esm --target node --external @barefootjs/vite --external vite --external typescript",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",

--- a/packages/adapter-mojolicious/package.json
+++ b/packages/adapter-mojolicious/package.json
@@ -22,7 +22,7 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./dist/vite.d.ts",
+      "types": "./src/vite.ts",
       "import": "./dist/vite.js"
     }
   },

--- a/packages/adapter-rust/package.json
+++ b/packages/adapter-rust/package.json
@@ -22,8 +22,8 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./src/vite.ts",
-      "import": "./src/vite.ts"
+      "types": "./dist/vite.d.ts",
+      "import": "./dist/vite.js"
     }
   },
   "publishConfig": {
@@ -57,7 +57,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite && bun build ./src/vite.ts --outfile ./dist/vite.js --format esm --target node --external @barefootjs/vite --external vite --external typescript",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",

--- a/packages/adapter-rust/package.json
+++ b/packages/adapter-rust/package.json
@@ -22,7 +22,7 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./dist/vite.d.ts",
+      "types": "./src/vite.ts",
       "import": "./dist/vite.js"
     }
   },

--- a/packages/adapter-twig/package.json
+++ b/packages/adapter-twig/package.json
@@ -22,8 +22,8 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./src/vite.ts",
-      "import": "./src/vite.ts"
+      "types": "./dist/vite.d.ts",
+      "import": "./dist/vite.js"
     }
   },
   "publishConfig": {
@@ -59,7 +59,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite && bun build ./src/vite.ts --outfile ./dist/vite.js --format esm --target node --external @barefootjs/vite --external vite --external typescript",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",

--- a/packages/adapter-twig/package.json
+++ b/packages/adapter-twig/package.json
@@ -22,7 +22,7 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./dist/vite.d.ts",
+      "types": "./src/vite.ts",
       "import": "./dist/vite.js"
     }
   },

--- a/packages/adapter-xslate/package.json
+++ b/packages/adapter-xslate/package.json
@@ -22,8 +22,8 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./src/vite.ts",
-      "import": "./src/vite.ts"
+      "types": "./dist/vite.d.ts",
+      "import": "./dist/vite.js"
     }
   },
   "publishConfig": {
@@ -57,7 +57,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts ./src/vite.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external @barefootjs/vite --external vite && bun build ./src/vite.ts --outfile ./dist/vite.js --format esm --target node --external @barefootjs/vite --external vite --external typescript",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",

--- a/packages/adapter-xslate/package.json
+++ b/packages/adapter-xslate/package.json
@@ -22,7 +22,7 @@
       "import": "./src/build.ts"
     },
     "./vite": {
-      "types": "./dist/vite.d.ts",
+      "types": "./src/vite.ts",
       "import": "./dist/vite.js"
     }
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,7 +33,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/reactive.ts --outdir ./dist --format esm && bun build ./src/index.ts --outdir ./dist --format esm --external '@barefootjs/client/reactive' && bun build ./src/runtime/index.ts --outdir ./dist/runtime --format esm --external '@barefootjs/client/reactive' && bun build ./src/runtime/index.ts --outfile ./dist/runtime/standalone.js --format esm && bun build ./src/build.ts --outdir ./dist --format esm --external '@barefootjs/jsx'",
+    "build:js": "bun build ./src/reactive.ts --outdir ./dist --format esm && bun build ./src/index.ts --outdir ./dist --format esm --external '@barefootjs/client/reactive' && bun build ./src/runtime/index.ts --outdir ./dist/runtime --format esm --external '@barefootjs/client/reactive' && bun build ./src/runtime/index.ts --outfile ./dist/runtime/standalone.js --format esm && bun build ./src/build.ts --outdir ./dist --format esm --target node",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -3,23 +3,12 @@
   "version": "0.30.0",
   "description": "Vite plugin for BarefootJS: Vite/Rollup owns bundling, hashing, chunking, tree-shaking and minification of client assets, BarefootJS keeps only the JSX to (template, client JS) compile",
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts"
-    }
-  },
-  "//publishConfig": "At pack time, swap-publish-config.mjs merges these overrides into the top-level so the published tarball resolves entry points to dist/ instead of src/.",
-  "publishConfig": {
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-      ".": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
-      }
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": [
@@ -28,7 +17,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts --root ./src --outdir ./dist --format esm --external vite --external @barefootjs/jsx --external @barefootjs/shared --external typescript",
+    "build:js": "bun build ./src/index.ts --outfile ./dist/index.js --format esm --target node --external vite --external typescript",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -4,11 +4,22 @@
   "description": "Vite plugin for BarefootJS: Vite/Rollup owns bundling, hashing, chunking, tree-shaking and minification of client assets, BarefootJS keeps only the JSX to (template, client JS) compile",
   "type": "module",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
+    }
+  },
+  "//publishConfig": "At pack time, swap-publish-config.mjs merges these overrides into the top-level so the published tarball resolves `types` to dist/ instead of src/ too — nothing outside this workspace should type-check against source.",
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
     }
   },
   "files": [

--- a/packages/vite/tsconfig.json
+++ b/packages/vite/tsconfig.json
@@ -4,7 +4,9 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": [
-      "ES2022"
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
     ],
     "strict": true,
     "declaration": true,


### PR DESCRIPTION
**Stack 6e/7** — targets #2519. A real defect found by running the migration on a normal machine rather than in the dev container.

## The bug

```
$ bun run dev
failed to load config from .../integrations/hono/vite.config.ts
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"
  for .../packages/adapter-hono/src/vite.ts
```

Vite's config loader externalizes bare imports, so `import { barefoot } from '@barefootjs/hono/vite'` is resolved and loaded **by Node**, not bundled. Every `./vite` subpath pointed at TypeScript source:

```json
"./vite": { "types": "./src/vite.ts", "import": "./src/vite.ts" }
```

That worked in CI and in the dev container purely because both run **Node v22.22.2**, where native TypeScript type-stripping is on by default (22.18+). On any older Node it fails immediately. Six PRs of this stack passed on an accident of one machine's Node version.

## Why the shape looked right

`./build` points at source too, and has for a long time. But `./build` is only ever loaded by `bf build` running under **bun**, which reads `.ts` natively. Vite's config loader is a new kind of consumer, and copying `./build`'s shape imported an assumption that no longer held.

The repo's convention already had the answer: entries Node loads point at built JS, with `publishConfig` swapping src→dist at pack time for packages whose dev consumers are bun. `@barefootjs/client` skips even that and always points at `dist`. The `/vite` entries were the outliers.

## What it actually took

The first hop was the visible failure; four more were behind it, and two of those only appear when a real integration builds — not from an "does it import" smoke check.

1. `./vite` (and `@barefootjs/vite`'s `.`) point at `dist/*.js` unconditionally, not swapped only at pack time.
2. Each `./vite` gets its own `bun build` that does **not** externalize `@barefootjs/jsx` / `@barefootjs/shared` — otherwise Node hits the identical `.ts` error one hop later, resolving those packages' own still-source exports.
3. `--target node` on those builds. Bun's default `browser` target polyfills `node:fs/promises` into non-functional stubs: it builds silently, then throws `TypeError: readFile is not a function` the moment Vite invokes the plugin.
4. `@barefootjs/client`'s `./build` had the same defect one hop further down — `CSRAdapter` imports `BaseAdapter` from `@barefootjs/jsx` as a real value. Surfaced by testing `integrations/csr`.
5. Root `build` gains `@barefootjs/vite` as an explicit early step; without it, `build:types` broke for hono/go-template/mojolicious, which type-check their `./vite` against `@barefootjs/vite`'s now-dist-only `.d.ts`.
6. `packages/vite/tsconfig.json` was missing `DOM` / `DOM.Iterable` that every sibling adapter has — harmless while its `.d.ts` was never consulted, blocking once it became load-bearing.

## Verification

The container's Node hides this bug, so a plain run proves nothing. Both directions were checked under `NODE_OPTIONS=--no-experimental-strip-types`, which simulates an older Node:

| Branch | Result |
|---|---|
| #2519 (before) | fails with the user's exact error |
| this PR | `✓ built in 13.18s`, assets assembled |

Confirmed on `hono` and `gin` (different adapter families), and `csr` is what surfaced item 4.

## Mechanical backstop

`__tests__/vite-entry-node-loadable.test.ts` scans every workspace manifest and fails if any `./vite` export — or `@barefootjs/vite`'s `.` — resolves to raw `.ts` (a `.d.ts` is fine). Verified to fail loudly when the fix is reverted. A tenth adapter added later cannot silently reintroduce a dependency on a new-enough Node.

## DX cost, stated plainly

Every touched package now **requires `bun run build` before its `./vite` entry resolves to anything**. This was always true in principle — the entry was meant to be a build artifact — but in practice this container's Node bypassed it. `integrations/hono`, `gin` and `csr` all need workspace packages built before `vite build` or `vite dev` will work at all.

That is a genuine new requirement for anyone working in the monorepo and should be in the contributor docs; it is not papered over here.

## Note on test noise

Several pre-existing environment-specific failures were observed and ruled out by stashing onto the original commit before diagnosing: `adapter-erb` Ruby `US-ASCII` locale, `adapter-mojolicious` / `adapter-xslate` Perl timezone oracles, `adapter-rust` transient `cargo build` contention under parallel load, `packages/cli`'s missing `runtimes.generated` artifact, and `packages/jsx` timeouts under load. None are related to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ)_