### PR TITLE
fix(adapters): guard emitSpread's local-const fallback against loop-shadowed names (#2489)

### DIFF
--- a/.changeset/emitspread-loop-shadow-guard.md
+++ b/.changeset/emitspread-loop-shadow-guard.md
@@ -1,0 +1,10 @@
+---
+"@barefootjs/twig": patch
+"@barefootjs/jinja": patch
+"@barefootjs/blade": patch
+"@barefootjs/xslate": patch
+"@barefootjs/rust": patch
+"@barefootjs/erb": patch
+---
+
+Fix a loop-scope resolution bug found by the #2482 audit. `elementAttrEmitter.emitSpread`'s local-const fallback resolved a bare spread identifier against `localConstants` with no loop-shadow check, so a `.map()` row like `<p {...attrs} />` spread the OUTER `const attrs = ...` instead of the per-row value. The fallback now consults the live `loopBoundNames` map and skips local-const resolution for a name currently bound by an enclosing loop, mirroring the Mojolicious adapter's existing guard (#2489).

--- a/packages/adapter-blade/src/adapter/blade-adapter.ts
+++ b/packages/adapter-blade/src/adapter/blade-adapter.ts
@@ -444,10 +444,10 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
    * `staticLoopSourceBoundNames` above: that set is a whole-component
    * union used only to guard static-const inlining (safe to over-suppress
    * there — the fallback is just "don't inline"), whereas the boolean-prop
-   * and nullable-optional classification sites need to know whether a name
-   * is loop-bound AT THIS POSITION, because for those two the coarse
-   * fallback would silently mis-render a genuine prop occurrence outside
-   * the loop too (#2488).
+   * and nullable-optional classification sites (#2488) and `emitSpread`'s
+   * local-const fallback (#2489) need to know whether a name is loop-bound
+   * AT THIS POSITION, because for those the coarse fallback would silently
+   * mis-render a genuine occurrence of the same name outside the loop too.
    */
   private loopBoundNames: Map<string, number> = new Map()
 
@@ -1627,7 +1627,14 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
       // and route through the same conditional-spread lowering. Only
       // function-scope (`!isModule`) consts whose value is NOT itself a bare
       // identifier (loop guard) are considered.
-      if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) {
+      //
+      // `loopBoundNames` guard (#2489): an enclosing `.map()` callback's own
+      // param can shadow this outer const's name (`.map((attrs) => <p
+      // {...attrs} />)`) — without the guard this forwarded the OUTER
+      // const's value at every iteration instead of the per-item value.
+      // Must be the LIVE map, not `staticLoopSourceBoundNames` — the same
+      // name spread at ROOT must still resolve the const.
+      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.loopBoundNames.has(trimmed)) {
         const localConst = (this.localConstants ?? []).find(
           c => c.name === trimmed && !c.isModule,
         )

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -32,10 +32,4 @@ export const renderDivergences: RenderDivergences = {
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'composite-row-child-aliased-prop':
     'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
-
-  // #2482 audit follow-ups: loop-scope holes in per-adapter name
-  // classification. Graduate by applying the loop-bound-name guards
-  // described in each issue and deleting the line.
-  'loop-param-shadows-spread-const':
-    'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/packages/adapter-erb/src/adapter/erb-adapter.ts
+++ b/packages/adapter-erb/src/adapter/erb-adapter.ts
@@ -1536,7 +1536,12 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
       // text and route through the same conditional-spread lowering. Only
       // function-scope (`!isModule`) consts whose value is NOT itself a
       // bare identifier (loop guard) are considered.
-      if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed)) {
+      //
+      // `loopBoundNames` guard (#2489): an enclosing `.map()` callback's own
+      // param can shadow this outer const's name (`.map((attrs) => <p
+      // {...attrs} />)`) — without the guard this forwarded the OUTER
+      // const's value at every iteration instead of the per-item value.
+      if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed) && !this.loopBoundNames.has(trimmed)) {
         const localConst = this.localConstants.find(
           c => c.name === trimmed && !c.isModule,
         )

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -30,10 +30,4 @@ export const renderDivergences: RenderDivergences = {
   // `skipJsx` entries).
   'aliased-destructured-prop':
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
-
-  // #2482 audit follow-ups: loop-scope holes in per-adapter name
-  // classification. Graduate by applying the loop-bound-name guards
-  // described in each issue and deleting the line.
-  'loop-param-shadows-spread-const':
-    'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check (the live `loopBoundNames` map exists but is not consulted on this path), so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -293,10 +293,10 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
    * `staticLoopSourceBoundNames` above: that set is a whole-component
    * union used only to guard static-const inlining (safe to over-suppress
    * there — the fallback is just "don't inline"), whereas the boolean-prop
-   * and nullable-optional classification sites need to know whether a name
-   * is loop-bound AT THIS POSITION, because for those two the coarse
-   * fallback would silently mis-render a genuine prop occurrence outside
-   * the loop too (#2488).
+   * and nullable-optional classification sites (#2488) and `emitSpread`'s
+   * local-const fallback (#2489) need to know whether a name is loop-bound
+   * AT THIS POSITION, because for those the coarse fallback would silently
+   * mis-render a genuine occurrence of the same name outside the loop too.
    */
   private loopBoundNames: Map<string, number> = new Map()
 
@@ -1449,7 +1449,14 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
       // and route through the same conditional-spread lowering. Only
       // function-scope (`!isModule`) consts whose value is NOT itself a bare
       // identifier (loop guard) are considered.
-      if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) {
+      //
+      // `loopBoundNames` guard (#2489): an enclosing `.map()` callback's own
+      // param can shadow this outer const's name (`.map((attrs) => <p
+      // {...attrs} />)`) — without the guard this forwarded the OUTER
+      // const's value at every iteration instead of the per-item value.
+      // Must be the LIVE map, not `staticLoopSourceBoundNames` — the same
+      // name spread at ROOT must still resolve the const.
+      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.loopBoundNames.has(trimmed)) {
         const localConst = (this.localConstants ?? []).find(
           c => c.name === trimmed && !c.isModule,
         )

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -32,10 +32,4 @@ export const renderDivergences: RenderDivergences = {
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'composite-row-child-aliased-prop':
     'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
-
-  // #2482 audit follow-ups: loop-scope holes in per-adapter name
-  // classification. Graduate by applying the loop-bound-name guards
-  // described in each issue and deleting the line.
-  'loop-param-shadows-spread-const':
-    'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -341,10 +341,10 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
    * `staticLoopSourceBoundNames` above: that set is a whole-component
    * union used only to guard static-const inlining (safe to over-suppress
    * there — the fallback is just "don't inline"), whereas the boolean-prop
-   * and nullable-optional classification sites need to know whether a name
-   * is loop-bound AT THIS POSITION, because for those two the coarse
-   * fallback would silently mis-render a genuine prop occurrence outside
-   * the loop too (#2488).
+   * and nullable-optional classification sites (#2488) and `emitSpread`'s
+   * local-const fallback (#2489) need to know whether a name is loop-bound
+   * AT THIS POSITION, because for those the coarse fallback would silently
+   * mis-render a genuine occurrence of the same name outside the loop too.
    */
   private loopBoundNames: Map<string, number> = new Map()
 
@@ -1501,7 +1501,14 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
       // and route through the same conditional-spread lowering. Only
       // function-scope (`!isModule`) consts whose value is NOT itself a bare
       // identifier (loop guard) are considered.
-      if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) {
+      //
+      // `loopBoundNames` guard (#2489): an enclosing `.map()` callback's own
+      // param can shadow this outer const's name (`.map((attrs) => <p
+      // {...attrs} />)`) — without the guard this forwarded the OUTER
+      // const's value at every iteration instead of the per-item value.
+      // Must be the LIVE map, not `staticLoopSourceBoundNames` — the same
+      // name spread at ROOT must still resolve the const.
+      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.loopBoundNames.has(trimmed)) {
         const localConst = (this.localConstants ?? []).find(
           c => c.name === trimmed && !c.isModule,
         )

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -34,10 +34,4 @@ export const renderDivergences: RenderDivergences = {
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'composite-row-child-aliased-prop':
     'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
-
-  // #2482 audit follow-ups: loop-scope holes in per-adapter name
-  // classification. Graduate by applying the loop-bound-name guards
-  // described in each issue and deleting the line.
-  'loop-param-shadows-spread-const':
-    'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -344,10 +344,10 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
    * `staticLoopSourceBoundNames` above: that set is a whole-component
    * union used only to guard static-const inlining (safe to over-suppress
    * there — the fallback is just "don't inline"), whereas the boolean-prop
-   * and nullable-optional classification sites need to know whether a name
-   * is loop-bound AT THIS POSITION, because for those two the coarse
-   * fallback would silently mis-render a genuine prop occurrence outside
-   * the loop too (#2488).
+   * and nullable-optional classification sites (#2488) and `emitSpread`'s
+   * local-const fallback (#2489) need to know whether a name is loop-bound
+   * AT THIS POSITION, because for those the coarse fallback would silently
+   * mis-render a genuine occurrence of the same name outside the loop too.
    */
   private loopBoundNames: Map<string, number> = new Map()
 
@@ -1498,7 +1498,14 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
       // and route through the same conditional-spread lowering. Only
       // function-scope (`!isModule`) consts whose value is NOT itself a bare
       // identifier (loop guard) are considered.
-      if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) {
+      //
+      // `loopBoundNames` guard (#2489): an enclosing `.map()` callback's own
+      // param can shadow this outer const's name (`.map((attrs) => <p
+      // {...attrs} />)`) — without the guard this forwarded the OUTER
+      // const's value at every iteration instead of the per-item value.
+      // Must be the LIVE map, not `staticLoopSourceBoundNames` — the same
+      // name spread at ROOT must still resolve the const.
+      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.loopBoundNames.has(trimmed)) {
         const localConst = (this.localConstants ?? []).find(
           c => c.name === trimmed && !c.isModule,
         )

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -32,10 +32,4 @@ export const renderDivergences: RenderDivergences = {
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'composite-row-child-aliased-prop':
     'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
-
-  // #2482 audit follow-ups: loop-scope holes in per-adapter name
-  // classification. Graduate by applying the loop-bound-name guards
-  // described in each issue and deleting the line.
-  'loop-param-shadows-spread-const':
-    'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -267,10 +267,10 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
    * `staticLoopSourceBoundNames` above: that set is a whole-component
    * union used only to guard static-const inlining (safe to over-suppress
    * there — the fallback is just "don't inline"), whereas the boolean-prop
-   * and nullable-optional classification sites need to know whether a name
-   * is loop-bound AT THIS POSITION, because for those two the coarse
-   * fallback would silently mis-render a genuine prop occurrence outside
-   * the loop too (#2488).
+   * and nullable-optional classification sites (#2488) and `emitSpread`'s
+   * local-const fallback (#2489) need to know whether a name is loop-bound
+   * AT THIS POSITION, because for those the coarse fallback would silently
+   * mis-render a genuine occurrence of the same name outside the loop too.
    */
   private loopBoundNames: Map<string, number> = new Map()
 
@@ -1412,7 +1412,14 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       // and route through the same conditional-spread lowering. Only
       // function-scope (`!isModule`) consts whose value is NOT itself a bare
       // identifier (loop guard) are considered.
-      if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) {
+      //
+      // `loopBoundNames` guard (#2489): an enclosing `.map()` callback's own
+      // param can shadow this outer const's name (`.map((attrs) => <p
+      // {...attrs} />)`) — without the guard this forwarded the OUTER
+      // const's value at every iteration instead of the per-item value.
+      // Must be the LIVE map, not `staticLoopSourceBoundNames` — the same
+      // name spread at ROOT must still resolve the const.
+      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.loopBoundNames.has(trimmed)) {
         const localConst = (this.localConstants ?? []).find(
           c => c.name === trimmed && !c.isModule,
         )

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -32,10 +32,4 @@ export const renderDivergences: RenderDivergences = {
     'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
   'composite-row-child-aliased-prop':
     'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
-
-  // #2482 audit follow-ups: loop-scope holes in per-adapter name
-  // classification. Graduate by applying the loop-bound-name guards
-  // described in each issue and deleting the line.
-  'loop-param-shadows-spread-const':
-    'a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)',
 }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2339,32 +2339,6 @@
           ]
         }
       },
-      "loop-param-shadows-spread-const": {
-        "blade": {
-          "kind": "render",
-          "reason": "a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check (the live `loopBoundNames` map exists but is not consulted on this path), so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "a .map() param shadowing an object const is resolved by `emitSpread` against `localConstants` with no loop-shadow check, so every row spreads the OUTER const instead of the row value (https://github.com/piconic-ai/barefootjs/issues/2489)"
-        }
-      },
       "map-array-builder-body": {
         "blade": {
           "kind": "refusal",
@@ -2904,10 +2878,6 @@
       "flatmap-typeof-projection": {
         "description": "Off-subset `.flatMap()` projection (typeof) — JS-runtime faithful, DSL diagnostic",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/flatmap-typeof-projection.ts"
-      },
-      "loop-param-shadows-spread-const": {
-        "description": ".map() param shadowing an object const spreads the row value, not the outer const",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/loop-param-shadows-spread-const.ts"
       },
       "map-array-builder-body": {
         "description": "imperative array-builder .map() body — JS-runtime verbatim, DSL refuses (BF021)",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1433,7 +1433,7 @@
           ]
         },
         "blade": {
-          "pass": 183,
+          "pass": 184,
           "total": 200,
           "gaps": [
             {
@@ -1479,10 +1479,6 @@
               "issues": []
             },
             {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
-            {
               "fixture": "preamble-cells",
               "issues": []
             },
@@ -1517,7 +1513,7 @@
           ]
         },
         "erb": {
-          "pass": 185,
+          "pass": 186,
           "total": 200,
           "gaps": [
             {
@@ -1550,10 +1546,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -1667,7 +1659,7 @@
           ]
         },
         "jinja": {
-          "pass": 183,
+          "pass": 184,
           "total": 200,
           "gaps": [
             {
@@ -1710,10 +1702,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -1751,7 +1739,7 @@
           ]
         },
         "minijinja": {
-          "pass": 183,
+          "pass": 184,
           "total": 200,
           "gaps": [
             {
@@ -1794,10 +1782,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -1909,7 +1893,7 @@
           ]
         },
         "twig": {
-          "pass": 183,
+          "pass": 184,
           "total": 200,
           "gaps": [
             {
@@ -1952,10 +1936,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -1993,7 +1973,7 @@
           ]
         },
         "xslate": {
-          "pass": 183,
+          "pass": 184,
           "total": 200,
           "gaps": [
             {
@@ -2036,10 +2016,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2097,15 +2073,11 @@
           "total": 24
         },
         "blade": {
-          "pass": 21,
+          "pass": 22,
           "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2115,15 +2087,11 @@
           ]
         },
         "erb": {
-          "pass": 21,
+          "pass": 22,
           "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2147,15 +2115,11 @@
           ]
         },
         "jinja": {
-          "pass": 21,
+          "pass": 22,
           "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2165,15 +2129,11 @@
           ]
         },
         "minijinja": {
-          "pass": 21,
+          "pass": 22,
           "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2197,15 +2157,11 @@
           ]
         },
         "twig": {
-          "pass": 21,
+          "pass": 22,
           "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2215,15 +2171,11 @@
           ]
         },
         "xslate": {
-          "pass": 21,
+          "pass": 22,
           "total": 24,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2261,7 +2213,7 @@
           ]
         },
         "blade": {
-          "pass": 268,
+          "pass": 269,
           "total": 288,
           "gaps": [
             {
@@ -2311,10 +2263,6 @@
               "issues": []
             },
             {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
@@ -2357,7 +2305,7 @@
           ]
         },
         "erb": {
-          "pass": 270,
+          "pass": 271,
           "total": 288,
           "gaps": [
             {
@@ -2394,10 +2342,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2531,7 +2475,7 @@
           ]
         },
         "jinja": {
-          "pass": 268,
+          "pass": 269,
           "total": 288,
           "gaps": [
             {
@@ -2578,10 +2522,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2627,7 +2567,7 @@
           ]
         },
         "minijinja": {
-          "pass": 268,
+          "pass": 269,
           "total": 288,
           "gaps": [
             {
@@ -2674,10 +2614,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2809,7 +2745,7 @@
           ]
         },
         "twig": {
-          "pass": 268,
+          "pass": 269,
           "total": 288,
           "gaps": [
             {
@@ -2856,10 +2792,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -2905,7 +2837,7 @@
           ]
         },
         "xslate": {
-          "pass": 268,
+          "pass": 269,
           "total": 288,
           "gaps": [
             {
@@ -2952,10 +2884,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3073,7 +3001,7 @@
           "total": 238
         },
         "blade": {
-          "pass": 226,
+          "pass": 227,
           "total": 238,
           "gaps": [
             {
@@ -3094,10 +3022,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3129,7 +3053,7 @@
           ]
         },
         "erb": {
-          "pass": 226,
+          "pass": 227,
           "total": 238,
           "gaps": [
             {
@@ -3150,10 +3074,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3237,7 +3157,7 @@
           ]
         },
         "jinja": {
-          "pass": 226,
+          "pass": 227,
           "total": 238,
           "gaps": [
             {
@@ -3258,10 +3178,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3293,7 +3209,7 @@
           ]
         },
         "minijinja": {
-          "pass": 226,
+          "pass": 227,
           "total": 238,
           "gaps": [
             {
@@ -3314,10 +3230,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3401,7 +3313,7 @@
           ]
         },
         "twig": {
-          "pass": 226,
+          "pass": 227,
           "total": 238,
           "gaps": [
             {
@@ -3422,10 +3334,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3457,7 +3365,7 @@
           ]
         },
         "xslate": {
-          "pass": 226,
+          "pass": 227,
           "total": 238,
           "gaps": [
             {
@@ -3478,10 +3386,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3689,7 +3593,7 @@
           ]
         },
         "blade": {
-          "pass": 135,
+          "pass": 136,
           "total": 154,
           "gaps": [
             {
@@ -3735,10 +3639,6 @@
               "issues": []
             },
             {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
-            {
               "fixture": "map-array-builder-body",
               "issues": []
             },
@@ -3781,7 +3681,7 @@
           ]
         },
         "erb": {
-          "pass": 137,
+          "pass": 138,
           "total": 154,
           "gaps": [
             {
@@ -3814,10 +3714,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -3947,7 +3843,7 @@
           ]
         },
         "jinja": {
-          "pass": 135,
+          "pass": 136,
           "total": 154,
           "gaps": [
             {
@@ -3990,10 +3886,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -4039,7 +3931,7 @@
           ]
         },
         "minijinja": {
-          "pass": 135,
+          "pass": 136,
           "total": 154,
           "gaps": [
             {
@@ -4082,10 +3974,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -4213,7 +4101,7 @@
           ]
         },
         "twig": {
-          "pass": 135,
+          "pass": 136,
           "total": 154,
           "gaps": [
             {
@@ -4256,10 +4144,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -4305,7 +4189,7 @@
           ]
         },
         "xslate": {
-          "pass": 135,
+          "pass": 136,
           "total": 154,
           "gaps": [
             {
@@ -4348,10 +4232,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -4417,13 +4297,9 @@
           "total": 55
         },
         "blade": {
-          "pass": 52,
+          "pass": 53,
           "total": 55,
           "gaps": [
-            {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -4437,13 +4313,9 @@
           ]
         },
         "erb": {
-          "pass": 52,
+          "pass": 53,
           "total": 55,
           "gaps": [
-            {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -4473,13 +4345,9 @@
           ]
         },
         "jinja": {
-          "pass": 52,
+          "pass": 53,
           "total": 55,
           "gaps": [
-            {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -4493,13 +4361,9 @@
           ]
         },
         "minijinja": {
-          "pass": 52,
+          "pass": 53,
           "total": 55,
           "gaps": [
-            {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -4529,13 +4393,9 @@
           ]
         },
         "twig": {
-          "pass": 52,
+          "pass": 53,
           "total": 55,
           "gaps": [
-            {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -4549,13 +4409,9 @@
           ]
         },
         "xslate": {
-          "pass": 52,
+          "pass": 53,
           "total": 55,
           "gaps": [
-            {
-              "fixture": "loop-param-shadows-spread-const",
-              "issues": []
-            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -7690,15 +7546,11 @@
           "total": 101
         },
         "blade": {
-          "pass": 95,
+          "pass": 96,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7720,15 +7572,11 @@
           ]
         },
         "erb": {
-          "pass": 95,
+          "pass": 96,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7776,15 +7624,11 @@
           ]
         },
         "jinja": {
-          "pass": 95,
+          "pass": 96,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7806,15 +7650,11 @@
           ]
         },
         "minijinja": {
-          "pass": 95,
+          "pass": 96,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7862,15 +7702,11 @@
           ]
         },
         "twig": {
-          "pass": 95,
+          "pass": 96,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7892,15 +7728,11 @@
           ]
         },
         "xslate": {
-          "pass": 95,
+          "pass": 96,
           "total": 101,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7942,7 +7774,7 @@
           "total": 168
         },
         "blade": {
-          "pass": 159,
+          "pass": 160,
           "total": 168,
           "gaps": [
             {
@@ -7963,10 +7795,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -7986,7 +7814,7 @@
           ]
         },
         "erb": {
-          "pass": 159,
+          "pass": 160,
           "total": 168,
           "gaps": [
             {
@@ -8007,10 +7835,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -8070,7 +7894,7 @@
           ]
         },
         "jinja": {
-          "pass": 159,
+          "pass": 160,
           "total": 168,
           "gaps": [
             {
@@ -8091,10 +7915,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -8114,7 +7934,7 @@
           ]
         },
         "minijinja": {
-          "pass": 159,
+          "pass": 160,
           "total": 168,
           "gaps": [
             {
@@ -8135,10 +7955,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -8198,7 +8014,7 @@
           ]
         },
         "twig": {
-          "pass": 159,
+          "pass": 160,
           "total": 168,
           "gaps": [
             {
@@ -8219,10 +8035,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {
@@ -8242,7 +8054,7 @@
           ]
         },
         "xslate": {
-          "pass": 159,
+          "pass": 160,
           "total": 168,
           "gaps": [
             {
@@ -8263,10 +8075,6 @@
             },
             {
               "fixture": "flatmap-typeof-projection",
-              "issues": []
-            },
-            {
-              "fixture": "loop-param-shadows-spread-const",
               "issues": []
             },
             {


### PR DESCRIPTION
Fixes #2489.

## What

`elementAttrEmitter.emitSpread`'s last fallback resolved a bare spread identifier against `localConstants` with no loop-shadow check, so a `.map((attrs) => <p {...attrs} />)` row spread the **outer** `const attrs = …` instead of the per-row value — a silent wrong render in twig, jinja, blade, xslate, rust (minijinja), and erb. Mojolicious was already immune (it consults its live `loopBoundNames` map on this path); this PR brings the other six in line with that exact pattern: one added conjunct on the identifier guard.

## Why the live map, not `staticLoopSourceBoundNames`

The fixture's component uses the **same name at two positions**: the root `<div {...attrs}>` must still resolve the outer conditional const (`role="note"` on the root), while the loop rows must not. The coarse whole-component union would suppress the root resolution too; the live ref-counted `loopBoundNames` map is true only while rendering inside the loop. Comments at each guard record this constraint.

## Pin graduation

The six `loop-param-shadows-spread-const` entries are deleted from each adapter's `render-divergences.ts` (which auto-unskips the fixture via `skipJsx: Object.keys(renderDivergences)`), and both locks are regenerated — the fixture now runs as the regression test, per the repo's defect-lands-as-fixture convention.

## Verification

- Real-engine renders of the fixture match `expectedHtml` byte-for-byte on **jinja (python3/jinja2), erb (ruby), rust (minijinja via bf-render), twig and blade (php, composer vendors installed during review)**; xslate verified at the emitted-template level (structurally identical to the five verified adapters; `Text::Xslate` unavailable locally).
- Full suites: twig 1281 / 0 fail, jinja 1273 / 0 fail, blade 1273 / 0 fail, xslate 1274 / 0 fail, rust 1272 / 0 fail, erb 1248 / 0 fail, adapter-tests 1875 / 0 fail, compat 197 / 0 fail (remaining skips are pre-existing missing-engine skips in this environment).
- Lock diffs are mechanical only: the six divergence cells removed from `ui/compat.lock.json`, 48 gap entries removed / `pass` +1 in `ui/support-matrix.lock.json`; adapter and fixture totals unchanged.
- Reviewed by an independent pass (approve; two comment-clarity nits applied, plus one out-of-scope observation: `spread-codegen.ts`'s `IDENT[KEY]` spread-value resolution has the same hazard family unguarded — to be reproduced and filed separately per the fixture convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANWdijiBRfuNqnACEPEyKD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANWdijiBRfuNqnACEPEyKD)_