### PR TITLE
chore(compat): re-point aliased-prop pins from closed #2460 to open trackers #2524/#2525 (#2508)

### DIFF
--- a/.changeset/repoint-2460-divergences-to-2524-2525.md
+++ b/.changeset/repoint-2460-divergences-to-2524-2525.md
@@ -1,0 +1,29 @@
+---
+"@barefootjs/blade": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/rust": patch
+"@barefootjs/twig": patch
+"@barefootjs/xslate": patch
+---
+
+Re-point render-divergence citations from the now-closed #2460 to its open per-adapter trackers (#2524/#2525)
+
+No behavior change — this only updates `renderDivergences` reason strings
+(published to `ui/compat.lock.json` and the docs compatibility matrix). The
+shared-layer defect these entries originally cited (#2460, an aliased
+destructured prop `{ n: count }` losing its rename) is now FIXED
+(b4f5075) for the shared compiler layer and the Hono reference adapter.
+The `aliased-destructured-prop` / `composite-row-child-aliased-prop`
+divergences remain live per-adapter:
+
+- The 7 template-string adapters (`blade`, `erb`, `jinja`, `mojolicious`,
+  `rust`/minijinja, `twig`, `xslate`) still silently drop the rename in
+  their emitted templates — tracked by #2524.
+- `go-template`'s generated Go fails `go run` outright (unknown Input
+  struct field) — tracked by #2525.
+
+Each entry's docstring is rewritten to stop claiming Hono still emits the
+broken form (it doesn't) and to point at the correct open tracker.

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -20,16 +20,20 @@ export const renderDivergences: RenderDivergences = {
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` is
-  // hand-authored to the CORRECT output because the emission bug lives in
+  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
+  // hand-authored to the CORRECT output while the emission bug lived in
   // the shared compiler layer — every adapter, including the Hono
-  // reference, currently emits the broken form (verified against this
-  // adapter's emitted template; see each fixture's docstring). Graduate
-  // by fixing the shared emission, regenerating `expectedHtml` from the
-  // fixed reference, and deleting these lines (and the matching hono
-  // `skipJsx` entries).
+  // reference, used to emit the broken form. That shared-layer defect
+  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
+  // Hono reference like any other fixture. The remaining gap is
+  // per-template-adapter — this adapter still keys its template vars /
+  // ssr-defaults / props bridge off the local binding instead of
+  // `sourceName ?? name` — tracked by #2524 (the 7 silent template
+  // adapters). Graduate by applying the same `sourceName ?? name` fix to
+  // this adapter's emission path and deleting these lines (and the
+  // matching hono `skipJsx` entries, already gone).
   'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
+    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)',
   'composite-row-child-aliased-prop':
-    'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
+    'same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)',
 }

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -20,14 +20,18 @@ export const renderDivergences: RenderDivergences = {
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` is
-  // hand-authored to the CORRECT output because the emission bug lives in
+  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
+  // hand-authored to the CORRECT output while the emission bug lived in
   // the shared compiler layer — every adapter, including the Hono
-  // reference, currently emits the broken form (verified against this
-  // adapter's emitted template; see each fixture's docstring). Graduate
-  // by fixing the shared emission, regenerating `expectedHtml` from the
-  // fixed reference, and deleting these lines (and the matching hono
-  // `skipJsx` entries).
+  // reference, used to emit the broken form. That shared-layer defect
+  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
+  // Hono reference like any other fixture. The remaining gap is
+  // per-template-adapter — this adapter still keys its template vars /
+  // ssr-defaults / props bridge off the local binding instead of
+  // `sourceName ?? name` — tracked by #2524 (the 7 silent template
+  // adapters). Graduate by applying the same `sourceName ?? name` fix to
+  // this adapter's emission path and deleting this line (and the
+  // matching hono `skipJsx` entries, already gone).
   'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
+    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)',
 }

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -30,14 +30,18 @@ export const renderDivergences: RenderDivergences = {
   // `test-render.ts`) now replicates that documented contract for a
   // signal-backed dynamic child-component loop.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` is
-  // hand-authored to the CORRECT output because the emission bug lives in
+  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
+  // hand-authored to the CORRECT output while the emission bug lived in
   // the shared compiler layer — every adapter, including the Hono
-  // reference, currently emits the broken form (verified against this
-  // adapter's emitted template; see each fixture's docstring). Graduate
-  // by fixing the shared emission, regenerating `expectedHtml` from the
-  // fixed reference, and deleting these lines (and the matching hono
-  // `skipJsx` entries).
+  // reference, used to emit the broken form. That shared-layer defect
+  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
+  // Hono reference like any other fixture. The remaining gap is
+  // Go-specific — the Input struct field stays keyed by the local
+  // binding instead of `sourceName ?? name`, so the caller-side struct
+  // literal fails `go run` outright — tracked by #2525 (go-template's
+  // `go run` exit-1 failure). Graduate by keying the Input struct field
+  // by `sourceName ?? name` and deleting this line (and the matching
+  // hono `skipJsx` entry, already gone).
   'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — the Input struct field is Count `json:"count"`, so the caller-side struct literal keyed by the real prop name fails `go run` outright (unknown field N, exit 1) (https://github.com/piconic-ai/barefootjs/issues/2460)',
+    'aliased destructured prop `{ n: count }` loses its rename — the Input struct field is Count `json:"count"`, so the caller-side struct literal keyed by the real prop name fails `go run` outright (unknown field N, exit 1) (https://github.com/piconic-ai/barefootjs/issues/2525)',
 }

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -20,16 +20,20 @@ export const renderDivergences: RenderDivergences = {
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` is
-  // hand-authored to the CORRECT output because the emission bug lives in
+  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
+  // hand-authored to the CORRECT output while the emission bug lived in
   // the shared compiler layer — every adapter, including the Hono
-  // reference, currently emits the broken form (verified against this
-  // adapter's emitted template; see each fixture's docstring). Graduate
-  // by fixing the shared emission, regenerating `expectedHtml` from the
-  // fixed reference, and deleting these lines (and the matching hono
-  // `skipJsx` entries).
+  // reference, used to emit the broken form. That shared-layer defect
+  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
+  // Hono reference like any other fixture. The remaining gap is
+  // per-template-adapter — this adapter still keys its template vars /
+  // ssr-defaults / props bridge off the local binding instead of
+  // `sourceName ?? name` — tracked by #2524 (the 7 silent template
+  // adapters). Graduate by applying the same `sourceName ?? name` fix to
+  // this adapter's emission path and deleting these lines (and the
+  // matching hono `skipJsx` entries, already gone).
   'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
+    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)',
   'composite-row-child-aliased-prop':
-    'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
+    'same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)',
 }

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -20,17 +20,20 @@ export const renderDivergences: RenderDivergences = {
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` is
-  // hand-authored to the CORRECT output because the emission bug lives in
+  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
+  // hand-authored to the CORRECT output while the emission bug lived in
   // the shared compiler layer — every adapter, including the Hono
-  // reference, currently emits the broken form (verified against this
-  // adapter's emitted template; see each fixture's docstring). Graduate
-  // by fixing the shared emission, regenerating `expectedHtml` from the
-  // fixed reference, and deleting these lines (and the matching hono
-  // `skipJsx` entries).
+  // reference, used to emit the broken form. That shared-layer defect
+  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
+  // Hono reference like any other fixture. The remaining gap is
+  // per-template-adapter — this adapter still keys its template vars /
+  // ssr-defaults / props bridge off the local binding instead of
+  // `sourceName ?? name` — tracked by #2524 (the 7 silent template
+  // adapters). Graduate by applying the same `sourceName ?? name` fix to
+  // this adapter's emission path and deleting these lines (and the
+  // matching hono `skipJsx` entries, already gone).
   'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
+    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)',
   'composite-row-child-aliased-prop':
-    'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
-
+    'same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)',
 }

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -22,16 +22,20 @@ export const renderDivergences: RenderDivergences = {
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` is
-  // hand-authored to the CORRECT output because the emission bug lives in
+  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
+  // hand-authored to the CORRECT output while the emission bug lived in
   // the shared compiler layer — every adapter, including the Hono
-  // reference, currently emits the broken form (verified against this
-  // adapter's emitted template; see each fixture's docstring). Graduate
-  // by fixing the shared emission, regenerating `expectedHtml` from the
-  // fixed reference, and deleting these lines (and the matching hono
-  // `skipJsx` entries).
+  // reference, used to emit the broken form. That shared-layer defect
+  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
+  // Hono reference like any other fixture. The remaining gap is
+  // per-template-adapter — this adapter still keys its template vars /
+  // ssr-defaults / props bridge off the local binding instead of
+  // `sourceName ?? name` — tracked by #2524 (the 7 silent template
+  // adapters). Graduate by applying the same `sourceName ?? name` fix to
+  // this adapter's emission path and deleting these lines (and the
+  // matching hono `skipJsx` entries, already gone).
   'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
+    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)',
   'composite-row-child-aliased-prop':
-    'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
+    'same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)',
 }

--- a/packages/adapter-tests/fixtures/aliased-destructured-prop.ts
+++ b/packages/adapter-tests/fixtures/aliased-destructured-prop.ts
@@ -4,7 +4,7 @@ import { createFixture } from '../src/types'
  * Aliased (renaming) destructured prop on a plain stateless component:
  * `{ text, n: count }` — the caller supplies `n`, the body reads `count`.
  *
- * Pins #2460, which is NOT Hono-only: every consumer that keys off
+ * Originally filed as #2460, which was NOT Hono-only: every consumer that keys off
  * `ParamInfo.name` instead of `sourceName ?? name` drops the rename.
  * Verified per adapter: Hono used to emit `{ text, count }` (reading a
  * `count` property off a props object shaped `{ text, n }` → always
@@ -22,14 +22,20 @@ import { createFixture } from '../src/types'
  * `expectedHtml` below is the CORRECT output (the `s1` slot carries `7`)
  * and is now generated from Hono like any other fixture (Hono was the
  * broken party before, which is exactly why #2460 notes no aliased-prop
- * fixture could exist until it was fixed). Adapters that still drop the
- * rename skip this fixture with a pointer to
- * https://github.com/piconic-ai/barefootjs/issues/2460; graduating
- * means fixing the emission and deleting the skip entry.
+ * fixture could exist until it was fixed). #2460 itself is CLOSED (fixed
+ * in b4f5075) — the shared layer (Hono, `extractSsrDefaults`) now keys
+ * off `sourceName ?? name` correctly. The 7 template-string adapters
+ * still drop the rename silently and are tracked by
+ * https://github.com/piconic-ai/barefootjs/issues/2524; Go's `go run`
+ * exit-1 failure is tracked by
+ * https://github.com/piconic-ai/barefootjs/issues/2525. Adapters that
+ * still drop the rename skip this fixture with a pointer to the
+ * relevant tracker; graduating means fixing the emission and deleting
+ * the skip entry.
  */
 export const fixture = createFixture({
   id: 'aliased-destructured-prop',
-  description: 'Aliased destructured prop ({ n: count }) keeps the rename (#2460)',
+  description: 'Aliased destructured prop ({ n: count }) keeps the rename (#2524)',
   source: `
 export function Badge({ text, n: count }: { text: string; n: number }) {
   return <span>{text}:{count}</span>

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -250,17 +250,22 @@ describe('CSR Conformance Tests', () => {
     //     component's own first slot id coincides with the wrapper's slot
     //     number (see `site/ui`'s xyflow Highlight-Depth demo regression).
     'grandchild-composition',
-    // #2460: the CSR template drops the destructure rename the same way
-    // the SSR side does — the aliased `count` reads a property named
-    // `count` off a props object shaped `{ text, n }`, so the `s1` slot
-    // renders empty instead of the fixture's corrected expectedHtml.
-    // https://github.com/piconic-ai/barefootjs/issues/2460
+    // Originally filed under #2460: the CSR template drops the
+    // destructure rename the same way the SSR side used to — the aliased
+    // `count` reads a property named `count` off a props object shaped
+    // `{ text, n }`, so the `s1` slot renders empty instead of the
+    // fixture's corrected expectedHtml. #2460 itself is CLOSED (the
+    // shared SSR-side layer was fixed in b4f5075); this CSR client-JS
+    // gap is still live and is now tracked by
+    // https://github.com/piconic-ai/barefootjs/issues/2524. Re-verified
+    // still failing (2026-08-03).
     'aliased-destructured-prop',
-    // Same #2460 CSR-template gap as `aliased-destructured-prop`, inside
-    // a keyed `.map()` loop row: the nested child's renamed prop reads
+    // Same CSR-template gap as `aliased-destructured-prop`, inside a
+    // keyed `.map()` loop row: the nested child's renamed prop reads
     // `_p.count` off a row object shaped `{ text, n }`, so both rows'
     // `s1` slot renders empty instead of the fixture's expectedHtml.
-    // https://github.com/piconic-ai/barefootjs/issues/2460
+    // Tracked by https://github.com/piconic-ai/barefootjs/issues/2524.
+    // Re-verified still failing (2026-08-03).
     'composite-row-child-aliased-prop',
     // #2463 FIXED: the fixture now lowers to the root-ternary plan and
     // its template evaluates cleanly — but the synthetic scope wrapper

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -20,16 +20,20 @@ export const renderDivergences: RenderDivergences = {
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` is
-  // hand-authored to the CORRECT output because the emission bug lives in
+  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
+  // hand-authored to the CORRECT output while the emission bug lived in
   // the shared compiler layer — every adapter, including the Hono
-  // reference, currently emits the broken form (verified against this
-  // adapter's emitted template; see each fixture's docstring). Graduate
-  // by fixing the shared emission, regenerating `expectedHtml` from the
-  // fixed reference, and deleting these lines (and the matching hono
-  // `skipJsx` entries).
+  // reference, used to emit the broken form. That shared-layer defect
+  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
+  // Hono reference like any other fixture. The remaining gap is
+  // per-template-adapter — this adapter still keys its template vars /
+  // ssr-defaults / props bridge off the local binding instead of
+  // `sourceName ?? name` — tracked by #2524 (the 7 silent template
+  // adapters). Graduate by applying the same `sourceName ?? name` fix to
+  // this adapter's emission path and deleting these lines (and the
+  // matching hono `skipJsx` entries, already gone).
   'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
+    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)',
   'composite-row-child-aliased-prop':
-    'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
+    'same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)',
 }

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -20,16 +20,20 @@ export const renderDivergences: RenderDivergences = {
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` is
-  // hand-authored to the CORRECT output because the emission bug lives in
+  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
+  // hand-authored to the CORRECT output while the emission bug lived in
   // the shared compiler layer — every adapter, including the Hono
-  // reference, currently emits the broken form (verified against this
-  // adapter's emitted template; see each fixture's docstring). Graduate
-  // by fixing the shared emission, regenerating `expectedHtml` from the
-  // fixed reference, and deleting these lines (and the matching hono
-  // `skipJsx` entries).
+  // reference, used to emit the broken form. That shared-layer defect
+  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
+  // Hono reference like any other fixture. The remaining gap is
+  // per-template-adapter — this adapter still keys its template vars /
+  // ssr-defaults / props bridge off the local binding instead of
+  // `sourceName ?? name` — tracked by #2524 (the 7 silent template
+  // adapters). Graduate by applying the same `sourceName ?? name` fix to
+  // this adapter's emission path and deleting these lines (and the
+  // matching hono `skipJsx` entries, already gone).
   'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)',
+    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)',
   'composite-row-child-aliased-prop':
-    'same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)',
+    'same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)',
 }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1819,61 +1819,61 @@
       "aliased-destructured-prop": {
         "blade": {
           "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)"
+          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)"
         },
         "erb": {
           "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)"
+          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)"
         },
         "go-template": {
           "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — the Input struct field is Count `json:\"count\"`, so the caller-side struct literal keyed by the real prop name fails `go run` outright (unknown field N, exit 1) (https://github.com/piconic-ai/barefootjs/issues/2460)"
+          "reason": "aliased destructured prop `{ n: count }` loses its rename — the Input struct field is Count `json:\"count\"`, so the caller-side struct literal keyed by the real prop name fails `go run` outright (unknown field N, exit 1) (https://github.com/piconic-ai/barefootjs/issues/2525)"
         },
         "jinja": {
           "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)"
+          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)"
         },
         "minijinja": {
           "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)"
+          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)"
         },
         "mojolicious": {
           "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)"
+          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)"
         },
         "twig": {
           "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)"
+          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)"
         },
         "xslate": {
           "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2460)"
+          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)"
         }
       },
       "composite-row-child-aliased-prop": {
         "blade": {
           "kind": "render",
-          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+          "reason": "same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)"
         },
         "jinja": {
           "kind": "render",
-          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+          "reason": "same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)"
         },
         "minijinja": {
           "kind": "render",
-          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+          "reason": "same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)"
         },
         "mojolicious": {
           "kind": "render",
-          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+          "reason": "same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)"
         },
         "twig": {
           "kind": "render",
-          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+          "reason": "same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)"
         },
         "xslate": {
           "kind": "render",
-          "reason": "same #2460 defect as `aliased-destructured-prop`, inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2460)"
+          "reason": "same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)"
         }
       },
       "date-method-uncatalogued": {
@@ -2840,7 +2840,7 @@
     },
     "docs": {
       "aliased-destructured-prop": {
-        "description": "Aliased destructured prop ({ n: count }) keeps the rename (#2460)",
+        "description": "Aliased destructured prop ({ n: count }) keeps the rename (#2524)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/aliased-destructured-prop.ts"
       },
       "composite-row-child-aliased-prop": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -2936,7 +2936,7 @@
       },
       "example": {
         "fixture": "aliased-destructured-prop",
-        "description": "Aliased destructured prop ({ n: count }) keeps the rename (#2460)",
+        "description": "Aliased destructured prop ({ n: count }) keeps the rename (#2524)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/aliased-destructured-prop.ts",
         "code": "text"
       }


### PR DESCRIPTION
Resolves the decisions demanded by #2508 (the compat-issue-freshness alert). Stacked on #2527 — merge that first; this PR's base is that branch.

## Decision: superseded tracker, not resolved limitation

Issue #2460 was closed when the **Hono reference adapter and the shared `ssr-defaults` layer** were fixed (b4f5075). The eight template adapters were never fixed — the `sourceName`-dropping defect is still live in each — so the divergence pins stay and only the tracker link changes:

- **#2524** — blade, erb, jinja, minijinja (adapter-rust), mojolicious, twig, xslate: silent undefined render (fixtures `aliased-destructured-prop`, `composite-row-child-aliased-prop`).
- **#2525** — go-template: the generated Input struct drops the rename, so `go run` fails outright (`unknown field N`, exit 1) — a distinct failure mode, split into its own tracker.

## Changes

- 8 × `render-divergences.ts`: reason URLs re-pointed (13 → #2524, 1 → #2525); the shared docstring block no longer claims "every adapter, including the Hono reference, currently emits the broken form" (false since b4f5075).
- `csr-conformance.test.ts`: both skips **re-verified today** — removing them still fails (`s1` slot renders empty; the shared client JS reads the local name too), so they are kept and re-pointed to #2524.
- `aliased-destructured-prop.ts`: docstring reframed ("originally filed as #2460 … now tracked by #2524/#2525"); `description` → `(#2524)`, which flows into both locks' docs strings.
- Locks regenerated: `issues/2460` count in `ui/compat.lock.json` is now **0**; `issues/2524` = 13, `issues/2525` = 1 (14 citations moved, nothing else changed — verified line-by-line). `ui/support-matrix.lock.json` changes only the one description string.
- Changeset: patch bumps for the 8 adapter packages (render-divergences.ts is published source; precedent 07aecae).

The freshness workflow closes #2508 itself once every lock citation points at an open issue; the cited set after this lands is 2320, 2321, 2356, 2524, 2525 — all open.

## Verification

`bun test` in `packages/compat` (197 pass / 0 fail) and `packages/adapter-tests` (1875 pass / 0 fail) on the stacked tree; locks confirmed byte-reproducible from source (`git status` clean after regeneration). Reviewed by an independent pass (approve; erb docstring pluralization, fixture docstring tense, and a stray blank line tidied per review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANWdijiBRfuNqnACEPEyKD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANWdijiBRfuNqnACEPEyKD)_