### PR TITLE
fix(vite): restore the cross-language dev-reload sentinel, and make hono's dev one command

### DIFF
--- a/.changeset/vite-dev-reload-sentinel.md
+++ b/.changeset/vite-dev-reload-sentinel.md
@@ -1,0 +1,38 @@
+---
+"@barefootjs/vite": patch
+---
+
+Restore the cross-language dev-reload sentinel (`<outDir>/.dev/build-id`) from `vite dev`
+
+The legacy CLI's `bf build --watch` used to write `<outDir>/.dev/build-id`
+after every rebuild that changed output; several adapter runtimes still
+poll that exact path and push an SSE `event: reload` when it changes —
+`bfdev.NewReloadHandler` (Go — echo/gin/chi/nethttp),
+`Mojolicious::Plugin::BarefootJS::DevReload` / `BarefootJS::DevReload`
+(Perl — mojolicious/xslate), and `barefoot_js/dev_reload.rb` (Ruby —
+sinatra/rails). When those adapters' `build:watch` moved to `vite dev`,
+nothing wrote the sentinel any more — the backend process kept picking up
+fresh templates on every request (dev-mode template caching was already
+off), but the open browser tab was never told to reload, so an edit only
+showed up after a manual refresh.
+
+`barefoot()`'s dev pass now writes a fresh timestamp to
+`devSentinelPath(templatesDir)` — one directory above `templates`, matching
+`packages/cli/src/lib/build.ts`'s `DEV_SENTINEL_SUBDIR`/
+`DEV_SENTINEL_FILENAME` under `outDir` (every adapter following that
+layout nests `templates` as a direct child of `outDir`, so the two
+locations coincide) — on the initial pass and every subsequent rebuild,
+mirroring the `.barefootjs-dev-build` marker's existing write lifecycle.
+`writeBundle` (`vite build`) removes it, so a production build never
+leaves a stale dev sentinel for a still-running dev backend to trip over.
+
+Written unconditionally whenever `templates` is configured — no new
+plugin option. Hono's own dev-reload story doesn't consume this file at
+all (Cloudflare Workers detect a Worker-isolate restart directly via
+`dev-worker.ts`'s boot id over the same SSE endpoint), so the write is
+inert there.
+
+Verified end-to-end (`vite dev` + the backend's own dev command, editing
+`integrations/shared/components/Counter.tsx`) against `integrations/echo`
+and `integrations/mojolicious`, restoring their documented dev flow with
+zero changes to either integration or their Go/Perl runtime packages.

--- a/integrations/hono/package.json
+++ b/integrations/hono/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "vite build && bun run scripts/assemble-public.ts",
     "build:watch": "vite dev",
-    "dev": "bun run build && wrangler dev",
+    "dev": "bun run build && concurrently -k -n vite,wrangler -c blue,green \"vite dev\" \"wrangler dev\"",
     "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
     "test:e2e:ui": "bunx playwright test --ui"
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@barefootjs/vite": "workspace:*",
     "bun-types": "^1.1.0",
+    "concurrently": "^9.1.0",
     "vite": "^6.0.0",
     "wrangler": "^4"
   }

--- a/integrations/hono/server.tsx
+++ b/integrations/hono/server.tsx
@@ -39,7 +39,11 @@ app.use(renderer)
 //
 // NOT superseded by Vite's own dev websocket (kept deliberately, unlike
 // the import map above): `vite dev` and `wrangler dev` are two separate
-// processes solving two separate problems. Vite's websocket only tells the
+// processes solving two separate problems — `package.json`'s `dev` script
+// runs both together via `concurrently` so one command covers editing
+// EITHER a shared component (Vite's own websocket reloads for that) OR
+// this file / `blog.tsx` (this SSE reloader catches the Worker restart
+// that causes). Vite's websocket only tells the
 // browser "a CLIENT bundle changed" (the URLs `registerComponentScripts`
 // baked into a page, via `devScriptAssets`'s `@vite/client` entry) — it
 // has no visibility into wrangler restarting the Worker isolate for a

--- a/packages/vite/src/__tests__/e2e-vite-build.test.ts
+++ b/packages/vite/src/__tests__/e2e-vite-build.test.ts
@@ -183,4 +183,9 @@ describe('e2e: vite build', () => {
     // `component-manifest.test.ts` — this test's job is just proving the
     // combined file actually lands on disk from a REAL build.
   })
+
+  test('a production build leaves no dev-reload sentinel behind (see e2e-vite-dev.test.ts for the dev-side write)', async () => {
+    const sentinel = await readFile(resolve(templatesDir, '..', '.dev', 'build-id'), 'utf8').catch(() => null)
+    expect(sentinel).toBeNull()
+  })
 })

--- a/packages/vite/src/__tests__/e2e-vite-dev.test.ts
+++ b/packages/vite/src/__tests__/e2e-vite-dev.test.ts
@@ -182,6 +182,28 @@ describe('e2e: vite dev server', () => {
     expect(marker).toContain('DEV BUILD OUTPUT')
   })
 
+  test('writes the legacy cross-language dev-reload sentinel one directory above templates', async () => {
+    const sentinel = await readIfExists(resolve(templatesDir, '..', '.dev', 'build-id'))
+    expect(sentinel).not.toBeNull()
+    expect(sentinel).toMatch(/^\d+$/)
+  })
+
+  test('editing a component updates the dev-reload sentinel value', async () => {
+    const sentinelPath = resolve(templatesDir, '..', '.dev', 'build-id')
+    const before = await readFile(sentinelPath, 'utf8')
+    try {
+      const edited = originalGreetingSource.replace('Hello', 'Hello!!!')
+      await writeFile(GREETING_PATH, edited)
+
+      await waitFor(async () => {
+        const after = await readIfExists(sentinelPath)
+        return after !== null && after !== before
+      })
+    } finally {
+      await writeFile(GREETING_PATH, originalGreetingSource)
+    }
+  })
+
   test('a request with a cross-origin Origin header gets the localhost-only CORS default', async () => {
     const res = await fetch(`${baseUrl}/@vite/client`, {
       headers: { Origin: 'http://localhost:3010' },

--- a/packages/vite/src/dev-server.ts
+++ b/packages/vite/src/dev-server.ts
@@ -3,15 +3,17 @@
  * dev origin, building the two-URL `scriptAssets` list a `'use client'`
  * component needs in dev (the `@vite/client` HMR/full-reload socket plus
  * the component's own `.tsx` module), the localhost-only CORS default,
- * and the on-disk marker that flags a `templates` directory as holding
- * dev artifacts (localhost URLs baked in) rather than production output.
+ * the on-disk marker that flags a `templates` directory as holding dev
+ * artifacts (localhost URLs baked in) rather than production output, and
+ * the legacy cross-language dev-reload sentinel path (see
+ * `devSentinelPath`'s docstring).
  *
  * The pure, easily-unit-tested pieces live here; the orchestration
  * (compiling, writing files, wiring the watcher) stays in `plugin.ts`
  * where the shared `CompileCache` / `componentDirs` / `templatesDir`
  * closures already live.
  */
-import { sep } from 'node:path'
+import { resolve, sep } from 'node:path'
 import type { ResolvedConfig, ViteDevServer } from 'vite'
 import { joinBaseAndFile } from './manifest.ts'
 
@@ -147,3 +149,40 @@ Run \`vite build\` to regenerate this directory with real, hashed,
 production asset URLs — the build overwrites every template here and
 removes this file.
 `
+
+/**
+ * Legacy cross-language dev-reload sentinel: `<outDir>/.dev/build-id`,
+ * ONE DIRECTORY ABOVE `templates` — matching `packages/cli/src/lib/
+ * build.ts`'s `DEV_SENTINEL_SUBDIR`/`DEV_SENTINEL_FILENAME` under
+ * `config.outDir`, where `templatesSubdir` was always a direct child of
+ * `outDir` (`layout?.templates ?? 'components'`, never nested deeper) —
+ * so "one directory above `templates`" and "the legacy CLI's `outDir`"
+ * are the same location for every adapter that followed that layout.
+ *
+ * Several adapter runtimes still poll this exact path for a value change
+ * and push an SSE `event: reload` on it — a mechanism that does NOT
+ * require the polling process to restart, only the file's mtime/content
+ * to change: `bfdev.NewReloadHandler` (Go — echo/gin/chi/nethttp),
+ * `Mojolicious::Plugin::BarefootJS::DevReload` /
+ * `BarefootJS::DevReload` (Perl — mojolicious/xslate), and
+ * `barefoot_js/dev_reload.rb` (Ruby — sinatra/rails, ERB). The legacy CLI
+ * (`bf build --watch`) used to write it; nothing did once those adapters'
+ * `build:watch` moved to `vite dev` — this restores it from the one place
+ * every migrated adapter's dev pass now runs through.
+ *
+ * Hono's dev-reload story does not consume this at all: Cloudflare
+ * Workers detect a Worker-isolate restart directly (`dev-worker.ts`'s
+ * boot id over the SAME SSE endpoint, no file involved), and the Node
+ * scaffold target's sentinel-reading `dev.tsx` is fed by the legacy CLI,
+ * which is unmigrated. Writing this sentinel unconditionally whenever
+ * `templates` is configured is harmless there — nothing reads it — which
+ * is what keeps this a zero-config, adapter-agnostic signal rather than a
+ * 4th plugin option naming which adapters want it.
+ */
+export const DEV_SENTINEL_SUBDIR = '.dev'
+export const DEV_SENTINEL_FILENAME = 'build-id'
+
+/** Absolute path of the dev-reload sentinel for a given `templates` dir. */
+export function devSentinelPath(templatesDir: string): string {
+  return resolve(templatesDir, '..', DEV_SENTINEL_SUBDIR, DEV_SENTINEL_FILENAME)
+}

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -85,6 +85,7 @@ import {
   DEV_ARTIFACT_MARKER_FILENAME,
   DEV_WATCH_DEBOUNCE_MS,
   devScriptAssets,
+  devSentinelPath,
   resolveDevOrigin,
 } from './dev-server.ts'
 import { createDebouncedSerialRunner } from './debounced-serial-runner.ts'
@@ -376,6 +377,15 @@ export function barefoot(options: BarefootViteOptions): Plugin {
 
     await writeFile(resolve(templatesDir, DEV_ARTIFACT_MARKER_FILENAME), DEV_ARTIFACT_MARKER_CONTENT)
 
+    // Legacy cross-language dev-reload sentinel (see `devSentinelPath`'s
+    // docstring) — written unconditionally on every pass, initial pass
+    // included, matching the legacy CLI's `watch()` writing it both on
+    // the initial build and every rebuild. A fresh timestamp is enough:
+    // consumers only compare it against their own last-seen value.
+    const sentinelPath = devSentinelPath(templatesDir)
+    await mkdir(resolve(sentinelPath, '..'), { recursive: true })
+    await writeFile(sentinelPath, String(Date.now()))
+
     if (options.afterEmit) {
       await options.afterEmit({
         types,
@@ -527,6 +537,11 @@ export function barefoot(options: BarefootViteOptions): Plugin {
       // with production URLs, so the marker is now stale. Best-effort:
       // there may never have been one.
       await rm(resolve(templatesDir, DEV_ARTIFACT_MARKER_FILENAME), { force: true })
+      // Same for the dev-reload sentinel: a production build is not a dev
+      // rebuild, so a stale `.dev/build-id` left over from an earlier
+      // `vite dev` session should not trick a still-running Go/Perl dev
+      // server into firing a reload for output that didn't come from it.
+      await rm(devSentinelPath(templatesDir), { force: true })
 
       if (options.afterEmit) {
         await options.afterEmit({ types, projectDir: config.root, templatesDir, outDir, mode: 'build' })


### PR DESCRIPTION
**Stack 6f/7** — targets #2526. A second defect found by a user running the real thing rather than the test suite.

> `integrations/hono` で `bun run dev` した状態で `Counter.tsx` を更新しても反映されない。前は自動 reload されていた。

## Two separate causes, and my first diagnosis of it was wrong

I initially blamed `packages/adapter-hono/src/dev.tsx` — it documents the old loop (`bf build --watch` writes `<distDir>/.dev/build-id` → `createDevReloader` watches it → SSE → browser reload), and stack 3 retired the sentinel writer while stack 5 kept the reader. That reasoning was tidy and wrong.

`dev.tsx` is **dead code for this integration**: nothing imports it but its own test. `integrations/hono/server.tsx` uses `createDevReloader` from `@barefootjs/hono/dev-worker`, a Worker boot-id mechanism that predates the migration and is untouched by it — and `@vite/client`'s websocket, baked into every `'use client'` template's `scriptAssets` in dev, is a second independent channel. Hono's reload *mechanism* was never broken.

What the user actually hit is that **`integrations/hono`'s `dev` script has always been one-shot** — `bun run build && wrangler dev`, before and after the migration. Nothing watched, so neither reload channel had anything to react to. Pre-migration the working flow was a second terminal running `build:watch`.

The genuine migration regression is elsewhere, and it is broader: the `<outDir>/.dev/build-id` sentinel is still polled by **Go** (`bfdev.NewReloadHandler` — echo, gin, chi, nethttp), **Perl** (`Mojolicious::Plugin::BarefootJS::DevReload`, `BarefootJS::DevReload` — mojolicious, xslate) and the **Ruby** ERB equivalent (sinatra, rails). `bf build --watch` wrote it; once `build:watch` became `vite dev`, nothing did. Confirmed by running the real `integrations/echo` (`go run .`) and `integrations/mojolicious` (`perl app.pl daemon`) dev flows and watching the browser silently fail to reload while the backend served fresh templates on every request.

Stack 3's assumption — "Vite's websocket replaces the sentinel" — only holds when the page is served **by Vite's dev server**. For a separate-process backend it never did.

## Fix

**`packages/vite`**: the dev pass writes a fresh timestamp to `devSentinelPath(templatesDir)` on every pass (one directory above `templates`, matching the legacy CLI's `outDir` convention); `vite build` removes it. No new plugin option — written unconditionally and inert for adapters that don't consume it. That restores reload for every migrated Go/Perl/Ruby integration with **no per-integration changes**.

**`integrations/hono`**: `dev` now runs `vite dev` and `wrangler dev` together via `concurrently`, so one command closes the loop — matching what `create-barefootjs`'s own Hono scaffolds already do.

## Verified with real processes and a real browser

| Flow | Before | After |
|---|---|---|
| `integrations/hono`: `bun run dev`, edit `Counter.tsx` | change never reaches the browser | auto-reloads with new content (confirmed via Playwright) |
| `integrations/echo`: `go run .` + `bun run build:watch` | no reload | auto-reload, **zero echo-side changes** |
| `integrations/mojolicious`: `perl app.pl daemon` + `bun run build:watch` | no reload | auto-reload, **zero mojo-side changes** |

`packages/vite` 122 pass (+3). `integrations/hono` E2E 105 pass. `packages/adapter-hono` 115 pass.

## Still not as good as it could be — stated plainly

- Echo and Mojolicious still need two terminals (backend process + `build:watch`). That was **already** true pre-migration — their `dev` scripts were one-shot too — so it is not a new regression, but it was not improved either.
- Editing shared CSS under `integrations/hono` does not hot-reload: `assemble-public.ts` copies it into `public/` only on `bun run build`, not under `vite dev`. Pre-existing, out of scope here.

## Note

`packages/adapter-hono/src/dev.tsx` is now demonstrably dead — imported only by its own test, superseded by `dev-worker.ts`. Left alone here because deleting it belongs with the rest of the legacy removal in stack 7, but worth flagging so it is not mistaken for a live path again.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ)_