### PR TITLE
fix(jsx,hono): key the `_p` props object by the caller-facing prop name (#2524 CSR half)

### DIFF
--- a/.changeset/csr-props-caller-key-2524.md
+++ b/.changeset/csr-props-caller-key-2524.md
@@ -1,0 +1,19 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/hono": patch
+---
+
+`_p` props-object keys are now uniformly the caller-facing property name (`sourceName ?? name`)
+
+Fixes aliased destructured props rendering empty on the CSR/hydration path
+(#2524 CSR half). A renaming destructure (`{ n: count }`) previously
+compiled to client JS reading `_p.count` — the LOCAL binding — while the
+caller always passes `n`, so the local binding hydrated to `undefined`
+and the corresponding slot rendered empty.
+
+Every `_p` producer and consumer is now keyed by the caller-facing name:
+the SSR `bf-p` hydration blob (Hono adapter), the generated `initXxx`
+props-extraction, the CSR `template:` lambda, controlled-signal sync,
+rest-spread exclude keys, and the `relocate()` prop-lift path. `sourceName
+?? name` is an identity for un-aliased props, so every existing snapshot
+and fixture stays byte-identical — this is a rename-only fix.

--- a/packages/adapter-hono/src/__tests__/aliased-destructured-prop.test.ts
+++ b/packages/adapter-hono/src/__tests__/aliased-destructured-prop.test.ts
@@ -99,10 +99,11 @@ describe('aliased destructured props (#2460)', () => {
   })
 
   test('aliased prop reaches client-side hydration serialization with the correct value', async () => {
-    // The client init function reads `_p.<localName>` (props-extraction
+    // The client init function reads `_p.<callerKey>` (props-extraction
     // phase), so the SSR-serialized `bf-p` blob must carry the correct
-    // value under the LOCAL key (`count`) — the rename only affects the
-    // caller-facing key, not the local binding the hydration bridge uses.
+    // value under the CALLER-facing key (`n`) — `_p` is uniformly keyed
+    // by `sourceName ?? name` across every producer/consumer (#2524 CSR
+    // half), not the local binding the destructure renames it to.
     const html = await renderHonoComponent({
       adapter: new HonoAdapter(),
       source: `
@@ -120,9 +121,9 @@ describe('aliased destructured props (#2460)', () => {
 
     // The rendered value is correct...
     expect(html).toContain(':<!--bf:s1-->7<!--/-->')
-    // ...and the serialized hydration payload carries it under the LOCAL
-    // binding name, which is what the generated client JS's
-    // `const count = _p.count` extraction reads.
-    expect(html).toMatch(/bf-p="[^"]*count[^"]*7/)
+    // ...and the serialized hydration payload carries it under the
+    // CALLER-facing key, which is what the generated client JS's
+    // `const count = _p.n` extraction reads.
+    expect(html).toMatch(/bf-p="[^"]*n[^"]*7/)
   })
 })

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -34,8 +34,8 @@ import {
   emitIRNode,
   emitAttrValue,
   buildLoopChainExpr,
+  propsDestructureBinding,
 } from '@barefootjs/jsx'
-import ts from 'typescript'
 
 /**
  * Hono adapter's IRNode render context: which surrounding render
@@ -96,28 +96,6 @@ function applyHonoLoopChain(loop: IRLoop): string {
     filterPredicate: loop.filterPredicate,
     chainOrder: loop.chainOrder,
   })
-}
-
-/**
- * Authoritative IdentifierName classification for a destructure-pattern
- * property key, built on TS's own `isIdentifierStart` / `isIdentifierPart`
- * primitives (Unicode-aware, stays aligned with what TS itself accepts as
- * a bare property key). Mirrors the `isIdent` precedent in
- * `jsx-to-ir.ts` (#1244) — a source key like `data-key` or `aria-label`
- * can't be emitted as a bare `key: local` destructure and must be quoted
- * (`"data-key": local`).
- */
-function isIdentifierName(key: string): boolean {
-  if (key.length === 0) return false
-  for (let i = 0; i < key.length; ) {
-    const cp = key.codePointAt(i)!
-    const ok = i === 0
-      ? ts.isIdentifierStart(cp, ts.ScriptTarget.Latest)
-      : ts.isIdentifierPart(cp, ts.ScriptTarget.Latest)
-    if (!ok) return false
-    i += cp > 0xFFFF ? 2 : 1
-  }
-  return true
 }
 
 export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderCtx> {
@@ -594,25 +572,11 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
     } else {
       const hydrationProps = `__instanceId, ${bfScopeAlias}, ${bfChildAlias}, ${bfParentPropsAlias}, ${bfParentAlias}, ${bfMountAlias}, ${dataKeyAlias}`
       const parts: string[] = []
+      // Rename-aware `key: local` bindings (b4f5075), shared with
+      // TestAdapter via `propsDestructureBinding` — see its docstring for
+      // the `class` → `className` reserved-word rationale.
       const propsParams = ir.metadata.propsParams
-        .map((p: ParamInfo) => {
-          // The caller-facing key is `sourceName ?? name` (ParamInfo's own
-          // rule) — `name` is only ever the LOCAL binding. Emit the plain
-          // shorthand when they match (byte-identical to before this was
-          // rename-aware); emit a `key: local` rename otherwise. This also
-          // covers the `class` → `className` rename correctly: a source
-          // prop literally named `class` can only reach `propsParams` via
-          // an aliased destructure (`{ class: className }` — `class` is a
-          // reserved word, so it can never be an un-aliased binding), which
-          // already sets `sourceName: 'class'` and is handled by the rename
-          // branch below (`class: className`), not a bare `className`.
-          const callerKey = p.sourceName ?? p.name
-          const localName = p.name
-          const binding = callerKey === localName
-            ? localName
-            : `${isIdentifierName(callerKey) ? callerKey : JSON.stringify(callerKey)}: ${localName}`
-          return p.defaultValue ? `${binding} = ${p.defaultValue}` : binding
-        })
+        .map((p: ParamInfo) => propsDestructureBinding(p))
         .join(', ')
       if (propsParams) {
         parts.push(propsParams)
@@ -696,7 +660,12 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
         // Skip functions and JSX elements (they can't be JSON serialized)
         // Use propsObjectName.propName for SolidJS-style, direct propName for destructured
         const propAccess = propsObjectName ? `${propsObjectName}.${p.name}` : p.name
-        lines.push(`  if (typeof ${propAccess} !== 'function' && !(typeof ${propAccess} === 'object' && ${propAccess} !== null && 'isEscaped' in ${propAccess})) __hydrateProps['${p.name}'] = ${propAccess}`)
+        // The `bf-p` blob key is always the caller-facing name (#2524 CSR
+        // half) — every non-Hono `_p` producer/consumer keys the same way,
+        // so a renaming destructure (`{ n: count }`) must serialize under
+        // `n`, not the local binding `count`.
+        const callerKey = p.sourceName ?? p.name
+        lines.push(`  if (typeof ${propAccess} !== 'function' && !(typeof ${propAccess} === 'object' && ${propAccess} !== null && 'isEscaped' in ${propAccess})) __hydrateProps['${callerKey}'] = ${propAccess}`)
       }
       lines.push(`  const __bfPropsJson = __bfParentProps || (Object.keys(__hydrateProps).length > 0 ? JSON.stringify(__hydrateProps) : undefined)`)
     } else if (hasClientInteractivity && isRootComponent) {

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -250,23 +250,6 @@ describe('CSR Conformance Tests', () => {
     //     component's own first slot id coincides with the wrapper's slot
     //     number (see `site/ui`'s xyflow Highlight-Depth demo regression).
     'grandchild-composition',
-    // Originally filed under #2460: the CSR template drops the
-    // destructure rename the same way the SSR side used to — the aliased
-    // `count` reads a property named `count` off a props object shaped
-    // `{ text, n }`, so the `s1` slot renders empty instead of the
-    // fixture's corrected expectedHtml. #2460 itself is CLOSED (the
-    // shared SSR-side layer was fixed in b4f5075); this CSR client-JS
-    // gap is still live and is now tracked by
-    // https://github.com/piconic-ai/barefootjs/issues/2524. Re-verified
-    // still failing (2026-08-03).
-    'aliased-destructured-prop',
-    // Same CSR-template gap as `aliased-destructured-prop`, inside a
-    // keyed `.map()` loop row: the nested child's renamed prop reads
-    // `_p.count` off a row object shaped `{ text, n }`, so both rows'
-    // `s1` slot renders empty instead of the fixture's expectedHtml.
-    // Tracked by https://github.com/piconic-ai/barefootjs/issues/2524.
-    // Re-verified still failing (2026-08-03).
-    'composite-row-child-aliased-prop',
     // #2463 FIXED: the fixture now lowers to the root-ternary plan and
     // its template evaluates cleanly — but the synthetic scope wrapper
     // has style="display:contents" before bf-s, the same CSR/SSR

--- a/packages/jsx/src/__tests__/aliased-destructured-prop-csr.test.ts
+++ b/packages/jsx/src/__tests__/aliased-destructured-prop-csr.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Aliased (renaming) destructured props on the CSR/client-JS path (#2524).
+ *
+ * `_p` is uniformly keyed by the caller-facing property name
+ * (`sourceName ?? name` — see `ParamInfo.sourceName`'s docstring in
+ * `types.ts`) across every producer/consumer. Before this fix, client-JS
+ * emission kept reading `_p.<localBinding>` for a renaming destructure
+ * (`{ n: count }`), so `_p.count` read a property the caller never sent
+ * (the caller passes `n`) and the local binding hydrated to `undefined`.
+ *
+ * Mirrors `ssr-defaults.test.ts`'s aliased-prop describes (#2460) for the
+ * SSR-defaults half; this covers the generated `initXxx` extraction and
+ * the CSR `template:` lambda.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('aliased destructured props reach client JS under the caller-facing key (#2524)', () => {
+  test('{ text, n: count } — init extraction and template lambda both read `_p.n`, not `_p.count`', () => {
+    const source = `
+      'use client'
+      import { createEffect } from '@barefootjs/client'
+      export function Badge({ text, n: count }: { text: string; n: number }) {
+        createEffect(() => {
+          console.log(count)
+        })
+        return <span>{text}:{count}</span>
+      }
+    `
+    const result = compileJSX(source, 'Badge.tsx', { adapter })
+    const errors = result.errors.filter((e) => e.severity === 'error')
+    expect(errors).toEqual([])
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    // `initBadge` extracts the local binding `count` from the
+    // CALLER-facing key `n` — never the local key `count`.
+    expect(clientJs!.content).toContain('const count = _p.n')
+    expect(clientJs!.content).not.toContain('_p.count')
+    // The CSR `template:` lambda (module-scope SSR fallback) reads the
+    // same caller-facing key.
+    expect(clientJs!.content).toContain('escapeText(_p.n)')
+  })
+
+  test('{ text, n } — un-aliased: byte-identical to the pre-fix `_p.n` extraction', () => {
+    // `sourceName ?? name` is an identity for an un-aliased prop, so this
+    // case must be indistinguishable from before the rename-aware fix.
+    const source = `
+      'use client'
+      import { createEffect } from '@barefootjs/client'
+      export function Badge({ text, n }: { text: string; n: number }) {
+        createEffect(() => {
+          console.log(n)
+        })
+        return <span>{text}:{n}</span>
+      }
+    `
+    const result = compileJSX(source, 'Badge.tsx', { adapter })
+    const errors = result.errors.filter((e) => e.severity === 'error')
+    expect(errors).toEqual([])
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('const n = _p.n')
+    expect(clientJs!.content).toContain('escapeText(_p.n)')
+  })
+
+  test('aliased controlled-signal prop — the accessor reads the caller-facing key', () => {
+    // `build-declaration-emit`'s controlled-signal path resolves
+    // `controlled.propName` (a LOCAL name) through the prop's
+    // `sourceName` before emitting the `_p.` accessor.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Toggle({ isOpen: open = false }: { isOpen?: boolean }) {
+        const [openState, setOpenState] = createSignal(open)
+        return <button onClick={() => setOpenState(!openState())}>{openState() ? 'on' : 'off'}</button>
+      }
+    `
+    const result = compileJSX(source, 'Toggle.tsx', { adapter })
+    const errors = result.errors.filter((e) => e.severity === 'error')
+    expect(errors).toEqual([])
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('_p.isOpen')
+    expect(clientJs!.content).not.toContain('_p.open')
+  })
+
+  test('aliased event-handler prop — the handler const reads the caller-facing key', () => {
+    // `props-event-handlers` extracts the handler under its LOCAL name
+    // from the CALLER-facing `_p` key.
+    const source = `
+      'use client'
+      export function Clicker({ onPress: handlePress }: { onPress?: () => void }) {
+        return <button onClick={handlePress}>go</button>
+      }
+    `
+    const result = compileJSX(source, 'Clicker.tsx', { adapter })
+    const errors = result.errors.filter((e) => e.severity === 'error')
+    expect(errors).toEqual([])
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('const handlePress = _p.onPress')
+    expect(clientJs!.content).not.toContain('_p.handlePress')
+  })
+})

--- a/packages/jsx/src/__tests__/staged-ir/08-relocate-unit.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/08-relocate-unit.test.ts
@@ -20,6 +20,7 @@ function envWith(
     propsForLift: new Set(
       bindings.filter(([, k]) => k === 'prop').map(([n]) => n),
     ),
+    propSourceNames: options?.propSourceNames ?? new Map(),
     propsObjectName: options?.propsObjectName ?? 'props',
     allowFallback: options?.allowFallback ?? true,
   }

--- a/packages/jsx/src/__tests__/staged-ir/11-template-primitive-registry.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/11-template-primitive-registry.test.ts
@@ -35,6 +35,7 @@ function envWith(
     propsForLift: new Set(
       bindings.filter(([, k]) => k === 'prop').map(([n]) => n),
     ),
+    propSourceNames: options?.propSourceNames ?? new Map(),
     propsObjectName: options?.propsObjectName ?? 'props',
     allowFallback: options?.allowFallback ?? true,
     templatePrimitives: options?.templatePrimitives,

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -5,6 +5,7 @@
  * Generates simple JSX output without framework-specific features.
  */
 
+import ts from 'typescript'
 import type {
   ComponentIR,
   IRNode,
@@ -20,6 +21,7 @@ import type {
 import type { AdapterOutput, TemplateSections } from './interface.ts'
 import { type JsxAdapterConfig, JsxAdapter } from './jsx-adapter.ts'
 import { rewriteImportsForTemplate } from './template-imports.ts'
+import { propsDestructureBinding } from '../props-binding.ts'
 
 export class TestAdapter extends JsxAdapter {
   name = 'test'
@@ -122,8 +124,10 @@ export class TestAdapter extends JsxAdapter {
     const bodyRefText = [jsxBody, signalInits, scopeIdLine].join('\n')
     const bfScopeAlias = /\b__bfScope\b/.test(bodyRefText) ? '__bfScope' : '__bfScope: _bfScope'
 
+    // `key: local` rename-aware bindings, shared with the Hono SSR
+    // destructure — one renderer, zero drift (`propsDestructureBinding`).
     const propsParams = ir.metadata.propsParams
-      .map((p: ParamInfo) => (p.defaultValue ? `${p.name} = ${p.defaultValue}` : p.name))
+      .map((p: ParamInfo) => propsDestructureBinding(p))
       .join(', ')
 
     const restPropsName = ir.metadata.restPropsName

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -11,6 +11,7 @@ import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo, Decline
 import { parseExpression, parseBlockBodyTolerant, foldBlockToExpr } from './expression-parser.ts'
 import type { CallbackBodyAcceptor } from './adapters/interface.ts'
 import { rewriteBarePropRefs } from './prop-rewrite.ts'
+import { buildPropAliasMap } from './props-binding.ts'
 import { incrementCounter } from './instrumentation.ts'
 import {
   type AnalyzerContext,
@@ -1273,7 +1274,8 @@ function collectSignal(node: ts.VariableDeclaration, ctx: AnalyzerContext): void
   if (!ctx.propsObjectName && callExpr.arguments[0]) {
     const propNames = new Set(ctx.propsParams.map(p => p.name))
     if (propNames.size > 0) {
-      templateInitialValue = rewriteBarePropRefs(initialValue, callExpr.arguments[0], propNames)
+      const propAliases = buildPropAliasMap(ctx.propsParams)
+      templateInitialValue = rewriteBarePropRefs(initialValue, callExpr.arguments[0], propNames, undefined, propAliases)
     }
   }
 
@@ -1613,7 +1615,8 @@ function collectMemo(node: ts.VariableDeclaration, ctx: AnalyzerContext): void {
   if (!ctx.propsObjectName && callExpr.arguments[0]) {
     const propNames = new Set(ctx.propsParams.map(p => p.name))
     if (propNames.size > 0) {
-      templateComputation = rewriteBarePropRefs(computation, callExpr.arguments[0], propNames)
+      const propAliases = buildPropAliasMap(ctx.propsParams)
+      templateComputation = rewriteBarePropRefs(computation, callExpr.arguments[0], propNames, undefined, propAliases)
     }
   }
 
@@ -3129,9 +3132,15 @@ function collectConstant(
   let templateValue: string | undefined
   if (value && ctx.propsParams.length > 0 && node.initializer) {
     let propNames: Set<string>
+    // Local → caller-facing key (#2524 CSR half) — only Case 1 propsParams
+    // entries can carry `sourceName`; Case 2's alias set below is keyed by
+    // the destructured-from-`props.X` local name, which by its own
+    // `isPureAlias` construction always equals the source key.
+    let propAliases: Map<string, string> | undefined
     if (!ctx.propsObjectName) {
       // Case 1: destructured-arg — all propsParams are bare locals.
       propNames = new Set(ctx.propsParams.map(p => p.name))
+      propAliases = buildPropAliasMap(ctx.propsParams)
     } else {
       // Case 2: `(props)`-arg — restrict to body-destructured pure aliases
       // of `props.X` (entries pushed by the body-destructure expansion at
@@ -3157,7 +3166,7 @@ function collectConstant(
       )
     }
     if (propNames.size > 0) {
-      const rewritten = rewriteBarePropRefs(value, node.initializer, propNames)
+      const rewritten = rewriteBarePropRefs(value, node.initializer, propNames, undefined, propAliases)
       if (rewritten !== undefined) {
         templateValue = rewritten
         // For the body-destructure case, also rewrite the init-body

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -10,6 +10,9 @@ export type { CompileResult, CompileOptions, CompileOptionsWithAdapter, FileOutp
 
 // SSR template-variable defaults (manifest seeds for stash-based adapters)
 export { extractSsrDefaults } from './ssr-defaults.ts'
+
+// Shared props-destructure binding + alias-map helpers (#2524)
+export { propsDestructureBinding, buildPropAliasMap, isIdentifierName } from './props-binding.ts'
 export type { SsrDefault } from './ssr-defaults.ts'
 
 // Backend-neutral SSR seed plan (in-template derived signal/memo seeding)

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -933,8 +933,11 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, insideCond
           // alone was wrong on both counts — it keys on HTML attr names
           // (`aria-invalid` ≠ source key `error`) and omits event handlers.
           // (#1467)
+          // `applyRestAttrs` filters `Object.keys(_p)` — which is always
+          // caller-keyed (#2524 CSR half) — so the exclude list must use
+          // the caller-facing key too, not the local binding name.
           const consumedKeys =
-            spreadVal === elemRestName ? ctx.propsParams.map(p => p.name) : []
+            spreadVal === elemRestName ? ctx.propsParams.map(p => p.sourceName ?? p.name) : []
           const staticAttrKeys = element.attrs
             .filter(a => a.name !== '...')
             .map(a => a.name)

--- a/packages/jsx/src/ir-to-client-js/emit-reactive.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-reactive.ts
@@ -91,10 +91,12 @@ export function rewriteDestructuredPropsInExpr(expr: string, ctx: ClientJsContex
     const pattern = new RegExp(`(?<![-.])\\b${prop.name}\\b`, 'g')
     if (!pattern.test(result)) continue
 
+    // `_p` is always keyed by the caller-facing name (#2524 CSR half).
+    const callerKey = prop.sourceName ?? prop.name
     const defaultVal = prop.defaultValue
     const replacement = defaultVal
-      ? `(${PROPS_PARAM}.${prop.name} ?? ${prop.defaultContainsArrow ? `(${defaultVal})` : defaultVal})`
-      : `${PROPS_PARAM}.${prop.name}`
+      ? `(${PROPS_PARAM}.${callerKey} ?? ${prop.defaultContainsArrow ? `(${defaultVal})` : defaultVal})`
+      : `${PROPS_PARAM}.${callerKey}`
     result = result.replace(new RegExp(`(?<![-.])\\b${prop.name}\\b`, 'g'), replacement)
   }
 

--- a/packages/jsx/src/ir-to-client-js/phases/props-event-handlers.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/props-event-handlers.ts
@@ -25,9 +25,10 @@ export function emitPropsEventHandlers(
   for (const handlerName of usedFunctions) {
     if (localNames.has(handlerName)) continue
     if (neededProps.has(handlerName)) continue
-    const isProp = ctx.propsParams.some(p => p.name === handlerName)
-    if (!isProp) continue
-    lines.push(`  const ${handlerName} = ${PROPS_PARAM}.${handlerName}`)
+    const prop = ctx.propsParams.find(p => p.name === handlerName)
+    if (!prop) continue
+    // `_p` is always keyed by the caller-facing name (#2524 CSR half).
+    lines.push(`  const ${handlerName} = ${PROPS_PARAM}.${prop.sourceName ?? handlerName}`)
     addedAny = true
   }
   if (addedAny) lines.push('')

--- a/packages/jsx/src/ir-to-client-js/phases/props-extraction.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/props-extraction.ts
@@ -41,23 +41,26 @@ export function emitPropsExtraction(
 
   for (const propName of neededProps) {
     const prop = ctx.propsParams.find(p => p.name === propName)
+    // `_p` is always keyed by the caller-facing name (#2524 CSR half); the
+    // local binding on the left of `const` stays `propName`.
+    const callerKey = prop?.sourceName ?? propName
     const usage = propUsage.get(propName)
     const defaultVal = prop?.defaultValue
     if (defaultVal) {
       // `props.onInput ?? () => {}` is a syntax error — `??` binds tighter
       // than the arrow head. Wrap arrow defaults in parens.
       const wrappedDefault = prop?.defaultContainsArrow ? `(${defaultVal})` : defaultVal
-      lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName} ?? ${wrappedDefault}`)
+      lines.push(`  const ${propName} = ${PROPS_PARAM}.${callerKey} ?? ${wrappedDefault}`)
     } else if (usage?.usedAsLoopArray) {
-      lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName} ?? []`)
+      lines.push(`  const ${propName} = ${PROPS_PARAM}.${callerKey} ?? []`)
     } else if (propHasPropertyAccess(usage) && !propsUsedAsConditions.has(propName)) {
-      lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName} ?? {}`)
+      lines.push(`  const ${propName} = ${PROPS_PARAM}.${callerKey} ?? {}`)
     } else {
       // No synthesized default for a defaultless optional (`{ size }:
       // { size?: number }`): the JS binding is `undefined` when absent, and
       // a zero default would diverge from SSR (`size ?? 1` seeds 1
       // server-side; a `_p.size ?? 0` extraction would hydrate to 0).
-      lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName}`)
+      lines.push(`  const ${propName} = ${PROPS_PARAM}.${callerKey}`)
     }
   }
   lines.push('')

--- a/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
@@ -159,7 +159,8 @@ function resolveSignalInitialValue(
     // Case 2b: synthesize the prop accessor + default.
     const prop = lookups.propByName.get(controlled.propName)
     const defaultVal = prop?.defaultValue ?? inferDefaultValue(signal.type)
-    return `${PROPS_PARAM}.${controlled.propName} ?? ${defaultVal}`
+    // `_p` is always keyed by the caller-facing name (#2524 CSR half).
+    return `${PROPS_PARAM}.${prop?.sourceName ?? controlled.propName} ?? ${defaultVal}`
   }
 
   // Case 3: non-controlled `propsObjectName.X` (only when destructured-
@@ -181,9 +182,11 @@ function buildControlledSignalEffect(
   if (!signal.setter) return null // read-only — no sync needed
 
   const prop = lookups.propByName.get(controlled.propName)
+  // `_p` is always keyed by the caller-facing name (#2524 CSR half).
+  const callerKey = prop?.sourceName ?? controlled.propName
   const accessorExpr = prop?.defaultValue
-    ? `(${PROPS_PARAM}.${controlled.propName} ?? ${prop.defaultValue})`
-    : `${PROPS_PARAM}.${controlled.propName}`
+    ? `(${PROPS_PARAM}.${callerKey} ?? ${prop.defaultValue})`
+    : `${PROPS_PARAM}.${callerKey}`
 
   return { setter: signal.setter, accessorExpr }
 }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -49,6 +49,7 @@ import {
   rewriteBarePropRefs as rewriteBarePropRefsCore,
   collectAstPropRefs,
 } from './prop-rewrite.ts'
+import { buildPropAliasMap } from './props-binding.ts'
 import { resolveFreeRefs, isNameBound as isNameBoundInEnv, type BindingEnvironment } from './free-refs.ts'
 import { computeFileScope } from './ir-to-client-js/component-scope.ts'
 import { createTemplateAwareStringProtector } from './ir-to-client-js/html-template.ts'
@@ -91,6 +92,15 @@ interface TransformContext {
   _moduleClientSignalNames?: Set<string>
   /** Cached set of destructured prop names for AST-based rewriting */
   _destructuredPropNames?: Set<string> | null
+  /**
+   * Cached local-name → caller-facing-key (`sourceName ?? name`) map for
+   * `_destructuredPropNames`, entries only for names that actually rename
+   * (`{ n: count }` → `count` → `n`). Built alongside `_destructuredPropNames`
+   * so both stay in lockstep with the same shadow-filtered eligible set —
+   * consumed by `rewriteBarePropRefsCore` to emit `_p.<caller>` instead of
+   * `_p.<local>` (#2524 CSR half: `_p` is always caller-keyed).
+   */
+  _destructuredPropAliases?: Map<string, string> | null
   /** Active loop parameter names for slotId assignment to loop-param-dependent expressions */
   loopParams: Set<string>
   /**
@@ -536,7 +546,8 @@ function rewriteBarePropRefs(text: string, expr: ts.Node, ctx: TransformContext)
   // `_branchScopePropDeps` at branch entry; here we just walk `expr`
   // for references to those locals and union the matching dep sets.
   const extraPropRefs = collectBranchLocalPropRefsViaSubstitution(expr, ctx)
-  return rewriteBarePropRefsCore(dateLowered, expr, propNames, extraPropRefs)
+  const propAliases = getDestructuredPropAliases(ctx)
+  return rewriteBarePropRefsCore(dateLowered, expr, propNames, extraPropRefs, propAliases ?? undefined)
 }
 
 /**
@@ -618,12 +629,24 @@ function getDestructuredPropNames(ctx: TransformContext): Set<string> | null {
         if (!isDestructureFromProps) shadowed.add(c.name)
       }
     }
-    const names = ctx.analyzer.propsParams
-      .map(p => p.name)
-      .filter(n => !shadowed.has(n))
+    const eligible = ctx.analyzer.propsParams.filter(p => !shadowed.has(p.name))
+    const names = eligible.map(p => p.name)
     ctx._destructuredPropNames = names.length > 0 ? new Set(names) : null
+    ctx._destructuredPropAliases = buildPropAliasMap(eligible) ?? null
   }
   return ctx._destructuredPropNames ?? null
+}
+
+/**
+ * Companion to `getDestructuredPropNames`: the local-name → caller-key
+ * alias map for the SAME shadow-filtered eligible set, populated as a
+ * side effect of that call. Always call `getDestructuredPropNames` first
+ * (or accept it may return an empty cache) — the two caches are written
+ * together in one pass.
+ */
+function getDestructuredPropAliases(ctx: TransformContext): Map<string, string> | null {
+  if (ctx._destructuredPropNames === undefined) getDestructuredPropNames(ctx)
+  return ctx._destructuredPropAliases ?? null
 }
 
 function createTransformContext(analyzer: AnalyzerContext): TransformContext {

--- a/packages/jsx/src/prop-rewrite.ts
+++ b/packages/jsx/src/prop-rewrite.ts
@@ -135,7 +135,11 @@ export function collectAstPropRefs(
  * Returns null when `text` does not parse cleanly as an expression —
  * the caller falls back to the legacy regex rewrite.
  */
-function applyScopedPropRefRewrite(text: string, propRefs: Set<string>): string | null {
+function applyScopedPropRefRewrite(
+  text: string,
+  propRefs: Set<string>,
+  propAliases?: ReadonlyMap<string, string>,
+): string | null {
   // Wrap in parens so object literals and arrows parse as expressions.
   const prefix = '('
   const sf = ts.createSourceFile('__bf_prop_rewrite.ts', `${prefix}${text}\n)`, ts.ScriptTarget.Latest, true)
@@ -149,11 +153,15 @@ function applyScopedPropRefRewrite(text: string, propRefs: Set<string>): string 
     const start = n.getStart(sf) - prefix.length
     const end = n.getEnd() - prefix.length
     if (start < 0 || end > text.length) return
+    // `_p` is always keyed by the caller-facing name (`sourceName ?? name`
+    // — #2524 CSR half); the local binding (`n.text`) only survives on the
+    // left of a shorthand expansion.
+    const callerKey = propAliases?.get(n.text) ?? n.text
     if (parent && ts.isShorthandPropertyAssignment(parent) && parent.name === n) {
-      edits.push({ start, end, replacement: `${n.text}: ${PROPS_PARAM}.${n.text}` })
+      edits.push({ start, end, replacement: `${n.text}: ${PROPS_PARAM}.${callerKey}` })
       return
     }
-    edits.push({ start, end, replacement: `${PROPS_PARAM}.${n.text}` })
+    edits.push({ start, end, replacement: `${PROPS_PARAM}.${callerKey}` })
   })
 
   if (edits.length === 0) return text
@@ -177,11 +185,14 @@ function applyScopedPropRefRewrite(text: string, propRefs: Set<string>): string 
 export function applyRegexPropRefRewrite(
   text: string,
   propRefs: Iterable<string>,
+  propAliases?: ReadonlyMap<string, string>,
 ): string {
   const { protect, restore } = createTemplateAwareStringProtector()
   let result = protect(text)
 
   for (const propName of propRefs) {
+    // `_p` is always keyed by the caller-facing name (#2524 CSR half).
+    const callerKey = propAliases?.get(propName) ?? propName
     const pattern = new RegExp(`(?<!${PROPS_PARAM}\\.)(?<!['"\\w.-])\\b${propName}\\b(?![a-zA-Z0-9_$])`, 'g')
     result = result.replace(pattern, (match, offset, str) => {
       // Skip object literal keys: preceded by { or , and followed by :
@@ -190,7 +201,7 @@ export function applyRegexPropRefRewrite(
         const before = str.slice(0, offset)
         if (/[{,]\s*$/.test(before)) return match
       }
-      return `${PROPS_PARAM}.${propName}`
+      return `${PROPS_PARAM}.${callerKey}`
     })
   }
 
@@ -209,12 +220,18 @@ export function applyRegexPropRefRewrite(
  *   `text` was produced by inlining a branch-local whose initializer
  *   references the prop). The rewrite only touches genuine value
  *   references, so passing an over-broad set is safe.
+ * @param propAliases - Local name → caller-facing key (`sourceName ?? name`)
+ *   for aliased destructured props (`{ n: count }` → `count` → `n`).
+ *   `_p` is always keyed by the caller-facing name (#2524 CSR half); a name
+ *   absent from this map emits `_p.<name>` unchanged (the un-aliased case,
+ *   where `sourceName ?? name` is an identity).
  */
 export function rewriteBarePropRefs(
   text: string,
   node: ts.Node,
   propNames: Set<string>,
   extraPropRefs?: ReadonlySet<string>,
+  propAliases?: ReadonlyMap<string, string>,
 ): string | undefined {
   // Walk AST to find which prop names are actually used as value references
   const foundPropRefs = new Set<string>()
@@ -225,5 +242,8 @@ export function rewriteBarePropRefs(
     }
   }
   if (foundPropRefs.size === 0) return undefined
-  return applyScopedPropRefRewrite(text, foundPropRefs) ?? applyRegexPropRefRewrite(text, foundPropRefs)
+  return (
+    applyScopedPropRefRewrite(text, foundPropRefs, propAliases) ??
+    applyRegexPropRefRewrite(text, foundPropRefs, propAliases)
+  )
 }

--- a/packages/jsx/src/props-binding.ts
+++ b/packages/jsx/src/props-binding.ts
@@ -1,0 +1,70 @@
+import ts from 'typescript'
+import type { ParamInfo } from './types.ts'
+
+/**
+ * Authoritative IdentifierName classification for a destructure-pattern
+ * property key, built on TS's own `isIdentifierStart` / `isIdentifierPart`
+ * primitives (Unicode-aware, stays aligned with what TS itself accepts as
+ * a bare property key). Mirrors the `isIdent` precedent in
+ * `jsx-to-ir.ts` (#1244) — a source key like `data-key` or `aria-label`
+ * can't be emitted as a bare `key: local` destructure and must be quoted
+ * (`"data-key": local`).
+ */
+export function isIdentifierName(key: string): boolean {
+  if (key.length === 0) return false
+  for (let i = 0; i < key.length; ) {
+    const cp = key.codePointAt(i)!
+    const ok = i === 0
+      ? ts.isIdentifierStart(cp, ts.ScriptTarget.Latest)
+      : ts.isIdentifierPart(cp, ts.ScriptTarget.Latest)
+    if (!ok) return false
+    i += cp > 0xFFFF ? 2 : 1
+  }
+  return true
+}
+
+/**
+ * The single destructure-binding renderer for a props param, shared by
+ * every JSX-runtime SSR adapter (Hono, TestAdapter). The caller-facing
+ * key is `sourceName ?? name` (ParamInfo's own rule) — `name` is only
+ * ever the LOCAL binding. Emits the plain shorthand when they match
+ * (byte-identical to the pre-rename-aware form); emits a `key: local`
+ * rename otherwise (b4f5075). This also covers the `class` → `className`
+ * rename: a source prop literally named `class` can only reach
+ * `propsParams` via an aliased destructure (`{ class: className }` —
+ * `class` is a reserved word, so it can never be an un-aliased binding),
+ * which sets `sourceName: 'class'` and takes the rename branch
+ * (`class: className`), not a bare `className`.
+ *
+ * One exported implementation, two consumers, zero drift — the
+ * hono/test-adapter pair carrying private copies is exactly the
+ * lockstep-rule duplication #2460/#2524 were about.
+ */
+export function propsDestructureBinding(p: ParamInfo): string {
+  const callerKey = p.sourceName ?? p.name
+  const localName = p.name
+  const binding = callerKey === localName
+    ? localName
+    : `${isIdentifierName(callerKey) ? callerKey : JSON.stringify(callerKey)}: ${localName}`
+  return p.defaultValue ? `${binding} = ${p.defaultValue}` : binding
+}
+
+/**
+ * Local-name → caller-facing-key map for prop-reference rewrites —
+ * entries only for `ParamInfo`s that actually rename (`sourceName` set,
+ * see its docstring in `types.ts`). `_p` is always keyed by the
+ * caller-facing name (#2524 CSR half); an un-aliased prop leaves no
+ * entry, so `map?.get(name) ?? name` degrades to an identity there.
+ * Returns `undefined` when nothing renames, so callers can
+ * short-circuit.
+ */
+export function buildPropAliasMap(params: readonly ParamInfo[]): Map<string, string> | undefined {
+  let map: Map<string, string> | undefined
+  for (const p of params) {
+    if (p.sourceName) {
+      if (!map) map = new Map()
+      map.set(p.name, p.sourceName)
+    }
+  }
+  return map
+}

--- a/packages/jsx/src/relocate.ts
+++ b/packages/jsx/src/relocate.ts
@@ -15,6 +15,7 @@ import type { Scope, BindingKind, IRMetadata } from './types.ts'
 import { isVisibleIn } from './types.ts'
 import type { AnalyzerContext } from './analyzer-context.ts'
 import { PROPS_PARAM } from './ir-to-client-js/utils.ts'
+import { buildPropAliasMap } from './props-binding.ts'
 import type {
   TemplatePrimitiveRegistry,
   TemplateCallAcceptor,
@@ -42,6 +43,15 @@ export interface RelocateEnv {
    * `TransformContext._destructuredPropNames`.
    */
   propsForLift: Set<string>
+  /**
+   * Local prop name → caller-facing key (`sourceName ?? name`), entries
+   * only for `ParamInfo`s that rename (`{ n: count }` → `count` → `n`).
+   * `_p` is always keyed by the caller-facing name (#2524 CSR half) — the
+   * `lift-to-prop` action reads this so `count` lifts to `_p.n`, not
+   * `_p.count`. A name absent from this map is un-aliased, so
+   * `propSourceNames.get(name) ?? name` degrades to an identity there.
+   */
+  propSourceNames: ReadonlyMap<string, string>
   /**
    * Name of the props parameter (e.g. `props`). Used to detect
    * `props.X` member access at lift sites — those are not free refs
@@ -179,8 +189,10 @@ function decideAction(
     if (env.propsObjectName !== null && name === env.propsObjectName) {
       return { action: 'lift-to-prop', rewrittenAs: PROPS_PARAM }
     }
-    // Lift `name` → `_p.name`.
-    return { action: 'lift-to-prop', rewrittenAs: `${PROPS_PARAM}.${name}` }
+    // Lift `name` → `_p.<caller-facing key>` — `_p` is always keyed by
+    // the caller-facing name (#2524 CSR half), not the local binding.
+    const callerKey = env.propSourceNames.get(name) ?? name
+    return { action: 'lift-to-prop', rewrittenAs: `${PROPS_PARAM}.${callerKey}` }
   }
 
   if ((kind === 'init-local' || kind === 'sub-init-local') && toScope === 'template') {
@@ -860,6 +872,10 @@ function buildRelocateEnvFromFields(src: EnvFields): RelocateEnv {
     if (kind === 'prop') propsForLift.add(name)
   }
 
+  // propSourceNames: local prop name → caller-facing key, entries only
+  // for `ParamInfo`s that actually rename. See `RelocateEnv.propSourceNames`.
+  const propSourceNames = buildPropAliasMap(src.propsParams) ?? new Map<string, string>()
+
   // aliasTargets (#2069 R2): one-hop alias resolution table for
   // `isCallAcceptedByAdapter`. A const whose FINAL resolved binding kind
   // is `init-local` or `module-local` (i.e. not a signal/memo/prop-alias
@@ -884,6 +900,7 @@ function buildRelocateEnvFromFields(src: EnvFields): RelocateEnv {
     bindings,
     inlinable: new Map(), // populated by compute-inlinability after analyzer runs
     propsForLift,
+    propSourceNames,
     propsObjectName,
     allowFallback: true,
     aliasTargets,


### PR DESCRIPTION
Part 1 of 3 for #2524/#2525 (the CSR half of #2524). Follow-ups: the template adapters' SSR-seeding half of #2524, then #2525 (Go), each stacked on this.

## What

An aliased destructured prop (`{ n: count }`) hydrated and CSR-rendered as `undefined`: client-JS emission read `_p.count` (the local binding) while the child bridge and the CSR root key props by the caller-facing name (`n`). The `_p` props object now has **one key convention everywhere: `sourceName ?? name`** — `ParamInfo`'s own documented rule, and an identity for un-aliased props, so every existing snapshot stays byte-identical.

Consumers flipped (all in `packages/jsx`): props extraction (`const count = _p.n`), event-handler props, reactive attr rewrites, controlled-signal accessors, template-lambda bare-prop rewrites (an alias map threaded through `rewriteBarePropRefs`, computed after the shadow/membership gate so shadowed occurrences never alias), `relocate`'s lift-to-prop, and rest-spread exclude keys (the runtime filters by source key). Producers flipped in the same change: Hono's `bf-p` hydration blob serializes under the caller key, and `TestAdapter`'s SSR destructure uses the same rename-aware `key: local` binding — both now share one renderer (`packages/jsx/src/props-binding.ts`, exported as `propsDestructureBinding` / `buildPropAliasMap`) instead of carrying private copies.

## Pin graduation

The two `csr-conformance` skips (`aliased-destructured-prop`, `composite-row-child-aliased-prop`) are deleted — both tests now **run and pass** against the Hono-generated `expectedHtml`, becoming the regression armor.

## Verification

- New jsx-side pins: `aliased-destructured-prop-csr.test.ts` (init extraction, template lambda, controlled-signal accessor, event-handler prop, un-aliased byte-identity) — 4/4.
- Full suites: jsx 2914 pass / 2 fail (**both pre-existing on main** — `map-body-no-silent-divergence` JS-runtime cases, stash-verified identical on a clean `origin/main` tree), adapter-hono 1364/0, adapter-tests 1877/0 (incl. snapshot-determinism, no snapshot diffs; csr-conformance 254/0), client 627/0, compat 197/0, `packages/test` 48/0, `ui/components` 1240/0.
- `tsgo --noEmit` clean for jsx and adapter-hono.
- Lock no-drift verified: `bun run build && bun run compat:lock && bun run support-matrix:lock` → `git diff ui/` empty.
- Independent review pass: approve; its two dedup findings (shared `propsDestructureBinding` / `buildPropAliasMap`) are applied in this diff. Two **pre-existing** adjacent gaps it verified are NOT regressions and are left for follow-up trackers: aliased-prop + rest-spread leaks the caller key into the rest expansion (`analyzer.ts` restPropsExpandedKeys), and shorthand-in-inlined-const object literals produce `{ _p.n, … }` even un-aliased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANWdijiBRfuNqnACEPEyKD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANWdijiBRfuNqnACEPEyKD)_