### PR TITLE
fix(adapters): seed template SSR vars from the caller-facing prop key (#2524 SSR half)

### DIFF
--- a/.changeset/ssr-props-caller-key-2524.md
+++ b/.changeset/ssr-props-caller-key-2524.md
@@ -1,0 +1,91 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/blade": patch
+"@barefootjs/erb": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/rust": patch
+"@barefootjs/twig": patch
+"@barefootjs/xslate": patch
+"@barefootjs/php": patch
+"@barefootjs/cli": patch
+---
+
+Template-adapter SSR seeding now honors an aliased destructured prop's caller-facing key (#2524 SSR half)
+
+A renaming destructure (`{ n: count }`) keys template variables by the LOCAL
+binding (`count`, correctly — the template body reads `count`) but the
+caller only ever supplies the CALLER-facing name (`n`). `extractSsrDefaults`
+already emitted that mapping as `SsrDefault.propName`
+(`{"count":{"propName":"n","value":null}}`), but nothing consumed it: every
+template-string adapter's conformance harness (and 3 shipped production
+sites) either discarded `propName` outright or keyed its seeding loop off
+the local name, so a renamed prop's caller value was silently dropped and
+the slot rendered its static default (`null`/`undefined`/`0`) instead.
+
+- New shared helper `deriveStashFromDefaults` (`@barefootjs/jsx`) — the TS
+  twin of the runtime `derive_vars_from_defaults` /
+  `_derive_stash_from_defaults` family that already ships in the Ruby,
+  Python, PHP, Perl, and Rust runtime ports. For each defaults entry, prefers
+  `props[propName]` when the caller supplied a non-nullish value, else the
+  static fallback; `isRestProps` entries pass the caller's assembled rest bag
+  through; propName-less entries (signal/memo locals) always use the static
+  value.
+- All 7 template-string adapters' conformance harnesses (blade, erb, jinja,
+  mojolicious, rust/minijinja, twig, xslate) now derive both root-level and
+  child-component seeding through this helper (or the matching PRODUCTION
+  runtime function, when the harness already drives one) instead of
+  hand-flattening `SsrDefault.value`. Child-defaults seeding now carries the
+  FULL `{value, propName?, isRestProps?}` shape into the generated render
+  script/payload and resolves it per-call against the real caller props, the
+  same way `@barefootjs/erb`'s harness already did.
+- Rest-bag "keep" sets (which caller-supplied keys are declared params vs.
+  undeclared extras routed into `...rest`) now key off `sourceName ?? name`
+  (the caller-facing spelling) instead of the local binding.
+- Three shipped PRODUCTION sites had the same defect class and are fixed
+  too: `@barefootjs/rust`'s runtime (`register_components_from_manifest`
+  used to flatten `ssrDefaults` with an EMPTY props document at
+  registration time, before any caller was known — resolution now happens
+  per-call, inside `render_child`, against the real caller props);
+  `@barefootjs/mojolicious`'s plugin (`before_render` hook's top-level
+  stash seeding); and `@barefootjs/cli`'s Text::Xslate scaffold
+  (`app.psgi`'s `ssr_defaults`/`render_component` helpers). All three now
+  route through the corresponding runtime's `derive_stash_from_defaults` /
+  `_derive_stash_from_defaults`.
+- `Barefoot\BarefootJS::deriveStashFromDefaults` (`@barefootjs/php`) is now
+  `public` (was `private`) so the blade/twig conformance harnesses — and any
+  caller composing a render by hand, mirroring the Ruby port's own public
+  `derive_vars_from_defaults` — can route through the real production logic
+  instead of re-deriving it.
+
+`sourceName ?? name` is an identity for every un-aliased prop, so the rename
+visibility fix itself has no effect on the non-aliased corpus. The merge
+ORDER flip that makes `propName` resolution possible (defaults-derived
+`extra` now applies LAST, over the caller's raw props, instead of first)
+does have two deliberate, narrower behavior changes even for non-aliased
+props — both intentional alignments with the semantics every other runtime
+port (`derive_vars_from_defaults` / `_derive_stash_from_defaults` /
+`derive_stash_from_defaults`) already had, not regressions introduced here:
+
+- A caller prop passed as explicit `null`/`undefined` now loses to the
+  static default, instead of the explicit nullish value winning. This
+  matches `deriveStashFromDefaults`'s (and every runtime port's)
+  "present and non-nullish" check on `props[propName]` — a flat
+  `{...defaults, ...callerProps}` merge can't express that distinction (any
+  own key wins, nullish or not); routing through the shared helper can.
+- A caller prop whose name collides with a `propName`-less entry (a
+  signal/memo local, e.g. a prop happens to be named the same as an
+  internal signal getter) now loses to the signal/memo's static value
+  instead of overriding it — `propName`-less entries are, by construction,
+  never sourced from `props` in any port; a flat merge accidentally let a
+  same-named caller prop shadow one anyway.
+
+Both changes only bite an existing caller relying on one of these two
+narrow, previously-inconsistent-with-every-other-port behaviors; the common
+case (a caller prop with a concrete, non-nullish value and no name
+collision with an internal signal/memo) is unaffected. Graduates the
+`aliased-destructured-prop` / `composite-row-child-aliased-prop`
+render-divergence pins for all 7 adapters (erb graduates
+`aliased-destructured-prop` only — its child-seeding path was already
+correct). Go's `go run` exit-1 failure (#2525) is untouched by this change
+and stays pinned.

--- a/integrations/axum/src/render.rs
+++ b/integrations/axum/src/render.rs
@@ -127,7 +127,7 @@ pub fn new_session(state: &AppState, signal_init: &HashMap<String, JsValue>) -> 
             barefootjs::ChildRendererSpec {
                 component_name: name.to_string(),
                 template: name.to_string(),
-                ssr_defaults: MjValue::from(BTreeMap::<String, MjValue>::new()),
+                ssr_defaults: empty_obj(),
                 rest_props_name: None,
                 param_names: Vec::new(),
             },

--- a/packages/adapter-blade/src/__tests__/blade-reserved-word-child-prop.test.ts
+++ b/packages/adapter-blade/src/__tests__/blade-reserved-word-child-prop.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression for the review finding on #2524's SSR half (BLOCKER 1): a
+ * reserved-word aliased/defaulted prop passed to a CHILD component used to
+ * be silently clobbered by the child's static default.
+ *
+ * `$child_props` arrives at `deriveStashFromDefaults` already
+ * keyword-mangled (`blade_ident`, `naming.php`) — `loop` becomes `loop_`
+ * (Blade's reserved-word set, unlike Twig's, is render-time-PHP-scope
+ * collisions, not template-syntax keywords — see `naming.php`'s docstring)
+ * — but the serialised `$_defaults` array's own keys and each entry's
+ * `propName` were the RAW (un-mangled) spellings `extractSsrDefaults`
+ * emits. For a reserved-word prop, `deriveStashFromDefaults` looked up
+ * `$props['loop']` (never present — the real key is `loop_`), missed, and
+ * fell back to the static default under the RAW key `loop`; after
+ * `$_vars = array_merge($child_props, $_extra)`, the WRONG static default
+ * won over the real caller value.
+ *
+ * `deriveStashFromDefaults` now takes the caller's `$backend` and mangles
+ * both the output key and the `propName` lookup through the same
+ * `Backend::ident()` the caller's `$child_props` were mangled with. See
+ * `BarefootJS.php`'s `deriveStashFromDefaults` docstring.
+ */
+import { test, expect } from 'bun:test'
+import { BladeAdapter } from '../adapter'
+import { renderBladeComponent, BladeNotAvailableError } from '../test-render'
+
+const SOURCE = `
+import { Tag } from './Tag'
+export function Wrapper() {
+  return <Tag loop="section" label="hi" />
+}
+`
+
+const TAG_SOURCE = `
+export function Tag({ loop = 'span', label }: { loop?: string; label: string }) {
+  return <div>{loop}:{label}</div>
+}
+`
+
+test('a reserved-word aliased/defaulted prop survives the child-render path (blade, #2524 follow-up)', async () => {
+  let html: string
+  try {
+    html = await renderBladeComponent({
+      source: SOURCE,
+      adapter: new BladeAdapter(),
+      components: { './Tag': TAG_SOURCE },
+    })
+  } catch (err) {
+    if (err instanceof BladeNotAvailableError) {
+      console.log(`Skipping: ${err.message}`)
+      return
+    }
+    throw err
+  }
+  // The caller passed `loop="section"` — it must win over the child's own
+  // `loop = 'span'` destructure default. Text is wrapped in bf slot
+  // markers, so match each interpolated value rather than the literal
+  // `x:y` shape.
+  expect(html).toContain('>section<')
+  expect(html).toContain('>hi<')
+  expect(html).not.toContain('>span<')
+})

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -20,20 +20,4 @@ export const renderDivergences: RenderDivergences = {
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
-  // hand-authored to the CORRECT output while the emission bug lived in
-  // the shared compiler layer — every adapter, including the Hono
-  // reference, used to emit the broken form. That shared-layer defect
-  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
-  // Hono reference like any other fixture. The remaining gap is
-  // per-template-adapter — this adapter still keys its template vars /
-  // ssr-defaults / props bridge off the local binding instead of
-  // `sourceName ?? name` — tracked by #2524 (the 7 silent template
-  // adapters). Graduate by applying the same `sourceName ?? name` fix to
-  // this adapter's emission path and deleting these lines (and the
-  // matching hono `skipJsx` entries, already gone).
-  'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)',
-  'composite-row-child-aliased-prop':
-    'same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)',
 }

--- a/packages/adapter-blade/src/test-render.ts
+++ b/packages/adapter-blade/src/test-render.ts
@@ -38,8 +38,8 @@
  *     caller's `props` and needs no JSON round-trip.
  */
 
-import { compileJSX, extractSsrDefaults, importsSearchParams, evaluateSignalInit } from '@barefootjs/jsx'
-import type { ComponentIR } from '@barefootjs/jsx'
+import { compileJSX, extractSsrDefaults, deriveStashFromDefaults, importsSearchParams, evaluateSignalInit } from '@barefootjs/jsx'
+import type { ComponentIR, SsrDefault } from '@barefootjs/jsx'
 import { mkdir, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
@@ -384,7 +384,17 @@ function collectImportedComponentNames(ir: ComponentIR): string[] {
  * (mirrors the Jinja/Python runtime's `render_child` contract) — so the
  * rest-bag routing below and the `_bf_slot` / `key` / `children` pops all
  * compare against ALREADY-mangled key spellings; the `keep` set mangles the
- * child's declared param names to match.
+ * child's declared param (CALLER-facing, `sourceName ?? name`) names to
+ * match.
+ *
+ * Template vars seed through the production
+ * `\Barefoot\BarefootJS::deriveStashFromDefaults` (the same static method
+ * `register_components_from_manifest` calls) rather than a flat
+ * `array_merge($_defaults, $child_props)`: the flat merge never resolves an
+ * aliased destructured prop's CALLER-facing key (`n`) onto its local
+ * template var (`count`) — `$_defaults` carries the FULL `{value, propName?,
+ * isRestProps?}` shape (not flattened to bare values) so the propName
+ * resolution has something to read (#2524 SSR half).
  */
 function buildChildRenderersPhp(
   childTemplates: Map<string, { template: string; ir: ComponentIR }>,
@@ -396,10 +406,14 @@ function buildChildRenderersPhp(
 
   for (const [componentName, { ir: childIR }] of childTemplates) {
     const snakeName = toSnakeCase(componentName)
+    // Statically-derived ssrDefaults the child template's vars seed from,
+    // serialised VERBATIM (propName / isRestProps intact) — resolved
+    // per-call against the REAL child props by `deriveStashFromDefaults`
+    // below, not flattened here.
     const ssrDefaults = extractSsrDefaults(childIR.metadata) ?? {}
     const defaultsPhp = ssrDefaultsToPhp(ssrDefaults)
     const restPropsName = childIR.metadata.restPropsName
-    const paramNames = (childIR.metadata.propsParams ?? []).map(p => p.name)
+    const paramNames = (childIR.metadata.propsParams ?? []).map(p => p.sourceName ?? p.name)
 
     lines.push(
       `$bf->register_child_renderer(${phpStr(snakeName)}, function ($child_props, $caller_bf = null) use ($backend, $bf) {`,
@@ -461,8 +475,13 @@ function buildChildRenderersPhp(
     lines.push(`    $child_bf->_child_renderers($bf->_child_renderers());`)
     lines.push(`    $child_bf->_scripts($bf->_scripts());`)
     lines.push(`    $child_bf->_script_seen($bf->_script_seen());`)
-    // Seed template vars: static ssrDefaults first, caller's props win.
-    lines.push(`    $_vars = array_merge($_defaults, $child_props);`)
+    // Seed template vars through the production `deriveStashFromDefaults` —
+    // resolves each entry's `propName` against the REAL `$child_props`,
+    // falling back to the static `value`; `isRestProps` entries pass the
+    // already-routed rest bag through. Caller props still win overall via
+    // the final merge (mirrors the ERB harness's `child_props.merge(extra)`).
+    lines.push(`    $_extra = \\Barefoot\\BarefootJS::deriveStashFromDefaults($_defaults, $child_props, $backend);`)
+    lines.push(`    $_vars = array_merge($child_props, $_extra);`)
     lines.push(`    $rendered = $backend->render_named(${phpStr(snakeName)}, $child_bf, $_vars);`)
     lines.push(`    if (is_string($rendered) && substr($rendered, -1) === "\\n") { $rendered = substr($rendered, 0, -1); }`)
     lines.push(`    return $rendered;`)
@@ -506,23 +525,29 @@ function buildBladeProps(
   setEntry('scope_id', explicitScope)
 
   // Prop params with defaults (before signals, so signals can reference them).
+  // Seeded through the shared `deriveStashFromDefaults` (the TS twin of the
+  // production `\Barefoot\BarefootJS::deriveStashFromDefaults` this harness
+  // ALSO calls at render time for child components) so an aliased
+  // destructured prop's CALLER-facing key (`propName`, e.g. `n` for
+  // `{ n: count }`) is honoured, not just the local template var name
+  // (#2524 SSR half). `props` is keyed by the caller-facing name, exactly
+  // what `propName` resolves against.
+  const rootSsrDefaults = extractSsrDefaults(ir.metadata) ?? {}
+  const derivedProps = deriveStashFromDefaults(rootSsrDefaults, props ?? {})
   for (const param of ir.metadata.propsParams) {
-    if (props && param.name in props) continue
-    if (param.defaultValue) {
-      const value = evaluateSignalInit(param.defaultValue.trim(), props)
-      if (value !== null) {
-        setEntry(param.name, value)
-        continue
-      }
-    }
+    if (param.isRest) continue
     // No default + no caller value: pass `null` so Blade's var lookup for
     // an optional prop doesn't fault before its falsy branch elides.
-    setEntry(param.name, null)
+    setEntry(param.name, derivedProps[param.name] ?? null)
   }
 
   // Route undeclared props into the rest bag (`bf.spread_attrs($<rest>)`).
   const restPropsName = ir.metadata.restPropsName
-  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.name))
+  // Caller-facing keys — an aliased destructured prop's DECLARED set for
+  // rest-bag routing must match what the caller actually sent (`n`), not
+  // the local binding (`count`), or the caller's own prop silently gets
+  // swept into the rest bag as an undeclared extra (#2524).
+  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.sourceName ?? p.name))
   const restBagEntries: Array<[string, unknown]> = []
   if (restPropsName && props) {
     for (const [key, value] of Object.entries(props)) {
@@ -537,11 +562,20 @@ function buildBladeProps(
     setEntry(restPropsName, Object.fromEntries(restBagEntries))
   }
 
-  // User props.
+  // User props. Skip a key that's already a declared param's LOCAL template
+  // var name — `derivedProps` above already resolved that var correctly
+  // (through `propName`, for an aliased prop); re-`setEntry`-ing the raw
+  // `props[key]` here would silently clobber it with an UNRELATED value
+  // whenever a caller happens to also pass a same-spelled-as-local-name prop
+  // that isn't this param's actual `propName` (#2524 — surfaced by the
+  // aliased-destructured-prop generated data points, which pass both `n`
+  // (the real propName) and an incidental `count` key).
+  const localParamNames = new Set(ir.metadata.propsParams.map(p => p.name))
   if (props) {
     for (const [key, value] of Object.entries(props)) {
       if (key.startsWith('__')) continue
       if (routedKeys.has(key)) continue
+      if (localParamNames.has(key)) continue
       if (
         typeof value === 'string' ||
         typeof value === 'number' ||
@@ -567,13 +601,9 @@ function buildBladeProps(
 
   // Memo values seeded from the statically-evaluated ssrDefaults, same
   // as the production plugin's before_render hook.
-  const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
   for (const memo of ir.metadata.memos) {
-    const entry = ssrDefaults[memo.name]
-    const value =
-      entry && typeof entry === 'object' && 'value' in (entry as Record<string, unknown>)
-        ? (entry as Record<string, unknown>).value
-        : 0
+    const entry = rootSsrDefaults[memo.name]
+    const value = entry ? entry.value : 0
     setEntry(memo.name, value ?? 0)
   }
 
@@ -652,22 +682,29 @@ function toPhpLiteral(value: unknown): string {
 
 /**
  * Serialise an ssrDefaults map to a PHP assoc-array literal (the `$_defaults`
- * var a child renderer merges caller props over). This top-level container
- * is the "vars bag" domain (like `$vars` elsewhere in this file), not a JS
- * VALUE flowing into a template — so, unlike a nested object VALUE inside
- * one of its entries, it stays a plain PHP array rather than `(object) [...]`.
+ * var `deriveStashFromDefaults` resolves against the real `$child_props`).
+ * This top-level container is the "vars bag" domain (like `$vars` elsewhere
+ * in this file), not a JS VALUE flowing into a template — so, unlike a
+ * nested object VALUE inside one of its entries, it stays a plain PHP array
+ * rather than `(object) [...]`. Emits each entry VERBATIM — `value` /
+ * `propName` / `isRestProps` intact, exactly the shape
+ * `deriveStashFromDefaults` expects. Do NOT flatten to bare `value`s here:
+ * that was the #2524 SSR-half bug — a flattened entry has nothing left for
+ * the propName-aware resolution to read, so an aliased destructured prop's
+ * caller-facing key is silently dropped.
  */
-function ssrDefaultsToPhp(defaults: Record<string, unknown>): string {
+function ssrDefaultsToPhp(defaults: Record<string, SsrDefault>): string {
   const entries: string[] = []
   for (const [name, d] of Object.entries(defaults)) {
-    // ssrDefaults entries are `{ value, propName?, isRestProps? }` or a
-    // bare value. The child renderer's caller props win, so we only need
-    // the static fallback `value` here.
-    let value: unknown = d
-    if (d && typeof d === 'object' && 'value' in (d as Record<string, unknown>)) {
-      value = (d as Record<string, unknown>).value
-    }
-    entries.push(`${phpStr(name)} => ${toPhpLiteral(value)}`)
+    entries.push(`${phpStr(name)} => ${ssrDefaultEntryToPhp(d)}`)
   }
   return `[${entries.join(', ')}]`
+}
+
+/** Serialise a single `SsrDefault` entry to a PHP assoc-array literal. */
+function ssrDefaultEntryToPhp(d: SsrDefault): string {
+  const parts: string[] = [`'value' => ${toPhpLiteral(d.value)}`]
+  if (d.propName !== undefined) parts.push(`'propName' => ${phpStr(d.propName)}`)
+  if (d.isRestProps) parts.push(`'isRestProps' => true`)
+  return `[${parts.join(', ')}]`
 }

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -20,18 +20,4 @@ export const renderDivergences: RenderDivergences = {
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
-  // hand-authored to the CORRECT output while the emission bug lived in
-  // the shared compiler layer — every adapter, including the Hono
-  // reference, used to emit the broken form. That shared-layer defect
-  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
-  // Hono reference like any other fixture. The remaining gap is
-  // per-template-adapter — this adapter still keys its template vars /
-  // ssr-defaults / props bridge off the local binding instead of
-  // `sourceName ?? name` — tracked by #2524 (the 7 silent template
-  // adapters). Graduate by applying the same `sourceName ?? name` fix to
-  // this adapter's emission path and deleting this line (and the
-  // matching hono `skipJsx` entries, already gone).
-  'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)',
 }

--- a/packages/adapter-erb/src/test-render.ts
+++ b/packages/adapter-erb/src/test-render.ts
@@ -36,7 +36,7 @@
  * regression test.
  */
 
-import { compileJSX, extractSsrDefaults, importsSearchParams, evaluateSignalInit, tryEvaluateSignalInit } from '@barefootjs/jsx'
+import { compileJSX, extractSsrDefaults, deriveStashFromDefaults, importsSearchParams, evaluateSignalInit } from '@barefootjs/jsx'
 import type { ComponentIR, SsrDefault } from '@barefootjs/jsx'
 import { mkdir, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
@@ -415,7 +415,11 @@ function buildChildRenderersRuby(
       // branch and JSX rest semantics: a caller prop the child didn't
       // destructure belongs in the bag, not as a top-level vars key the
       // template never reads.
-      const paramNames = (childIR.metadata.propsParams ?? []).map(p => p.name)
+      // Caller-facing keys — `child_props` (below) is keyed by whatever the
+      // CALLING template passed (the JSX attribute name), so the keep-set
+      // must match that spelling, not an aliased child's local binding
+      // (#2524).
+      const paramNames = (childIR.metadata.propsParams ?? []).map(p => p.sourceName ?? p.name)
       const keep = [...new Set([...paramNames, restPropsName, 'children', 'key', '_bf_slot'])]
       const keepList = keep.map(rubySymbol).join(', ')
       lines.push(`  keep = [${keepList}]`)
@@ -499,24 +503,29 @@ function buildRubyProps(
   obj.scope_id = explicitScope
 
   // Prop params with defaults (before signals, so signals can reference them).
+  // Seeded through the shared `deriveStashFromDefaults` (the TS twin of the
+  // production `derive_vars_from_defaults` this harness ALSO calls below for
+  // child components) so an aliased destructured prop's CALLER-facing key
+  // (`propName`, e.g. `n` for `{ n: count }`) is honoured, not just the
+  // local template var name (#2524 SSR half). `props` is keyed by the
+  // caller-facing name, exactly what `propName` resolves against.
+  const rootSsrDefaults = extractSsrDefaults(ir.metadata) ?? {}
+  const derivedProps = deriveStashFromDefaults(rootSsrDefaults, props ?? {})
   for (const param of ir.metadata.propsParams) {
-    if (props && param.name in props) continue
-    if (param.defaultValue) {
-      const result = tryEvaluateSignalInit(param.defaultValue.trim(), props)
-      if (result.ok) {
-        obj[param.name] = result.value
-        continue
-      }
-    }
+    if (param.isRest) continue
     // No default + no caller value: seed `nil` so a bare reference to an
     // optional prop's vars-Hash key resolves (to nil) instead of the key
     // being wholly absent — matches the Perl harnesses' explicit `undef`.
-    obj[param.name] = null
+    obj[param.name] = derivedProps[param.name] ?? null
   }
 
   // Route undeclared props into the rest bag (`spread_attrs(v[:<rest>])`).
   const restPropsName = ir.metadata.restPropsName
-  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.name))
+  // Caller-facing keys, per prop — an aliased destructured prop's DECLARED
+  // set for rest-bag routing purposes must match what the caller actually
+  // sent (`n`), not the local binding (`count`), or the caller's own prop
+  // silently gets swept into the rest bag as an undeclared extra (#2524).
+  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.sourceName ?? p.name))
   const restBagEntries: Array<[string, unknown]> = []
   if (restPropsName && props) {
     for (const [key, value] of Object.entries(props)) {
@@ -531,11 +540,20 @@ function buildRubyProps(
     obj[restPropsName] = Object.fromEntries(restBagEntries)
   }
 
-  // User props.
+  // User props. Skip a key that's already a declared param's LOCAL template
+  // var name — `derivedProps` above already resolved that var correctly
+  // (through `propName`, for an aliased prop); re-assigning the raw
+  // `props[key]` here would silently clobber it with an UNRELATED value
+  // whenever a caller happens to also pass a same-spelled-as-local-name prop
+  // that isn't this param's actual `propName` (#2524 — surfaced by the
+  // aliased-destructured-prop generated data points, which pass both `n`
+  // (the real propName) and an incidental `count` key).
+  const localParamNames = new Set(ir.metadata.propsParams.map(p => p.name))
   if (props) {
     for (const [key, value] of Object.entries(props)) {
       if (key.startsWith('__')) continue
       if (routedKeys.has(key)) continue
+      if (localParamNames.has(key)) continue
       obj[key] = value
     }
   }
@@ -553,9 +571,8 @@ function buildRubyProps(
 
   // Memo values seeded from the statically-evaluated ssrDefaults, same
   // as the production plugin's before_render hook.
-  const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
   for (const memo of ir.metadata.memos) {
-    obj[memo.name] = ssrDefaults[memo.name]?.value ?? 0
+    obj[memo.name] = rootSsrDefaults[memo.name]?.value ?? 0
   }
 
   const needsSearchParams = importsSearchParams(ir.metadata)

--- a/packages/adapter-jinja/python/barefootjs/runtime.py
+++ b/packages/adapter-jinja/python/barefootjs/runtime.py
@@ -484,20 +484,35 @@ _DATE_EPOCH = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
 def _derive_stash_from_defaults(defaults: dict, props: dict) -> dict:
     """Derive template-stash kvs from a manifest entry's `ssrDefaults`
     section. See BarefootJS.pm's `_derive_stash_from_defaults` docstring for
-    the full field-shape contract."""
+    the full field-shape contract.
+
+    `props` arrives ALREADY keyword-mangled (`render_child` / the manifest
+    renderer closure both mangle every prop key via `jinja_ident` before
+    calling in -- see their docstrings), but `defaults`' own keys and each
+    entry's `propName` are the RAW (un-mangled) spellings `extractSsrDefaults`
+    emitted. For a reserved-word prop (`as`, `for`, `class`, ...) an
+    unmangled lookup/output key misses the mangled `props` map entirely --
+    silently falling back to the static default even when the caller DID
+    supply a value -- and then writes the stash under the RAW key, which a
+    subsequent mangling pass (or the template itself, keyed by the mangled
+    name) never reads. Both the output key and the `propName` lookup are
+    mangled here so this resolves correctly regardless of whether the prop
+    name happens to collide with a reserved word (#2524 follow-up)."""
     extra: dict = {}
     for name, d in (defaults or {}).items():
+        key = jinja_ident(name)
         if not isinstance(d, dict):
-            extra[name] = d
+            extra[key] = d
             continue
         if d.get("isRestProps"):
-            extra[name] = props[name] if name in props else d.get("value")
+            extra[key] = props[key] if key in props else d.get("value")
             continue
         prop_name = d.get("propName")
-        if prop_name is not None and props.get(prop_name) is not None:
-            extra[name] = props[prop_name]
+        mangled_prop_name = jinja_ident(prop_name) if prop_name is not None else None
+        if mangled_prop_name is not None and props.get(mangled_prop_name) is not None:
+            extra[key] = props[mangled_prop_name]
         else:
-            extra[name] = d.get("value")
+            extra[key] = d.get("value")
     return extra
 
 

--- a/packages/adapter-jinja/src/__tests__/jinja-reserved-word-child-prop.test.ts
+++ b/packages/adapter-jinja/src/__tests__/jinja-reserved-word-child-prop.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression for the review finding on #2524's SSR half (BLOCKER 1): a
+ * reserved-word aliased/defaulted prop passed to a CHILD component used to
+ * be silently clobbered by the child's static default.
+ *
+ * `child_props` arrives at `_derive_stash_from_defaults` already
+ * keyword-mangled (`jinja_ident`, `runtime.py`) — `as` becomes `as_` — but
+ * the serialised `_defaults` map's own keys and each entry's `propName` were
+ * the RAW (un-mangled) spellings `extractSsrDefaults` emits. For a
+ * reserved-word prop, `_derive_stash_from_defaults` looked up `props['as']`
+ * (never present — the real key is `as_`), missed, and fell back to the
+ * static default under the RAW key `as`; after `_vars = {**child_props,
+ * **_extra}`, the WRONG static default won over the real caller value.
+ *
+ * `_derive_stash_from_defaults` now mangles both the output key and the
+ * `propName` lookup (mirrors the Rust runtime's `resolve_child_vars`), so
+ * this resolves correctly. See `runtime.py`'s `_derive_stash_from_defaults`
+ * docstring.
+ */
+import { test, expect } from 'bun:test'
+import { JinjaAdapter } from '../adapter'
+import { renderJinjaComponent, PythonNotAvailableError } from '../test-render'
+
+const SOURCE = `
+import { Tag } from './Tag'
+export function Wrapper() {
+  return <Tag as="section" label="hi" />
+}
+`
+
+const TAG_SOURCE = `
+export function Tag({ as = 'span', label }: { as?: string; label: string }) {
+  return <div>{as}:{label}</div>
+}
+`
+
+test('a reserved-word aliased/defaulted prop survives the child-render path (jinja, #2524 follow-up)', async () => {
+  let html: string
+  try {
+    html = await renderJinjaComponent({
+      source: SOURCE,
+      adapter: new JinjaAdapter(),
+      components: { './Tag': TAG_SOURCE },
+    })
+  } catch (err) {
+    if (err instanceof PythonNotAvailableError) {
+      console.log(`Skipping: ${err.message}`)
+      return
+    }
+    throw err
+  }
+  // The caller passed `as="section"` — it must win over the child's own
+  // `as = 'span'` destructure default. Text is wrapped in bf slot markers,
+  // so match each interpolated value rather than the literal `x:y` shape.
+  expect(html).toContain('>section<')
+  expect(html).toContain('>hi<')
+  expect(html).not.toContain('>span<')
+})

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -20,20 +20,4 @@ export const renderDivergences: RenderDivergences = {
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
-  // hand-authored to the CORRECT output while the emission bug lived in
-  // the shared compiler layer — every adapter, including the Hono
-  // reference, used to emit the broken form. That shared-layer defect
-  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
-  // Hono reference like any other fixture. The remaining gap is
-  // per-template-adapter — this adapter still keys its template vars /
-  // ssr-defaults / props bridge off the local binding instead of
-  // `sourceName ?? name` — tracked by #2524 (the 7 silent template
-  // adapters). Graduate by applying the same `sourceName ?? name` fix to
-  // this adapter's emission path and deleting these lines (and the
-  // matching hono `skipJsx` entries, already gone).
-  'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)',
-  'composite-row-child-aliased-prop':
-    'same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)',
 }

--- a/packages/adapter-jinja/src/test-render.ts
+++ b/packages/adapter-jinja/src/test-render.ts
@@ -16,8 +16,8 @@
  * generated render script (Python, not Perl) and its literal syntax differ.
  */
 
-import { compileJSX, extractSsrDefaults, importsSearchParams, evaluateSignalInit, tryEvaluateSignalInit } from '@barefootjs/jsx'
-import type { ComponentIR } from '@barefootjs/jsx'
+import { compileJSX, extractSsrDefaults, deriveStashFromDefaults, importsSearchParams, evaluateSignalInit } from '@barefootjs/jsx'
+import type { ComponentIR, SsrDefault } from '@barefootjs/jsx'
 import { mkdir, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
@@ -252,7 +252,7 @@ import uuid
 
 from barefootjs import BarefootJS, SearchParams
 from barefootjs.backend_jinja import JinjaBackend
-from barefootjs.runtime import jinja_ident
+from barefootjs.runtime import jinja_ident, _derive_stash_from_defaults
 
 # Single Jinja2 backend over the temp template dir.
 backend = JinjaBackend(paths=[${pyStr(tempDir)}])
@@ -333,7 +333,16 @@ function collectImportedComponentNames(ir: ComponentIR): string[] {
  * `runtime.BarefootJS.render_child`'s docstring. So the rest-bag routing
  * below and the `_bf_slot` / `key` / `children` pops all compare against
  * ALREADY-mangled key spellings; the `keep` set mangles the child's declared
- * param names to match.
+ * param (CALLER-facing, `sourceName ?? name`) names to match.
+ *
+ * Template vars seed through the production `_derive_stash_from_defaults`
+ * (`barefootjs.runtime`, the same function `register_components_from_
+ * manifest`'s `make_renderer` calls) rather than a flat `{**_defaults,
+ * **child_props}` merge: the flat merge never resolves an aliased
+ * destructured prop's CALLER-facing key (`n`) onto its local template var
+ * (`count`) — `_defaults` carries the FULL `{value, propName?,
+ * isRestProps?}` shape (not flattened to bare values) so the propName
+ * resolution has something to read (#2524 SSR half).
  */
 function buildChildRenderers(
   childTemplates: Map<string, { template: string; ir: ComponentIR }>,
@@ -348,12 +357,14 @@ function buildChildRenderers(
     const snakeName = toSnakeCase(componentName)
     const fnSuffix = snakeName.replace(/[^a-zA-Z0-9_]/g, '_')
     // Statically-derived ssrDefaults the child template's vars seed from
-    // (prop defaults + signal / memo initial values), serialised to a
-    // Python dict literal.
+    // (prop defaults + signal / memo initial values), serialised VERBATIM
+    // (propName / isRestProps intact) to a Python dict literal — resolved
+    // per-call against the REAL child props by `_derive_stash_from_defaults`
+    // below, not flattened here.
     const ssrDefaults = extractSsrDefaults(childIR.metadata) ?? {}
     const defaultsPy = ssrDefaultsToPy(ssrDefaults)
     const restPropsName = childIR.metadata.restPropsName
-    const paramNames = (childIR.metadata.propsParams ?? []).map(p => p.name)
+    const paramNames = (childIR.metadata.propsParams ?? []).map(p => p.sourceName ?? p.name)
 
     lines.push(`def _make_child_renderer_${fnSuffix}():`)
     lines.push(`    _defaults = ${defaultsPy}`)
@@ -404,8 +415,15 @@ function buildChildRenderers(
     lines.push(`        child_bf._child_renderers(bf._child_renderers())`)
     lines.push(`        child_bf._scripts(bf._scripts())`)
     lines.push(`        child_bf._script_seen(bf._script_seen())`)
-    // Seed template vars: static ssrDefaults first, caller's props win.
-    lines.push(`        _vars = {**_defaults, **child_props}`)
+    // Seed template vars through the production `_derive_stash_from_defaults`
+    // — resolves each entry's `propName` against the REAL `child_props`
+    // (already keyword-mangled above), falling back to the static `value`;
+    // `isRestProps` entries pass the already-routed rest bag through. Caller
+    // props still win overall via the final merge (mirrors the ERB
+    // harness's `child_props.merge(extra)` and the production
+    // `register_components_from_manifest` renderer closure).
+    lines.push(`        _extra = _derive_stash_from_defaults(_defaults, child_props)`)
+    lines.push(`        _vars = {**child_props, **_extra}`)
     lines.push(`        rendered = backend.render_named(${pyStr(snakeName)}, child_bf, _vars)`)
     lines.push(`        if isinstance(rendered, str) and rendered.endswith('\\n'):`)
     lines.push(`            rendered = rendered[:-1]`)
@@ -424,20 +442,29 @@ function pyList(names: string[]): string {
   return `[${names.map(pyStr).join(', ')}]`
 }
 
-/** Serialise an ssrDefaults map to a Python dict literal. */
-function ssrDefaultsToPy(defaults: Record<string, unknown>): string {
+/**
+ * Serialise an ssrDefaults map to a Python dict literal, VERBATIM —
+ * `value` / `propName` / `isRestProps` intact, exactly the shape
+ * `_derive_stash_from_defaults` expects (and exactly what the production
+ * build manifest embeds). Do NOT flatten to bare `value`s here: that was
+ * the #2524 SSR-half bug — a flattened entry has nothing left for the
+ * propName-aware resolution to read, so an aliased destructured prop's
+ * caller-facing key is silently dropped.
+ */
+function ssrDefaultsToPy(defaults: Record<string, SsrDefault>): string {
   const entries: string[] = []
   for (const [name, d] of Object.entries(defaults)) {
-    // ssrDefaults entries are `{ value, propName?, isRestProps? }` or a
-    // bare value. The child renderer's caller props win, so we only need
-    // the static fallback `value` here.
-    let value: unknown = d
-    if (d && typeof d === 'object' && 'value' in (d as Record<string, unknown>)) {
-      value = (d as Record<string, unknown>).value
-    }
-    entries.push(`${pyStr(name)}: ${toPyLiteral(value)}`)
+    entries.push(`${pyStr(name)}: ${ssrDefaultEntryToPy(d)}`)
   }
   return `{${entries.join(', ')}}`
+}
+
+/** Serialise a single `SsrDefault` entry to a Python dict literal. */
+function ssrDefaultEntryToPy(d: SsrDefault): string {
+  const parts: string[] = [`'value': ${toPyLiteral(d.value)}`]
+  if (d.propName !== undefined) parts.push(`'propName': ${pyStr(d.propName)}`)
+  if (d.isRestProps) parts.push(`'isRestProps': True`)
+  return `{${parts.join(', ')}}`
 }
 
 /**
@@ -465,23 +492,29 @@ function buildPythonProps(
   entries.push(`${pyStr('scope_id')}: ${pyStr(explicitScope)}`)
 
   // Prop params with defaults (before signals, so signals can reference them).
+  // Seeded through the shared `deriveStashFromDefaults` (the TS twin of the
+  // production `_derive_stash_from_defaults` this harness ALSO calls at
+  // render time for child components) so an aliased destructured prop's
+  // CALLER-facing key (`propName`, e.g. `n` for `{ n: count }`) is honoured,
+  // not just the local template var name (#2524 SSR half). `props` is keyed
+  // by the caller-facing name, exactly what `propName` resolves against.
+  const rootSsrDefaults = extractSsrDefaults(ir.metadata) ?? {}
+  const derivedProps = deriveStashFromDefaults(rootSsrDefaults, props ?? {})
   for (const param of ir.metadata.propsParams) {
-    if (props && param.name in props) continue
-    if (param.defaultValue) {
-      const result = tryEvaluateSignalInit(param.defaultValue.trim(), props)
-      if (result.ok) {
-        entries.push(`${pyStr(param.name)}: ${toPyLiteral(result.value)}`)
-        continue
-      }
-    }
+    if (param.isRest) continue
     // No default + no caller value: pass `None` so Jinja's var lookup for
     // an optional prop doesn't fault before its falsy branch elides.
-    entries.push(`${pyStr(param.name)}: None`)
+    const value = derivedProps[param.name] ?? null
+    entries.push(`${pyStr(param.name)}: ${toPyLiteral(value)}`)
   }
 
   // Route undeclared props into the rest bag (`bf.spread_attrs($<rest>)`).
   const restPropsName = ir.metadata.restPropsName
-  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.name))
+  // Caller-facing keys — an aliased destructured prop's DECLARED set for
+  // rest-bag routing must match what the caller actually sent (`n`), not
+  // the local binding (`count`), or the caller's own prop silently gets
+  // swept into the rest bag as an undeclared extra (#2524).
+  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.sourceName ?? p.name))
   const restBagEntries: Array<[string, unknown]> = []
   if (restPropsName && props) {
     for (const [key, value] of Object.entries(props)) {
@@ -496,11 +529,20 @@ function buildPythonProps(
     entries.push(`${pyStr(restPropsName)}: ${toPyLiteral(Object.fromEntries(restBagEntries))}`)
   }
 
-  // User props.
+  // User props. Skip a key that's already a declared param's LOCAL template
+  // var name — `derivedProps` above already resolved that var correctly
+  // (through `propName`, for an aliased prop); re-pushing the raw `props[key]`
+  // here would silently clobber it with an UNRELATED value whenever a caller
+  // happens to also pass a same-spelled-as-local-name prop that isn't this
+  // param's actual `propName` (#2524 — surfaced by the aliased-destructured-prop
+  // generated data points, which pass both `n` (the real propName) and an
+  // incidental `count` key).
+  const localParamNames = new Set(ir.metadata.propsParams.map(p => p.name))
   if (props) {
     for (const [key, value] of Object.entries(props)) {
       if (key.startsWith('__')) continue
       if (routedKeys.has(key)) continue
+      if (localParamNames.has(key)) continue
       if (typeof value === 'string') {
         entries.push(`${pyStr(key)}: ${pyStr(value)}`)
       } else if (typeof value === 'number') {
@@ -526,10 +568,9 @@ function buildPythonProps(
 
   // Memo values seeded from the statically-evaluated ssrDefaults, same
   // as the production plugin's before_render hook.
-  const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
   for (const memo of ir.metadata.memos) {
-    const entry = ssrDefaults[memo.name]
-    const value = entry && typeof entry === 'object' && 'value' in entry ? entry.value : 0
+    const entry = rootSsrDefaults[memo.name]
+    const value = entry ? entry.value : 0
     entries.push(`${pyStr(memo.name)}: ${toPyLiteral(value ?? 0)}`)
   }
 

--- a/packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS.pm
@@ -110,15 +110,41 @@ sub register ($self, $app, $config = {}) {
         $bf->_scope_id($template . '_' . substr(rand() =~ s/^0\.//r, 0, 6));
         $bf->register_components_from_manifest($m);
 
-        # Seed each ssrDefault into the stash unless the caller has
-        # already supplied a value for that key — callers always win.
+        # Seed each ssrDefault into the stash unless the caller has already
+        # supplied a value for that key — callers always win. Resolved
+        # through the production `BarefootJS::_derive_stash_from_defaults`
+        # (the same call `register_components_from_manifest` above makes for
+        # child components) so an aliased destructured prop's CALLER-facing
+        # key (`propName`, e.g. `n` for `{ n: count }`) is honoured — the
+        # caller stash IS the props document for a top-level render (a route
+        # handler sets `$c->stash(n => 5)` before `$c->render(...)`).
+        # Resolving `$d->{value}` directly, ignoring `propName`, was the
+        # #2524 production bug: it could never see a caller-supplied `n`,
+        # only ever the static default.
+        #
+        # CONSTRAINT (documented, not fixed): because the caller stash IS
+        # the props document here, `propName` resolution also sees every
+        # key Mojolicious itself already populates on `$c->stash` before
+        # this hook runs — `action`, `controller`, `template`,
+        # `template_class`, and friends (Mojolicious::Controller's own
+        # reserved stash keys). A ROOT-level component whose destructured
+        # prop happens to alias FROM one of those names (e.g. `{ action:
+        # label }`) resolves `propName => 'action'` against Mojo's OWN
+        # internal value, not a genuinely absent prop — the component
+        # silently picks up the current route's action name instead of its
+        # static default. This can't collide for a CHILD render
+        # (`register_components_from_manifest`'s renderer closure passes a
+        # fresh, purpose-built props hash, never the live `$c->stash`), only
+        # for a root-level render where the stash doubles as both Mojo's
+        # own bookkeeping and the props document. Avoid destructuring a prop
+        # named `action`/`controller`/`template`/`template_class`/etc. on a
+        # ROOT component if this matters to you.
         my $defaults = $entry->{ssrDefaults};
         if (ref($defaults) eq 'HASH') {
-            for my $name (keys %$defaults) {
+            my %extra = BarefootJS::_derive_stash_from_defaults($defaults, $c->stash);
+            for my $name (keys %extra) {
                 next if exists $c->stash->{$name};
-                my $d = $defaults->{$name};
-                my $value = ref($d) eq 'HASH' ? $d->{value} : $d;
-                $c->stash->{$name} = $value;
+                $c->stash->{$name} = $extra{$name};
             }
         }
 

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -20,20 +20,4 @@ export const renderDivergences: RenderDivergences = {
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
-  // hand-authored to the CORRECT output while the emission bug lived in
-  // the shared compiler layer — every adapter, including the Hono
-  // reference, used to emit the broken form. That shared-layer defect
-  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
-  // Hono reference like any other fixture. The remaining gap is
-  // per-template-adapter — this adapter still keys its template vars /
-  // ssr-defaults / props bridge off the local binding instead of
-  // `sourceName ?? name` — tracked by #2524 (the 7 silent template
-  // adapters). Graduate by applying the same `sourceName ?? name` fix to
-  // this adapter's emission path and deleting these lines (and the
-  // matching hono `skipJsx` entries, already gone).
-  'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)',
-  'composite-row-child-aliased-prop':
-    'same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)',
 }

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -5,8 +5,8 @@
  * Used by adapter-tests conformance runner.
  */
 
-import { compileJSX, extractSsrDefaults, augmentInheritedPropAccesses, importsSearchParams, evaluateSignalInit, tryEvaluateSignalInit } from '@barefootjs/jsx'
-import type { ComponentIR } from '@barefootjs/jsx'
+import { compileJSX, extractSsrDefaults, deriveStashFromDefaults, augmentInheritedPropAccesses, importsSearchParams, evaluateSignalInit } from '@barefootjs/jsx'
+import type { ComponentIR, SsrDefault } from '@barefootjs/jsx'
 import { mkdir, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
@@ -376,8 +376,10 @@ function buildChildRenderers(
       // (#1897) Route non-param props into the rest bag (JSX rest
       // semantics): a caller prop the child didn't destructure belongs
       // in the bag, not as a top-level stash var. Mirrors the Xslate
-      // harness and the production isRestProps branch.
-      const paramNames = (childIR.metadata.propsParams ?? []).map(p => p.name)
+      // harness and the production isRestProps branch. Keep-set uses
+      // CALLER-facing names (`sourceName ?? name`) — `$child_props` is
+      // keyed by whatever the calling template passed (#2524).
+      const paramNames = (childIR.metadata.propsParams ?? []).map(p => p.sourceName ?? p.name)
       const keepList = [...new Set([...paramNames, rest, 'children', 'key', '_bf_slot'])]
         .map(n => `'${n.replace(/[\\']/g, m => `\\${m}`)}'`)
         .join(', ')
@@ -408,9 +410,16 @@ function buildChildRenderers(
     lines.push(`    } else {`)
     lines.push(`      $child_bf->_scope_id('${componentName}_' . substr(rand() =~ s/^0\\.//r, 0, 6));`)
     lines.push(`    }`)
-    // Seed statically-derived defaults under the caller's props (#1897)
-    // so undeclared optional props / signals don't abort strict vars.
-    lines.push(`    my $rendered = $child_mt->render($child_tmpl, { %$defaults_${snakeName}, %$child_props, bf => $child_bf });`)
+    // Seed statically-derived defaults under the caller's props (#1897) so
+    // undeclared optional props / signals don't abort strict vars — through
+    // the production `BarefootJS::_derive_stash_from_defaults`, which
+    // resolves each entry's `propName` against the REAL `$child_props`
+    // (falling back to the static `value`) instead of a flat merge that
+    // never resolves an aliased destructured prop's CALLER-facing key (`n`)
+    // onto its local template var (`count`) (#2524 SSR half). Caller props
+    // still win overall via the final merge.
+    lines.push(`    my %extra_${snakeName} = BarefootJS::_derive_stash_from_defaults($defaults_${snakeName}, $child_props);`)
+    lines.push(`    my $rendered = $child_mt->render($child_tmpl, { %$child_props, %extra_${snakeName}, bf => $child_bf });`)
     lines.push(`    die $rendered->to_string if ref $rendered;`)
     lines.push(`    chomp $rendered;`)
     lines.push(`    return $rendered;`)
@@ -441,10 +450,14 @@ function toSnakeCase(name: string): string {
  * `props.<x>` accesses, signal initial values, and memo ssrDefaults.
  * Without these, a child template referencing an optional prop the
  * caller didn't pass (`$id`, `$className`) or its own signal (`$open`)
- * aborts under Mojo::Template's strict vars. Caller-passed props win at
- * merge time (`{ %$defaults, %$child_props }`). Mirrors the root-side
- * seeding in `buildPerlProps` and the production plugin's
- * `ssrDefaults` consumption.
+ * aborts under Mojo::Template's strict vars. Caller-passed props are
+ * resolved at merge time through `BarefootJS::_derive_stash_from_defaults`
+ * (see `buildChildRenderers`), not a flat merge — declared-prop entries
+ * below are therefore emitted VERBATIM (`{value, propName?}`, from
+ * `extractSsrDefaults`, not flattened) so that resolution has an aliased
+ * prop's CALLER-facing key to read (#2524 SSR half). Mirrors the root-side
+ * seeding in `buildPerlProps` and the production plugin's `ssrDefaults`
+ * consumption.
  */
 function buildChildDefaultsPerl(ir: ComponentIR): string {
   // Surface inherited `props.<x>` reads hidden inside template-literal
@@ -454,16 +467,12 @@ function buildChildDefaultsPerl(ir: ComponentIR): string {
   augmentInheritedPropAccesses(ir)
   const entries: string[] = []
   const declared = new Set<string>()
+  const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
   for (const param of ir.metadata.propsParams) {
+    if (param.isRest) continue
     declared.add(param.name)
-    if (param.defaultValue) {
-      const result = tryEvaluateSignalInit(param.defaultValue.trim())
-      if (result.ok) {
-        entries.push(`${param.name} => ${toPerlLiteral(result.value)}`)
-        continue
-      }
-    }
-    entries.push(`${param.name} => undef`)
+    const d = ssrDefaults[param.name]
+    entries.push(`${param.name} => ${d ? ssrDefaultEntryToPerl(d) : 'undef'}`)
   }
   if (ir.metadata.propsObjectName) {
     for (const name of collectPropsObjectAccesses(ir, ir.metadata.propsObjectName)) {
@@ -472,16 +481,33 @@ function buildChildDefaultsPerl(ir: ComponentIR): string {
       entries.push(`${name} => undef`)
     }
   }
+  // Signal / memo entries are emitted as BARE Perl values (not the
+  // `{value=>..., propName=>...}` hashref shape `ssrDefaultEntryToPerl`
+  // wraps declared-prop entries in). Under the merge-order flip
+  // (`buildChildRenderers`: `{ %$child_props, %extra, ... }`, extra applied
+  // LAST — see its docstring), a bare entry now wins over a same-named
+  // caller prop, same as it would over an un-mangled caller prop before the
+  // flip it lost to. This is NOT a regression to fix: `_derive_stash_from_
+  // defaults`'s non-hashref branch (`$extra{$name} = $d`, unconditional)
+  // and its hashref-with-no-`propName` branch (`else { $extra{$name} =
+  // $d->{value} }`) are BEHAVIORALLY IDENTICAL — both always use the
+  // static value, ignoring `$props` entirely — so wrapping these in
+  // `{value=>...}` would change nothing. A propName-less entry (signal /
+  // memo local) is BY DESIGN never sourced from props in ANY of the ported
+  // runtimes (see `ssr-defaults.ts`'s `deriveStashFromDefaults` docstring:
+  // "the caller cannot override them by construction") — the Jinja/Twig
+  // harnesses' own signal/memo entries (`{value: X}`, no `propName`) clobber
+  // a same-named caller prop the exact same way under their own extras-win
+  // merge. Mojolicious's bare-entry shape is a representation choice, not a
+  // semantic divergence from those adapters.
   for (const signal of ir.metadata.signals) {
     if (signal.envReader) continue // env signal is the request reader, not a stashed value (#2057)
     const value = evaluateSignalInit(signal.initialValue.trim(), undefined)
     entries.push(`${signal.getter} => ${value !== null ? toPerlLiteral(value) : 'undef'}`)
   }
-  const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
   for (const memo of ir.metadata.memos) {
     const entry = ssrDefaults[memo.name]
-    const value =
-      entry && typeof entry === 'object' && 'value' in entry ? entry.value : undefined
+    const value = entry ? entry.value : undefined
     entries.push(
       `${memo.name} => ${value !== undefined && value !== null ? toPerlLiteral(value) : 'undef'}`,
     )
@@ -503,16 +529,18 @@ function buildPerlProps(
   const explicitScope = typeof props?.__instanceId === 'string' ? props.__instanceId : 'test'
   entries.push(`scope_id => '${escapePerlSingleQuoted(explicitScope)}'`)
 
-  // Add props params with defaults (before signals, so signals can reference them)
+  // Add props params with defaults (before signals, so signals can reference
+  // them). Seeded through the shared `deriveStashFromDefaults` (the TS twin
+  // of the production `BarefootJS::_derive_stash_from_defaults` this harness
+  // ALSO calls at render time for child components) so an aliased
+  // destructured prop's CALLER-facing key (`propName`, e.g. `n` for
+  // `{ n: count }`) is honoured, not just the local template var name
+  // (#2524 SSR half). `props` is keyed by the caller-facing name, exactly
+  // what `propName` resolves against.
+  const rootSsrDefaults = extractSsrDefaults(ir.metadata) ?? {}
+  const derivedProps = deriveStashFromDefaults(rootSsrDefaults, props ?? {})
   for (const param of ir.metadata.propsParams) {
-    if (props && param.name in props) continue
-    if (param.defaultValue) {
-      const result = tryEvaluateSignalInit(param.defaultValue.trim(), props)
-      if (result.ok) {
-        entries.push(`${param.name} => ${toPerlLiteral(result.value)}`)
-        continue
-      }
-    }
+    if (param.isRest) continue
     // No default and no caller-supplied value: pass `undef` so the
     // Mojo::Template `vars => 1` auto-declaration fires. Without
     // this, references to an optional prop variable (`$label`,
@@ -523,7 +551,8 @@ function buildPerlProps(
     // Surfaces with #1443: lowering `[a, b].filter(Boolean).join(' ')`
     // emits a literal `$label` reference where the BF101 path used
     // to emit `''`, exposing this latent test-harness gap.
-    entries.push(`${param.name} => undef`)
+    const value = derivedProps[param.name]
+    entries.push(`${param.name} => ${value !== undefined && value !== null ? toPerlLiteral(value) : 'undef'}`)
   }
 
   // (#checkbox) SolidJS props-object pattern: `function Checkbox(props:
@@ -554,7 +583,11 @@ function buildPerlProps(
   // rather than silently dropping it into an unused `my $placeholder`. (#1467
   // Phase 2b — mirrors the Go harness fix in the sibling `test-render.ts`.)
   const restPropsName = ir.metadata.restPropsName
-  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.name))
+  // Caller-facing keys — an aliased destructured prop's DECLARED set for
+  // rest-bag routing must match what the caller actually sent (`n`), not
+  // the local binding (`count`), or the caller's own prop silently gets
+  // swept into the rest bag as an undeclared extra (#2524).
+  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.sourceName ?? p.name))
   const restBagEntries: Array<[string, unknown]> = []
   if (restPropsName && props) {
     for (const [key, value] of Object.entries(props)) {
@@ -579,10 +612,19 @@ function buildPerlProps(
     entries.push(`${restPropsName} => ${toPerlLiteral(Object.fromEntries(restBagEntries))}`)
   }
 
-  // Add user props
+  // Add user props. Skip a key that's already a declared param's LOCAL
+  // template var name — `derivedProps` above already resolved that var
+  // correctly (through `propName`, for an aliased prop); re-pushing the raw
+  // `props[key]` here would silently clobber it with an UNRELATED value
+  // whenever a caller happens to also pass a same-spelled-as-local-name prop
+  // that isn't this param's actual `propName` (#2524 — surfaced by the
+  // aliased-destructured-prop generated data points, which pass both `n`
+  // (the real propName) and an incidental `count` key).
+  const localParamNames = new Set(ir.metadata.propsParams.map(p => p.name))
   if (props) {
     for (const [key, value] of Object.entries(props)) {
       if (routedKeys.has(key)) continue
+      if (localParamNames.has(key)) continue
       if (value === null) {
         // An explicit-null prop must still DECLARE the template var —
         // `typeof null === 'object'` fails every branch below, so the key
@@ -639,10 +681,9 @@ function buildPerlProps(
   // computation. Mirror that here so the test harness doesn't diverge
   // from the plugin: hard-coding `0` masked memos with non-zero
   // initial values until #1423 added a fixture that exposed the gap.
-  const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
   for (const memo of ir.metadata.memos) {
-    const entry = ssrDefaults[memo.name]
-    const value = entry && typeof entry === 'object' && 'value' in entry ? entry.value : 0
+    const entry = rootSsrDefaults[memo.name]
+    const value = entry ? entry.value : 0
     entries.push(`${memo.name} => ${toPerlLiteral(value ?? 0)}`)
   }
 
@@ -700,6 +741,21 @@ function collectPropsObjectAccesses(ir: ComponentIR, propsObj: string): Set<stri
  */
 function perlSingleQuote(s: string): string {
   return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+}
+
+/**
+ * Serialise a single `SsrDefault` entry to a Perl hashref literal, VERBATIM
+ * — `value` / `propName` / `isRestProps` intact, exactly the shape
+ * `BarefootJS::_derive_stash_from_defaults` expects. Do NOT flatten to a
+ * bare `value` here: that was the #2524 SSR-half bug — a flattened entry
+ * has nothing left for the propName-aware resolution to read, so an aliased
+ * destructured prop's caller-facing key is silently dropped.
+ */
+function ssrDefaultEntryToPerl(d: SsrDefault): string {
+  const parts: string[] = [`value => ${toPerlLiteral(d.value)}`]
+  if (d.propName !== undefined) parts.push(`propName => ${perlSingleQuote(d.propName)}`)
+  if (d.isRestProps) parts.push(`isRestProps => 1`)
+  return `{${parts.join(', ')}}`
 }
 
 function toPerlLiteral(value: unknown): string {

--- a/packages/adapter-mojolicious/t/manifest_defaults.t
+++ b/packages/adapter-mojolicious/t/manifest_defaults.t
@@ -126,6 +126,37 @@ subtest 'plugin before_render — caller stash wins over manifest defaults' => s
     is $c->stash('count'), 10, 'caller-supplied stash value preserved';
 };
 
+subtest 'plugin before_render — resolves an aliased destructured prop\'s CALLER-facing key (#2524)' => sub {
+    # `{ n: count }` — the manifest entry is keyed by the LOCAL binding
+    # (`count`) but carries `propName: 'n'`, the CALLER-facing key. A route
+    # handler stashes the caller-facing prop (`$c->stash(n => 7)`, as it
+    # would set any other prop) before rendering; the hook must resolve it
+    # onto the template's `count` var, not just fall back to the static
+    # default. Before this fix, `$d->{value}` was read directly (ignoring
+    # `propName`), so a caller-supplied `n` was silently discarded.
+    my $dir = tempdir;
+    my $manifest_file = $dir->child('manifest.json');
+    $manifest_file->spew(encode_json({
+        Badge => {
+            markedTemplate => 'templates/Badge.html.ep',
+            ssrDefaults    => {
+                count => { propName => 'n', value => undef },
+                text  => { propName => 'text', value => undef },
+            },
+        },
+    }));
+
+    my $app = Mojolicious->new;
+    $app->plugin('BarefootJS' => { manifest_path => "$manifest_file" });
+    my $c = $app->build_controller;
+
+    $c->stash(n => 7, text => 'hello');
+    $app->plugins->emit_hook(before_render => $c, { template => 'Badge' });
+
+    is $c->stash('count'), 7,       'caller-facing `n` resolved onto the local `count` var';
+    is $c->stash('text'),  'hello', 'un-aliased prop still resolves';
+};
+
 subtest 'plugin before_render — seeds searchParams from the request query (#1922)' => sub {
     my $dir = tempdir;
     my $manifest_file = $dir->child('manifest.json');

--- a/packages/adapter-php/src/BarefootJS.php
+++ b/packages/adapter-php/src/BarefootJS.php
@@ -511,7 +511,7 @@ final class BarefootJS
                 if ($signalInit !== null) {
                     $extra = $signalInit($props);
                 } elseif ($manifestDefaults !== null) {
-                    $extra = self::deriveStashFromDefaults($manifestDefaults, $props);
+                    $extra = self::deriveStashFromDefaults($manifestDefaults, $props, $parent->backend);
                 }
 
                 $html = $parent->backend->render_named($templateName, $childBf, array_merge($props, $extra));
@@ -554,25 +554,64 @@ final class BarefootJS
     }
 
     /** Derive template-stash kvs from a manifest entry's `ssrDefaults`
-     * section. Each entry shape: `{value, propName, isRestProps}`. */
-    private static function deriveStashFromDefaults($defaults, array $props): array
+     * section. Each entry shape: `{value, propName, isRestProps}`. For
+     * `isRestProps`, the rest bag passes through unchanged (or the static
+     * `{}` if the caller didn't supply one). For ordinary entries the
+     * caller's `$props[propName]` wins when present and non-null, otherwise
+     * the static `value` does. `propName`-less entries (signal / memo
+     * locals) always use the static value.
+     *
+     * `$props` arrives ALREADY keyword-mangled -- `render_child` above (and
+     * every generated child-renderer closure calling this method directly)
+     * mangles every prop key via the engine's `Backend::ident()` before
+     * handing the props array in -- but `$defaults`' own keys and each
+     * entry's `propName` are the RAW (un-mangled) spellings `extractSsrDefaults`
+     * emitted. `$backend`, when supplied, mangles both the output key and
+     * the `propName` lookup through the SAME `ident()` the caller's props
+     * were mangled with, so a reserved-word prop (Twig's `for`/`filter`,
+     * Blade's `bf`, ...) resolves against the mangled `$props` map instead
+     * of silently missing it and falling back to the static default even
+     * when the caller DID supply a value (#2524 follow-up). `$backend` is
+     * optional (defaults to no mangling) only because a caller with no
+     * engine identity to mangle against -- none exist in this codebase
+     * today, but the signature stays permissive for a hand-rolled caller
+     * outside it -- has nothing meaningful to pass; every real caller
+     * (production `register_components_from_manifest` below and the
+     * Twig/Blade `test-render.ts` harnesses) has a `$backend` in scope and
+     * MUST pass it.
+     *
+     * Public (not `private`): mirrors the Ruby port's
+     * `derive_vars_from_defaults` (`packages/adapter-erb/lib/barefoot_js.rb`)
+     * being deliberately public — `register_components_from_manifest` above
+     * uses it for the `ui/*` registry path, but a caller composing a
+     * template render by hand (e.g. this package's own conformance test
+     * harnesses, `packages/adapter-blade` / `packages/adapter-twig`'s
+     * `test-render.ts`, which register child renderers directly rather than
+     * through a manifest) needs the exact same ssrDefaults-seeding logic,
+     * not a hand-flattened re-derivation (#2157 lesson, restated at
+     * `packages/adapter-erb/src/test-render.ts:276-287` — a harness-local
+     * shortcut is exactly what let that class of bug hide). */
+    public static function deriveStashFromDefaults($defaults, array $props, $backend = null): array
     {
+        $ident = ($backend !== null) ? static fn(string $n): string => $backend->ident($n) : static fn(string $n): string => $n;
         $extra = [];
         foreach (self::toAssoc($defaults) as $name => $d) {
+            $key = $ident((string) $name);
             $dArr = ($d instanceof \stdClass || is_array($d)) ? self::toAssoc($d) : null;
             if ($dArr === null) {
-                $extra[$name] = $d;
+                $extra[$key] = $d;
                 continue;
             }
             if (!empty($dArr['isRestProps'])) {
-                $extra[$name] = array_key_exists($name, $props) ? $props[$name] : ($dArr['value'] ?? null);
+                $extra[$key] = array_key_exists($key, $props) ? $props[$key] : ($dArr['value'] ?? null);
                 continue;
             }
             $propName = $dArr['propName'] ?? null;
-            if ($propName !== null && array_key_exists($propName, $props) && $props[$propName] !== null) {
-                $extra[$name] = $props[$propName];
+            $mangledPropName = $propName !== null ? $ident((string) $propName) : null;
+            if ($mangledPropName !== null && array_key_exists($mangledPropName, $props) && $props[$mangledPropName] !== null) {
+                $extra[$key] = $props[$mangledPropName];
             } else {
-                $extra[$name] = $dArr['value'] ?? null;
+                $extra[$key] = $dArr['value'] ?? null;
             }
         }
         return $extra;

--- a/packages/adapter-rust/runtime/src/bin/bf-render.rs
+++ b/packages/adapter-rust/runtime/src/bin/bf-render.rs
@@ -12,7 +12,7 @@
 
 use barefootjs::backend_minijinja;
 use barefootjs::num::JsValue;
-use barefootjs::runtime::{js_to_mj, BfInstance, ChildRendererSpec, RenderSession};
+use barefootjs::runtime::{BfInstance, ChildRendererSpec, RenderSession};
 use barefootjs::search_params::SearchParams;
 use minijinja::value::Value as MjValue;
 use serde::Deserialize;
@@ -96,11 +96,12 @@ fn run(payload_path: &str) -> Result<String, String> {
             ChildRendererSpec {
                 component_name: child.name.clone(),
                 template: child.template.clone(),
-                // Converted from JSON to `Value` HERE, at registration time
-                // -- `render_child` keeps props as `Value` end-to-end from
-                // this point on (see `ChildRendererSpec::ssr_defaults`'s
-                // docstring).
-                ssr_defaults: js_to_mj(&decode_value(&child.ssr_defaults)),
+                // Kept RAW (`JsValue`, the FULL `{value, propName?,
+                // isRestProps?}` shape) -- `render_child` resolves this
+                // PER-CALL against the real caller props via
+                // `derive_stash_from_defaults` (see `ChildRendererSpec::
+                // ssr_defaults`'s docstring; #2524).
+                ssr_defaults: decode_value(&child.ssr_defaults),
                 rest_props_name: child.rest_props_name.clone(),
                 param_names: child.param_names.clone(),
             },

--- a/packages/adapter-rust/runtime/src/manifest.rs
+++ b/packages/adapter-rust/runtime/src/manifest.rs
@@ -33,22 +33,34 @@
 //! REGISTER a [`ChildRendererSpec`] per entry: [`crate::runtime::BfInstance::
 //! render_child`] already implements that whole contract generically for
 //! every registered child (scope-id chaining, `_bf_slot`/`key` popping,
-//! rest-bag routing, ssrDefaults-then-caller-props merge -- see its
-//! docstring), because it was built to serve `bf-render`'s payload-driven
-//! children the same way. Registering a manifest entry is therefore just:
-//! derive the registry key + template name from `markedTemplate`, flatten
-//! `ssrDefaults` to its static fallback values via
-//! [`derive_stash_from_defaults`] (called with EMPTY props, since the
-//! caller-props override Python's closure applies per-call is already
-//! applied generically, once, inside `render_child`), and derive
-//! `rest_props_name`/`param_names` from which `ssrDefaults` entries carry
-//! `isRestProps`/`propName` (see `packages/jsx/src/ssr-defaults.ts`'s
-//! `extractSsrDefaults`, which only ever sets `propName` to the entry's OWN
-//! key -- so this static-then-override merge order is exactly equivalent
-//! to Python's per-call `props.get(propName, value)` derivation).
+//! rest-bag routing, `derive_stash_from_defaults`-then-caller-props merge --
+//! see its docstring), because it was built to serve `bf-render`'s
+//! payload-driven children the same way. Registering a manifest entry is
+//! therefore just: derive the registry key + template name from
+//! `markedTemplate`, keep `ssrDefaults` RAW (the FULL `{value, propName?,
+//! isRestProps?}` shape, with any STATIC `signal_init` override applied as
+//! a bare replacement value), and derive `rest_props_name`/`param_names`
+//! from which `ssrDefaults` entries carry `isRestProps`/`propName`.
+//!
+//! `ssrDefaults` is stored RAW, not flattened, and resolved PER-CALL inside
+//! `render_child` against the caller's ACTUAL props (#2524). An earlier
+//! version of this function flattened via [`derive_stash_from_defaults`]
+//! called with an EMPTY props document AT REGISTRATION TIME -- on the
+//! (false) assumption that every `propName` equals its own entry's key, so
+//! resolving early against no props and resolving later against the real
+//! caller props would agree. That assumption breaks for an ALIASED
+//! destructured prop (`{ n: count }`, see `packages/jsx/src/ssr-defaults.ts`'s
+//! `extractSsrDefaults`): the entry's own key is the LOCAL binding
+//! (`count`), but `propName` is the CALLER-facing name (`n`) -- resolving
+//! against an empty props document can only ever produce the static
+//! fallback, silently discarding whatever the caller actually passed as
+//! `n`. `param_names` has the matching fix: it carries the CALLER-facing
+//! `propName`, not the entry's own (local) key, since `render_child`'s
+//! rest-bag "keep" set compares against child props keyed by whatever the
+//! calling template passed.
 
 use crate::num::JsValue;
-use crate::runtime::{js_to_mj, ChildRendererSpec, RenderSession};
+use crate::runtime::{ChildRendererSpec, RenderSession};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
@@ -84,12 +96,17 @@ pub fn to_template_name(component_name: &str) -> String {
 ///     rest-props bag the caller may have already assembled), else the
 ///     static `value` fallback (normally `{}`).
 ///   * `propName` set -- prefer `props[propName]` when present AND not
-///     `null`/`undefined`, else the static `value` fallback. Every
-///     `propName` the TS extractor emits equals its own entry's key (see
-///     `extractSsrDefaults`), so this always reads back the SAME key it
-///     writes -- a caller with no relevant props (this module's own
-///     registration path, below) can pass an empty `props` document to get
-///     pure static fallbacks.
+///     `null`/`undefined`, else the static `value` fallback. For an
+///     UN-aliased prop `propName` equals the entry's own key; for an
+///     ALIASED destructured prop (`{ n: count }`, see
+///     `packages/jsx/src/ssr-defaults.ts`'s `extractSsrDefaults`) the
+///     entry's key is the LOCAL binding (`count`) but `propName` is the
+///     CALLER-facing name (`n`) -- callers MUST pass the real caller props
+///     (not an empty document) for this branch to do anything useful (see
+///     `render_child`, which calls this per-call against the actual caller
+///     props; this module's own registration path keeps `ssrDefaults` RAW
+///     and defers to that per-call resolution rather than resolving early
+///     against an empty `props` document -- #2524).
 ///   * neither set -- the static `value` (a signal/memo's default,
 ///     internal to the component, never sourced from `props`).
 pub fn derive_stash_from_defaults(defaults: &JsValue, props: &JsValue) -> JsValue {
@@ -204,17 +221,49 @@ pub fn register_components_from_manifest(
         let template_name = strip_manifest_template_path(marked);
         let registry_key = to_template_name(&component_name);
 
-        let empty_props = JsValue::Object(BTreeMap::new());
         let ssr_defaults = entry_obj.get("ssrDefaults").cloned().unwrap_or_else(|| JsValue::Object(BTreeMap::new()));
-        let mut defaults = derive_stash_from_defaults(&ssr_defaults, &empty_props);
+
+        // Apply any STATIC `signal_init` overrides by REPLACING the
+        // overridden key's entry with the bare override value --
+        // `resolve_child_vars`'s non-object-entry branch (`runtime.rs`) uses
+        // a bare value as-is, unconditionally (ignoring caller props), so an
+        // overridden key now WINS over a same-named caller prop. This is a
+        // DELIBERATE FLIP from the prior contract, not a preservation of it:
+        // previously this function flattened `ssr_defaults` against an EMPTY
+        // props document at registration time and `render_child` applied the
+        // caller's props LAST (`vars = defaults; vars.extend(props)`), so a
+        // caller prop always beat a `signal_init` override. Now
+        // `render_child` applies the RESOLVED extras last (`vars = props;
+        // vars.extend(extra)`), so an override -- and any `propName` that
+        // resolves against the real caller props -- wins instead. This
+        // matches the Python/PHP/Perl ports, where `signal_init_fn`'s
+        // returned `extra` (or the propName-resolved `_derive_stash_from_
+        // defaults` output) is merged LAST over `props`
+        // (`{**props, **extra}` / `props.merge(extra)`) rather than first.
+        // Resolution against the REAL caller props now happens PER-CALL,
+        // inside `render_child`, against these RAW (un-flattened) defaults
+        // -- registering with an EMPTY props document at THIS point (the
+        // pre-#2524-fix shape) is exactly the production bug: it flattened
+        // via `derive_stash_from_defaults` before any caller was known,
+        // discarding `propName` so an aliased destructured prop's
+        // CALLER-facing key could never later resolve.
+        let mut defaults_map = match &ssr_defaults {
+            JsValue::Object(m) => m.clone(),
+            _ => BTreeMap::new(),
+        };
         if let Some(overrides) = signal_init.get(&registry_key) {
-            if let (JsValue::Object(base), Some(over)) = (&mut defaults, overrides.as_object()) {
+            if let Some(over) = overrides.as_object() {
                 for (k, v) in over {
-                    base.insert(k.clone(), v.clone());
+                    defaults_map.insert(k.clone(), v.clone());
                 }
             }
         }
+        let defaults = JsValue::Object(defaults_map);
 
+        // `param_names` carries the CALLER-facing name (`propName`), not the
+        // entry's own (local) key -- `render_child`'s rest-bag "keep" set
+        // compares against child props keyed by whatever the calling
+        // template passed, not the child's local binding (#2524).
         let (rest_props_name, param_names) = match ssr_defaults.as_object() {
             Some(m) => {
                 let mut rest = None;
@@ -223,8 +272,8 @@ pub fn register_components_from_manifest(
                     let Some(dm) = d.as_object() else { continue };
                     if matches!(dm.get("isRestProps"), Some(JsValue::Bool(true))) {
                         rest = Some(name.clone());
-                    } else if dm.contains_key("propName") {
-                        params.push(name.clone());
+                    } else if let Some(prop_name) = dm.get("propName").and_then(|v| v.as_str()) {
+                        params.push(prop_name.to_string());
                     }
                 }
                 (rest, params)
@@ -237,7 +286,7 @@ pub fn register_components_from_manifest(
             ChildRendererSpec {
                 component_name: template_name.clone(),
                 template: template_name,
-                ssr_defaults: js_to_mj(&defaults),
+                ssr_defaults: defaults,
                 rest_props_name,
                 param_names,
             },

--- a/packages/adapter-rust/runtime/src/runtime.rs
+++ b/packages/adapter-rust/runtime/src/runtime.rs
@@ -796,13 +796,19 @@ pub struct ChildRendererSpec {
     pub component_name: String,
     /// snake_case `.j2` template base name.
     pub template: String,
-    /// Static ssrDefaults values (already flattened to plain values, NOT
-    /// the `{value, propName, isRestProps}` wrapper shape -- see the module
-    /// docstring's note on why `_derive_stash_from_defaults` isn't ported).
-    /// Converted from JSON to `Value` at REGISTRATION time (`bf-render.rs`)
-    /// -- see `render_child`'s docstring on why child props stay `Value`
-    /// end-to-end rather than round-tripping through `JsValue`.
-    pub ssr_defaults: MjValue,
+    /// Static ssrDefaults, RAW -- the FULL `{value, propName?, isRestProps?}`
+    /// wrapper shape (or a bare value for a propName-less entry), exactly as
+    /// `extractSsrDefaults` emits it. Resolved PER-CALL against the real
+    /// caller props by [`crate::manifest::derive_stash_from_defaults`] inside
+    /// `render_child` below -- NOT flattened at registration time (that was
+    /// the #2524 production bug: flattening early, before the caller's props
+    /// are known, discards `propName` and so can never resolve an aliased
+    /// destructured prop's CALLER-facing key onto its local template var).
+    /// Kept as `JsValue` (not `MjValue`) because `derive_stash_from_defaults`
+    /// operates in the JSON-shaped `JsValue` domain; converted to `MjValue`
+    /// only for the resolved OUTPUT (see `render_child`'s docstring on why
+    /// child props otherwise stay `Value` end-to-end).
+    pub ssr_defaults: JsValue,
     pub rest_props_name: Option<String>,
     pub param_names: Vec<String>,
 }
@@ -1115,16 +1121,88 @@ impl BfInstance {
             data_key,
         };
 
-        // Seed template vars: static ssrDefaults first, caller's props win
-        // -- mirrors buildChildRenderers' `_vars = {**_defaults, **child_props}`.
-        let mut vars: BTreeMap<String, MjValue> =
-            mj_map_to_btreemap(&spec.ssr_defaults).into_iter().map(|(k, v)| (mangle_ident(&k), v)).collect();
-        vars.extend(map);
+        // Seed template vars through `resolve_child_vars`, resolving each
+        // entry's `propName` against the REAL (already-mangled) caller props
+        // -- mirrors the Ruby/Python/PHP/Perl runtime ports'
+        // `derive_vars_from_defaults` / `_derive_stash_from_defaults` (#2524
+        // SSR half: a flat `{**_defaults, **child_props}` merge never
+        // resolves an aliased destructured prop's CALLER-facing key (`n`)
+        // onto its local template var (`count`) -- `spec.ssr_defaults` is
+        // the FULL `{value, propName?, isRestProps?}` shape, not flattened,
+        // so this resolution has something to read). Caller props still win
+        // for any key resolution did NOT touch (an extraneous, undeclared
+        // prop); `extra` wins for the keys it DOES resolve -- the same
+        // `props.merge(extra)` order every other language port uses.
+        //
+        // Deliberately NOT `crate::manifest::derive_stash_from_defaults`
+        // (the `JsValue`-only free function): that would round-trip every
+        // caller prop through `mj_to_js`/`js_to_mj`, which has no safe/
+        // unsafe distinction and silently strips a SAFE `Value`'s flag (a
+        // JSX children capture, `bf.string(...)`'d markup) -- exactly the
+        // "children lost their safe flag" bug this method's docstring
+        // above warns about. `resolve_child_vars` stays in the `MjValue`
+        // domain for every caller-supplied value; only the STATIC fallback
+        // (`d.value`, from the manifest/generated payload, never JSX
+        // content) goes through `js_to_mj`.
+        let extra = resolve_child_vars(&spec.ssr_defaults, &map);
+        let mut vars: BTreeMap<String, MjValue> = map;
+        vars.extend(extra);
 
         let rendered = backend_minijinja::render_named_from_state_values(state, &spec.template, child.as_mj_value(), vars)?;
         // chomp: remove at most one trailing newline.
         Ok(rendered.strip_suffix('\n').map(str::to_string).unwrap_or(rendered))
     }
+}
+
+/// `MjValue`-domain twin of [`crate::manifest::derive_stash_from_defaults`],
+/// used by [`BfInstance::render_child`] so a caller-supplied prop value --
+/// which may be a SAFE `Value` (a JSX children capture, `bf.string(...)`'d
+/// markup) -- is used AS-IS when `propName` resolves it, never round-tripped
+/// through the JSON-shaped `JsValue` domain (which has no safe/unsafe
+/// distinction and would silently strip that flag, double-escaping the
+/// child's HTML -- see `render_child`'s docstring). `ssr_defaults` is the
+/// RAW (un-flattened) `{value, propName?, isRestProps?}` shape; `props` is
+/// the caller's ALREADY-mangled prop map. Only the STATIC fallback
+/// (`d.value`, from the manifest/generated payload -- JSX prop values are
+/// never statically evaluable, so they're always `null` there) goes through
+/// [`js_to_mj`]. Returns keys already mangled (matching `props`'s own
+/// convention), ready to merge/overwrite directly.
+fn resolve_child_vars(ssr_defaults: &JsValue, props: &BTreeMap<String, MjValue>) -> BTreeMap<String, MjValue> {
+    let mut extra = BTreeMap::new();
+    let defaults_map = match ssr_defaults.as_object() {
+        Some(m) => m,
+        None => return extra,
+    };
+    for (name, d) in defaults_map {
+        let key = mangle_ident(name);
+        let dm = match d.as_object() {
+            Some(m) => m,
+            None => {
+                // Bare (non-object) entry -- used as-is, mirrors every other
+                // port's `ref($d) eq 'HASH'` / `isinstance(d, dict)` guard.
+                extra.insert(key, js_to_mj(d));
+                continue;
+            }
+        };
+        let fallback = || js_to_mj(&dm.get("value").cloned().unwrap_or(JsValue::Null));
+        if matches!(dm.get("isRestProps"), Some(JsValue::Bool(true))) {
+            // The rest bag is already assembled (as a real `Value`, member
+            // safe flags intact) under its own mangled key by the rest-bag
+            // routing above -- prefer that live value over the static
+            // fallback.
+            let v = props.get(&key).cloned().unwrap_or_else(fallback);
+            extra.insert(key, v);
+            continue;
+        }
+        let prop_name = dm.get("propName").and_then(|v| v.as_str());
+        let from_props = prop_name.and_then(|pn| props.get(&mangle_ident(pn)));
+        let v = match from_props {
+            Some(pv) if !matches!(pv.kind(), ValueKind::None | ValueKind::Undefined) => pv.clone(),
+            _ => fallback(),
+        };
+        extra.insert(key, v);
+    }
+    extra
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/adapter-rust/runtime/tests/manifest.rs
+++ b/packages/adapter-rust/runtime/tests/manifest.rs
@@ -146,6 +146,41 @@ fn register_from_flat_manifest_applies_signal_init_override() {
     assert_eq!(html.trim(), "9");
 }
 
+/// A `signal_init` override wins over a CALLER-SUPPLIED prop of the same
+/// name, not just the manifest's static default (#2524 precedence flip --
+/// see `manifest.rs`'s registration-site comment). Pre-#2524 this function
+/// flattened `ssr_defaults` at registration time and `render_child` applied
+/// the caller's props LAST, so a caller-supplied `level` would have beaten
+/// the override; now `render_child` applies the resolved `signal_init`
+/// override LAST, matching the Python/PHP/Perl ports' `{**props, **extra}`
+/// / `props.merge(extra)` merge order.
+#[test]
+fn register_from_flat_manifest_override_wins_over_caller_prop() {
+    let dir = TempDir::new("override-vs-caller");
+    dir.write("root.j2", "{{ bf.render_child('widget', {'level': 3}) | safe }}");
+    dir.write("Widget.j2", "{{ bf.string(level) }}");
+
+    let manifest = obj(vec![(
+        "Widget",
+        obj(vec![
+            ("markedTemplate", JsValue::String("templates/Widget.j2".into())),
+            ("ssrDefaults", obj(vec![("level", obj(vec![("value", JsValue::Number(1.0))]))])),
+        ]),
+    )]);
+
+    let mut signal_init = HashMap::new();
+    signal_init.insert("widget".to_string(), obj(vec![("level", JsValue::Number(9.0))]));
+
+    let session = RenderSession::new();
+    register_components_from_manifest(&session, &manifest, &signal_init);
+
+    let env = backend_minijinja::build_environment(&dir.0);
+    let root = BfInstance::root(Arc::clone(&session), "test".to_string());
+    let html = backend_minijinja::render_named(&env, "root", root.as_mj_value(), &JsValue::Object(BTreeMap::new())).unwrap();
+    // The caller passed `level: 3`, but the `signal_init` override (9) wins.
+    assert_eq!(html.trim(), "9");
+}
+
 /// `ui/<name>/index`-shaped entries (the component-library registry
 /// convention Python's port targets) still register correctly.
 #[test]

--- a/packages/adapter-rust/runtime/tests/render_child.rs
+++ b/packages/adapter-rust/runtime/tests/render_child.rs
@@ -14,9 +14,8 @@
 //! additionally exercises the actual `Object::call_method` dispatch path.
 
 use barefootjs::num::JsValue;
-use barefootjs::runtime::{js_to_mj, ChildRendererSpec};
+use barefootjs::runtime::ChildRendererSpec;
 use barefootjs::{backend_minijinja, BfInstance, RenderSession};
-use minijinja::value::Value as MjValue;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -46,10 +45,11 @@ fn no_defaults() -> JsValue {
     JsValue::Object(BTreeMap::new())
 }
 
-/// `ChildRendererSpec::ssr_defaults`, which is `minijinja::Value` (props
-/// stay `Value` end-to-end through `render_child` -- see its docstring).
-fn no_ssr_defaults() -> MjValue {
-    MjValue::from(BTreeMap::<String, MjValue>::new())
+/// `ChildRendererSpec::ssr_defaults`, which is a RAW `JsValue` (the FULL
+/// `{value, propName?, isRestProps?}` shape, resolved per-call against the
+/// real caller props inside `render_child` -- see its docstring).
+fn no_ssr_defaults() -> JsValue {
+    JsValue::Object(BTreeMap::new())
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn rest_bag_routing_and_ssr_defaults_merge() {
         ChildRendererSpec {
             component_name: "Card".to_string(),
             template: "card".to_string(),
-            ssr_defaults: js_to_mj(&JsValue::Object(defaults)),
+            ssr_defaults: JsValue::Object(defaults),
             rest_props_name: Some("rest".to_string()),
             param_names: vec!["title".to_string()],
         },
@@ -136,6 +136,40 @@ fn rest_bag_routing_and_ssr_defaults_merge() {
     let root = BfInstance::root(session, "Root_test");
     let out = backend_minijinja::render_entry(&env, "root", root.as_mj_value(), &no_defaults(), &[]).unwrap();
     assert_eq!(out, "Hi|Sub|E|dark");
+}
+
+#[test]
+fn aliased_prop_resolves_callers_facing_key_onto_local_template_var() {
+    // #2524 (SSR half): a renaming destructure (`{ n: count }`) keys the
+    // ssrDefaults entry by the LOCAL binding (`count`) but its `propName`
+    // is the CALLER-facing key (`n`) -- the call site passes `n` (it has no
+    // visibility into how the child renames it internally), so
+    // `render_child` must resolve `n` onto the child template's `count`,
+    // not leave `count` at its static (`null`) fallback.
+    let dir = TempDir::new("aliased");
+    dir.write("root.j2", "{{ bf.render_child('badge', {'n': 7}) }}");
+    dir.write("badge.j2", "{{ count }}");
+
+    let env = backend_minijinja::build_environment(&dir.0);
+    let session = RenderSession::new();
+    let mut count_entry = BTreeMap::new();
+    count_entry.insert("value".to_string(), JsValue::Null);
+    count_entry.insert("propName".to_string(), JsValue::from("n"));
+    let mut defaults = BTreeMap::new();
+    defaults.insert("count".to_string(), JsValue::Object(count_entry));
+    session.register_child_renderer(
+        "badge".to_string(),
+        ChildRendererSpec {
+            component_name: "Badge".to_string(),
+            template: "badge".to_string(),
+            ssr_defaults: JsValue::Object(defaults),
+            rest_props_name: None,
+            param_names: vec!["n".to_string()],
+        },
+    );
+    let root = BfInstance::root(session, "Root_test");
+    let out = backend_minijinja::render_entry(&env, "root", root.as_mj_value(), &no_defaults(), &[]).unwrap();
+    assert_eq!(out, "7");
 }
 
 #[test]

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -22,20 +22,4 @@ export const renderDivergences: RenderDivergences = {
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
-  // hand-authored to the CORRECT output while the emission bug lived in
-  // the shared compiler layer — every adapter, including the Hono
-  // reference, used to emit the broken form. That shared-layer defect
-  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
-  // Hono reference like any other fixture. The remaining gap is
-  // per-template-adapter — this adapter still keys its template vars /
-  // ssr-defaults / props bridge off the local binding instead of
-  // `sourceName ?? name` — tracked by #2524 (the 7 silent template
-  // adapters). Graduate by applying the same `sourceName ?? name` fix to
-  // this adapter's emission path and deleting these lines (and the
-  // matching hono `skipJsx` entries, already gone).
-  'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)',
-  'composite-row-child-aliased-prop':
-    'same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)',
 }

--- a/packages/adapter-rust/src/test-render.ts
+++ b/packages/adapter-rust/src/test-render.ts
@@ -28,8 +28,8 @@
  * that closes that gap.
  */
 
-import { compileJSX, extractSsrDefaults, importsSearchParams, evaluateSignalInit } from '@barefootjs/jsx'
-import type { ComponentIR } from '@barefootjs/jsx'
+import { compileJSX, extractSsrDefaults, deriveStashFromDefaults, importsSearchParams, evaluateSignalInit } from '@barefootjs/jsx'
+import type { ComponentIR, SsrDefault } from '@barefootjs/jsx'
 import { mkdir, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
@@ -362,24 +362,30 @@ function collectImportedComponentNames(ir: ComponentIR): string[] {
  * design doc; see `runtime/src/backend_minijinja.rs`'s `render_child` for
  * the Rust-side closure — the near-verbatim structural counterpart of
  * adapter-jinja's `buildChildRenderers`, which instead emitted Python
- * closure SOURCE per child). `ssr_defaults` mirrors `ssrDefaultsToPy`:
- * only the static fallback `value` of each `{ value, propName?,
- * isRestProps? }` ssrDefaults entry is needed — the child renderer's
- * caller props always win over it.
+ * closure SOURCE per child). `ssr_defaults` is sent VERBATIM — `value` /
+ * `propName` / `isRestProps` intact — so the Rust runtime's
+ * `derive_stash_from_defaults` (called per-call, inside `render_child`,
+ * against the REAL child props) can resolve an aliased destructured prop's
+ * CALLER-facing key (`n`) onto its local template var (`count`). Sending
+ * only the flattened static `value` here was the #2524 SSR-half bug — it
+ * left nothing for that resolution to read. `param_names` carries the
+ * CALLER-facing name (`sourceName ?? name`) per prop — `render_child`'s
+ * rest-bag "keep" set compares against child props keyed by whatever the
+ * calling template passed, not the child's local binding.
  */
 function buildChildrenPayload(
   childTemplates: Map<string, { template: string; ir: ComponentIR }>,
 ): Array<{
   name: string
   template: string
-  ssr_defaults: Record<string, unknown>
+  ssr_defaults: Record<string, SsrDefault>
   rest_props_name: string | null
   param_names: string[]
 }> {
   const out: Array<{
     name: string
     template: string
-    ssr_defaults: Record<string, unknown>
+    ssr_defaults: Record<string, SsrDefault>
     rest_props_name: string | null
     param_names: string[]
   }> = []
@@ -388,25 +394,10 @@ function buildChildrenPayload(
     out.push({
       name: componentName,
       template: toSnakeCase(componentName),
-      ssr_defaults: ssrDefaultsToVars(ssrDefaults),
+      ssr_defaults: ssrDefaults,
       rest_props_name: childIR.metadata.restPropsName ?? null,
-      param_names: (childIR.metadata.propsParams ?? []).map(p => p.name),
+      param_names: (childIR.metadata.propsParams ?? []).map(p => p.sourceName ?? p.name),
     })
-  }
-  return out
-}
-
-/** Reduce an ssrDefaults map to its static fallback values (plain JS object). */
-function ssrDefaultsToVars(defaults: Record<string, unknown>): Record<string, unknown> {
-  const out: Record<string, unknown> = {}
-  for (const [name, d] of Object.entries(defaults)) {
-    // ssrDefaults entries are `{ value, propName?, isRestProps? }` or a
-    // bare value. The child renderer's caller props win, so we only need
-    // the static fallback `value` here.
-    out[name] =
-      d && typeof d === 'object' && 'value' in (d as Record<string, unknown>)
-        ? (d as Record<string, unknown>).value
-        : d
   }
   return out
 }
@@ -445,24 +436,31 @@ function buildVars(
   const vars: Record<string, unknown> = {}
 
   // Prop params with defaults (before signals, so signals can reference them).
+  // Seeded through the shared `deriveStashFromDefaults` (the TS twin of the
+  // production `derive_stash_from_defaults` the Rust runtime calls at
+  // render time for child components — see `render_child` in
+  // `runtime/src/runtime.rs`) so an aliased destructured prop's
+  // CALLER-facing key (`propName`, e.g. `n` for `{ n: count }`) is
+  // honoured, not just the local template var name (#2524 SSR half).
+  // `props` is keyed by the caller-facing name, exactly what `propName`
+  // resolves against.
+  const rootSsrDefaults = extractSsrDefaults(ir.metadata) ?? {}
+  const derivedProps = deriveStashFromDefaults(rootSsrDefaults, props ?? {})
   for (const param of ir.metadata.propsParams) {
-    if (props && param.name in props) continue
-    if (param.defaultValue) {
-      const value = evaluateSignalInit(param.defaultValue.trim(), props)
-      if (value !== null) {
-        vars[param.name] = value
-        continue
-      }
-    }
+    if (param.isRest) continue
     // No default + no caller value: pass `null` (Rust's `None`/minijinja
     // Undefined) so a bare reference to an optional prop doesn't fault
     // before its falsy branch elides.
-    vars[param.name] = null
+    vars[param.name] = derivedProps[param.name] ?? null
   }
 
   // Route undeclared props into the rest bag (`bf.spread_attrs($<rest>)`).
   const restPropsName = ir.metadata.restPropsName
-  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.name))
+  // Caller-facing keys — an aliased destructured prop's DECLARED set for
+  // rest-bag routing must match what the caller actually sent (`n`), not
+  // the local binding (`count`), or the caller's own prop silently gets
+  // swept into the rest bag as an undeclared extra (#2524).
+  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.sourceName ?? p.name))
   const restBagEntries: Array<[string, unknown]> = []
   if (restPropsName && props) {
     for (const [key, value] of Object.entries(props)) {
@@ -477,11 +475,20 @@ function buildVars(
     vars[restPropsName] = Object.fromEntries(restBagEntries)
   }
 
-  // User props.
+  // User props. Skip a key that's already a declared param's LOCAL template
+  // var name — `derivedProps` above already resolved that var correctly
+  // (through `propName`, for an aliased prop); re-assigning the raw
+  // `props[key]` here would silently clobber it with an UNRELATED value
+  // whenever a caller happens to also pass a same-spelled-as-local-name prop
+  // that isn't this param's actual `propName` (#2524 — surfaced by the
+  // aliased-destructured-prop generated data points, which pass both `n`
+  // (the real propName) and an incidental `count` key).
+  const localParamNames = new Set(ir.metadata.propsParams.map(p => p.name))
   if (props) {
     for (const [key, value] of Object.entries(props)) {
       if (key.startsWith('__')) continue
       if (routedKeys.has(key)) continue
+      if (localParamNames.has(key)) continue
       if (
         typeof value === 'string' ||
         typeof value === 'number' ||
@@ -507,11 +514,9 @@ function buildVars(
 
   // Memo values seeded from the statically-evaluated ssrDefaults, same
   // as the production plugin's before_render hook.
-  const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
   for (const memo of ir.metadata.memos) {
-    const entry = ssrDefaults[memo.name]
-    const value = entry && typeof entry === 'object' && 'value' in entry ? entry.value : 0
-    vars[memo.name] = value ?? 0
+    const entry = rootSsrDefaults[memo.name]
+    vars[memo.name] = entry ? (entry.value ?? 0) : 0
   }
 
   return vars

--- a/packages/adapter-tests/fixtures/aliased-destructured-prop.ts
+++ b/packages/adapter-tests/fixtures/aliased-destructured-prop.ts
@@ -10,11 +10,11 @@ import { createFixture } from '../src/types'
  * `count` property off a props object shaped `{ text, n }` → always
  * `undefined`, `s1` rendered empty) — FIXED, Hono now emits
  * `{ text, n: count }` and this fixture is no longer skipped for it. The
- * template-string adapters still key `ssrDefaults` / template vars as
- * `count` so props seeding misses; Go's Input struct field is `Count`
+ * template-string adapters used to key `ssrDefaults` / template vars as
+ * `count` so props seeding missed; Go's Input struct field is `Count`
  * `json:"count"`, so the caller-side struct literal keyed by the real
  * prop name fails `go run` outright (unknown field N); the shared client
- * JS reads `_p.count` too. All silent except Go's exit 1.
+ * JS used to read `_p.count` too. All silent except Go's exit 1.
  * `ParamInfo.sourceName` carries the original property name precisely
  * for this; its docstring rule is "consumers keying into
  * `propsType.properties` must use `sourceName ?? name`".
@@ -24,14 +24,25 @@ import { createFixture } from '../src/types'
  * broken party before, which is exactly why #2460 notes no aliased-prop
  * fixture could exist until it was fixed). #2460 itself is CLOSED (fixed
  * in b4f5075) — the shared layer (Hono, `extractSsrDefaults`) now keys
- * off `sourceName ?? name` correctly. The 7 template-string adapters
- * still drop the rename silently and are tracked by
- * https://github.com/piconic-ai/barefootjs/issues/2524; Go's `go run`
- * exit-1 failure is tracked by
- * https://github.com/piconic-ai/barefootjs/issues/2525. Adapters that
- * still drop the rename skip this fixture with a pointer to the
- * relevant tracker; graduating means fixing the emission and deleting
- * the skip entry.
+ * off `sourceName ?? name` correctly.
+ *
+ * Status (#2524 split into two halves, each fixed separately):
+ *   - CSR half (the client JS reading `_p.count` off a `{ text, n }`
+ *     props object) — FIXED (PR A, `claude/2524-csr-props-key`, this
+ *     branch stacks on it).
+ *   - SSR half (the 7 template-string adapters — blade, erb, jinja,
+ *     mojolicious, twig, xslate, rust — silently dropping the rename in
+ *     their `ssrDefaults` seeding) — FIXED here: each harness now derives
+ *     its seeded vars through `deriveStashFromDefaults` (or the matching
+ *     production runtime function) instead of hand-flattening
+ *     `SsrDefault.value`, so a caller-facing `propName` resolves onto the
+ *     local template var. `packages/jsx/src/ssr-defaults.ts`'s
+ *     `deriveStashFromDefaults` is the shared TS twin of those runtime
+ *     ports.
+ *   - Go's `go run` exit-1 failure is STILL tracked by
+ *     https://github.com/piconic-ai/barefootjs/issues/2525 — Go's `skipJsx`
+ *     pin stays; graduating it means fixing the Go emission and deleting
+ *     that pin.
  */
 export const fixture = createFixture({
   id: 'aliased-destructured-prop',

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -22,27 +22,24 @@
       }
     },
     {
-      "name": "gen:count:zero",
+      "name": "gen:n:zero",
       "props": {
         "text": "hello",
-        "n": 7,
-        "count": 0
+        "n": 0
       }
     },
     {
-      "name": "gen:count:negative",
+      "name": "gen:n:negative",
       "props": {
         "text": "hello",
-        "n": 7,
-        "count": -7
+        "n": -7
       }
     },
     {
-      "name": "gen:count:large",
+      "name": "gen:n:large",
       "props": {
         "text": "hello",
-        "n": 7,
-        "count": 1234567890
+        "n": 1234567890
       }
     }
   ],

--- a/packages/adapter-tests/src/adversarial-catalog.ts
+++ b/packages/adapter-tests/src/adversarial-catalog.ts
@@ -85,6 +85,18 @@ interface PropParamType {
 /** Matches the IR's `ParamInfo`/`TypeInfo` shapes (structurally). */
 interface PropParam {
   name: string
+  /**
+   * CALLER-facing key for a renaming destructure (`{ n: count }` → `name:
+   * 'count', sourceName: 'n'`); unset for an un-aliased param, where it's
+   * an identity with `name` (`sourceName ?? name`, the repo-wide rule —
+   * see `packages/jsx/src/types.ts`'s `ParamInfo.sourceName` docstring).
+   * Generated data points key their props objects by this, NOT `name`: the
+   * `props` bag this module builds is handed to `render()` as the
+   * CALLER's props, and a caller can only ever supply the caller-facing
+   * spelling — keying by the local binding silently generates a point that
+   * never reaches the aliased prop at all (#2524 follow-up).
+   */
+  sourceName?: string
   optional: boolean
   isRest?: boolean
   defaultValue?: string
@@ -387,17 +399,24 @@ export function generateDataPointsForFixture(fixture: JSXFixture): JSXDataPoint[
   for (const param of propsParams) {
     if (param.isRest) continue
     if (param.name.startsWith('__')) continue
+    // CALLER-facing key (`sourceName ?? name`, the repo-wide rule — see
+    // `PropParam.sourceName`'s docstring above): `props` here is handed to
+    // `render()` as the CALLER's props object, so an aliased param
+    // (`{ n: count }`) must be keyed `n`, not the local binding `count`,
+    // or the generated point never reaches the aliased prop at all (#2524
+    // follow-up).
+    const callerKey = param.sourceName ?? param.name
     for (const { tag, value } of catalogValuesFor(param)) {
       const props: Record<string, unknown> = structuredClone(base)
       if (value === ABSENT) {
-        delete props[param.name]
+        delete props[callerKey]
       } else {
-        props[param.name] = structuredClone(value)
+        props[callerKey] = structuredClone(value)
       }
-      const key = stableStringify(props)
-      if (seen.has(key)) continue
-      seen.add(key)
-      points.push({ name: `gen:${param.name}:${tag}`, props })
+      const dedupeKey = stableStringify(props)
+      if (seen.has(dedupeKey)) continue
+      seen.add(dedupeKey)
+      points.push({ name: `gen:${callerKey}:${tag}`, props })
     }
   }
   return points

--- a/packages/adapter-twig/src/__tests__/twig-reserved-word-child-prop.test.ts
+++ b/packages/adapter-twig/src/__tests__/twig-reserved-word-child-prop.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression for the review finding on #2524's SSR half (BLOCKER 1): a
+ * reserved-word aliased/defaulted prop passed to a CHILD component used to
+ * be silently clobbered by the child's static default.
+ *
+ * `$child_props` arrives at `deriveStashFromDefaults` already
+ * keyword-mangled (`twig_ident`, `naming.php`) — `as` becomes `as_` — but
+ * the serialised `$_defaults` array's own keys and each entry's `propName`
+ * were the RAW (un-mangled) spellings `extractSsrDefaults` emits. For a
+ * reserved-word prop, `deriveStashFromDefaults` looked up `$props['as']`
+ * (never present — the real key is `as_`), missed, and fell back to the
+ * static default under the RAW key `as`; after `$_vars = array_merge(
+ * $child_props, $_extra)`, the WRONG static default won over the real
+ * caller value.
+ *
+ * `deriveStashFromDefaults` now takes the caller's `$backend` and mangles
+ * both the output key and the `propName` lookup through the same
+ * `Backend::ident()` the caller's `$child_props` were mangled with. See
+ * `BarefootJS.php`'s `deriveStashFromDefaults` docstring.
+ */
+import { test, expect } from 'bun:test'
+import { TwigAdapter } from '../adapter'
+import { renderTwigComponent, TwigNotAvailableError } from '../test-render'
+
+const SOURCE = `
+import { Tag } from './Tag'
+export function Wrapper() {
+  return <Tag as="section" label="hi" />
+}
+`
+
+const TAG_SOURCE = `
+export function Tag({ as = 'span', label }: { as?: string; label: string }) {
+  return <div>{as}:{label}</div>
+}
+`
+
+test('a reserved-word aliased/defaulted prop survives the child-render path (twig, #2524 follow-up)', async () => {
+  let html: string
+  try {
+    html = await renderTwigComponent({
+      source: SOURCE,
+      adapter: new TwigAdapter(),
+      components: { './Tag': TAG_SOURCE },
+    })
+  } catch (err) {
+    if (err instanceof TwigNotAvailableError) {
+      console.log(`Skipping: ${err.message}`)
+      return
+    }
+    throw err
+  }
+  // The caller passed `as="section"` — it must win over the child's own
+  // `as = 'span'` destructure default. Text is wrapped in bf slot markers,
+  // so match each interpolated value rather than the literal `x:y` shape.
+  expect(html).toContain('>section<')
+  expect(html).toContain('>hi<')
+  expect(html).not.toContain('>span<')
+})

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -20,20 +20,4 @@ export const renderDivergences: RenderDivergences = {
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
-  // hand-authored to the CORRECT output while the emission bug lived in
-  // the shared compiler layer — every adapter, including the Hono
-  // reference, used to emit the broken form. That shared-layer defect
-  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
-  // Hono reference like any other fixture. The remaining gap is
-  // per-template-adapter — this adapter still keys its template vars /
-  // ssr-defaults / props bridge off the local binding instead of
-  // `sourceName ?? name` — tracked by #2524 (the 7 silent template
-  // adapters). Graduate by applying the same `sourceName ?? name` fix to
-  // this adapter's emission path and deleting these lines (and the
-  // matching hono `skipJsx` entries, already gone).
-  'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)',
-  'composite-row-child-aliased-prop':
-    'same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)',
 }

--- a/packages/adapter-twig/src/test-render.ts
+++ b/packages/adapter-twig/src/test-render.ts
@@ -38,8 +38,8 @@
  *     caller's `props` and needs no JSON round-trip.
  */
 
-import { compileJSX, extractSsrDefaults, importsSearchParams, evaluateSignalInit } from '@barefootjs/jsx'
-import type { ComponentIR } from '@barefootjs/jsx'
+import { compileJSX, extractSsrDefaults, deriveStashFromDefaults, importsSearchParams, evaluateSignalInit } from '@barefootjs/jsx'
+import type { ComponentIR, SsrDefault } from '@barefootjs/jsx'
 import { mkdir, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
@@ -382,8 +382,17 @@ function collectImportedComponentNames(ir: ComponentIR): string[] {
  * before invoking the registered renderer (mirrors the Jinja/Python
  * runtime's `render_child` contract) — so the rest-bag routing below and the
  * `_bf_slot` / `key` / `children` pops all compare against ALREADY-mangled
- * key spellings; the `keep` set mangles the child's declared param names to
- * match.
+ * key spellings; the `keep` set mangles the child's declared param
+ * (CALLER-facing, `sourceName ?? name`) names to match.
+ *
+ * Template vars seed through the production
+ * `\Barefoot\BarefootJS::deriveStashFromDefaults` (the same static method
+ * `register_components_from_manifest` calls) rather than a flat
+ * `array_merge($_defaults, $child_props)`: the flat merge never resolves an
+ * aliased destructured prop's CALLER-facing key (`n`) onto its local
+ * template var (`count`) — `$_defaults` carries the FULL `{value, propName?,
+ * isRestProps?}` shape (not flattened to bare values) so the propName
+ * resolution has something to read (#2524 SSR half).
  */
 function buildChildRenderersPhp(
   childTemplates: Map<string, { template: string; ir: ComponentIR }>,
@@ -395,10 +404,14 @@ function buildChildRenderersPhp(
 
   for (const [componentName, { ir: childIR }] of childTemplates) {
     const snakeName = toSnakeCase(componentName)
+    // Statically-derived ssrDefaults the child template's vars seed from,
+    // serialised VERBATIM (propName / isRestProps intact) — resolved
+    // per-call against the REAL child props by `deriveStashFromDefaults`
+    // below, not flattened here.
     const ssrDefaults = extractSsrDefaults(childIR.metadata) ?? {}
     const defaultsPhp = ssrDefaultsToPhp(ssrDefaults)
     const restPropsName = childIR.metadata.restPropsName
-    const paramNames = (childIR.metadata.propsParams ?? []).map(p => p.name)
+    const paramNames = (childIR.metadata.propsParams ?? []).map(p => p.sourceName ?? p.name)
 
     lines.push(
       `$bf->register_child_renderer(${phpStr(snakeName)}, function ($child_props, $caller_bf = null) use ($backend, $bf) {`,
@@ -460,8 +473,13 @@ function buildChildRenderersPhp(
     lines.push(`    $child_bf->_child_renderers($bf->_child_renderers());`)
     lines.push(`    $child_bf->_scripts($bf->_scripts());`)
     lines.push(`    $child_bf->_script_seen($bf->_script_seen());`)
-    // Seed template vars: static ssrDefaults first, caller's props win.
-    lines.push(`    $_vars = array_merge($_defaults, $child_props);`)
+    // Seed template vars through the production `deriveStashFromDefaults` —
+    // resolves each entry's `propName` against the REAL `$child_props`,
+    // falling back to the static `value`; `isRestProps` entries pass the
+    // already-routed rest bag through. Caller props still win overall via
+    // the final merge (mirrors the ERB harness's `child_props.merge(extra)`).
+    lines.push(`    $_extra = \\Barefoot\\BarefootJS::deriveStashFromDefaults($_defaults, $child_props, $backend);`)
+    lines.push(`    $_vars = array_merge($child_props, $_extra);`)
     lines.push(`    $rendered = $backend->render_named(${phpStr(snakeName)}, $child_bf, $_vars);`)
     lines.push(`    if (is_string($rendered) && substr($rendered, -1) === "\\n") { $rendered = substr($rendered, 0, -1); }`)
     lines.push(`    return $rendered;`)
@@ -505,23 +523,29 @@ function buildTwigProps(
   setEntry('scope_id', explicitScope)
 
   // Prop params with defaults (before signals, so signals can reference them).
+  // Seeded through the shared `deriveStashFromDefaults` (the TS twin of the
+  // production `\Barefoot\BarefootJS::deriveStashFromDefaults` this harness
+  // ALSO calls at render time for child components) so an aliased
+  // destructured prop's CALLER-facing key (`propName`, e.g. `n` for
+  // `{ n: count }`) is honoured, not just the local template var name
+  // (#2524 SSR half). `props` is keyed by the caller-facing name, exactly
+  // what `propName` resolves against.
+  const rootSsrDefaults = extractSsrDefaults(ir.metadata) ?? {}
+  const derivedProps = deriveStashFromDefaults(rootSsrDefaults, props ?? {})
   for (const param of ir.metadata.propsParams) {
-    if (props && param.name in props) continue
-    if (param.defaultValue) {
-      const value = evaluateSignalInit(param.defaultValue.trim(), props)
-      if (value !== null) {
-        setEntry(param.name, value)
-        continue
-      }
-    }
+    if (param.isRest) continue
     // No default + no caller value: pass `null` so Twig's var lookup for
     // an optional prop doesn't fault before its falsy branch elides.
-    setEntry(param.name, null)
+    setEntry(param.name, derivedProps[param.name] ?? null)
   }
 
   // Route undeclared props into the rest bag (`bf.spread_attrs($<rest>)`).
   const restPropsName = ir.metadata.restPropsName
-  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.name))
+  // Caller-facing keys — an aliased destructured prop's DECLARED set for
+  // rest-bag routing must match what the caller actually sent (`n`), not
+  // the local binding (`count`), or the caller's own prop silently gets
+  // swept into the rest bag as an undeclared extra (#2524).
+  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.sourceName ?? p.name))
   const restBagEntries: Array<[string, unknown]> = []
   if (restPropsName && props) {
     for (const [key, value] of Object.entries(props)) {
@@ -536,11 +560,20 @@ function buildTwigProps(
     setEntry(restPropsName, Object.fromEntries(restBagEntries))
   }
 
-  // User props.
+  // User props. Skip a key that's already a declared param's LOCAL template
+  // var name — `derivedProps` above already resolved that var correctly
+  // (through `propName`, for an aliased prop); re-`setEntry`-ing the raw
+  // `props[key]` here would silently clobber it with an UNRELATED value
+  // whenever a caller happens to also pass a same-spelled-as-local-name prop
+  // that isn't this param's actual `propName` (#2524 — surfaced by the
+  // aliased-destructured-prop generated data points, which pass both `n`
+  // (the real propName) and an incidental `count` key).
+  const localParamNames = new Set(ir.metadata.propsParams.map(p => p.name))
   if (props) {
     for (const [key, value] of Object.entries(props)) {
       if (key.startsWith('__')) continue
       if (routedKeys.has(key)) continue
+      if (localParamNames.has(key)) continue
       if (
         typeof value === 'string' ||
         typeof value === 'number' ||
@@ -566,13 +599,9 @@ function buildTwigProps(
 
   // Memo values seeded from the statically-evaluated ssrDefaults, same
   // as the production plugin's before_render hook.
-  const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
   for (const memo of ir.metadata.memos) {
-    const entry = ssrDefaults[memo.name]
-    const value =
-      entry && typeof entry === 'object' && 'value' in (entry as Record<string, unknown>)
-        ? (entry as Record<string, unknown>).value
-        : 0
+    const entry = rootSsrDefaults[memo.name]
+    const value = entry ? entry.value : 0
     setEntry(memo.name, value ?? 0)
   }
 
@@ -651,22 +680,29 @@ function toPhpLiteral(value: unknown): string {
 
 /**
  * Serialise an ssrDefaults map to a PHP assoc-array literal (the `$_defaults`
- * var a child renderer merges caller props over). This top-level container
- * is the "vars bag" domain (like `$vars` elsewhere in this file), not a JS
- * VALUE flowing into a template — so, unlike a nested object VALUE inside
- * one of its entries, it stays a plain PHP array rather than `(object) [...]`.
+ * var `deriveStashFromDefaults` resolves against the real `$child_props`).
+ * This top-level container is the "vars bag" domain (like `$vars` elsewhere
+ * in this file), not a JS VALUE flowing into a template — so, unlike a
+ * nested object VALUE inside one of its entries, it stays a plain PHP array
+ * rather than `(object) [...]`. Emits each entry VERBATIM — `value` /
+ * `propName` / `isRestProps` intact, exactly the shape
+ * `deriveStashFromDefaults` expects. Do NOT flatten to bare `value`s here:
+ * that was the #2524 SSR-half bug — a flattened entry has nothing left for
+ * the propName-aware resolution to read, so an aliased destructured prop's
+ * caller-facing key is silently dropped.
  */
-function ssrDefaultsToPhp(defaults: Record<string, unknown>): string {
+function ssrDefaultsToPhp(defaults: Record<string, SsrDefault>): string {
   const entries: string[] = []
   for (const [name, d] of Object.entries(defaults)) {
-    // ssrDefaults entries are `{ value, propName?, isRestProps? }` or a
-    // bare value. The child renderer's caller props win, so we only need
-    // the static fallback `value` here.
-    let value: unknown = d
-    if (d && typeof d === 'object' && 'value' in (d as Record<string, unknown>)) {
-      value = (d as Record<string, unknown>).value
-    }
-    entries.push(`${phpStr(name)} => ${toPhpLiteral(value)}`)
+    entries.push(`${phpStr(name)} => ${ssrDefaultEntryToPhp(d)}`)
   }
   return `[${entries.join(', ')}]`
+}
+
+/** Serialise a single `SsrDefault` entry to a PHP assoc-array literal. */
+function ssrDefaultEntryToPhp(d: SsrDefault): string {
+  const parts: string[] = [`'value' => ${toPhpLiteral(d.value)}`]
+  if (d.propName !== undefined) parts.push(`'propName' => ${phpStr(d.propName)}`)
+  if (d.isRestProps) parts.push(`'isRestProps' => true`)
+  return `[${parts.join(', ')}]`
 }

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -20,20 +20,4 @@ export const renderDivergences: RenderDivergences = {
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`
   // from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))`.
 
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
-  // hand-authored to the CORRECT output while the emission bug lived in
-  // the shared compiler layer — every adapter, including the Hono
-  // reference, used to emit the broken form. That shared-layer defect
-  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
-  // Hono reference like any other fixture. The remaining gap is
-  // per-template-adapter — this adapter still keys its template vars /
-  // ssr-defaults / props bridge off the local binding instead of
-  // `sourceName ?? name` — tracked by #2524 (the 7 silent template
-  // adapters). Graduate by applying the same `sourceName ?? name` fix to
-  // this adapter's emission path and deleting these lines (and the
-  // matching hono `skipJsx` entries, already gone).
-  'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)',
-  'composite-row-child-aliased-prop':
-    'same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child\'s renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)',
 }

--- a/packages/adapter-xslate/src/test-render.ts
+++ b/packages/adapter-xslate/src/test-render.ts
@@ -17,8 +17,8 @@
  * than the Mojo harness's literal `test_<sN>`.
  */
 
-import { compileJSX, extractSsrDefaults, importsSearchParams, evaluateSignalInit, tryEvaluateSignalInit } from '@barefootjs/jsx'
-import type { ComponentIR } from '@barefootjs/jsx'
+import { compileJSX, extractSsrDefaults, deriveStashFromDefaults, importsSearchParams, evaluateSignalInit } from '@barefootjs/jsx'
+import type { ComponentIR, SsrDefault } from '@barefootjs/jsx'
 import { mkdir, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
@@ -343,6 +343,15 @@ function collectImportedComponentNames(ir: ComponentIR): string[] {
  * `ssrDefaults`, shares the parent's script list, and renders the child
  * `.tx` through the same backend. Loop children (no `_bf_slot`) fall back
  * to `<snake_name>` like the Mojo harness.
+ *
+ * Template vars seed through the production `BarefootJS::_derive_stash_from_
+ * defaults` (the same sub `derive_vars_from_defaults`'s Ruby twin and
+ * `register_components_from_manifest`'s Python/PHP twins call) rather than a
+ * flat `(%$defaults, %$child_props)` merge: the flat merge never resolves an
+ * aliased destructured prop's CALLER-facing key (`n`) onto its local
+ * template var (`count`) — `$defaults` carries the FULL `{value, propName?,
+ * isRestProps?}` shape (not flattened to bare values) so the propName
+ * resolution has something to read (#2524 SSR half).
  */
 function buildChildRenderers(
   childTemplates: Map<string, { template: string; ir: ComponentIR }>,
@@ -356,8 +365,10 @@ function buildChildRenderers(
   for (const [componentName, { ir: childIR }] of childTemplates) {
     const snakeName = toSnakeCase(componentName)
     // Statically-derived ssrDefaults the child template's vars seed from
-    // (prop defaults + signal / memo initial values), serialised to a
-    // Perl hashref literal.
+    // (prop defaults + signal / memo initial values), serialised VERBATIM
+    // (propName / isRestProps intact) to a Perl hashref literal — resolved
+    // per-call against the REAL child props by `_derive_stash_from_defaults`
+    // below, not flattened here.
     const ssrDefaults = extractSsrDefaults(childIR.metadata) ?? {}
     const defaultsPerl = ssrDefaultsToPerl(ssrDefaults)
     const restPropsName = childIR.metadata.restPropsName
@@ -379,8 +390,9 @@ function buildChildRenderers(
       // branch and JSX rest semantics: a caller prop the child didn't
       // destructure (`href` on PaginationPrevious's `{...props}` anchor)
       // belongs in the bag, not as a top-level stash var the template
-      // never reads.
-      const paramNames = (childIR.metadata.propsParams ?? []).map(p => p.name)
+      // never reads. Keep-set uses CALLER-facing names (`sourceName ?? name`)
+      // — `$child_props` is keyed by whatever the calling template passed.
+      const paramNames = (childIR.metadata.propsParams ?? []).map(p => p.sourceName ?? p.name)
       const keep = JSON.stringify([...new Set([...paramNames, restPropsName, 'children', 'key', '_bf_slot'])])
       lines.push(`    {`)
       lines.push(`      my %keep = map { $_ => 1 } @{ ${perlArrayLiteral(keep)} };`)
@@ -409,8 +421,13 @@ function buildChildRenderers(
     lines.push(`    $child_bf->_child_renderers($bf->_child_renderers);`)
     lines.push(`    $child_bf->_scripts($bf->_scripts);`)
     lines.push(`    $child_bf->_script_seen($bf->_script_seen);`)
-    // Seed template vars: static ssrDefaults first, caller's props win.
-    lines.push(`    my %vars = (%$defaults, %$child_props);`)
+    // Seed template vars through the production `_derive_stash_from_defaults`
+    // — resolves each entry's `propName` against the REAL `$child_props`,
+    // falling back to the static `value`; `isRestProps` entries pass the
+    // already-routed rest bag through. Caller props still win overall via
+    // the final merge (mirrors the ERB harness's `child_props.merge(extra)`).
+    lines.push(`    my %extra = BarefootJS::_derive_stash_from_defaults($defaults, $child_props);`)
+    lines.push(`    my %vars = (%$child_props, %extra);`)
     lines.push(`    my $rendered = $backend->render_named('${snakeName}', $child_bf, \\%vars);`)
     lines.push(`    chomp $rendered;`)
     lines.push(`    return $rendered;`)
@@ -430,20 +447,29 @@ function perlArrayLiteral(jsonArray: string): string {
   return `[${names.map(n => `'${n.replace(/[\\']/g, m => `\\${m}`)}'`).join(', ')}]`
 }
 
-/** Serialise an ssrDefaults map to a Perl hashref literal. */
-function ssrDefaultsToPerl(defaults: Record<string, unknown>): string {
+/**
+ * Serialise an ssrDefaults map to a Perl hashref literal, VERBATIM — `value`
+ * / `propName` / `isRestProps` intact, exactly the shape
+ * `BarefootJS::_derive_stash_from_defaults` expects (and exactly what the
+ * production build manifest embeds). Do NOT flatten to bare `value`s here:
+ * that was the #2524 SSR-half bug — a flattened entry has nothing left for
+ * the propName-aware resolution to read, so an aliased destructured prop's
+ * caller-facing key is silently dropped.
+ */
+function ssrDefaultsToPerl(defaults: Record<string, SsrDefault>): string {
   const entries: string[] = []
   for (const [name, d] of Object.entries(defaults)) {
-    // ssrDefaults entries are `{ value, propName?, isRestProps? }` or a
-    // bare value. The child renderer's caller props win, so we only need
-    // the static fallback `value` here.
-    let value: unknown = d
-    if (d && typeof d === 'object' && 'value' in (d as Record<string, unknown>)) {
-      value = (d as Record<string, unknown>).value
-    }
-    entries.push(`${perlSingleQuote(name)} => ${toPerlLiteral(value)}`)
+    entries.push(`${perlSingleQuote(name)} => ${ssrDefaultEntryToPerl(d)}`)
   }
   return `{${entries.join(', ')}}`
+}
+
+/** Serialise a single `SsrDefault` entry to a Perl hashref literal. */
+function ssrDefaultEntryToPerl(d: SsrDefault): string {
+  const parts: string[] = [`value => ${toPerlLiteral(d.value)}`]
+  if (d.propName !== undefined) parts.push(`propName => ${perlSingleQuote(d.propName)}`)
+  if (d.isRestProps) parts.push(`isRestProps => 1`)
+  return `{${parts.join(', ')}}`
 }
 
 /**
@@ -471,23 +497,30 @@ function buildPerlProps(
   entries.push(`scope_id => '${escapePerlSingleQuoted(explicitScope)}'`)
 
   // Prop params with defaults (before signals, so signals can reference them).
+  // Seeded through the shared `deriveStashFromDefaults` (the TS twin of the
+  // production `BarefootJS::_derive_stash_from_defaults` this harness ALSO
+  // calls at render time for child components) so an aliased destructured
+  // prop's CALLER-facing key (`propName`, e.g. `n` for `{ n: count }`) is
+  // honoured, not just the local template var name (#2524 SSR half).
+  // `props` is keyed by the caller-facing name, exactly what `propName`
+  // resolves against.
+  const rootSsrDefaults = extractSsrDefaults(ir.metadata) ?? {}
+  const derivedProps = deriveStashFromDefaults(rootSsrDefaults, props ?? {})
   for (const param of ir.metadata.propsParams) {
-    if (props && param.name in props) continue
-    if (param.defaultValue) {
-      const result = tryEvaluateSignalInit(param.defaultValue.trim(), props)
-      if (result.ok) {
-        entries.push(`${param.name} => ${toPerlLiteral(result.value)}`)
-        continue
-      }
-    }
+    if (param.isRest) continue
     // No default + no caller value: pass `undef` so Kolon's var lookup
     // for an optional prop doesn't fault before its falsy branch elides.
-    entries.push(`${param.name} => undef`)
+    const value = derivedProps[param.name] ?? null
+    entries.push(`${param.name} => ${toPerlLiteral(value)}`)
   }
 
   // Route undeclared props into the rest bag (`spread_attrs($<rest>)`).
   const restPropsName = ir.metadata.restPropsName
-  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.name))
+  // Caller-facing keys — an aliased destructured prop's DECLARED set for
+  // rest-bag routing must match what the caller actually sent (`n`), not
+  // the local binding (`count`), or the caller's own prop silently gets
+  // swept into the rest bag as an undeclared extra (#2524).
+  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.sourceName ?? p.name))
   const restBagEntries: Array<[string, unknown]> = []
   if (restPropsName && props) {
     for (const [key, value] of Object.entries(props)) {
@@ -502,11 +535,20 @@ function buildPerlProps(
     entries.push(`${restPropsName} => ${toPerlLiteral(Object.fromEntries(restBagEntries))}`)
   }
 
-  // User props.
+  // User props. Skip a key that's already a declared param's LOCAL template
+  // var name — `derivedProps` above already resolved that var correctly
+  // (through `propName`, for an aliased prop); re-pushing the raw
+  // `props[key]` here would silently clobber it with an UNRELATED value
+  // whenever a caller happens to also pass a same-spelled-as-local-name prop
+  // that isn't this param's actual `propName` (#2524 — surfaced by the
+  // aliased-destructured-prop generated data points, which pass both `n`
+  // (the real propName) and an incidental `count` key).
+  const localParamNames = new Set(ir.metadata.propsParams.map(p => p.name))
   if (props) {
     for (const [key, value] of Object.entries(props)) {
       if (key.startsWith('__')) continue
       if (routedKeys.has(key)) continue
+      if (localParamNames.has(key)) continue
       if (typeof value === 'string') {
         entries.push(`${key} => '${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`)
       } else if (typeof value === 'number') {
@@ -534,10 +576,9 @@ function buildPerlProps(
 
   // Memo values seeded from the statically-evaluated ssrDefaults, same
   // as the production plugin's before_render hook.
-  const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
   for (const memo of ir.metadata.memos) {
-    const entry = ssrDefaults[memo.name]
-    const value = entry && typeof entry === 'object' && 'value' in entry ? entry.value : 0
+    const entry = rootSsrDefaults[memo.name]
+    const value = entry ? entry.value : 0
     entries.push(`${memo.name} => ${toPerlLiteral(value ?? 0)}`)
   }
 

--- a/packages/cli/src/lib/adapters/xslate.ts
+++ b/packages/cli/src/lib/adapters/xslate.ts
@@ -128,26 +128,37 @@ sub load_manifest () {
 my $MANIFEST = $DEV ? undef : load_manifest();
 sub manifest () { return $DEV ? load_manifest() : $MANIFEST }
 
-# Build the SSR stash for a component from its manifest \`ssrDefaults\`.
-sub ssr_defaults ($component) {
+# Build the SSR stash for a component from its manifest \`ssrDefaults\`,
+# resolved against \`%props\` (the caller-supplied override) through the
+# production \`BarefootJS::_derive_stash_from_defaults\` (mirrors the
+# corrected Perl shape in \`BarefootJS.pm\`'s own \`register_components_
+# from_manifest\`) — so an aliased destructured prop's CALLER-facing key
+# (\`propName\`, e.g. \`n\` for \`{ n: count }\`) is honoured, not just the
+# local template var name. Resolving \`$d->{value}\` directly, ignoring
+# \`propName\`, silently dropped every caller-supplied value for a renamed
+# prop.
+sub ssr_defaults ($component, %props) {
     my $entry = manifest()->{$component} or return ();
     my $defaults = $entry->{ssrDefaults} or return ();
-    my %stash;
-    for my $name (keys %$defaults) {
-        my $d = $defaults->{$name};
-        $stash{$name} = ref($d) eq 'HASH' ? $d->{value} : $d;
-    }
-    return %stash;
+    return BarefootJS::_derive_stash_from_defaults($defaults, \\%props);
 }
 
 sub rand_suffix () { return substr(sprintf('%f', rand()) =~ s/^0\\.//r, 0, 6) }
 
 # Render a top-level component template and wrap it in the page layout.
-# Manifest defaults seed the stash; any caller-supplied \`%override\` wins.
+# Manifest defaults seed the stash (resolved against \`%override\`, the
+# caller-supplied props, so an aliased prop's rename resolves correctly).
+# \`ssr_defaults\`' resolved extras go LAST in the hash literal (later key
+# wins in a Perl hash construction), so they win over the raw \`%override\`
+# map for any key they resolve — matching the production merge order
+# (\`BarefootJS.pm\`'s \`register_components_from_manifest\`: \`{ %\$props,
+# %extra }\`, extra applied last) instead of the reverse. \`%override\`
+# still wins for any key \`ssr_defaults\` did NOT touch (an extraneous,
+# undeclared prop \`ssr_defaults\` has no manifest entry for).
 sub render_component ($component, %override) {
     my $bf = BarefootJS->new(undef, { backend => $backend });
     $bf->_scope_id($component . '_' . rand_suffix());
-    my %stash = (ssr_defaults($component), %override);
+    my %stash = (%override, ssr_defaults($component, %override));
     my $body = $backend->render_named($component, $bf, \\%stash);
     return layout(body => $body, scripts => $bf->scripts);
 }

--- a/packages/jsx/src/__tests__/ssr-defaults.test.ts
+++ b/packages/jsx/src/__tests__/ssr-defaults.test.ts
@@ -13,7 +13,8 @@
 //     computations that derive from those signals (`count() * 2`).
 
 import { describe, test, expect } from 'bun:test'
-import { extractSsrDefaults } from '../ssr-defaults'
+import { extractSsrDefaults, deriveStashFromDefaults } from '../ssr-defaults'
+import type { SsrDefault } from '../ssr-defaults'
 import { analyzeComponent } from '../analyzer'
 import { buildMetadata } from '../compiler'
 
@@ -251,5 +252,127 @@ describe('extractSsrDefaults', () => {
     // props.className is undefined → `?? ''` → '' → 'a b c d  tail' (the double
     // space mirrors Hono's empty-className interpolation).
     expect(defaults?.classes).toEqual({ value: 'a b c d  tail' })
+  })
+})
+
+// TS twin of the Ruby/Python/PHP/Perl/Rust `derive*FromDefaults` runtime
+// ports (#2524 SSR half). Matches `derive_vars_from_defaults`'s edge cases
+// exactly — see that Ruby method's docstring
+// (packages/adapter-erb/lib/barefoot_js.rb:337-360) for the reference
+// semantics this mirrors.
+describe('deriveStashFromDefaults', () => {
+  test('aliased prop: resolves the CALLER-facing propName, not the local key', () => {
+    // `{ n: count }` — extractSsrDefaults keys the entry by the LOCAL
+    // binding (`count`) with `propName: 'n'`. The caller supplies `n`.
+    const defaults: Record<string, SsrDefault> = {
+      count: { propName: 'n', value: null },
+    }
+    expect(deriveStashFromDefaults(defaults, { n: 7 })).toEqual({ count: 7 })
+  })
+
+  test('un-aliased prop: propName equals the local key, resolves the same way', () => {
+    const defaults: Record<string, SsrDefault> = {
+      n: { propName: 'n', value: null },
+    }
+    expect(deriveStashFromDefaults(defaults, { n: 7 })).toEqual({ n: 7 })
+  })
+
+  test('caller omits the prop: falls back to the static default value', () => {
+    const defaults: Record<string, SsrDefault> = {
+      count: { propName: 'n', value: 3 },
+    }
+    expect(deriveStashFromDefaults(defaults, {})).toEqual({ count: 3 })
+  })
+
+  test('caller supplies null / undefined for the propName: falls back to the static value', () => {
+    // Mirrors every runtime port's "present AND defined" check — an
+    // explicit null/undefined caller value does not count as an override.
+    const defaults: Record<string, SsrDefault> = {
+      count: { propName: 'n', value: 3 },
+    }
+    expect(deriveStashFromDefaults(defaults, { n: null })).toEqual({ count: 3 })
+    expect(deriveStashFromDefaults(defaults, { n: undefined })).toEqual({ count: 3 })
+  })
+
+  test('caller supplies a falsy-but-defined propName value: the caller value wins', () => {
+    // `0` / `''` / `false` are legitimate override values, not "absent".
+    const defaults: Record<string, SsrDefault> = {
+      count: { propName: 'n', value: 99 },
+    }
+    expect(deriveStashFromDefaults(defaults, { n: 0 })).toEqual({ count: 0 })
+  })
+
+  test('propName-less entry (signal / memo local): always uses the static value', () => {
+    // A caller cannot override an internal signal/memo by construction —
+    // even a same-named caller prop must not leak in.
+    const defaults: Record<string, SsrDefault> = {
+      doubled: { value: 10 },
+    }
+    expect(deriveStashFromDefaults(defaults, { doubled: 999 })).toEqual({ doubled: 10 })
+  })
+
+  test('isRestProps entry: prefers the caller-assembled rest bag under its OWN key', () => {
+    const defaults: Record<string, SsrDefault> = {
+      rest: { isRestProps: true, value: {} },
+    }
+    expect(deriveStashFromDefaults(defaults, { rest: { href: '/x' } })).toEqual({
+      rest: { href: '/x' },
+    })
+  })
+
+  test('isRestProps entry: falls back to the static value (normally {}) when the caller supplied none', () => {
+    const defaults: Record<string, SsrDefault> = {
+      rest: { isRestProps: true, value: {} },
+    }
+    expect(deriveStashFromDefaults(defaults, {})).toEqual({ rest: {} })
+  })
+
+  test('isRestProps entry: an explicit `undefined` caller value still counts as supplied', () => {
+    // Unlike the ordinary propName branch (nullish check), the isRestProps
+    // branch tests presence via `in` — the rest bag is a caller-assembled
+    // aggregate, not a single scalar with a meaningful "absent" state, so
+    // an explicit `undefined` still wins over the static fallback instead
+    // of falling through to it.
+    const defaults: Record<string, SsrDefault> = {
+      rest: { isRestProps: true, value: { fallback: true } },
+    }
+    const result = deriveStashFromDefaults(defaults, { rest: undefined })
+    expect('rest' in result).toBe(true)
+    expect(result.rest).toBeUndefined()
+  })
+
+  test('a bare (non-object) entry passes through as-is', () => {
+    // Defensive parity with every runtime port's `ref($d) eq 'HASH'` /
+    // `isinstance(d, dict)` guard — never emitted by `extractSsrDefaults`
+    // itself, but a caller may hand this a manifest round-tripped through a
+    // generic JSON domain.
+    const defaults = { flag: true } as unknown as Record<string, SsrDefault>
+    expect(deriveStashFromDefaults(defaults, {})).toEqual({ flag: true })
+  })
+
+  test('a literal null entry hits the same non-object passthrough guard', () => {
+    // `d === null` is checked ALONGSIDE `typeof d !== 'object'` (not just
+    // the latter) — `typeof null === 'object'` in JS, so without the
+    // explicit `d === null` check a null entry would wrongly fall into the
+    // object-shaped branches below and throw reading `d.isRestProps`.
+    const defaults = { flag: null } as unknown as Record<string, SsrDefault>
+    expect(deriveStashFromDefaults(defaults, {})).toEqual({ flag: null })
+  })
+
+  test('mixed defaults map resolves every entry kind independently', () => {
+    const defaults: Record<string, SsrDefault> = {
+      count: { propName: 'n', value: null },
+      text: { propName: 'text', value: null },
+      doubled: { value: 0 },
+      rest: { isRestProps: true, value: {} },
+    }
+    expect(
+      deriveStashFromDefaults(defaults, { n: 7, rest: { extra: 'x' } }),
+    ).toEqual({
+      count: 7,
+      text: null,
+      doubled: 0,
+      rest: { extra: 'x' },
+    })
   })
 })

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -9,7 +9,7 @@ export { compileJSX, buildMetadata } from './compiler.ts'
 export type { CompileResult, CompileOptions, CompileOptionsWithAdapter, FileOutput } from './compiler.ts'
 
 // SSR template-variable defaults (manifest seeds for stash-based adapters)
-export { extractSsrDefaults } from './ssr-defaults.ts'
+export { extractSsrDefaults, deriveStashFromDefaults } from './ssr-defaults.ts'
 
 // Shared props-destructure binding + alias-map helpers (#2524)
 export { propsDestructureBinding, buildPropAliasMap, isIdentifierName } from './props-binding.ts'

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -62,6 +62,76 @@ export interface SsrDefault {
   isRestProps?: boolean
 }
 
+/**
+ * TS twin of the runtime `derive*FromDefaults` family that ships in every
+ * OTHER SSR runtime port (Ruby's `BarefootJS::Context.derive_vars_from_defaults`
+ * — `packages/adapter-erb/lib/barefoot_js.rb:337-360` — plus Python's
+ * `barefootjs.runtime._derive_stash_from_defaults`, PHP's
+ * `Barefoot\BarefootJS::deriveStashFromDefaults`, Perl's
+ * `BarefootJS::_derive_stash_from_defaults`, and Rust's
+ * `barefootjs::manifest::derive_stash_from_defaults`). TypeScript had no such
+ * function — every adapter-tests conformance harness (and 3 production
+ * integration sites) either discarded `SsrDefault.propName` outright or keyed
+ * its seeding loop off the LOCAL template-var name instead of the
+ * caller-facing prop key, which is exactly the #2157 defect class (and its
+ * #2524 SSR-seeding recurrence) restated at
+ * `packages/adapter-erb/src/test-render.ts:276-287`. Any harness or
+ * integration deriving template-stash vars from an `extractSsrDefaults(...)`
+ * map MUST route through this function (or its runtime-language twin, when
+ * one is reachable) instead of hand-flattening `SsrDefault.value` and
+ * merging raw caller props over it — that flattening is precisely what
+ * silently drops the rename.
+ *
+ * Semantics (mirrors `derive_vars_from_defaults`'s observable behavior,
+ * including its edge cases — though not always the identical mechanism;
+ * e.g. Python's `_derive_stash_from_defaults` checks `props.get(prop_name)
+ * is not None` with no separate `in` membership test, relying on `dict.get`
+ * defaulting a missing key to `None` — behaviorally identical to this
+ * function's explicit `propName in props && props[propName] != null` for a
+ * plain dict/object, just expressed differently):
+ *   - A non-object entry (a bare JSON value some callers may still pass,
+ *     e.g. a manifest round-tripped through a generic JSON domain) is used
+ *     AS-IS.
+ *   - `isRestProps` entries: prefer `props[<this entry's own key>]` when the
+ *     caller supplied one (checked via `in`, so an explicit `undefined` /
+ *     `null` value still counts as "supplied" — the rest bag is a
+ *     caller-assembled aggregate, not a single scalar with a meaningful
+ *     "absent" state), else the static `value` fallback (normally `{}`).
+ *   - Otherwise: prefer `props[propName]` when `propName` is set AND the
+ *     caller supplied a NON-NULLISH (`!= null`, so `undefined` and `null`
+ *     both fall through — mirrors every other port's "present and defined"
+ *     check) value for it, else the static `value` fallback. `propName`-less
+ *     entries (signal / memo locals) always use the static value — the
+ *     caller cannot override them by construction.
+ */
+export function deriveStashFromDefaults(
+  defaults: Record<string, SsrDefault>,
+  props: Record<string, unknown>,
+): Record<string, unknown> {
+  const extra: Record<string, unknown> = {}
+  for (const [name, d] of Object.entries(defaults)) {
+    if (d === null || typeof d !== 'object') {
+      // Defensive: every ENTRY `extractSsrDefaults` itself emits is always
+      // the `{ value, propName?, isRestProps? }` shape, but a caller may
+      // feed this a manifest round-tripped through a generic JSON domain
+      // (mirrors every runtime port's own `ref($d) eq 'HASH'` /
+      // `d.is_a?(Hash)` / `isinstance(d, dict)` guard).
+      extra[name] = d
+      continue
+    }
+    if (d.isRestProps) {
+      extra[name] = name in props ? props[name] : d.value
+      continue
+    }
+    if (d.propName !== undefined && d.propName in props && props[d.propName] != null) {
+      extra[name] = props[d.propName]
+    } else {
+      extra[name] = d.value
+    }
+  }
+  return extra
+}
+
 const UNRESOLVED = Symbol('unresolved')
 type EvalResult = unknown | typeof UNRESOLVED
 

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1817,63 +1817,9 @@
     "totalFixtures": 307,
     "fixtures": {
       "aliased-destructured-prop": {
-        "blade": {
-          "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)"
-        },
         "go-template": {
           "kind": "render",
           "reason": "aliased destructured prop `{ n: count }` loses its rename — the Input struct field is Count `json:\"count\"`, so the caller-side struct literal keyed by the real prop name fails `go run` outright (unknown field N, exit 1) (https://github.com/piconic-ai/barefootjs/issues/2525)"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — template vars, ssr-defaults, and the props bridge all key off the local name, so the prop is always undefined (https://github.com/piconic-ai/barefootjs/issues/2524)"
-        }
-      },
-      "composite-row-child-aliased-prop": {
-        "blade": {
-          "kind": "render",
-          "reason": "same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "same defect as `aliased-destructured-prop` (#2524), inside a keyed `.map()` loop row: the nested child's renamed prop (`{ n: count }`) is always undefined, so both rows render an empty count (https://github.com/piconic-ai/barefootjs/issues/2524)"
         }
       },
       "date-method-uncatalogued": {
@@ -2842,10 +2788,6 @@
       "aliased-destructured-prop": {
         "description": "Aliased destructured prop ({ n: count }) keeps the rename (#2524)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/aliased-destructured-prop.ts"
-      },
-      "composite-row-child-aliased-prop": {
-        "description": "Nested child in a dynamic loop row destructures a renamed prop ({ n: count })",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/composite-row-child-aliased-prop.ts"
       },
       "date-method-uncatalogued": {
         "description": "Method call on a Date-typed prop refuses with BF021 (no catalogued lowering)",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1433,13 +1433,9 @@
           ]
         },
         "blade": {
-          "pass": 184,
+          "pass": 185,
           "total": 200,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1659,13 +1655,9 @@
           ]
         },
         "jinja": {
-          "pass": 184,
+          "pass": 185,
           "total": 200,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1739,13 +1731,9 @@
           ]
         },
         "minijinja": {
-          "pass": 184,
+          "pass": 185,
           "total": 200,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1819,13 +1807,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 185,
+          "pass": 186,
           "total": 200,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1893,13 +1877,9 @@
           ]
         },
         "twig": {
-          "pass": 184,
+          "pass": 185,
           "total": 200,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1973,13 +1953,9 @@
           ]
         },
         "xslate": {
-          "pass": 184,
+          "pass": 185,
           "total": 200,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2213,17 +2189,9 @@
           ]
         },
         "blade": {
-          "pass": 269,
+          "pass": 271,
           "total": 288,
           "gaps": [
-            {
-              "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2305,13 +2273,9 @@
           ]
         },
         "erb": {
-          "pass": 271,
+          "pass": 272,
           "total": 288,
           "gaps": [
-            {
-              "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2475,17 +2439,9 @@
           ]
         },
         "jinja": {
-          "pass": 269,
+          "pass": 271,
           "total": 288,
           "gaps": [
-            {
-              "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2567,17 +2523,9 @@
           ]
         },
         "minijinja": {
-          "pass": 269,
+          "pass": 271,
           "total": 288,
           "gaps": [
-            {
-              "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2659,17 +2607,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 270,
+          "pass": 272,
           "total": 288,
           "gaps": [
-            {
-              "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2745,17 +2685,9 @@
           ]
         },
         "twig": {
-          "pass": 269,
+          "pass": 271,
           "total": 288,
           "gaps": [
-            {
-              "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2837,17 +2769,9 @@
           ]
         },
         "xslate": {
-          "pass": 269,
+          "pass": 271,
           "total": 288,
           "gaps": [
-            {
-              "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3593,13 +3517,9 @@
           ]
         },
         "blade": {
-          "pass": 136,
+          "pass": 137,
           "total": 154,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3843,13 +3763,9 @@
           ]
         },
         "jinja": {
-          "pass": 136,
+          "pass": 137,
           "total": 154,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3931,13 +3847,9 @@
           ]
         },
         "minijinja": {
-          "pass": 136,
+          "pass": 137,
           "total": 154,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4019,13 +3931,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 137,
+          "pass": 138,
           "total": 154,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4101,13 +4009,9 @@
           ]
         },
         "twig": {
-          "pass": 136,
+          "pass": 137,
           "total": 154,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4189,13 +4093,9 @@
           ]
         },
         "xslate": {
-          "pass": 136,
+          "pass": 137,
           "total": 154,
           "gaps": [
-            {
-              "fixture": "composite-row-child-aliased-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [


### PR DESCRIPTION
## Summary

The SSR half of #2524, stacked on the CSR half (#2531). Template variables are the LOCAL destructured name (`count`) — that part was always correct. The bug was on the seeding side: nothing mapped the caller-facing key (`n`) onto the local template variable, so an aliased destructured prop (`{ n: count }`) rendered as `undefined` across all seven template adapters.

## Changes

**Shared helper (`@barefootjs/jsx`)**
- New exported `deriveStashFromDefaults(defaults, props)` in `packages/jsx/src/ssr-defaults.ts` — the TS twin of the runtime derive-from-defaults family (Python `_derive_stash_from_defaults`, PHP `deriveStashFromDefaults`, Perl `_derive_stash_from_defaults`, Ruby `derive_vars_from_defaults`). Resolves each defaults entry's `propName` from the caller props before falling back to the static value. Unit tests cover aliased, un-aliased, default-value, rest-props, explicit-`undefined`, and non-object passthrough cases.

**Conformance harnesses (7 adapters: blade, erb, jinja, mojolicious, rust, twig, xslate)**
- Root seeding goes through `deriveStashFromDefaults` instead of hand-flattened `param.name` loops (the #2157 lesson).
- Child defaults are serialized verbatim (`propName` intact) into generated render scripts and resolved per call by each adapter's **production** runtime function — no harness-side reimplementation.
- Rest-bag keep sets and `declaredParams` are built from `sourceName ?? name`.

**Production fixes (same defect class, real shipped bugs)**
- **rust runtime**: `manifest.rs` used to flatten defaults with EMPTY props at registration; now `resolve_child_vars` resolves per call, staying in the MjValue domain so minijinja's safe-HTML flag survives, with `mangle_ident` applied to keys and propName lookups.
- **jinja `runtime.py` / php `BarefootJS.php`**: the derive functions now ident-mangle both the output key and the `propName` lookup, so reserved-word props (`as`, `for`, `class`, …) are not clobbered by static defaults under the merge-order flip. Real-engine regression probes added for jinja/twig/blade (each verified red without the fix).
- **Mojolicious plugin**: root stash seeding resolves `propName` from the caller stash before falling back to the default.
- **cli xslate scaffold**: merge order flipped so derived extras win, matching production runtimes.

**Fixtures / locks**
- `adversarial-catalog.ts` keys generated data points by the caller-facing name (`gen:n:*` instead of the dead `gen:count:*`); `generated-data-points.json` regenerated.
- Graduated 13 `renderDivergences` pins (`aliased-destructured-prop` + `composite-row-child-aliased-prop` across blade/jinja/mojolicious/twig/xslate/rust; aliased-only for erb) — the fixtures now run as regression tests. Go's pin stays for #2525 (next PR in the stack).
- `compat.lock.json` / `support-matrix.lock.json` regenerated; the diff is exactly the 13-cell graduation.

## Verification

- Real-engine renders: jinja 1285/0, twig 1292/0 (one CPU-contention flake, clean on isolated rerun), blade 1285/0, rust 1283/0 + `cargo test` 91/0, erb 1247 pass with 9 pre-existing tzdata failures (no erb source touched), mojolicious 1451/0 (Perl engine absent locally; render cases skip, verified via generated-script inspection — CI engine jobs are the arbiter), xslate same.
- Python unittest 91/0, PHP `tests/run.php` 568/0, packages/cli 1554/0, adapter-tests suites all green.
- `bun run build` clean across all workspaces.
- Reviewed by Opus (1 blocker + 8 minors/nits, all addressed; blocker fixed in production runtimes, not just call sites).

## Stack

1. #2531 — #2524 CSR half (`claude/2524-csr-props-key`) ← base of this PR
2. **this PR** — #2524 SSR half
3. next — #2525 Go Input struct (stacked on this)

Closes #2524 (together with #2531).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANWdijiBRfuNqnACEPEyKD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANWdijiBRfuNqnACEPEyKD)_