### PR TITLE
Unblock #2537: per-directory `components` entries + BfPreload truth

### DIFF
--- a/.changeset/bfpreload-truth.md
+++ b/.changeset/bfpreload-truth.md
@@ -1,0 +1,19 @@
+---
+"@barefootjs/hono": patch
+"@barefootjs/vite": patch
+---
+
+Correct the documentation around `BfPreload` and the plugin manifest's `clientJs` omission
+
+`@barefootjs/vite`'s manifest comment justified omitting `clientJs` with
+"no backend reads it (grep the PHP/Python/Ruby runtimes: zero hits)" — a
+grep scoped to native runtimes, when `@barefootjs/hono`'s `BfPreload` (not
+a native runtime) does read `clientJs` from a caller-supplied manifest.
+The omission stands; the justification now states its real scope and
+points plugin-manifest consumers at the `preloadAssets` path.
+
+`BfPreload`'s docs now say what silently failed before: `components`
+entries must match manifest keys exactly (path-qualified like `ui/button`
+for the legacy site build), a miss is skipped without error, and
+`ManifestEntry.dependencies` has no current producer — the dependency
+recursion only activates for hand-authored manifests.

--- a/.changeset/vite-per-dir-css-layer-and-skipdirs.md
+++ b/.changeset/vite-per-dir-css-layer-and-skipdirs.md
@@ -1,0 +1,53 @@
+---
+"@barefootjs/vite": minor
+---
+
+Per-directory `cssLayerPrefix` and `skipDirs` on `components` entries
+
+`site/ui/build.ts` compiles library components (`ui/components`) with
+`cssLayerPrefix: 'components'` and app/docs components without it — the
+cascade contract `site/ui/styles/globals.css` declares
+(`@layer preflights, base, shortcuts, components, default`): library base
+classes land in `@layer components`, user override classes stay un-layered
+in `default`, so an override always wins regardless of specificity or
+UnoCSS emission order. That distinction is load-bearing — `site/ui/components`
+passes `className` overrides roughly 490 times. `@barefootjs/vite`'s
+`barefoot()` plugin couldn't express it: whether a file needs a cascade
+layer depends on WHICH `components` entry it came from, and
+`BarefootViteOptions` is deliberately capped at exactly three fields.
+
+Separately, `site/ui/build.ts` skips any directory literally named `shared`
+under its roots (utility modules and non-component layouts live there).
+The low-level `discoverComponentFiles` already supported a `skipDirs`
+option; nothing in the Vite plugin plumbed it through.
+
+Both are directory-scoped compile behaviors, so both ride on the
+`components` entry itself instead of becoming 4th/5th top-level options.
+`components` widens from `string[]` to `(string | ComponentDirEntry)[]`:
+
+```ts
+export interface ComponentDirEntry {
+  dir: string
+  cssLayerPrefix?: string
+  skipDirs?: string[]
+}
+```
+
+A plain string entry is exactly equivalent to `{ dir: string }` — every
+existing `vite.config.ts` in this repo (and `discoverComponents`'s two
+external consumers, `integrations/h3`/`integrations/elysia`) keeps
+compiling and behaving byte-identically, confirmed by diffing
+`integrations/hono`'s built `dist/components/` before and after this
+change. `components` entries are processed in array order, and that order
+is also the precedence when the same file is reachable under more than
+one entry: the first entry's `cssLayerPrefix`/`skipDirs` win, matching the
+first-writer-wins precedence `@bf-child:` name resolution already
+documents.
+
+`skipDirs` gates BOTH halves of the plugin — the eager pass's discovery
+walk AND the `transform`/dev-watcher gate (`isUnderComponentDir`). Gating
+only discovery would have been a half-fix: a file living in a skipped
+subdirectory can still be reached by an ordinary relative `import` from a
+non-skipped sibling (`site/ui`'s `PageNavigation.tsx`, imported by pages
+out of a skipped `shared/` dir, is exactly this shape), and without the
+second gate the graph pass would compile it anyway.

--- a/packages/adapter-hono/src/preload.tsx
+++ b/packages/adapter-hono/src/preload.tsx
@@ -40,6 +40,12 @@ export interface ManifestEntry {
   markedTemplate: string
   clientJs?: string
   props?: Array<{ name: string; type: string; optional: boolean }>
+  /**
+   * Dependency component names for recursive preloading.
+   * Note: no current producer (neither legacy site build nor @barefootjs/vite)
+   * emits this field, so dependency recursion only activates for
+   * hand-authored manifests. Kept for API compatibility.
+   */
   dependencies?: string[]
 }
 
@@ -84,7 +90,11 @@ export interface BfPreloadProps {
  * Resolves the full dependency chain for given components.
  * Uses a visited set to prevent infinite loops from circular dependencies.
  *
- * @param components - Component names to resolve
+ * Manifest keys are whatever the manifest producer used — the legacy site
+ * build uses path-qualified keys like `ui/button`, so component name entries
+ * must match those exactly. A key mismatch is silently skipped (no error).
+ *
+ * @param components - Component names/keys to resolve (must match manifest keys exactly)
  * @param manifest - Component manifest with dependency information
  * @param visited - Set of already visited component names (for cycle detection)
  * @returns Array of clientJs paths for all dependencies
@@ -126,7 +136,10 @@ function resolveDependencyChain(
  * by all BarefootJS components.
  *
  * When manifest and components props are provided, automatically
- * preloads the full dependency chain for those components.
+ * preloads the full dependency chain for those components. The `components`
+ * array entries must match manifest keys exactly — for the legacy site
+ * build, use path-qualified keys like `ui/button`, not component names.
+ * A mismatched key is silently skipped.
  */
 export function BfPreload({
   staticPath = '/static',

--- a/packages/cli/src/lib/vite-config-loader.ts
+++ b/packages/cli/src/lib/vite-config-loader.ts
@@ -135,5 +135,12 @@ export async function loadViteBarefootConfig(configPath: string): Promise<ViteBa
     )
   }
 
-  return { root, sourceDirs: [...api.options.components] }
+  // `api.options.components` entries may be a plain string OR a
+  // `ComponentDirEntry` (`@barefootjs/vite`'s per-directory
+  // `cssLayerPrefix`/`skipDirs`) — `sourceDirs` only ever needs the bare
+  // directory, so unwrap `{ dir }` down to `dir`, the same "string is
+  // equivalent to `{ dir: string }`" collapse `ComponentDirEntry` itself
+  // documents.
+  const sourceDirs = api.options.components.map(entry => typeof entry === 'string' ? entry : entry.dir)
+  return { root, sourceDirs }
 }

--- a/packages/vite/src/__tests__/component-dir-entry.test.ts
+++ b/packages/vite/src/__tests__/component-dir-entry.test.ts
@@ -1,0 +1,239 @@
+/**
+ * `components` entries widened from `string[]` to `(string | ComponentDirEntry)[]`
+ * (`types.ts`) — per-directory `cssLayerPrefix`/`skipDirs` riding on the
+ * `components` entry itself instead of a 4th/5th top-level plugin option.
+ * See `types.ts`'s docstring and `plugin.ts`'s `normalizeComponents`/
+ * `entryForPath`/`isSkippedByEntry` for the mechanics these tests pin:
+ *
+ *   - a plain string entry stays exactly equivalent to `{ dir: string }`
+ *   - `cssLayerPrefix` reaches compiled output (template AND, for a
+ *     `'use client'` file, the hydration template embedded in client JS)
+ *     only for files under the entry that set it
+ *   - `skipDirs` excludes matching subdirectories from BOTH discovery (the
+ *     eager pass) and the `transform`/watcher gate (the graph pass) — a
+ *     half-fix on just one side is exactly what bit `site/ui`'s
+ *     `PageNavigation.tsx` (imported by pages from a `shared/` dir)
+ *   - precedence: a file reachable under more than one `components` entry
+ *     takes the FIRST entry's options, matching `buildChildNameIndex`'s
+ *     already-documented first-writer-wins rule
+ */
+import { describe, test, expect, afterEach } from 'bun:test'
+import { mkdtemp, rm, mkdir, writeFile, readFile, readdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { testAdapter } from '@barefootjs/jsx'
+import { barefoot } from '../plugin.ts'
+
+// biome-ignore lint: hooks are called directly, bypassing Vite's own
+// dispatch/typing — casting to `any` is the standard way to unit-test a
+// Vite plugin's hooks in isolation (same convention as `plugin.test.ts`).
+type AnyPlugin = any
+
+/** Drives `config` → `configResolved` → (fabricated empty manifest) →
+ * `writeBundle`, the same minimal sequence `plugin.test.ts`'s writeBundle
+ * describe block uses. */
+async function driveBuild(plugin: AnyPlugin, dir: string): Promise<void> {
+  await plugin.config({ root: dir }, { command: 'build', mode: 'production' })
+  await plugin.configResolved({ root: dir, base: '/', build: { outDir: 'dist', manifest: true } })
+  await mkdir(join(dir, 'dist/.vite'), { recursive: true })
+  await writeFile(join(dir, 'dist/.vite/manifest.json'), '{}')
+  await plugin.writeBundle()
+}
+
+/** `config` → `configResolved` only — enough to exercise `transform`
+ * without a real Vite build. */
+async function driveConfig(plugin: AnyPlugin, dir: string): Promise<void> {
+  await plugin.config({ root: dir }, { command: 'build', mode: 'production' })
+  await plugin.configResolved({ root: dir, base: '/', build: { outDir: 'dist', manifest: true } })
+}
+
+const ext = testAdapter.extension
+
+describe('ComponentDirEntry: string entry ≡ { dir } entry', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  test('same discovery and byte-identical compiled template as a plain string entry', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-entry-string-eq-'))
+    await mkdir(join(dir, 'a'), { recursive: true })
+    await mkdir(join(dir, 'b'), { recursive: true })
+    const source = 'export function Widget() { return <div className="bg-primary p-4">Hi</div> }'
+    await writeFile(join(dir, 'a/Widget.tsx'), source)
+    await writeFile(join(dir, 'b/Widget.tsx'), source)
+
+    const templatesA = join(dir, 'views-a')
+    const templatesB = join(dir, 'views-b')
+    const pluginString = barefoot({ adapter: testAdapter, components: ['a'], templates: templatesA })
+    const pluginObject = barefoot({ adapter: testAdapter, components: [{ dir: 'b' }], templates: templatesB })
+
+    await driveBuild(pluginString, dir)
+    await driveBuild(pluginObject, dir)
+
+    const outString = await readFile(join(templatesA, `Widget${ext}`), 'utf8')
+    const outObject = await readFile(join(templatesB, `Widget${ext}`), 'utf8')
+    expect(outString).toBe(outObject)
+    // Neither carries a cssLayerPrefix — the object form set none.
+    expect(outString).not.toContain('layer-')
+  })
+})
+
+describe('ComponentDirEntry: cssLayerPrefix', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  test('prefixes static classes in the compiled template only for the entry that set it', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-entry-css-layer-'))
+    await mkdir(join(dir, 'lib'), { recursive: true })
+    await mkdir(join(dir, 'app'), { recursive: true })
+    await writeFile(join(dir, 'lib/Card.tsx'), 'export function Card() { return <div className="bg-primary p-4">Hi</div> }')
+    await writeFile(join(dir, 'app/Panel.tsx'), 'export function Panel() { return <div className="bg-primary p-4">Hi</div> }')
+
+    const templatesDir = join(dir, 'views')
+    const plugin = barefoot({
+      adapter: testAdapter,
+      components: [
+        { dir: 'lib', cssLayerPrefix: 'components' },
+        'app',
+      ],
+      templates: templatesDir,
+    })
+    await driveBuild(plugin, dir)
+
+    const libTpl = await readFile(join(templatesDir, `Card${ext}`), 'utf8')
+    const appTpl = await readFile(join(templatesDir, `Panel${ext}`), 'utf8')
+
+    expect(libTpl).toContain('layer-components:bg-primary')
+    expect(libTpl).toContain('layer-components:p-4')
+    expect(appTpl).not.toContain('layer-')
+    expect(appTpl).toContain('bg-primary p-4')
+  })
+
+  test('reaches the hydration template embedded in compiled client JS too (the `transform` / graph-pass path)', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-entry-css-layer-clientjs-'))
+    await mkdir(join(dir, 'lib'), { recursive: true })
+    const clientSource = [
+      '\'use client\'',
+      'import { createSignal } from \'@barefootjs/client\'',
+      'export function Counter() {',
+      '  const [count, setCount] = createSignal(0)',
+      '  return <div className="bg-primary p-4"><button onClick={() => setCount(count() + 1)}>{count()}</button></div>',
+      '}',
+    ].join('\n')
+    await writeFile(join(dir, 'lib/Counter.tsx'), clientSource)
+
+    const plugin = barefoot({
+      adapter: testAdapter,
+      components: [{ dir: 'lib', cssLayerPrefix: 'components' }],
+      templates: join(dir, 'views'),
+    })
+    await driveConfig(plugin, dir)
+
+    const out = plugin.transform(clientSource, join(dir, 'lib/Counter.tsx'))
+    expect(out).not.toBeNull()
+    expect(out.code).toContain('layer-components:bg-primary')
+    expect(out.code).toContain('layer-components:p-4')
+  })
+})
+
+describe('ComponentDirEntry: skipDirs', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  test('excludes files under a matching subdirectory name from discovery (the eager pass)', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-entry-skipdirs-discovery-'))
+    await mkdir(join(dir, 'src/components/shared'), { recursive: true })
+    await writeFile(join(dir, 'src/components/Page.tsx'), 'export function Page() { return <p>Hi</p> }')
+    await writeFile(join(dir, 'src/components/shared/Helper.tsx'), 'export function Helper() { return <p>Hi</p> }')
+
+    const templatesDir = join(dir, 'views')
+    const plugin = barefoot({
+      adapter: testAdapter,
+      components: [{ dir: 'src/components', skipDirs: ['shared'] }],
+      templates: templatesDir,
+    })
+    await driveBuild(plugin, dir)
+
+    const emitted = await readdir(templatesDir)
+    expect(emitted).toContain(`Page${ext}`)
+    expect(emitted).not.toContain(`Helper${ext}`)
+  })
+
+  test('also gates the transform path — a file under a skipped subdir is not a component at all, even if directly imported', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-entry-skipdirs-transform-'))
+    await mkdir(join(dir, 'src/components/shared'), { recursive: true })
+
+    const clientTemplate = (name: string) => [
+      '\'use client\'',
+      'import { createSignal } from \'@barefootjs/client\'',
+      `export function ${name}() {`,
+      '  const [x, setX] = createSignal(0)',
+      '  return <button onClick={() => setX(x() + 1)}>{x()}</button>',
+      '}',
+    ].join('\n')
+
+    await writeFile(join(dir, 'src/components/Page.tsx'), clientTemplate('Page'))
+    // Lives inside the skipped `shared/` dir but is still a normal relative
+    // import target from a non-skipped sibling — the exact shape that used
+    // to reach `transform` anyway (discovery skips it, but nothing gated
+    // the graph pass) and got compiled despite being "skipped".
+    await writeFile(join(dir, 'src/components/shared/PageNavigation.tsx'), clientTemplate('PageNavigation'))
+
+    const plugin = barefoot({
+      adapter: testAdapter,
+      components: [{ dir: 'src/components', skipDirs: ['shared'] }],
+      templates: join(dir, 'views'),
+    })
+    await driveConfig(plugin, dir)
+
+    const pageOut = plugin.transform(clientTemplate('Page'), join(dir, 'src/components/Page.tsx'))
+    expect(pageOut).not.toBeNull()
+
+    const skippedOut = plugin.transform(
+      clientTemplate('PageNavigation'),
+      join(dir, 'src/components/shared/PageNavigation.tsx'),
+    )
+    expect(skippedOut).toBeNull()
+  })
+})
+
+describe('ComponentDirEntry: precedence', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  test('a file reachable under two entries (an outer dir and a nested dir both configured) takes the FIRST entry\'s cssLayerPrefix', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'barefoot-entry-precedence-'))
+    await mkdir(join(dir, 'src/nested'), { recursive: true })
+    await writeFile(join(dir, 'src/nested/Card.tsx'), 'export function Card() { return <div className="bg-primary">Hi</div> }')
+
+    const templatesDir = join(dir, 'views')
+    const plugin = barefoot({
+      adapter: testAdapter,
+      components: [
+        { dir: 'src', cssLayerPrefix: 'outer' },
+        { dir: 'src/nested', cssLayerPrefix: 'inner' },
+      ],
+      templates: templatesDir,
+    })
+    await driveBuild(plugin, dir)
+
+    // Emitted at `nested/Card...` — `planEmits` mirrors the file's position
+    // under whichever `componentDirs` entry contains it, and since `src`
+    // (the FIRST entry) also matches, that's `src`'s own relative position
+    // (`nested/Card.tsx`), not `src/nested`'s.
+    const tpl = await readFile(join(templatesDir, 'nested', `Card${ext}`), 'utf8')
+    expect(tpl).toContain('layer-outer:bg-primary')
+    expect(tpl).not.toContain('layer-inner:')
+  })
+})

--- a/packages/vite/src/component-manifest.ts
+++ b/packages/vite/src/component-manifest.ts
@@ -33,9 +33,12 @@
  *   there. The real client JS URL is content-hashed and mode-dependent
  *   (dev-origin vs. build-manifest-resolved) — exactly what
  *   `scriptAssets` already resolves and bakes directly into the compiled
- *   template's own script-registration call, so no backend reads
- *   `manifest[name].clientJs` (grep the PHP/Python/Ruby runtimes: zero
- *   hits), and a static value there would be actively misleading.
+ *   template's own script-registration call. No adapter backend or native
+ *   runtime reads `manifest[name].clientJs`; however, `@barefootjs/hono`'s
+ *   `BfPreload` component can read `clientJs` from a caller-supplied
+ *   manifest object (legacy site builds emit one). Plugin-manifest
+ *   consumers wanting preloads use the `preloadAssets` path instead
+ *   (`registerComponentPreloads` → `<link rel="modulepreload">`).
  */
 import type { CompileResult, TemplateAdapter } from '@barefootjs/jsx'
 import { perComponentRelPath, relativeUnderComponentDir, withExtension } from './paths.ts'

--- a/packages/vite/src/discover.ts
+++ b/packages/vite/src/discover.ts
@@ -95,20 +95,58 @@ export interface DiscoveredComponent {
    * exists; see `buildChildNameIndex`.
    */
   exportedComponents: string[]
+  /**
+   * `CompileOptions.cssLayerPrefix` this file should compile with, carried
+   * over unchanged from whichever `components` entry's `dir` this file was
+   * discovered under (see `ResolvedComponentDirEntry.cssLayerPrefix`).
+   * `undefined` when that entry set none (or was a plain string entry).
+   */
+  cssLayerPrefix?: string
 }
 
 /**
- * Scan every configured `components` directory (absolute paths) for `.tsx`
- * files and classify each as client (`'use client'`) or server-only.
+ * A `components` directory to scan, already resolved to an absolute `dir`,
+ * plus the per-directory compile behavior `barefoot()`'s `ComponentDirEntry`
+ * (`types.ts`) carries. `discoverComponents` also accepts a plain absolute
+ * path string as shorthand for `{ dir: string }` — the same "string is
+ * exactly equivalent to `{ dir }`" equivalence `ComponentDirEntry` itself
+ * documents — so existing callers that only ever had bare directories
+ * (`integrations/h3`/`elysia`'s `vite.config.ts`, reusing this exported
+ * function to resolve every discovered client component's URL) keep
+ * compiling and behaving unchanged.
+ */
+export interface ResolvedComponentDirEntry {
+  /** Absolute path to the source directory to scan. */
+  dir: string
+  /** Stamped onto every `DiscoveredComponent` found under `dir` — see
+   * `DiscoveredComponent.cssLayerPrefix`. */
+  cssLayerPrefix?: string
+  /** Directory NAMES to skip anywhere under `dir` — passed straight
+   * through to `discoverComponentFiles`. */
+  skipDirs?: string[]
+}
+
+/**
+ * Scan every configured `components` directory for `.tsx` files and
+ * classify each as client (`'use client'`) or server-only. Each entry may
+ * be a plain absolute path (shorthand for `{ dir }`, no `cssLayerPrefix`/
+ * `skipDirs`) or a `ResolvedComponentDirEntry`.
+ *
+ * A file reachable under more than one entry is discovered once, stamped
+ * with the FIRST matching entry's `cssLayerPrefix` — entries are walked in
+ * array order and `seen` short-circuits every later match, the same
+ * first-writer-wins precedence `buildChildNameIndex` already documents for
+ * `@bf-child:` name collisions.
  */
 export async function discoverComponents(
-  componentDirs: string[],
+  entries: readonly (string | ResolvedComponentDirEntry)[],
   readFile: (absPath: string) => Promise<string>,
 ): Promise<DiscoveredComponent[]> {
   const seen = new Set<string>()
   const out: DiscoveredComponent[] = []
-  for (const dir of componentDirs) {
-    for (const absPath of await discoverComponentFiles(dir)) {
+  for (const raw of entries) {
+    const entry: ResolvedComponentDirEntry = typeof raw === 'string' ? { dir: raw } : raw
+    for (const absPath of await discoverComponentFiles(entry.dir, { skipDirs: entry.skipDirs })) {
       if (seen.has(absPath)) continue
       seen.add(absPath)
       const content = await readFile(absPath)
@@ -120,6 +158,7 @@ export async function discoverComponents(
         absPath,
         isClient,
         exportedComponents: isClient ? listExportedComponents(content, absPath) : [],
+        cssLayerPrefix: entry.cssLayerPrefix,
       })
     }
   }

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,6 +1,6 @@
 export { barefoot, PLUGIN_NAME } from './plugin.ts'
 export { barefoot as default } from './plugin.ts'
-export type { AfterEmitContext, BarefootPluginApi, BarefootViteOptions } from './types.ts'
+export type { AfterEmitContext, BarefootPluginApi, BarefootViteOptions, ComponentDirEntry } from './types.ts'
 
 // Re-exported so an adapter's own `/vite` subpath (e.g.
 // `@barefootjs/go-template/vite`) can resolve script/asset URLs the SAME
@@ -22,4 +22,4 @@ export { toPosixRelative } from './paths.ts'
 // with ad hoc, possibly-diverging logic) is exactly the CLAUDE.md
 // "reuse or port it, don't reinvent" rule this module's own docstring
 // already invokes.
-export { discoverComponents, type DiscoveredComponent } from './discover.ts'
+export { discoverComponents, type DiscoveredComponent, type ResolvedComponentDirEntry } from './discover.ts'

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -63,7 +63,7 @@
  * for `go run .` to compile even in dev.
  */
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
+import { relative, resolve, sep } from 'node:path'
 import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
 import {
   compileJSX,
@@ -73,7 +73,13 @@ import {
 import type { BarefootPluginApi, BarefootViteOptions } from './types.ts'
 import { CompileCache } from './compile-cache.ts'
 import { BF_CHILD_NOOP_ID, bfChildMarkerName } from './child-marker.ts'
-import { buildChildNameIndex, discoverComponents, isComponentSourceFile, type DiscoveredComponent } from './discover.ts'
+import {
+  buildChildNameIndex,
+  discoverComponents,
+  isComponentSourceFile,
+  type DiscoveredComponent,
+  type ResolvedComponentDirEntry,
+} from './discover.ts'
 import { resolveClientJsSpecifier } from './resolve-client-js.ts'
 import { buildRelativeImportRewriter, relativeUnderComponentDir, safeRollupEntryName, toPosixRelative } from './paths.ts'
 import { loadManifest, resolvePreloadAssets, resolveScriptAssets } from './manifest.ts'
@@ -108,6 +114,31 @@ function reportErrors(result: CompileResult, source: string, projectDir: string)
   }
 }
 
+/**
+ * Resolves `options.components` (each entry a plain string OR a
+ * `ComponentDirEntry`) against `root` into `ResolvedComponentDirEntry[]` —
+ * `dir` always absolute, `cssLayerPrefix`/`skipDirs` carried through
+ * unchanged, array order preserved. A plain string entry becomes
+ * `{ dir: resolve(root, entry) }` with neither field set, exactly
+ * equivalent to `{ dir: entry }` per `ComponentDirEntry`'s own contract.
+ *
+ * Called twice per plugin instance with two different roots — `config`'s
+ * best-effort `guessedRoot` (Vite's real root isn't resolved yet at that
+ * point in its lifecycle) and `configResolved`'s authoritative
+ * `config.root` — which is why this takes `root` as a parameter instead of
+ * closing over one.
+ */
+function normalizeComponents(
+  components: BarefootViteOptions['components'],
+  root: string,
+): ResolvedComponentDirEntry[] {
+  return components.map(entry =>
+    typeof entry === 'string'
+      ? { dir: resolve(root, entry) }
+      : { dir: resolve(root, entry.dir), cssLayerPrefix: entry.cssLayerPrefix, skipDirs: entry.skipDirs },
+  )
+}
+
 export function barefoot(options: BarefootViteOptions): Plugin {
   const cache = new CompileCache()
 
@@ -124,6 +155,20 @@ export function barefoot(options: BarefootViteOptions): Plugin {
   // once in `config` with a best-effort root, so `rollupOptions.input` can
   // be set; then again in `configResolved` with Vite's authoritative
   // `root`, which is what `resolveId` / `transform` / `writeBundle` use.
+  //
+  // `dirEntries` is the normalized `options.components` — `dir` resolved
+  // to absolute, `cssLayerPrefix`/`skipDirs` carried through — in the
+  // OPTION'S OWN ORDER, which doubles as precedence: `entryForPath` below
+  // returns the FIRST entry whose `dir` prefixes a given path, so an
+  // earlier `components` entry shadows a later one for a file reachable
+  // under both (the same first-writer-wins precedence
+  // `buildChildNameIndex` already applies to `@bf-child:` name
+  // collisions). `componentDirs` is `dirEntries.map(e => e.dir)`, kept
+  // around unchanged because every existing bit of path arithmetic
+  // (`rewriterFor`, `planEmits`, `buildManifestEntry`,
+  // `safeRollupEntryName`) only ever needs the bare directory list, never
+  // the per-entry options.
+  let dirEntries: ResolvedComponentDirEntry[] = []
   let componentDirs: string[] = []
   // `undefined` exactly when `options.templates` was never set — the CSR
   // degenerate case. Every write path below (`writeEmits`, `manifest.json`,
@@ -198,11 +243,48 @@ export function barefoot(options: BarefootViteOptions): Plugin {
     )
   }
 
+  /**
+   * The FIRST `dirEntries` entry (option order) whose `dir` prefixes
+   * `absPath`, or `undefined` if no configured `components` entry contains
+   * it. This is the single source of precedence: whichever entry a path
+   * resolves to here is also the entry `isUnderComponentDir`'s `skipDirs`
+   * check consults, so a file's `cssLayerPrefix` and its skip/no-skip
+   * verdict always come from the SAME entry, never two different ones.
+   */
+  function entryForPath(absPath: string): ResolvedComponentDirEntry | undefined {
+    return dirEntries.find(entry => absPath === entry.dir || absPath.startsWith(`${entry.dir}/`))
+  }
+
+  /** Does `entry.skipDirs` name any directory component on the path from
+   * `entry.dir` down to `absPath`? Mirrors `discoverComponentFiles`'s own
+   * recursive skip (a directory whose NAME is listed is skipped, along
+   * with everything under it) so a file discovery never walks into is
+   * never treated as a component by the transform gate either — the
+   * "half-fix" this module's docstring on `isUnderComponentDir` warns
+   * about. The file's own basename (the last path segment) is excluded:
+   * `skipDirs` names directories, not files. */
+  function isSkippedByEntry(absPath: string, entry: ResolvedComponentDirEntry): boolean {
+    if (!entry.skipDirs || entry.skipDirs.length === 0) return false
+    const relParts = relative(entry.dir, absPath).split(sep)
+    return relParts.slice(0, -1).some(part => entry.skipDirs!.includes(part))
+  }
+
   function compileCanonical(absPath: string, content: string): CompileResult {
     return cache.getOrCompile(absPath, content, () =>
       compileJSX(content, absPath, {
         adapter: options.adapter,
         sourceMaps: true,
+        // Per-directory, from whichever `dirEntries` entry `absPath` falls
+        // under — `undefined` for a plain-string entry (or a file matching
+        // no entry, which shouldn't happen for anything reaching this
+        // function). `CompileCache` is keyed `(absPath, contentHash)` with
+        // NO `cssLayerPrefix` component — deliberately: the prefix is a
+        // pure function of `absPath` via `dirEntries`, and `dirEntries`
+        // only ever changes on a config reload (a full plugin restart,
+        // hence a fresh `cache` too), so two calls with the same
+        // `(absPath, content)` always agree on `cssLayerPrefix` and the
+        // cache key needs no widening. Do not "fix" this later.
+        cssLayerPrefix: entryForPath(absPath)?.cssLayerPrefix,
         // The canonical, cacheable compile always uses an empty
         // scriptAssets ("no scripts") — the one input every discovered
         // file (server-only or client) shares regardless of its eventual
@@ -233,8 +315,23 @@ export function barefoot(options: BarefootViteOptions): Plugin {
     )
   }
 
+  /**
+   * Is `absPath` a component this plugin should treat as live — under a
+   * configured `components` entry AND not inside that entry's `skipDirs`?
+   * Gates `transform` (the graph pass) and the dev watcher's
+   * `change`/`add`/`unlink` handlers. `skipDirs` must gate THIS, not just
+   * `discoverComponents`'s directory walk: discovery only decides what the
+   * EAGER pass walks up front, but a skipped file can still be reached by
+   * an ordinary `import` from a non-skipped sibling — `site/ui`'s
+   * `PageNavigation.tsx` (imported by pages, but living in a skipped
+   * `shared/` dir) is exactly that shape. Without this check the graph
+   * pass would compile it anyway: discovery silently skips it, but
+   * `transform` doesn't, which is the half-fix that used to bite that
+   * layout.
+   */
   function isUnderComponentDir(absPath: string): boolean {
-    return componentDirs.some(dir => absPath === dir || absPath.startsWith(`${dir}/`))
+    const entry = entryForPath(absPath)
+    return entry !== undefined && !isSkippedByEntry(absPath, entry)
   }
 
   /**
@@ -284,6 +381,11 @@ export function barefoot(options: BarefootViteOptions): Plugin {
           result = compileJSX(content, component.absPath, {
             adapter: options.adapter,
             sourceMaps: true,
+            // Already stamped on `component` by `discoverComponents` from
+            // the same `dirEntries` entry `compileCanonical` would have
+            // derived via `entryForPath` — reused directly rather than
+            // re-derived, since the two always agree.
+            cssLayerPrefix: component.cssLayerPrefix,
             scriptAssets,
             preloadAssets,
             rewriteRelativeImport: rewriterFor(component.absPath),
@@ -367,7 +469,7 @@ export function barefoot(options: BarefootViteOptions): Plugin {
     const config = resolvedConfig
     if (!config) return
 
-    const discovered = await discoverComponents(componentDirs, absPath => readFile(absPath, 'utf8'))
+    const discovered = await discoverComponents(dirEntries, absPath => readFile(absPath, 'utf8'))
     childNameIndex = buildChildNameIndex(discovered)
     const types = await emitTemplatesFor(discovered, config.root, component => ({
       scriptAssets: devScriptAssets(config, devOrigin, component.absPath),
@@ -425,8 +527,9 @@ export function barefoot(options: BarefootViteOptions): Plugin {
       // convenience `rollupOptions.input` keys this hook picks could be
       // off, not correctness.
       const guessedRoot = userConfig.root ? resolve(process.cwd(), userConfig.root) : process.cwd()
-      const dirs = options.components.map(d => resolve(guessedRoot, d))
-      const found = await discoverComponents(dirs, absPath => readFile(absPath, 'utf8'))
+      const guessedEntries = normalizeComponents(options.components, guessedRoot)
+      const dirs = guessedEntries.map(e => e.dir)
+      const found = await discoverComponents(guessedEntries, absPath => readFile(absPath, 'utf8'))
 
       const input: Record<string, string> = {}
       for (const c of found) {
@@ -474,9 +577,10 @@ export function barefoot(options: BarefootViteOptions): Plugin {
 
     async configResolved(config) {
       resolvedConfig = config
-      componentDirs = options.components.map(d => resolve(config.root, d))
+      dirEntries = normalizeComponents(options.components, config.root)
+      componentDirs = dirEntries.map(e => e.dir)
       templatesDir = options.templates !== undefined ? resolve(config.root, options.templates) : undefined
-      const discovered = await discoverComponents(componentDirs, absPath => readFile(absPath, 'utf8'))
+      const discovered = await discoverComponents(dirEntries, absPath => readFile(absPath, 'utf8'))
       childNameIndex = buildChildNameIndex(discovered)
     },
 
@@ -527,7 +631,7 @@ export function barefoot(options: BarefootViteOptions): Plugin {
 
       // Authoritative discovery — Vite's real root, not `config`'s guess.
       const discovered: DiscoveredComponent[] = await discoverComponents(
-        componentDirs,
+        dirEntries,
         absPath => readFile(absPath, 'utf8'),
       )
 

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -43,14 +43,37 @@ export interface AfterEmitContext {
 }
 
 /**
+ * One `components` entry with per-directory compile behavior. A plain
+ * string is exactly equivalent to `{ dir: string }` — see
+ * `BarefootViteOptions.components`.
+ */
+export interface ComponentDirEntry {
+  /** Source directory to scan, relative to the Vite root (or absolute). */
+  dir: string
+  /** `CompileOptions.cssLayerPrefix` for every component under `dir`:
+   *  static class strings get `layer-{value}:` prefixes so a library's
+   *  base classes land in a lower cascade layer than app overrides. Set
+   *  it on library entries, leave it off app entries. */
+  cssLayerPrefix?: string
+  /** Directory NAMES to skip anywhere under `dir` (e.g. `['shared']`). */
+  skipDirs?: string[]
+}
+
+/**
  * Public options for the `barefoot()` Vite plugin. Exactly three
- * BarefootJS-specific fields — everything else (bundling, hashing,
+ * BarefootJS-specific FIELDS — everything else (bundling, hashing,
  * chunking, tree-shaking, minification, dev server, `base`, `outDir`) is
  * stock Vite config. Do not add more fields here; see the design doc for
  * the full list of options this deliberately drops in favor of Vite's own
  * equivalents (`minify` → `build.minify`, `externals` → Rollup's automatic
  * chunk splitting, `clientJsBasePath`/`barefootJsPath` → `base` + manifest
  * resolution, etc).
+ *
+ * The cap is on FIELDS, not on per-directory expressiveness: whether a
+ * directory's classes need a CSS cascade layer, or which subdirectories to
+ * skip, is a function of WHICH `components` entry a file came from — so
+ * that behavior rides on the `components` entries themselves
+ * (`ComponentDirEntry`) rather than becoming a 4th/5th top-level option.
  */
 export interface BarefootViteOptions {
   /** A constructed `TemplateAdapter` instance (e.g. `new
@@ -58,8 +81,13 @@ export interface BarefootViteOptions {
    * the plugin never constructs adapters itself. */
   adapter: TemplateAdapter
   /** Source directories to scan for `.tsx` components, relative to the
-   * Vite project root (or absolute). */
-  components: string[]
+   * Vite project root (or absolute). A plain string is exactly equivalent
+   * to `{ dir: string }` (a `ComponentDirEntry` with no `cssLayerPrefix`/
+   * `skipDirs`) — use the object form only when a directory needs one of
+   * those. Entries are processed in array order, and that order is also
+   * the precedence when the same file is reachable under more than one
+   * entry: the first entry wins. */
+  components: (string | ComponentDirEntry)[]
   /**
    * Where compiled templates, `ssrDefaults`, and adapter-generated types
    * land — relative to the Vite project root (or absolute). This is a

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -104,7 +104,8 @@ export const renderer = jsxRenderer(
             <script type="importmap" dangerouslySetInnerHTML={{ __html: importMapScript }} />
             <BfPreload
               manifest={manifest as Manifest}
-              components={['Button', 'CopyButton', 'Toggle', 'ThemeToggle']}
+              // Manifest keys are path-qualified, not component names
+              components={['ui/button', 'copy-button', 'ui/toggle', 'theme-switcher']}
             />
             <meta charset="UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
Stacked on #2546. Resolves the two remaining non-deferred blockers from the #2537 survey ([corrected record](https://github.com/piconic-ai/barefootjs/issues/2537#issuecomment-5199147891)). The two deferred workstreams — the `ts.Program` root-cause fix (tens-of-seconds builds are not acceptable) and the ~350 never-compiled files — are tracked on the issue and not attempted here.

## 1. `docs: tell the truth about BfPreload` (`d0845b8a4`)

The plugin-manifest comment justified omitting `clientJs` with a grep scoped to the PHP/Python/Ruby runtimes — but `@barefootjs/hono`'s `BfPreload` is not a native runtime and reads `clientJs` from a caller-supplied manifest. The omission stands; the justification now states its true scope.

`site/ui`'s renderer had been sitting in `BfPreload`'s silent-skip mode: it asked for `['Button', 'CopyButton', 'Toggle', 'ThemeToggle']` against a manifest whose keys are path-qualified (`ui/button`, …) — and `ThemeToggle` names no component at all (the real one is `theme-switcher`). All four lookups missed silently; the head emitted only the runtime preload. With real keys, verified by rendering the page:

```
<link rel="modulepreload" href="/static/components/barefoot.js"/>
<link rel="modulepreload" href="/static/components/ui/button/button-eb68f3a2.js"/>
<link rel="modulepreload" href="/static/components/copy-button-fba24b48.js"/>
<link rel="modulepreload" href="/static/components/ui/toggle/toggle-a053025d.js"/>
<link rel="modulepreload" href="/static/components/theme-switcher-4565e5f0.js"/>
```

`BfPreload`'s docs now name the failure mode (exact-key match, silent skip) and the fact that `ManifestEntry.dependencies` has no current producer.

## 2. per-directory `cssLayerPrefix` + `skipDirs` (`07b77f49a`)

`site/ui` compiles library components with `cssLayerPrefix: 'components'` and app/docs components without — the cascade contract in `site/ui/styles/globals.css` (library base classes in `@layer components`, app overrides un-layered so they always win; ~490 `className` overrides depend on it). The plugin could not express a compile option whose value depends on which source directory a file came from, and `BarefootViteOptions` is deliberately capped at three fields.

The cap is on **fields**. This widens the element type of the existing `components` field instead:

```ts
components: (string | { dir: string; cssLayerPrefix?: string; skipDirs?: string[] })[]
```

Plain strings stay exactly equivalent to `{ dir }` — pinned by a byte-identical-output test — and per-directory behavior rides on the directory entry. `skipDirs` closes the survey's §4.1 in the same stroke, gating both discovery **and** the transform path: discovery only decides what the eager pass walks, but a skipped file can still arrive via an ordinary import from a non-skipped sibling (`site/ui`'s `PageNavigation.tsx` is exactly that shape), so gating only discovery would compile it anyway.

Two invariants that earned in-code comments:

- `CompileCache` stays keyed `(absPath, contentHash)`: the prefix is a pure function of absPath via the entry list, which only changes on a config reload (fresh plugin, fresh cache). The comment says "do not fix this later" so nobody widens the key defensively.
- `discoverComponents` keeps accepting plain path strings — it's a public export that `integrations/h3`/`elysia` call directly; the union keeps them untouched. One mechanical ripple: `packages/cli`'s `vite-config-loader` unwraps `{ dir }` down to the bare directory.

## Verification (re-run by the reviewer, not taken from the implementers)

- `packages/vite`: **140 pass / 0 fail** (6 new tests: string≡`{dir}` equivalence; prefix reaching the template AND the client-JS hydration template; `skipDirs` gating discovery AND transform; first-entry-wins precedence)
- `vite-config-loader`: 7 pass / 0 fail
- `packages/adapter-hono`: 1344 pass / 0 fail; the preload links above verified by rendering the page, twice (the first re-check hit a stale server and returned nothing — re-verified against a freshly started server)
- `integrations/hono` rebuilt: no `layer-` prefix appears anywhere under plain-string entries; templates unchanged