### PR TITLE
fix(site): make the 3 files failing plugin-grade compilation compile clean (#2537 item 4)

### DIFF
--- a/site/core/landing/components/hero.tsx
+++ b/site/core/landing/components/hero.tsx
@@ -34,6 +34,18 @@ const DEMO_TABS_SCRIPT = `(function(){
   if (adSelect) adSelect.addEventListener('change', apply);
 })();`
 
+// Flattened example × adapter pairs for the output panels, hoisted so the
+// template loop's body is a single JSX element rather than a nested
+// `.map()` (a shape the compiler rejects with BF021).
+const OUTPUT_PANELS = DEMO_EXAMPLES.flatMap((ex, exIndex) =>
+  ex.outputs.map((out, outIndex) => ({
+    panelId: `${ex.id}-${out.id}`,
+    file: out.file,
+    code: out.code,
+    active: exIndex === 0 && outIndex === 0,
+  }))
+)
+
 export function Hero({ uiHref = 'https://ui.barefootjs.dev' }: { uiHref?: string }) {
   return (
     <div className="lp-hero">
@@ -67,12 +79,12 @@ export async function DemoSection() {
               <span>what you write</span>
               <select className="demo-select" data-select="example" aria-label="Example source">
                 {DEMO_EXAMPLES.map((ex, i) => (
-                  <option value={ex.id} selected={i === 0}>{ex.file}</option>
+                  <option key={ex.id} value={ex.id} selected={i === 0}>{ex.file}</option>
                 ))}
               </select>
             </div>
             {DEMO_EXAMPLES.map((ex, i) => (
-              <div className={`src-panel${i === 0 ? ' active' : ''}`} data-example={ex.id}>
+              <div key={ex.id} className={`src-panel${i === 0 ? ' active' : ''}`} data-example={ex.id}>
                 <pre
                   className="shiki shiki-themes github-light github-dark"
                   tabindex={0}
@@ -86,21 +98,20 @@ export async function DemoSection() {
               <span>what your server renders</span>
               <select className="demo-select" data-select="adapter" aria-label="Compiled output language">
                 {DEMO_EXAMPLES[0].outputs.map((out, i) => (
-                  <option value={out.id} selected={i === 0}>{out.label}</option>
+                  <option key={out.id} value={out.id} selected={i === 0}>{out.label}</option>
                 ))}
               </select>
             </div>
-            {DEMO_EXAMPLES.map((ex, i) =>
-              ex.outputs.map((out, j) => (
-                <div
-                  className={`out-panel${i === 0 && j === 0 ? ' active' : ''}`}
-                  data-panel={`${ex.id}-${out.id}`}
-                >
-                  <div className="pane-file-row">{out.file}</div>
-                  <pre tabindex={0}><code>{out.code}</code></pre>
-                </div>
-              ))
-            )}
+            {OUTPUT_PANELS.map((panel) => (
+              <div
+                key={panel.panelId}
+                className={`out-panel${panel.active ? ' active' : ''}`}
+                data-panel={panel.panelId}
+              >
+                <div className="pane-file-row">{panel.file}</div>
+                <pre tabindex={0}><code>{panel.code}</code></pre>
+              </div>
+            ))}
           </div>
         </div>
         <p className="demo-note">

--- a/site/core/landing/components/sections.tsx
+++ b/site/core/landing/components/sections.tsx
@@ -28,6 +28,19 @@ interface CompatLock {
 
 const compat = lock as CompatLock
 
+// Matrix aggregates, at module scope: the template references them
+// (aria-label, matrix-foot), and template scope cannot reach init-body
+// locals (BF061). They only depend on the imported lock file anyway.
+const componentNames = Object.keys(compat.components).sort()
+const adapters = compat.adapters
+const totalCells = componentNames.length * adapters.length
+let okCells = 0
+for (const name of componentNames) {
+  for (const adapter of adapters) {
+    if (compat.components[name]?.[adapter]?.ok) okCells++
+  }
+}
+
 /* ── 2. The fork ─────────────────────────────────────────────── */
 
 export function ForkSection() {
@@ -77,16 +90,6 @@ export function ForkSection() {
 /* ── 3. Proof (matrix) ───────────────────────────────────────── */
 
 export function MatrixSection({ uiHref = 'https://ui.barefootjs.dev' }: { uiHref?: string }) {
-  const componentNames = Object.keys(compat.components).sort()
-  const adapters = compat.adapters
-  const totalCells = componentNames.length * adapters.length
-  let okCells = 0
-  for (const name of componentNames) {
-    for (const adapter of adapters) {
-      if (compat.components[name]?.[adapter]?.ok) okCells++
-    }
-  }
-
   return (
     <section className="lp-section">
       <div className="lp-wrap">
@@ -101,13 +104,14 @@ export function MatrixSection({ uiHref = 'https://ui.barefootjs.dev' }: { uiHref
           aria-label={`${componentNames.length} components by ${adapters.length} adapters, ${okCells} of ${totalCells} compiling clean`}
         >
           {adapters.map((adapter) => (
-            <div className="matrix-row">
+            <div key={adapter} className="matrix-row">
               <span className="rlabel">{adapter}</span>
               <div className="cells">
                 {componentNames.map((name) => {
                   const ok = compat.components[name]?.[adapter]?.ok
                   return (
                     <span
+                      key={name}
                       className={`cell${ok ? '' : ' cell-miss'}`}
                       title={ok ? `${name} × ${adapter}` : `${name} × ${adapter} — tracked limitation`}
                     />

--- a/site/shared/components/docs-tabs.tsx
+++ b/site/shared/components/docs-tabs.tsx
@@ -29,6 +29,7 @@ export function DocsTabs({ id, defaultTab, tabs }: DocsTabsProps) {
       <div role="tablist" className="bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px] mb-4">
         {tabs.map((tab) => (
           <button
+            key={tab.label}
             role="tab"
             aria-selected={tab.label === defaultTab}
             data-state={tab.label === defaultTab ? 'active' : 'inactive'}
@@ -42,6 +43,7 @@ export function DocsTabs({ id, defaultTab, tabs }: DocsTabsProps) {
       </div>
       {tabs.map((tab) => (
         <div
+          key={tab.label}
           role="tabpanel"
           data-docs-tab-panel={tab.label}
           className={tab.label === defaultTab ? '' : 'hidden'}


### PR DESCRIPTION
Lands the fix for #2537's item 4, sized by the [inventory](https://github.com/piconic-ai/barefootjs/issues/2537#issuecomment-5200395088): every file both site build scripts discover was put through `compileJSX` under plugin-equivalent conditions (shared corpus `ts.Program`, `HonoAdapter`, site/ui's per-directory options). 273 of 276 compiles were already clean — the "~350 never-compiled files" estimate collapsed to **3 files carrying all 12 error diagnostics**, each of which would make `@barefootjs/vite` throw (it has no copy-through path).

## The fixes

| file | was failing with | fix |
|---|---|---|
| `site/shared/components/docs-tabs.tsx` | BF023 ×2 | `key` props on the tab-trigger and tab-panel loops |
| `site/core/landing/components/hero.tsx` | BF023 ×3, BF021 | `key` props; flatten the example × adapter output panels into a module-scope `OUTPUT_PANELS` array so the loop body is a single JSX element instead of a nested `.map()` |
| `site/core/landing/components/sections.tsx` | BF023, BF024, BF061 ×2 | `key` props on the matrix loops; hoist the matrix aggregates (`componentNames` / `adapters` / `totalCells` / `okCells`) to module scope — the template references them and template scope cannot reach init-body locals |

No compiler changes, no `skipDirs` carve-outs — every failure was a small site-source edit.

## Why no conformance fixture

CLAUDE.md's fixture rule covers compiler/adapter divergences; these are site-source defects the compiler diagnoses **correctly**. The regression armor is the migration itself: once site/ui and site/core build through `@barefootjs/vite` (the remaining work on #2537), any reintroduced diagnostic fails the build loudly instead of being swallowed.

## Verification

- All three files recompile with **0 errors / 0 warnings** and emit both a marked template and client JS under the same corpus-program conditions the inventory used.
- All three currently render via Hono SSR from source, so SSR equivalence matters today: smoke-rendered each exported component — identical structure (9 matrix rows × 63 cells, 14 output panels with 1 active src + 1 active out panel, 2 tab panels; `key` props don't render in SSR, and the hoisted aggregates compute identically).

Refs #2537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ)_