### PR TITLE
fix(release): add @barefootjs/vite to the npm publish list (0.31.0 blocker)

### DIFF
--- a/scripts/changeset-publish.ts
+++ b/scripts/changeset-publish.ts
@@ -32,6 +32,12 @@ const PUBLISHABLE = [
   'packages/shared',
   'packages/streaming',
   'packages/jsx',
+  // After shared + jsx (its dependency / peer), before every adapter —
+  // each adapter's `/vite` subpath composes @barefootjs/vite's barefoot().
+  // Missing from this list until 0.31.0, which is why the package was
+  // never on npm even though scaffolds (`bf init` CSR) and the adapters'
+  // peerDependencies already referenced it.
+  'packages/vite',
   'packages/client',
   'packages/router',
   'packages/test',

--- a/scripts/changeset-publish.ts
+++ b/scripts/changeset-publish.ts
@@ -32,11 +32,6 @@ const PUBLISHABLE = [
   'packages/shared',
   'packages/streaming',
   'packages/jsx',
-  // After shared + jsx (its dependency / peer), before every adapter —
-  // each adapter's `/vite` subpath composes @barefootjs/vite's barefoot().
-  // Missing from this list until 0.31.0, which is why the package was
-  // never on npm even though scaffolds (`bf init` CSR) and the adapters'
-  // peerDependencies already referenced it.
   'packages/vite',
   'packages/client',
   'packages/router',


### PR DESCRIPTION
Found while auditing the 0.31.0 release path: `scripts/changeset-publish.ts`'s `PUBLISHABLE` list never gained `packages/vite`, so **`@barefootjs/vite` has never been published — npm returns E404 today** — even though every release version-bumps it (it's in the changeset `fixed` group).

That makes it a release blocker for "the vite release" three ways:
1. `bf init`'s CSR scaffold writes `"@barefootjs/vite": "latest"` into generated `package.json` — `npm create barefootjs` (CSR) fails at install.
2. Every adapter's `peerDependencies` references `@barefootjs/vite: >=0.2.0`.
3. The adapters' `/vite` subpaths (`@barefootjs/hono/vite` etc.) import it at vite-config load time.

One-line fix plus ordering rationale: inserted after `shared` + `jsx` (its dependency / peer), before every adapter. `smoke-publish.mjs` already packs `packages/vite`, so tarball integrity has been CI-verified all along — only the publish step was missing, and `changeset-publish.ts` already handles first-time publishes (E404 → publish).

**Release-time note (action for the release operator):** as a first-time publish, `@barefootjs/vite` needs its npmjs.com **Trusted Publisher** configured (the same one-time setup `release.yml`'s header documents: package settings → Trusted Publishers → GitHub Actions, repo `piconic-ai/barefootjs`, workflow `release.yml`) before the Version Packages PR merges — or the OIDC publish of this one package will fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ)_