### PR TITLE
fix(release): let the JSR mirror publish through workspace dependency cycles

### DIFF
--- a/scripts/jsr-publish.ts
+++ b/scripts/jsr-publish.ts
@@ -314,6 +314,10 @@ async function jsrHasVersion(name: string, version: string): Promise<boolean> {
 
 // ── Run ───────────────────────────────────────────────────────────────
 const selected = topoSort(candidates).filter(c => !only || only.has(c.pkg.name))
+// Names in this run — the cycle-breaker below consults this to distinguish
+// "dep not live because it's about to be published by THIS run" from a
+// genuinely missing dependency.
+const selectedNames = new Set(selected.map(c => c.pkg.name))
 const generated: string[] = []
 let published = 0
 let skipped = 0
@@ -375,17 +379,46 @@ try {
       continue
     }
 
-    console.log(`\n  publish  ${pkg.name}@${pkg.version} → JSR`)
-    // Type-checking stays ON — the generated `deno.json` carries
-    // `compilerOptions.lib` (Deno's DOM + runtime set) so the DOM types these
-    // libraries export resolve cleanly. --allow-slow-types lets JSR extract the
-    // public API for docs/.d.ts through its (benign) slow-types warning;
-    // --allow-dirty permits the in-tree generated manifest.
+    // Workspace-dependency CYCLE breaker: a member of a dependency cycle
+    // (client ↔ jsx are mutual peers, and client's CSRAdapter now
+    // value-imports jsx's BaseAdapter) can never pass publish-time
+    // type-checking — its `jsr:dep@^<version>` import is only resolvable
+    // once the OTHER cycle member is live, and vice versa, so every
+    // (re-)dispatch fails identically. When the only unresolvable deps are
+    // packages THIS run is about to publish, upload with --no-check: the
+    // published manifest keeps the correct constraint, which becomes
+    // resolvable the moment the rest of the run lands, and the sequential
+    // verify loop below guarantees this package is live before its cycle
+    // partner's own (fully checked) publish runs. Type safety isn't lost —
+    // the same sources already type-checked in CI; only Deno's
+    // publish-time re-check is skipped, and only for cycle members.
+    const workspaceDeps = Object.keys({
+      ...(pkg.dependencies ?? {}),
+      ...(pkg.peerDependencies ?? {}),
+    }).filter(d => selectedNames.has(d) && !unresolved.has(d))
+    const pendingDeps: string[] = []
+    for (const dep of workspaceDeps) {
+      const depVersion = versions.get(dep)
+      if (depVersion && !(await jsrHasVersion(dep, depVersion))) pendingDeps.push(dep)
+    }
+    const noCheck = pendingDeps.length > 0
+
+    console.log(`\n  publish  ${pkg.name}@${pkg.version} → JSR${noCheck ? ` (--no-check: cycle with ${pendingDeps.join(', ')})` : ''}`)
+    // Type-checking stays ON (except for the cycle case above) — the
+    // generated `deno.json` carries `compilerOptions.lib` (Deno's DOM +
+    // runtime set) so the DOM types these libraries export resolve cleanly.
+    // --allow-slow-types lets JSR extract the public API for docs/.d.ts
+    // through its (benign) slow-types warning; --allow-dirty permits the
+    // in-tree generated manifest.
     // `timeout` cuts Deno's post-upload poll short (see DENO_PUBLISH_TIMEOUT_S
     // note above); the verify loop below is what actually confirms success.
-    const pub = await $`timeout --kill-after=10s ${DENO_PUBLISH_TIMEOUT_S} deno publish --allow-slow-types --allow-dirty`
-      .cwd(dir)
-      .nothrow()
+    const pub = noCheck
+      ? await $`timeout --kill-after=10s ${DENO_PUBLISH_TIMEOUT_S} deno publish --allow-slow-types --allow-dirty --no-check`
+          .cwd(dir)
+          .nothrow()
+      : await $`timeout --kill-after=10s ${DENO_PUBLISH_TIMEOUT_S} deno publish --allow-slow-types --allow-dirty`
+          .cwd(dir)
+          .nothrow()
     // 124 (TERM) / 137 (KILL) mean our timeout fired while Deno was still
     // polling — expected, not a failure. Any other non-zero is a genuine
     // publish error (type error, auth, unresolvable dep, …).


### PR DESCRIPTION
The 0.31.0 release succeeded everywhere **except the JSR mirror** ([run 31107531910](https://github.com/piconic-ai/barefootjs/actions/runs/31107531910): npm all-green, CPAN/PyPI/RubyGems/crates/Packagist all-green, `jsr-release / jsr` failed — 2 published, 1 error, 16 pending).

## The deadlock

`@barefootjs/client` ↔ `@barefootjs/jsx` are mutual peerDependencies, and — new in the vite series — client's `CSRAdapter` **value-imports** jsx's `BaseAdapter` (`csr-adapter.ts`). So:

- client's publish-time type-check resolves `jsr:@barefootjs/jsx@^0.31.0` → **not live yet** → `deno exit 1`
- jsx defers behind client (`unresolved`), and 15 more packages cascade behind them

Re-dispatching cannot help: every run fails on the identical cycle. (Pre-0.31.0 the mutual peers were harmless because no client *source file* imported jsx — the check never resolved the mapping.)

## The fix

When a package's only unresolvable workspace deps are ones **this same run is about to publish**, upload it with `--no-check`:

- the published manifest keeps the correct `jsr:dep@^<version>` constraint, which becomes resolvable the moment the rest of the run lands;
- the existing sequential verify loop already guarantees the `--no-check` package is live **before** its cycle partner's own fully-checked publish runs, so only cycle members skip Deno's re-check (the same sources type-checked in repo CI);
- a genuinely missing dependency still fails loudly — the bypass only triggers for deps in the current run's selected set.

Expected flow on the next dispatch: `client` (--no-check, cycle with jsx) → verify live → `jsx` (full check) → `vite` (full check) → the 13 remaining cascade normally.

## After merge

Dispatch **Publish to JSR** (`workflow_dispatch`) against `main` — safe right now because main's package.json versions are still exactly the 0.31.0 release's (the workflow header's "dispatch against the release tag" caveat is about versions having moved on, and they haven't; the tag ref wouldn't contain this fix).

One residual risk, called out honestly: if JSR's *server-side* processing also refuses the unresolvable constraint (not just the local check), the verify loop will time out and the job fails with a clear signal — in that case the real fix is breaking the source-level cycle (moving `BaseAdapter` down into `@barefootjs/shared`), which I'd file as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ)_