### PR TITLE
fix(adapter-hono): wrapWithInlineScripts returns JSX.Element, not unknown (#2559)

### DIFF
--- a/.changeset/wrap-inline-scripts-return-type.md
+++ b/.changeset/wrap-inline-scripts-return-type.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/hono": patch
+---
+
+`wrapWithInlineScripts` now declares its return type as `JSX.Element`
+instead of leaking `unknown`. Every compiled template returns this call
+as its component body, so the `unknown` return made every island fail
+TS2786 ("cannot be used as a JSX component") in any consumer app that
+type-checks its compiled templates. Type-only — no emitted-JS change.

--- a/packages/adapter-hono/src/__tests__/consumer-typecheck.test.ts
+++ b/packages/adapter-hono/src/__tests__/consumer-typecheck.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression for piconic-ai/barefootjs#2559: type-check a CONSUMER program
+ * that imports a compiled template — the coverage gap that let
+ * `wrapWithInlineScripts`'s `unknown` return ship. Every generated
+ * component returns that call as its body, so an `unknown` return made
+ * every island fail TS2786 ("cannot be used as a JSX component") in any
+ * type-checking consumer (hit by sora's 0.26.2 → 0.31.0 migration), while
+ * nothing in-repo ever ran tsc over a program shaped like a consumer app.
+ *
+ * The test compiles a real `'use client'` component with a non-empty
+ * `scriptAssets` (so the emitted template wraps its return in
+ * `wrapWithInlineScripts`), writes it plus a scaffold-shaped `server.tsx`
+ * that renders the island, and type-checks the pair with the scaffold's
+ * own options (`strict`, `jsxImportSource: '@barefootjs/hono/jsx'`).
+ */
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import ts from 'typescript'
+import { compileJSX } from '@barefootjs/jsx'
+import { HonoAdapter } from '../adapter/index.ts'
+
+const HERE = resolve(import.meta.dir)
+
+const COMPONENT_SOURCE = `"use client"
+
+import { createSignal } from '@barefootjs/client'
+
+export function Counter() {
+  const [count, setCount] = createSignal(0)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+
+const SERVER_SOURCE = `import { Counter } from './components/Counter.tsx'
+
+export function Page() {
+  return (
+    <div>
+      <Counter />
+    </div>
+  )
+}
+`
+
+describe('consumer program type-check (#2559)', () => {
+  test('a compiled template used as a JSX component type-checks clean', () => {
+    const result = compileJSX(COMPONENT_SOURCE, '/virtual/Counter.tsx', {
+      adapter: new HonoAdapter(),
+      // Non-empty so the emitted template's component body returns
+      // wrapWithInlineScripts(...) — the #2559 shape.
+      scriptAssets: ['/static/components/assets/Counter.js'],
+    })
+    expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
+    const template = result.files.find(f => f.type === 'markedTemplate')?.content
+    expect(template).toContain('wrapWithInlineScripts(')
+
+    // Inside the package so module resolution reaches the workspace's
+    // node_modules (hono, @barefootjs/*) exactly like a scaffolded app's.
+    const tmp = mkdtempSync(join(HERE, '.consumer-typecheck-'))
+    try {
+      mkdirSync(join(tmp, 'components'), { recursive: true })
+      writeFileSync(join(tmp, 'components', 'Counter.tsx'), template!)
+      writeFileSync(join(tmp, 'server.tsx'), SERVER_SOURCE)
+
+      const program = ts.createProgram(
+        [join(tmp, 'server.tsx')],
+        {
+          strict: true,
+          noEmit: true,
+          target: ts.ScriptTarget.ESNext,
+          module: ts.ModuleKind.ESNext,
+          moduleResolution: ts.ModuleResolutionKind.Bundler,
+          jsx: ts.JsxEmit.ReactJSX,
+          jsxImportSource: '@barefootjs/hono/jsx',
+          lib: ['lib.esnext.d.ts', 'lib.dom.d.ts'],
+          allowImportingTsExtensions: true,
+          // Consumer apps skipLibCheck too; TS2786 fires in OUR files
+          // regardless, which is exactly what this test pins.
+          skipLibCheck: true,
+        },
+      )
+      const diagnostics = ts.getPreEmitDiagnostics(program).map(d => ({
+        code: d.code,
+        file: d.file?.fileName ?? '',
+        message: ts.flattenDiagnosticMessageText(d.messageText, ' '),
+      }))
+
+      // TS2786 = "'X' cannot be used as a JSX component." — the #2559
+      // failure. Assert none anywhere in the consumer program.
+      expect(diagnostics.filter(d => d.code === 2786)).toEqual([])
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/adapter-hono/src/scripts.tsx
+++ b/packages/adapter-hono/src/scripts.tsx
@@ -40,6 +40,7 @@
 
 import { useRequestContext } from 'hono/jsx-renderer'
 import { Fragment } from 'hono/jsx'
+import type { JSX } from 'hono/jsx/jsx-runtime'
 import { relPathFromComponentsBase, type BarefootBuildManifest } from './app.ts'
 
 export type CollectedScript = {
@@ -284,8 +285,8 @@ export function registerComponentPreloads(urls: string[]): string[] {
  * only ever pass `inlineScripts` (a component with `scriptAssets` but no
  * `preloadAssets`) keep compiling and behaving exactly as before.
  */
-export function wrapWithInlineScripts(jsx: unknown, inlineScripts: string[], inlinePreloads: string[] = []) {
-  if (inlineScripts.length === 0 && inlinePreloads.length === 0) return jsx
+export function wrapWithInlineScripts(jsx: unknown, inlineScripts: string[], inlinePreloads: string[] = []): JSX.Element {
+  if (inlineScripts.length === 0 && inlinePreloads.length === 0) return jsx as JSX.Element
   return (
     <Fragment>
       {inlinePreloads.map(href => <link rel="modulepreload" crossorigin="" href={href} />)}


### PR DESCRIPTION
Closes #2559.

## Fix

`wrapWithInlineScripts` now declares `: JSX.Element` (type from `hono/jsx/jsx-runtime`, matching the adapter's own `JSX.Element` alias) instead of leaking `unknown`. `jsx` stays `unknown` on the way in — callers hand this whatever their JSX runtime produced. Type-only; no emitted-JS change. Verified in `dist/scripts.d.ts` after `build`:

```ts
export declare function wrapWithInlineScripts(jsx: unknown, inlineScripts: string[], inlinePreloads?: string[]): JSX.Element;
```

## Regression backstop (the gap the issue calls out)

Nothing in-repo ever type-checked a **consumer-shaped program** that imports a compiled template — which is why the `unknown` return shipped. New `consumer-typecheck.test.ts`:

1. compiles a real `'use client'` component with non-empty `scriptAssets` (so the emitted template's body is `return wrapWithInlineScripts(...)` — the #2559 shape);
2. writes it plus a scaffold-shaped `server.tsx` that renders the island;
3. type-checks the pair via the TS API with the scaffold's own options (`strict`, `jsx: react-jsx`, `jsxImportSource: '@barefootjs/hono/jsx'`);
4. asserts **zero TS2786** anywhere in the program.

Confirmed red without the fix, green with it.

## Audit

`wrapWithInlineScripts`-style JS wrapping exists only in adapter-hono — DSL-template adapters (Go/ERB/Jinja/…) emit no JS-runtime wrapper, so no sibling has the same hole. The neighboring generated-template imports (`registerComponentScripts` / `registerComponentPreloads`) already declare `string[]`.

Changeset: `@barefootjs/hono` patch (type-only, consumers pick it up on the next patch release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2ohTSt6GpQcQbSBADjKeQ)_