### PR TITLE
fix(go-template): key the Input struct by the caller-facing prop name (#2525)

### DIFF
--- a/.changeset/go-input-struct-caller-key-2525.md
+++ b/.changeset/go-input-struct-caller-key-2525.md
@@ -1,0 +1,49 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Go adapter's Input struct now keys an aliased destructured prop by its caller-facing name (#2525)
+
+`function Badge({ n: count }: { n: number })` used to name the generated
+`BadgeInput` struct field from the LOCAL destructure binding
+(`capitalizeFieldName(param.name)` → `Count`), so a caller-side composite
+literal keyed by the real prop name (`BadgeInput{N: 5}`) failed `go run`
+outright (`unknown field N in struct literal of type BadgeInput`) — the
+Go-specific residual of #2460 tracked by #2525 (`aliased-destructured-prop`
+render-divergence pin, now graduated).
+
+The Input/Props split is now:
+
+- `BadgeInput.<field>` (what a caller writes) is keyed CALLER-facing —
+  `capitalizeFieldName(sourceName ?? name)`, so it's `N`.
+- `BadgeProps.<field>` (what `{{.X}}` in the template executes against)
+  stays keyed LOCAL — `capitalizeFieldName(name)`, so it's `Count`, unchanged.
+- **`BadgeProps`'s json tag flips to the caller-facing key** — `json:"n"`
+  instead of `json:"count"`. This is a **wire-format change**: the
+  hydration payload (`bf-p`) key for an aliased prop is now `n`, matching
+  the shared client JS (`@barefootjs/jsx`/`@barefootjs/client`, #2524) which
+  already reads `_p.n`. Before this fix the two were already mismatched in
+  the OTHER direction (Go emitted `json:"count"` while the client read
+  `_p.n`) — hydration for an aliased prop was already broken on Go; this
+  change makes the two sides agree instead of introducing a new mismatch.
+- `NewBadgeProps` bridges the two: `Count: in.N`.
+- The `bf.RegisterReprops` rebuilder (`#2448`, per-row composite-loop
+  overrides) carries both fields again — the case label matches the parent's
+  `bf_with_props`/`bf_reprops` call (Props field, unchanged), the assignment
+  target is the Input field (now caller-facing). 437f822 (#2457) had
+  collapsed this to one shared name when Input and Props were always
+  identical; it's split again now that they aren't for an aliased prop.
+
+Every other constructor-context Go emission that reads `in.<Field>` off a
+possibly-aliased prop (memo/signal initial values, spread-bag lowering,
+`Record`-index lookups, derived-const folding) was audited and updated to
+resolve the caller-facing Input field — an un-aliased prop is unaffected
+(identity). The `props.<X>` member-access sites in the source-expression walk
+(e.g. `collectPropsReadByCtorInit`) were audited too and correctly **left
+alone**: they read the LOCAL destructure binding straight off the TSX source,
+which #2525 never touches — only the constructed Input struct's own field
+naming changed.
+
+Graduates the `aliased-destructured-prop` render-divergence pin for
+`go-template` — the fixture now renders on real Go and matches the Hono
+reference.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4601,12 +4601,14 @@ export function SignalRowChildDerivedProp(props: { rows: Row[] }) {
   })
 
   // An ALIASED destructure (`{ n: count }`) is where the JSX attribute name
-  // (`n` → `"N"`) and the child's own Go field (`Count`) diverge. #2457: the
-  // reconciliation now happens ONCE, at the PARENT's emission site
-  // (`loopRowChildPropOverrides`, via `childPropFieldNames`) — the parent
-  // emits the child's own field name directly, so the rebuilder's switch
-  // (`recordRepropsSpec` / `emitRepropsRegistration`) needs no separate
-  // "wire" name and is keyed uniformly by that one field on both sides.
+  // (`n` → `"N"`) and the child's own Go PROPS field (`Count`) diverge. #2457:
+  // the parent's call-site reconciliation (`loopRowChildPropOverrides`, via
+  // `childPropFieldNames`'s `propsField`) still emits the child's PROPS field
+  // directly, so the pipeline call is unaffected. #2525 separately makes the
+  // child's own Input field CALLER-facing (`"N"`, for a caller-side composite
+  // `BadgeInput{N: 5}` literal) — so the rebuilder's switch, unlike before,
+  // once again needs BOTH names: the Props field as the case label (matching
+  // the call site) and the Input field as the assignment target.
   test('an aliased destructured prop maps the parent name onto the child field', () => {
     const result = compileJSX(`
 'use client'
@@ -4631,16 +4633,53 @@ export function AliasedRowChildDerivedProp(props: { rows: Row[] }) {
 `.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
     expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(0)
     const template = result.files.find(f => f.type === 'markedTemplate')!.content
-    // The parent now writes the child's OWN field name ("Count"), not the
-    // JSX attribute ("N").
+    // The parent now writes the child's own PROPS field name ("Count") —
+    // `bf_with_props`/`bf_reprops` patch the already-constructed Props
+    // instance, so the call site stays keyed by the LOCAL binding.
     expect(template).toContain('(bf_reprops "Badge" $.BadgeSlot0 "Text" .Label "Count" .N)')
     const types = result.files.find(f => f.type === 'types')!.content
+    // Case label: the PROPS field, matching the call site above.
     expect(types).toContain('case "Count":')
-    expect(types).toContain('&in.Count,')
+    // Assignment target: the child's own INPUT field — CALLER-facing (#2525),
+    // so it's "N" here, not "Count". 437f822 removed this field/wire pairing
+    // when Input and Props field names were unified everywhere; #2525
+    // reintroduces it because they diverge again for an aliased prop.
+    expect(types).toContain('&in.N,')
+    expect(types).not.toContain('&in.Count,')
     // "N" — the JSX attribute name — is never a case label: the switch is
-    // keyed by the child's field on both sides, and the parent already
+    // keyed by the child's PROPS field on that side, and the parent already
     // resolved the name before emitting the call.
     expect(types).not.toContain('case "N":')
+  })
+
+  // #2525: the Input struct is keyed by the CALLER-facing name
+  // (`sourceName ?? name`), so `BadgeInput{N: 5}` — the name a handler
+  // actually writes — type-checks. The Props struct's field stays the LOCAL
+  // binding (what `{{.X}}` in the template executes against), and its json
+  // tag flips to the caller-facing name to match the hydration payload key
+  // the shared client JS reads (PR A, #2524, 2e40dc6). `NewBadgeProps`
+  // bridges the two: `Count: in.N`.
+  test('an aliased destructured prop keys the Input struct by the caller-facing name', () => {
+    const result = compileJSX(`
+export function Badge({ text, n: count }: { text: string; n: number }) {
+  return <span class="badge">{text}:{count}</span>
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(0)
+    const types = result.files.find(f => f.type === 'types')!.content
+    // Input struct: caller-facing field, no json tag (Input is never
+    // marshalled).
+    expect(types).toContain('type BadgeInput struct {')
+    // Exact-field match (not `.toContain('N int')`, which also matches
+    // `N interface{}`) — tightened to match the adjacent negative's style.
+    expect(types).toContain('\tN int\n')
+    expect(types).not.toContain('Count int\n')
+    // Props struct: LOCAL field, json tag flipped to the caller-facing key.
+    expect(types).toContain('type BadgeProps struct {')
+    expect(types).toContain('Count int `json:"n"`')
+    expect(types).not.toContain('json:"count"')
+    // NewBadgeProps bridges Props(local) from Input(caller-facing).
+    expect(types).toContain('Count: in.N,')
   })
 
   // #2457: the SAME aliased destructure, but with NO derived field — the
@@ -4783,6 +4822,112 @@ export function CompositeRowChildComponent(props: { items: Item[] }) {
     expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(0)
     const template = result.files.find(f => f.type === 'markedTemplate')!.content
     expect(template).toContain('{{template "Badge" (bf_with_props $.BadgeSlot0 "Text" .Label)}}')
+  })
+})
+
+describe('GoTemplateAdapter - #2525 collision handling', () => {
+  // A caller-facing prop tag and a same-named signal's LOCAL tag are
+  // different Go identifiers wanting the same string, and
+  // `encoding/json.Marshal` drops BOTH fields under an ambiguous tag — the
+  // identifier de-dup sets cannot catch this (see `claimJsonTag`). The
+  // prop must win: on hono only props occupy `_p`.
+  test("an aliased prop's caller-facing json tag wins over a same-named signal's", () => {
+    const result = compileJSX(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function Counter({ count: initialCount }: { count: number }) {
+  const [count, setCount] = createSignal(initialCount)
+  return <button onClick={() => setCount(count() + 1)}>Count: {count()}</button>
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(0)
+    const types = result.files.find(f => f.type === 'types')!.content
+    // The prop keeps the shared "count" wire key...
+    expect(types).toContain('InitialCount int `json:"count"`')
+    // ...and the colliding signal field falls back to `json:"-"` instead of
+    // silently carrying the same tag. Leading `\t` (not `.toContain('Count
+    // int ...')`) so the assertion doesn't false-match inside
+    // "InitialCount int ..." above.
+    expect(types).toContain('\tCount int `json:"-"`')
+    expect(types).not.toContain('\tCount int `json:"count"`')
+    // Exactly one field claims "count".
+    expect((types.match(/json:"count"/g) ?? []).length).toBe(1)
+  })
+
+  // The nested-array skip check must union both namings at all four sites
+  // (`isNestedArrayShadowed`) — a one-sided check lets Input and
+  // Props/NewProps disagree on whether an aliased prop's field exists.
+  test('a nested-array field name collision skips the prop everywhere ({ rows: items } direction)', () => {
+    const result = compileJSX(`
+function Row(props: { label: string }) {
+  return <li>{props.label}</li>
+}
+export function List({ rows: items }: { rows: { id: number; label: string }[] }) {
+  return <ul>{items.map(item => <Row key={item.id} label={item.label} />)}</ul>
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(0)
+    const types = result.files.find(f => f.type === 'types')!.content
+    const listInput = types.slice(types.indexOf('type ListInput struct'), types.indexOf('type ListProps struct'))
+    const listPropsAndAfter = types.slice(types.indexOf('type ListProps struct'))
+    // Input carries only the typed nested-array field — no scalar "Items"
+    // field for the aliased prop the LOCAL-only check used to miss.
+    expect(listInput).toContain('Rows []RowInput')
+    expect(listInput).not.toContain('Items')
+    // Props carries exactly ONE `json:"rows"` tag (the nested array's) —
+    // a surviving duplicate would make encoding/json drop both fields.
+    expect((listPropsAndAfter.match(/json:"rows"/g) ?? []).length).toBe(1)
+    expect(listPropsAndAfter).not.toContain('Items')
+  })
+
+  // Same collision, opposite alias direction: the LOCAL name now matches
+  // the nested-array field (so Props/NewProps's LOCAL-only check happened
+  // to skip it by luck), but the CALLER name doesn't — Input's
+  // caller-facing-only check used to keep a live "Items" field with no
+  // Props counterpart, so a caller's override silently never reached the
+  // constructed Props at all.
+  test('a nested-array field name collision skips the prop everywhere ({ items: rows } direction)', () => {
+    const result = compileJSX(`
+function Row(props: { label: string }) {
+  return <li>{props.label}</li>
+}
+export function List({ items: rows }: { items: { id: number; label: string }[] }) {
+  return <ul>{rows.map(item => <Row key={item.id} label={item.label} />)}</ul>
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(0)
+    const types = result.files.find(f => f.type === 'types')!.content
+    const listInput = types.slice(types.indexOf('type ListInput struct'), types.indexOf('type ListProps struct'))
+    // Input carries only the typed nested-array field — no dead "Items"
+    // field the caller could write to with no effect.
+    expect(listInput).toContain('Rows []RowInput')
+    expect(listInput).not.toContain('Items')
+    expect(types).not.toContain('in.Items')
+  })
+
+  // `usesSearchParams` gates the field in Input (caller-facing names),
+  // Props (LOCAL) and NewProps with ONE boolean, so its collision check
+  // must union both namings — `{ q: searchParams }` collides only under
+  // the LOCAL one, and a one-sided check redeclares the Go field.
+  test('an aliased prop whose LOCAL binding is `searchParams` does not redeclare the field', () => {
+    const result = compileJSX(`
+'use client'
+import { createSearchParams } from '@barefootjs/client'
+export function Foo({ q: searchParams }: { q: string }) {
+  const [sp] = createSearchParams()
+  return <p>{searchParams}:{sp().get('tag') ?? 'none'}</p>
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
+    expect((result.errors ?? []).filter(e => e.code === 'BF101')).toHaveLength(0)
+    const types = result.files.find(f => f.type === 'types')!.content
+    const structStart = types.indexOf('type FooProps struct')
+    const fooPropsBody = types.slice(structStart, types.indexOf('}', structStart))
+    // Exactly one "SearchParams" field in the struct body — the prop's
+    // own — never a second `SearchParams bf.SearchParams` reader field
+    // colliding with it (a Go redeclaration error).
+    expect((fooPropsBody.match(/SearchParams/g) ?? []).length).toBe(1)
+    expect(fooPropsBody).toContain('SearchParams string `json:"q"`')
+    expect(types).not.toContain('bf.SearchParams')
   })
 })
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -158,17 +158,12 @@ type HigherOrderShape = {
 /**
  * Everything needed to emit a component's #2448 props rebuilder, captured when
  * its own types are generated so a PARENT can emit the registration into its
- * own type block (`emitOwnedReprops`). `params` are this component's own
- * Input fields — since #2457, the PARENT (`loopRowChildPropOverrides`, via
- * `childPropFieldNames`) already resolves the JSX attribute name to the
- * child's own field name before emitting the call, so the switch this spec
- * drives is keyed by that one name on both sides; there is no longer a
- * separate "wire" name to carry (an aliased destructure used to make the
- * parent's JSX-attribute name and the child's field name differ — `"N"` vs
- * `Count` — and this spec used to carry both).
+ * own type block (`emitOwnedReprops`). `propsField` (LOCAL) and `inputField`
+ * (caller-facing) diverge only for an aliased destructured prop — one name is
+ * not enough (see `emitRepropsRegistration`).
  */
 type RepropsSpec = {
-  params: string[]
+  params: { propsField: string; inputField: string }[]
   usesSearchParams: boolean
 }
 
@@ -688,35 +683,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private childDerivedFieldDeps: Map<string, Map<string, ReadonlySet<string>>> = new Map()
 
   /**
-   * component name -> (the prop name as WRITTEN AT THE JSX CALL SITE -> that
-   * component's own Go field name). #2457.
+   * component name -> (JSX-attribute name -> that component's own Props
+   * field, LOCAL binding). `bf.WithProps` treats an unknown field as a
+   * silent passthrough, so `bf_with_props`/`bf_reprops` call sites cannot
+   * just capitalize the JSX attribute: for `{ n: count }` that names a
+   * field (`N`) the Props struct doesn't have, dropping the override with
+   * no diagnostic. Input composite literals need no such lookup — Input
+   * fields are caller-facing, so `capitalizeFieldName(jsxName)` already
+   * names them (see `emitChildField`).
    *
-   * `generateInputStruct` / `emitPropsDataFields` name a child's Go field from
-   * its LOCAL binding (`capitalizeFieldName(param.name)`), but a parent
-   * emitting a per-row override
-   * (`loopRowChildPropOverrides`) only knows the JSX attribute it wrote. For
-   * an un-aliased prop those are the same string, so this map is an identity
-   * for every existing shape and every currently-passing fixture stays
-   * byte-identical. For an ALIASED destructure (`{ n: count }`) they differ
-   * (`"N"` vs `Count`) — `bf.WithProps` documents unknown-field pairs as a
-   * silent passthrough, so emitting the JSX name against a struct that has no
-   * such field drops the override with no diagnostic. Resolving through this
-   * map once, at the parent's emission site (the only place that has both
-   * the JSX name and the child's shape), replaces that silent drop with the
-   * correct field.
-   *
-   * Key = `p.sourceName ?? p.name` (identity for an un-aliased param, the JSX
-   * attribute name for an aliased one). Value = `capitalizeFieldName(p.name)`
-   * — the child's own field, from its LOCAL binding, same as
-   * `generateInputStruct` uses.
-   *
-   * Populated from the same two doors as `childDerivedFieldDeps` — inside
-   * `recordDerivedFieldDeps`, unconditionally (before that method's own
-   * `deps.size > 0` gate), so every component gets an entry here regardless
-   * of whether it has a derived field. `recordRepropsSpec` (the other nearby
-   * populator) returns early for components with no derived field or an
-   * ineligible shape — this map must NOT inherit either gate, since an
-   * aliased child with no derived field at all is exactly the #2457 shape.
+   * Populated inside `recordDerivedFieldDeps` BEFORE its `deps.size > 0`
+   * gate: an aliased child with no derived field at all is exactly the
+   * #2457 shape, so this map must not inherit `recordRepropsSpec`'s gates.
    */
   private childPropFieldNames: Map<string, Map<string, string>> = new Map()
 
@@ -798,9 +776,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     )
     const canonical = (local: string): string => capitalizeFieldName(sourceOf.get(local) ?? local)
     const propFieldNames = new Set([...paramNames].map(canonical))
-    // #2457: record the JSX-attribute-name -> child's-own-field-name map for
-    // EVERY component, unconditionally — see `childPropFieldNames`'s
-    // docstring for why this can't share `recordRepropsSpec`'s gates.
+    // Recorded for EVERY component — this must not share `recordRepropsSpec`'s
+    // gates (see `childPropFieldNames`).
     const fieldNames = new Map<string, string>()
     for (const p of ir.metadata.propsParams ?? []) {
       fieldNames.set(p.sourceName ?? p.name, capitalizeFieldName(p.name))
@@ -944,6 +921,53 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     return this.state.contextConsumers.filter(c => !taken.has(this.contextFieldName(c)))
   }
 
+  /**
+   * True when `param`'s prop is subsumed by a same-name nested-component
+   * array field (`<Row>` children collected into `Rows []RowProps`). Must
+   * check the LOCAL and caller-facing name together — Input keys its fields
+   * caller-facing while Props/NewProps key local, so a one-sided check lets
+   * the structs disagree on whether the field exists (a duplicate json tag,
+   * or a dead Input field whose caller writes are silently ignored).
+   */
+  private isNestedArrayShadowed(
+    param: { name: string; sourceName?: string },
+    nestedArrayFields: ReadonlySet<string>,
+  ): boolean {
+    return (
+      nestedArrayFields.has(capitalizeFieldName(param.name)) ||
+      nestedArrayFields.has(capitalizeFieldName(param.sourceName ?? param.name))
+    )
+  }
+
+  /**
+   * Every Go field name these props params could claim — LOCAL and
+   * caller-facing. A context-consumer field must exist in ALL of
+   * Input/Props/NewProps or none, and the three key prop fields under
+   * different namings, so their shared collision gate cannot check just one
+   * (`{ n: searchParams }` collides in Props but not Input).
+   */
+  private propParamFieldNamesUnion(params: ReadonlyArray<{ name: string; sourceName?: string }>): string[] {
+    return params.flatMap(p => [capitalizeFieldName(p.name), capitalizeFieldName(p.sourceName ?? p.name)])
+  }
+
+  /**
+   * Claim `desired` in the struct-wide set of emitted json tags, or fall
+   * back to `json:"-"` on collision. The identifier de-dup sets cannot cover
+   * this: an aliased prop's tag is caller-facing while other fields' tags
+   * stay local, so two DIFFERENT Go identifiers can want the same tag — and
+   * `encoding/json` silently drops every field sharing an ambiguous tag,
+   * losing the key from the bf-p payload entirely. Callers thread one set
+   * through the field-emitting loops in declaration order, so props win;
+   * that matches hono, whose hydration blob is built only from props params
+   * (a signal seeds by reading the prop's key, never a key of its own, so
+   * the dropped tag was never a client read path).
+   */
+  private claimJsonTag(desired: string, taken: Set<string>): string {
+    if (taken.has(desired)) return '-'
+    taken.add(desired)
+    return desired
+  }
+
   generateTypes(ir: ComponentIR): string | null {
     this.state.usesHtmlTemplate = false
     this.state.usesFmt = false
@@ -1004,8 +1028,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * Two invariants the emitted code depends on:
    *
    * - **Input is recoverable from Props.** `emitPropsDataFields` and
-   *   `generateInputStruct` emit each props param with the SAME field name and
-   *   the SAME `resolvePropGoType`, so `in.<F> = b.<F>` is exact. A prop read
+   *   `generateInputStruct` emit each props param with the SAME
+   *   `resolvePropGoType`, and the same field name EXCEPT for an aliased
+   *   destructured prop, where Props keeps the LOCAL field and Input keys by
+   *   the CALLER-facing name (a caller-side `BadgeInput{N: 5}` literal must
+   *   type-check). `in.<inputField> = b.<propsField>` bridges the pair
+   *   (identity when un-aliased). A prop read
    *   only by a memo still gets its passthrough field, so nothing is lost.
    *   Shapes that add Input fields with no Props counterpart (a rest bag, a
    *   spread slot, context consumers, nested child Inputs) are declined —
@@ -1016,17 +1044,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    *   BfMount come from the base, and the Props-only fields (Scripts,
    *   BfIsRoot/BfIsChild/BfDataKey) are reapplied after the constructor.
    *
-   * The override switch is keyed by the child's own Input field
-   * (`ParamInfo.name`) on both the case label and the assignment target. That
-   * used to differ under an aliased destructure — the case label carried the
-   * name the PARENT wrote (the JSX attribute, `ParamInfo.sourceName ?? name`)
-   * while the assignment targeted the child's own field, so this switch was
-   * where those two sides were reconciled. #2457 moved that reconciliation to
-   * the PARENT (`loopRowChildPropOverrides`, via `childPropFieldNames`): the
-   * parent now emits the child's own field name at the call site, so by the
-   * time a `bf_reprops` pipeline reaches this switch both sides already agree
-   * and there's exactly one place — the parent's emission — where the naming
-   * gets reconciled, instead of two.
+   * The override switch built from `params` is emitted by
+   * `emitRepropsRegistration`.
    */
   private recordRepropsSpec(
     ir: ComponentIR,
@@ -1036,11 +1055,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   ): void {
     if (!this.childDerivedFieldDeps.has(componentName)) return
 
+    // Must mirror `generateInputStruct`'s exclusion/collision checks exactly —
+    // both walk the Input struct's actual (caller-keyed) field names, or the
+    // reprops switch references fields the struct doesn't have.
     const nestedArrayFields = new Set(nestedComponents.map(n => `${n.name}s`))
     const params = (ir.metadata.propsParams ?? []).filter(
-      p => !nestedArrayFields.has(capitalizeFieldName(p.name)),
+      p => !this.isNestedArrayShadowed(p, nestedArrayFields),
     )
-    const takenInput = new Set((ir.metadata.propsParams ?? []).map(p => capitalizeFieldName(p.name)))
+    const takenInput = new Set(this.propParamFieldNamesUnion(ir.metadata.propsParams ?? []))
     const eligible =
       nestedComponents.every(n => n.isDynamic && !n.isPropDerived) &&
       spreadSlots.length === 0 &&
@@ -1049,7 +1071,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (!eligible) return
 
     this.childRepropsReady.set(componentName, {
-      params: params.map(p => capitalizeFieldName(p.name)),
+      params: params.map(p => ({
+        propsField: capitalizeFieldName(p.name),
+        inputField: capitalizeFieldName(p.sourceName ?? p.name),
+      })),
       usesSearchParams: this.usesSearchParams(ir),
     })
   }
@@ -1108,22 +1133,22 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     lines.push('\t\t\tBfParent: b.BfParent,')
     lines.push('\t\t\tBfMount: b.BfMount,')
     if (usesSearchParams) lines.push('\t\t\tSearchParams: b.SearchParams,')
-    for (const field of params) {
-      lines.push(`\t\t\t${field}: b.${field},`)
+    for (const { propsField, inputField } of params) {
+      lines.push(`\t\t\t${inputField}: b.${propsField},`)
     }
     lines.push('\t\t}')
     lines.push('\t\tfor i := 0; i < len(kv); i += 2 {')
     lines.push('\t\t\tname, _ := kv[i].(string)')
     lines.push('\t\t\tvar err error')
     lines.push('\t\t\tswitch name {')
-    for (const field of params) {
-      // Case label and assignment target are the same name: the child's own
-      // Input field. The parent (`loopRowChildPropOverrides`, via
-      // `childPropFieldNames`, #2457) already resolved the JSX attribute to
-      // this field before emitting the call, so there is nothing left to
-      // reconcile here.
-      lines.push(`\t\t\tcase ${JSON.stringify(field)}:`)
-      lines.push(`\t\t\t\terr = bf.RepropsAssign(${q}, ${JSON.stringify(field)}, &in.${field}, kv[i+1])`)
+    for (const { propsField, inputField } of params) {
+      // Case label = the child's own PROPS field (what the parent's
+      // `bf_with_props`/`bf_reprops` call is keyed by); target = the Input
+      // field. One name is not enough: an aliased destructure gives
+      // `{ n: count }` → Props `Count`, Input `N` (437f822 had unified the
+      // pair while the two could never diverge).
+      lines.push(`\t\t\tcase ${JSON.stringify(propsField)}:`)
+      lines.push(`\t\t\t\terr = bf.RepropsAssign(${q}, ${JSON.stringify(propsField)}, &in.${inputField}, kv[i+1])`)
     }
     // No silent drop. `bf_with_props` passes an unknown field through because
     // a rest-bag prop legitimately has no named field — but a rebuilder is
@@ -1301,10 +1326,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    */
   private usesSearchParams(ir: ComponentIR): boolean {
     if (this.state.searchParamsLocals.size === 0) return false
-    // Every other field-producing source: a `SearchParams` collision would
-    // redeclare the field and break the Go compile.
+    // A `SearchParams` collision would redeclare the field and break the Go
+    // compile. This ONE boolean gates the field in Input (caller-facing
+    // names), Props (LOCAL names) and NewProps at once, so a prop cannot be
+    // checked under just one naming: `{ x: searchParams }` collides only in
+    // Props, `{ searchParams: x }` only in Input.
     const taken = new Set<string>([
       ...ir.metadata.propsParams.map(p => capitalizeFieldName(p.name)),
+      ...ir.metadata.propsParams.map(p => capitalizeFieldName(p.sourceName ?? p.name)),
       // Env signals (`createSearchParams()`) don't produce a normal value field —
       // they ARE the `SearchParams` binding — so they must not poison this
       // collision set (a getter named `searchParams` would otherwise capitalise
@@ -1351,8 +1380,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const nestedArrayFields = new Set(nestedComponents.map(n => `${n.name}s`))
 
     for (const param of ir.metadata.propsParams) {
-      const fieldName = capitalizeFieldName(param.name)
-      if (nestedArrayFields.has(fieldName)) continue
+      // #2525: caller-facing name, not the local destructure binding — a
+      // caller-side composite `BadgeInput{N: 5}` literal is written against
+      // the name the callee's `{ n: count }` destructure was GIVEN, not the
+      // name it renamed to internally. `generatePropsStruct`'s field (what
+      // `{{.X}}` executes against) stays keyed by the local binding — see
+      // `emitPropsDataFields`.
+      const fieldName = capitalizeFieldName(param.sourceName ?? param.name)
+      if (this.isNestedArrayShadowed(param, nestedArrayFields)) continue
       const goType = resolvePropGoType(this.emitCtx, param, propTypeOverrides)
       lines.push(`\t${fieldName} ${goType}`)
     }
@@ -1374,8 +1409,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
 
     // `useContext` consumer fields — settable by an enclosing provider; default
-    // applied in NewXxxProps.
-    const takenInput = new Set(ir.metadata.propsParams.map(p => capitalizeFieldName(p.name)))
+    // applied in NewXxxProps. `taken` must union the local and caller-facing
+    // prop names (`propParamFieldNamesUnion`) or Input disagrees with
+    // Props/NewProps on whether the consumer field exists.
+    const takenInput = new Set(this.propParamFieldNamesUnion(ir.metadata.propsParams))
     for (const c of this.nonCollidingContextConsumers(takenInput)) {
       lines.push(`\t${this.contextFieldName(c)} ${this.contextConsumerGoType(c)}`)
     }
@@ -1413,9 +1450,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const propsTypeName = `${componentName}Props`
     this.emitPropsStructHeader(lines, ir, propsTypeName, componentName)
 
-    this.emitPropsDataFields(lines, ir, nestedComponents, propTypeOverrides)
+    // ONE taken-tags set spans every field-emitting loop below — per-loop
+    // sets would let two loops emit the same tag, and `encoding/json` drops
+    // both such fields silently (see `claimJsonTag`).
+    const takenJsonTags = new Set<string>()
 
-    this.emitPropsAuxFields(lines, ir, componentName, nestedComponents, spreadSlots)
+    this.emitPropsDataFields(lines, ir, nestedComponents, propTypeOverrides, takenJsonTags)
+
+    this.emitPropsAuxFields(lines, ir, componentName, nestedComponents, spreadSlots, takenJsonTags)
 
     lines.push('}')
     lines.push('')
@@ -1734,8 +1776,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     const propFieldNames = new Set<string>()
     for (const param of ir.metadata.propsParams) {
+      // Props field: LOCAL binding, what the template reads (`{{.X}}`).
+      // Everything on the right of `:` below reads `in.<inputField>`
+      // (caller-facing), never `in.<fieldName>` (local).
       const fieldName = capitalizeFieldName(param.name)
-      if (nestedArrayFields.has(fieldName)) continue
+      const inputField = capitalizeFieldName(param.sourceName ?? param.name)
+      if (this.isNestedArrayShadowed(param, nestedArrayFields)) continue
       const hoisted = propFallbackVars.get(param.name)
       if (hoisted) {
         lines.push(`\t\t${fieldName}: ${hoisted.varName},`)
@@ -1743,17 +1789,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const paramDefault = goPropDefault(param.defaultValue)
         const memoFold = memoFallbacks.get(fieldName)
         if (paramDefault !== null) {
-          lines.push(`\t\t${fieldName}: ${applyGoFallback(`in.${fieldName}`, paramDefault)},`)
+          lines.push(`\t\t${fieldName}: ${applyGoFallback(`in.${inputField}`, paramDefault)},`)
         } else if (memoFold !== undefined && memoFold.goType === 'string') {
-          lines.push(`\t\t${fieldName}: ${applyGoFallback(`in.${fieldName}`, memoFold.goFallback)},`)
+          lines.push(`\t\t${fieldName}: ${applyGoFallback(`in.${inputField}`, memoFold.goFallback)},`)
         } else if (memoFold !== undefined) {
           // interface{} field (`size ?? 'icon'`): the string zero-check doesn't
           // compile, so wrap in a nil/empty-tolerant IIFE.
           lines.push(
-            `\t\t${fieldName}: func() interface{} { v := interface{}(in.${fieldName}); if v == nil || v == "" { return ${memoFold.goFallback} }; return v }(),`,
+            `\t\t${fieldName}: func() interface{} { v := interface{}(in.${inputField}); if v == nil || v == "" { return ${memoFold.goFallback} }; return v }(),`,
           )
         } else {
-          lines.push(`\t\t${fieldName}: in.${fieldName},`)
+          lines.push(`\t\t${fieldName}: in.${inputField},`)
         }
       }
       propFieldNames.add(fieldName)
@@ -1823,9 +1869,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
 
     // `useContext` consumer fields default to the `createContext` default when
-    // the provider didn't set them.
+    // the provider didn't set them. Props params must contribute BOTH namings
+    // (`propParamFieldNamesUnion`) or this disagrees with Input/Props on
+    // whether the consumer field exists.
     const takenInit = new Set<string>([
-      ...ir.metadata.propsParams.map(p => capitalizeFieldName(p.name)),
+      ...this.propParamFieldNamesUnion(ir.metadata.propsParams),
       ...ir.metadata.signals.map(s => capitalizeFieldName(s.getter)),
       ...ir.metadata.memos.map(m => capitalizeFieldName(m.name)),
     ])
@@ -1891,14 +1939,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // A hyphenated attr (`aria-label`) can't be a Go field and, with no rest
         // bag to route it into, has nowhere to go — skip over emitting invalid Go.
         if (jsxName.includes('-')) return
-        // Same resolution as `loopRowChildPropOverrides` (#2457): the child's
-        // own Go field, which differs from the JSX attribute under an aliased
-        // destructure (`{ n: count }` → field `Count`). Emitting the attribute
-        // name here put an unknown field in a Go struct literal — a build
-        // error rather than a silent drop, but wrong either way. Falls back to
-        // the capitalized attribute for a child this run never registered.
-        const fieldName =
-          this.childPropFieldNames.get(child.name)?.get(jsxName) ?? capitalizeFieldName(jsxName)
+        // `<Child>Input{...}` composite literal: Input fields are
+        // caller-facing and `jsxName` IS the caller-facing name, so no
+        // `childPropFieldNames` lookup — that map resolves the child's
+        // LOCAL/Props field for `loopRowChildPropOverrides`'s different
+        // struct.
+        const fieldName = capitalizeFieldName(jsxName)
         lines.push(`\t\t\t${fieldName}: ${goValue},`)
       }
       for (const prop of child.props) {
@@ -2425,6 +2471,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     ir: ComponentIR,
     nestedComponents: NestedComponentInfo[],
     propTypeOverrides: Map<string, string>,
+    takenJsonTags: Set<string>,
   ): void {
     // Nested-component array fields are emitted as typed arrays below, not as
     // their raw prop; track them (and emitted names) to skip duplicates.
@@ -2433,12 +2480,21 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     for (const param of ir.metadata.propsParams) {
       const fieldName = capitalizeFieldName(param.name)
-      if (nestedArrayFields.has(fieldName)) continue
+      if (this.isNestedArrayShadowed(param, nestedArrayFields)) continue
       const goType = resolvePropGoType(this.emitCtx, param, propTypeOverrides)
       // Children are already rendered in the DOM; serialising them into bf-p
       // leaks nested scope ids and bloats the attribute. Exclude from JSON so
       // BfPropsAttr never marshals them.
-      const jsonTag = param.name === 'children' ? '-' : this.toJsonTag(param.name)
+      //
+      // The tag is CALLER-facing even though `fieldName` stays LOCAL: the
+      // tag is the hydration wire format and the client JS reads
+      // `_p.<callerKey>` (#2524) — a local tag would make hydration read the
+      // wrong key. Props are emitted FIRST into `takenJsonTags`, so a prop
+      // always wins a tag collision against a later signal/memo/etc field.
+      const jsonTag =
+        param.name === 'children'
+          ? '-'
+          : this.claimJsonTag(this.toJsonTag(param.sourceName ?? param.name), takenJsonTags)
       lines.push(`\t${fieldName} ${goType} \`json:"${jsonTag}"\``)
       propFieldNames.add(fieldName)
     }
@@ -2451,7 +2507,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (signal.envReader) continue
       const fieldName = capitalizeFieldName(signal.getter)
       if (propFieldNames.has(fieldName)) continue
-      const jsonTag = this.toJsonTag(signal.getter)
+      const jsonTag = this.claimJsonTag(this.toJsonTag(signal.getter), takenJsonTags)
       // A synthesised struct type wins outright — the signal is an untyped
       // object array we gave a concrete element type.
       const synthType = this.state.synthStructTypes.get(signal.getter)
@@ -2501,7 +2557,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     for (const memo of ir.metadata.memos) {
       const fieldName = capitalizeFieldName(memo.name)
       if (propFieldNames.has(fieldName)) continue
-      const jsonTag = this.toJsonTag(memo.name)
+      const jsonTag = this.claimJsonTag(this.toJsonTag(memo.name), takenJsonTags)
       const goType = this.inferMemoType(memo, ir.metadata.signals, propsParamMap)
       lines.push(`\t${fieldName} ${goType} \`json:"${jsonTag}"\``)
     }
@@ -2513,6 +2569,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     componentName: string,
     nestedComponents: NestedComponentInfo[],
     spreadSlots: SpreadSlotInfo[],
+    takenJsonTags: Set<string>,
   ): void {
     // Computed fields for component-scope derived string consts the template
     // references (e.g. `root = base || '/'`). Not serialised — the route handler
@@ -2527,14 +2584,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
 
     // `useContext` consumer fields (skip names already taken by a prop /
-    // signal / memo field).
+    // signal / memo field). Props params must contribute BOTH namings
+    // (`propParamFieldNamesUnion`) or this disagrees with Input on whether
+    // the consumer field exists.
     const takenProps = new Set<string>([
-      ...ir.metadata.propsParams.map(p => capitalizeFieldName(p.name)),
+      ...this.propParamFieldNamesUnion(ir.metadata.propsParams),
       ...ir.metadata.signals.map(s => capitalizeFieldName(s.getter)),
       ...ir.metadata.memos.map(m => capitalizeFieldName(m.name)),
     ])
     for (const c of this.nonCollidingContextConsumers(takenProps)) {
-      const jsonTag = this.toJsonTag(c.localName)
+      const jsonTag = this.claimJsonTag(this.toJsonTag(c.localName), takenJsonTags)
       lines.push(`\t${this.contextFieldName(c)} ${this.contextConsumerGoType(c)} \`json:"${jsonTag}"\``)
     }
 
@@ -2548,7 +2607,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         lines.push(`\t${nested.name}s []${elemType} \`json:"-"\``)
       } else {
         // Static + prop-derived arrays go in JSON so the client can hydrate.
-        const jsonTag = this.toJsonTag(`${nested.name.charAt(0).toLowerCase()}${nested.name.slice(1)}s`)
+        const jsonTag = this.claimJsonTag(
+          this.toJsonTag(`${nested.name.charAt(0).toLowerCase()}${nested.name.slice(1)}s`),
+          takenJsonTags,
+        )
         lines.push(`\t${nested.name}s []${elemType} \`json:"${jsonTag}"\``)
       }
     }
@@ -2562,7 +2624,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // map[string]any` field the template reads via `{{bf_spread_attrs}}`.
     // Loop-internal spreads emit inline and don't appear here.
     for (const slot of spreadSlots) {
-      const jsonTag = this.toJsonTag(slot.slotId)
+      const jsonTag = this.claimJsonTag(this.toJsonTag(slot.slotId), takenJsonTags)
       lines.push(`\t${slot.slotId} map[string]any \`json:"${jsonTag}"\``)
     }
   }
@@ -2870,7 +2932,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    */
   private lowerProviderMapMemberValue(
     node: ParsedExpr,
-    propsParams: ReadonlyArray<{ name: string }>,
+    propsParams: ReadonlyArray<{ name: string; sourceName?: string }>,
   ): string | null {
     if (node.kind === 'object-literal') return objectLiteralToGoMap(this.emitCtx, node)
     const literal = parsedLiteralToGo(this.emitCtx, node)
@@ -2889,8 +2951,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // closure below — TS drops property-path narrowing (`node.left.kind
       // === 'member'`) across a nested arrow function boundary.
       const propName = node.left.property
-      if (propsParams.some(param => param.name === propName)) {
-        const fieldRef = `in.${capitalizeFieldName(propName)}`
+      const matchedParam = propsParams.find(param => param.name === propName)
+      if (matchedParam) {
+        // `sourceName ?? name`: the Input struct's field is caller-facing
+        // (#2525). A `props.<key>` member read (this function's shape) has
+        // no destructure aliasing to begin with — `key` IS the caller-facing
+        // name — but resolving through the matched param keeps this in step
+        // with every other `in.<field>` read in the file rather than
+        // re-deriving the assumption locally.
+        const fieldRef = `in.${capitalizeFieldName(matchedParam.sourceName ?? matchedParam.name)}`
         return (
           `func() map[string]interface{} { ` +
           `if m := bf.AsMap(${fieldRef}); m != nil { return m }; ` +
@@ -2911,7 +2980,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    */
   private templatePartsToGoCode(
     parts: IRTemplatePart[],
-    propsParams: { name: string }[]
+    propsParams: { name: string; sourceName?: string }[]
   ): string | null {
     const segments: string[] = []
     for (const part of parts) {
@@ -2929,7 +2998,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const keyExpr = part.key.trim()
         const param = propsParams.find(p => p.name === keyExpr)
         if (!param) return null
-        const fieldName = capitalizeFieldName(keyExpr)
+        // Input field is caller-facing (#2525); `keyExpr` is the LOCAL prop
+        // binding used in the source expression.
+        const fieldName = capitalizeFieldName(param.sourceName ?? keyExpr)
         const caseEntries = Object.entries(part.cases)
         if (caseEntries.length === 0) {
           segments.push('""')
@@ -2964,7 +3035,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     expr: string,
     signals: { getter: string; setter: string | null; initialValue: string; type: TypeInfo; parsed?: ParsedExpr }[],
     memos: { name: string; computation: string; deps: string[] }[],
-    propsParams: { name: string }[]
+    propsParams: { name: string; sourceName?: string }[]
   ): string | null {
     // `getter() === 'lit'` / `!==` as a child-instance prop value
     // (`open={openItem() === 'item-1'}`): resolves to a Go bool when the
@@ -3069,8 +3140,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       passthroughName !== null &&
       ((localConst !== undefined && !isPropsDestructureAlias) ||
         this.state.localHelperNames.has(passthroughName))
-    if (passthroughName && !shadowedByLocal && propsParams.some(p => p.name === passthroughName)) {
-      return `in.${capitalizeFieldName(passthroughName)}`
+    const passthroughParam =
+      passthroughName && !shadowedByLocal
+        ? propsParams.find(p => p.name === passthroughName)
+        : undefined
+    if (passthroughParam) {
+      // Input field is caller-facing (#2525); `passthroughName` is the LOCAL
+      // binding (`bareIdentifier`) or the `props.<key>` source key
+      // (`barePropAccess`, never aliased) — resolve through the matched
+      // param rather than assuming the two coincide.
+      return `in.${capitalizeFieldName(passthroughParam.sourceName ?? passthroughParam.name)}`
     }
 
     return null
@@ -3175,7 +3254,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (!param) continue
       // A destructure default already wins via applyGoFallback below.
       if (goPropDefault(param.defaultValue) !== null) continue
-      const fieldName = capitalizeFieldName(match.propName)
+      // `PropFallbackVar.fieldName` is read off the INPUT struct (every
+      // consumer does `in.${fieldName}`, #2525) — caller-facing, not
+      // `match.propName`'s local binding.
+      const fieldName = capitalizeFieldName(param.sourceName ?? match.propName)
       // A `??`-consumed optional scalar lowered to `interface{}` (#2248) —
       // detected off the SAME `resolvePropGoType` pipeline the struct
       // generators use, so this can't drift from the emitted field type. The
@@ -5561,16 +5643,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         })
         continue
       }
-      // #2457: emit the CHILD's own Go field name, not the JSX attribute name.
-      // They differ under an aliased destructure (`{ n: count }` → attribute
-      // `n`, field `Count`); resolving through `childPropFieldNames` here —
-      // the parent's emission site, the only place that has both the JSX
-      // name and the child's shape — means `bf.WithProps`/`bf.RepropsAssign`
-      // never see a name the struct doesn't have. Falls back to today's
-      // capitalized-attribute behaviour for a cross-file child this run's
-      // pre-pass never registered (`childPropFieldNames` has no entry).
-      const fieldName =
-        this.childPropFieldNames.get(comp.name)?.get(prop.name) ?? capitalizeFieldName(prop.name)
+      // Emit the CHILD's own PROPS field name, not the JSX attribute name —
+      // `bf.WithProps`/`bf.RepropsAssign` patch the constructed PROPS
+      // instance, and passing a name the struct doesn't have (an aliased
+      // `{ n: count }` attribute) is a silent passthrough, not an error
+      // (#2457). Stays LOCAL even though the child's Input field is
+      // caller-facing. Falls back to the capitalized attribute for a
+      // cross-file child this run's pre-pass never registered.
+      const fieldName = this.childPropFieldNames.get(comp.name)?.get(prop.name) ?? capitalizeFieldName(prop.name)
       args.push(`${JSON.stringify(fieldName)} ${wrapIfMultiToken(go)}`)
     }
     if (args.length === 0) return null

--- a/packages/adapter-go-template/src/adapter/lib/types.ts
+++ b/packages/adapter-go-template/src/adapter/lib/types.ts
@@ -134,7 +134,10 @@ export interface SpreadSlotInfo {
 export interface PropFallbackVar {
   /** Local variable name (typically the lowercase prop identifier). */
   varName: string
-  /** Capitalised Go field name on the `Input` struct. */
+  /**
+   * Capitalised Go field name on the `Input` struct — caller-facing
+   * (`sourceName ?? name`, #2525), since every reader does `in.${fieldName}`.
+   */
   fieldName: string
   /** Go literal used when the input value equals its zero value. */
   goFallback: string

--- a/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
@@ -109,7 +109,7 @@ export function matchFilterArmMemo(
   ctx: GoEmitContext,
   body: ParsedExpr,
   signals: { getter: string; initialValue: string; type?: TypeInfo }[],
-  propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
+  propsParams: { name: string; sourceName?: string; type?: TypeInfo; defaultValue?: string }[],
 ): { propName: string; predJSON: string; paramName: string; freeVars: string[] } | null {
   const cb = asCallbackMethodCall(body)
   if (!cb || cb.method !== 'filter') return null
@@ -146,7 +146,7 @@ export function filterArmEarlierSiblingRefs(
   ctx: GoEmitContext,
   memo: { name: string; parsed?: ParsedExpr },
   signals: { getter: string; initialValue: string; type?: TypeInfo }[],
-  propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
+  propsParams: { name: string; sourceName?: string; type?: TypeInfo; defaultValue?: string }[],
 ): string[] {
   if (!memo.parsed) return []
   const match = matchFilterArmMemo(ctx, memo.parsed, signals, propsParams)
@@ -179,7 +179,7 @@ export function computeMemoInitialValue(
   ctx: GoEmitContext,
   memo: { name: string; computation: string; deps: string[]; parsed?: ParsedExpr },
   signals: { getter: string; initialValue: string; type?: TypeInfo }[],
-  propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
+  propsParams: { name: string; sourceName?: string; type?: TypeInfo; defaultValue?: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar> = EMPTY_PROP_FALLBACK_VARS,
   goType?: string,
 ): string {
@@ -221,7 +221,7 @@ export function memoInitialFromParsedBody(
   ctx: GoEmitContext,
   body: ParsedExpr,
   signals: { getter: string; initialValue: string; type?: TypeInfo }[],
-  propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
+  propsParams: { name: string; sourceName?: string; type?: TypeInfo; defaultValue?: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar>,
   currentMemoName: string,
   resolving: ReadonlySet<string> = new Set(),
@@ -229,7 +229,8 @@ export function memoInitialFromParsedBody(
   const propRef = (propName: string): string => {
     const hoisted = propFallbackVars.get(propName)
     if (hoisted) return hoisted.varName
-    return `in.${capitalizeFieldName(propName)}`
+    const param = propsParams.find(p => p.name === propName)
+    return `in.${capitalizeFieldName(param?.sourceName ?? propName)}`
   }
   // A request-scoped env-signal read (`searchParams().get('k')`, any local
   // alias, #1922) → the literal key and the reader's canonical field name,
@@ -393,7 +394,9 @@ export function memoInitialFromParsedBody(
       // being concretely typed, wouldn't compile against `nil` either).
       if (param && ctx.state.nillablePropNames.has(propName)) {
         const isNe = body.op === '!==' || body.op === '!='
-        return `in.${capitalizeFieldName(propName)} ${isNe ? '!=' : '=='} nil`
+        // `nillablePropNames` stays keyed by the LOCAL name (a source-level
+        // set); the emitted field is caller-facing (#2525).
+        return `in.${capitalizeFieldName(param.sourceName ?? propName)} ${isNe ? '!=' : '=='} nil`
       }
     }
   }
@@ -544,7 +547,7 @@ export function memoInitialFromParsedBody(
       const varName = body.left.name
       const param = propsParams.find(p => p.name === varName)
       if (param) {
-        const fieldName = capitalizeFieldName(varName)
+        const fieldName = capitalizeFieldName(param.sourceName ?? varName)
         if (param.type) {
           const goType = typeInfoToGo(ctx, param.type, param.defaultValue)
           if (goType === 'interface{}') return `in.${fieldName}.(int) ${operator} ${operand}`
@@ -574,7 +577,7 @@ export function memoInitialFromParsedBody(
   // () => var — destructured prop, return the input field directly.
   if (body.kind === 'identifier') {
     const param = propsParams.find(p => p.name === body.name)
-    if (param) return `in.${capitalizeFieldName(body.name)}`
+    if (param) return `in.${capitalizeFieldName(param.sourceName ?? body.name)}`
   }
 
   // () => <a> + <b> + … — a string-concatenation chain whose every leaf is a
@@ -607,7 +610,7 @@ function resolveStringConcatChainGo(
   ctx: GoEmitContext,
   expr: ParsedExpr,
   signals: { getter: string; initialValue: string; type?: TypeInfo }[],
-  propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
+  propsParams: { name: string; sourceName?: string; type?: TypeInfo; defaultValue?: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar>,
   propRef: (propName: string) => string,
 ): string | null {
@@ -647,7 +650,7 @@ export function computeMemoInitialValueOrNull(
   ctx: GoEmitContext,
   memo: { name: string; computation: string; deps: string[]; parsed?: ParsedExpr; parsedBlock?: ParsedStatement[]; parsedBlockComplete?: boolean },
   signals: { getter: string; initialValue: string; type?: TypeInfo }[],
-  propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
+  propsParams: { name: string; sourceName?: string; type?: TypeInfo; defaultValue?: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar> = EMPTY_PROP_FALLBACK_VARS,
   /**
    * Memo names currently being resolved on this call stack — guards against
@@ -729,7 +732,7 @@ export function resolveGetterValueAsGo(
   ctx: GoEmitContext,
   name: string,
   signals: { getter: string; initialValue: string; type?: TypeInfo }[],
-  propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
+  propsParams: { name: string; sourceName?: string; type?: TypeInfo; defaultValue?: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar>,
   resolving: ReadonlySet<string> = new Set(),
 ): string | null {
@@ -745,7 +748,8 @@ export function resolveGetterValueAsGo(
     const stripped = memo.computation.replace(/^\(\)\s*=>\s*/, '')
     const fb = ctx.extractPropFallback(stripped)
     if (fb && capitalizeFieldName(fb.propName) === capitalizeFieldName(memo.name)) {
-      const field = `in.${capitalizeFieldName(fb.propName)}`
+      const fbParam = propsParams.find(p => p.name === fb.propName)
+      const field = `in.${capitalizeFieldName(fbParam?.sourceName ?? fb.propName)}`
       return `func() interface{} { v := interface{}(${field}); if v == nil || v == "" { return ${fb.goFallback} }; return v }()`
     }
     return computeMemoInitialValueOrNull(
@@ -755,7 +759,7 @@ export function resolveGetterValueAsGo(
   const param = propsParams.find(p => p.name === name)
   if (param) {
     const hoisted = propFallbackVars.get(name)
-    return hoisted ? hoisted.varName : `in.${capitalizeFieldName(name)}`
+    return hoisted ? hoisted.varName : `in.${capitalizeFieldName(param.sourceName ?? name)}`
   }
   return null
 }
@@ -772,7 +776,7 @@ export function computeComparisonTernaryGo(
   ctx: GoEmitContext,
   parsed: ParsedExpr | undefined,
   signals: { getter: string; initialValue: string; type?: TypeInfo }[],
-  propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
+  propsParams: { name: string; sourceName?: string; type?: TypeInfo; defaultValue?: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar>,
   resolving: ReadonlySet<string> = new Set(),
 ): string | null {
@@ -828,7 +832,7 @@ export function resolveComparisonOperandGo(
   ctx: GoEmitContext,
   node: ParsedExpr,
   signals: { getter: string; initialValue: string; type?: TypeInfo }[],
-  propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
+  propsParams: { name: string; sourceName?: string; type?: TypeInfo; defaultValue?: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar>,
   resolving: ReadonlySet<string> = new Set(),
 ): string | null {

--- a/packages/adapter-go-template/src/adapter/spread/spread-codegen.ts
+++ b/packages/adapter-go-template/src/adapter/spread/spread-codegen.ts
@@ -225,7 +225,7 @@ export function buildSpreadInitializer(
     //    `{...extras}` resolves to `in.Extras`.
     const param = ir.metadata.propsParams.find(p => p.name === trimmed)
     if (param) {
-      return `in.${capitalizeFieldName(param.name)}`
+      return `in.${capitalizeFieldName(param.sourceName ?? param.name)}`
     }
     // 2. SolidJS-style props object: `function(props: P)` → spread
     //    `{...props}` enumerates all propsParams into a `map[string]any`
@@ -235,8 +235,11 @@ export function buildSpreadInitializer(
     //    `applyRestAttrs` hydrate path still applies them — worse than full
     //    enumeration, better than BF101 blocking the build.
     if (ir.metadata.propsObjectName === trimmed) {
+      // Bag key stays the caller-facing prop name (mirrors the spread bag's
+      // external shape); Input field read is caller-facing too (#2525) —
+      // identity here since the `props`-object pattern has no aliasing.
       const entries = ir.metadata.propsParams.map(p =>
-        `${JSON.stringify(p.name)}: in.${capitalizeFieldName(p.name)}`,
+        `${JSON.stringify(p.sourceName ?? p.name)}: in.${capitalizeFieldName(p.sourceName ?? p.name)}`,
       )
       return `map[string]any{${entries.join(', ')}}`
     }
@@ -344,7 +347,7 @@ function conditionToGoBool(
   if (node.kind !== 'identifier') return null
   const param = ir.metadata.propsParams.find(p => p.name === node.name)
   if (!param) return null
-  const field = `in.${capitalizeFieldName(param.name)}`
+  const field = `in.${capitalizeFieldName(param.sourceName ?? param.name)}`
   const prim = param.type.kind === 'primitive' ? param.type.primitive : undefined
   let truthy: string
   if (prim === 'boolean') {
@@ -396,7 +399,7 @@ function objectLiteralToGoSpreadMap(
     } else if (val.kind === 'identifier') {
       const param = ir.metadata.propsParams.find(p => p.name === val.name)
       if (!param) return null
-      goVal = `in.${capitalizeFieldName(param.name)}`
+      goVal = `in.${capitalizeFieldName(param.sourceName ?? param.name)}`
     } else {
       const indexed = recordIndexAccessToGoMap(ctx, val, ir)
       if (indexed === null) return null
@@ -453,6 +456,10 @@ function recordIndexAccessToGoMap(
     return `${JSON.stringify(e.key)}: ${mapVal}`
   })
   ctx.state.usesFmt = true
-  const field = `in.${capitalizeFieldName(parsed.indexPropName)}`
+  // `parsed.indexPropName` is the LOCAL binding (`parseRecordIndexAccess` is
+  // shared with other adapters and stays name-agnostic); resolve the Input
+  // field caller-facing here (#2525) rather than in the shared parser.
+  const indexParam = ir.metadata.propsParams.find(p => p.name === parsed.indexPropName)
+  const field = `in.${capitalizeFieldName(indexParam?.sourceName ?? parsed.indexPropName)}`
   return `map[string]any{${entries.join(', ')}}[fmt.Sprint(${field})]`
 }

--- a/packages/adapter-go-template/src/adapter/value/value-lowering.ts
+++ b/packages/adapter-go-template/src/adapter/value/value-lowering.ts
@@ -40,16 +40,25 @@ const EMPTY_PROP_FALLBACK_VARS: ReadonlyMap<string, PropFallbackVar> = new Map()
  * undefined` half is source-level documentation of nullability, not a
  * Go-representable branch, so it's unwrapped to its single non-
  * undefined/null primitive branch.
+ *
+ * `param.name` is the LOCAL binding — `nillablePropNames` (a source-level
+ * analysis set, `collectNillablePropNames`) stays keyed by it — while the
+ * emitted `in.<Field>` reference is caller-facing (`sourceName ?? name`,
+ * #2525), so the two must resolve separately rather than off one name.
  */
-function nillableAwarePropRef(ctx: GoEmitContext, propName: string, expectedType: TypeInfo): string {
-  const fieldRef = `in.${capitalizeFieldName(propName)}`
+function nillableAwarePropRef(
+  ctx: GoEmitContext,
+  param: { name: string; sourceName?: string },
+  expectedType: TypeInfo,
+): string {
+  const fieldRef = `in.${capitalizeFieldName(param.sourceName ?? param.name)}`
   const scalar =
     expectedType.kind === 'primitive'
       ? expectedType
       : expectedType.kind === 'union' && expectedType.unionTypes?.length === 2
         ? expectedType.unionTypes.find(t => t.primitive !== 'undefined' && t.primitive !== 'null')
         : undefined
-  if (ctx.state.nillablePropNames.has(propName) && scalar?.kind === 'primitive') {
+  if (ctx.state.nillablePropNames.has(param.name) && scalar?.kind === 'primitive') {
     const goType =
       scalar.primitive === 'boolean' ? 'bool' :
       scalar.primitive === 'number' ? 'float64' :
@@ -70,24 +79,27 @@ export function convertInitialValue(
   ctx: GoEmitContext,
   value: string,
   _typeInfo: TypeInfo,
-  propsParams?: { name: string }[],
+  propsParams?: { name: string; sourceName?: string }[],
   preParsed?: ParsedExpr,
 ): string {
   // Literal unions collapse to their backing primitive the same way
   // `typeInfoToGo` collapses the field's type — the two MUST agree, or a
   // `string` field gets a `nil` seed (#2477's `go run` failure).
   const typeInfo = collapseLiteralUnion(_typeInfo)
-  const propRef = (propName: string): string => nillableAwarePropRef(ctx, propName, typeInfo)
+  const propRef = (param: { name: string; sourceName?: string }): string =>
+    nillableAwarePropRef(ctx, param, typeInfo)
 
   if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
-    if (propsParams?.some(p => p.name === value)) {
-      return propRef(value)
+    const param = propsParams?.find(p => p.name === value)
+    if (param) {
+      return propRef(param)
     }
   }
 
   const propName = ctx.extractPropNameFromInitialValue(value, preParsed)
-  if (propName && propsParams?.some(p => p.name === propName)) {
-    return propRef(propName)
+  const param = propName ? propsParams?.find(p => p.name === propName) : undefined
+  if (param) {
+    return propRef(param)
   }
 
   if (typeInfo.kind === 'primitive') {
@@ -227,24 +239,28 @@ export function objectLiteralToGoMap(ctx: GoEmitContext, expr: ParsedExpr): stri
 export function getSignalInitialValueAsGo(
   ctx: GoEmitContext,
   initialValue: string,
-  propsParams: { name: string }[],
+  propsParams: { name: string; sourceName?: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar> = EMPTY_PROP_FALLBACK_VARS,
   signalType?: TypeInfo,
 ): string {
-  const propRef = (propName: string): string =>
-    signalType ? nillableAwarePropRef(ctx, propName, signalType) : `in.${capitalizeFieldName(propName)}`
+  const propRef = (param: { name: string; sourceName?: string }): string =>
+    signalType
+      ? nillableAwarePropRef(ctx, param, signalType)
+      : `in.${capitalizeFieldName(param.sourceName ?? param.name)}`
 
-  if (propsParams.some(p => p.name === initialValue)) {
+  const directParam = propsParams.find(p => p.name === initialValue)
+  if (directParam) {
     const hoisted = propFallbackVars.get(initialValue)
     if (hoisted) return hoisted.varName
-    return propRef(initialValue)
+    return propRef(directParam)
   }
 
   const propName = ctx.extractPropNameFromInitialValue(initialValue)
-  if (propName && propsParams.some(p => p.name === propName)) {
-    const hoisted = propFallbackVars.get(propName)
+  const param = propName ? propsParams.find(p => p.name === propName) : undefined
+  if (param) {
+    const hoisted = propFallbackVars.get(propName!)
     if (hoisted) return hoisted.varName
-    return propRef(propName)
+    return propRef(param)
   }
 
   // single quotes are normalized to Go double quotes
@@ -320,7 +336,7 @@ function resolveMapJoinBaseAsGo(
   ctx: GoEmitContext,
   object: ParsedExpr,
   signals: { getter: string; initialValue: string; type?: TypeInfo; parsed?: ParsedExpr }[],
-  propsParams: { name: string }[],
+  propsParams: { name: string; sourceName?: string }[],
 ): string | null {
   if (object.kind === 'call' && object.callee.kind === 'identifier' && object.args.length === 0) {
     const calleeName = object.callee.name
@@ -337,8 +353,9 @@ function resolveMapJoinBaseAsGo(
       : object.kind === 'identifier'
         ? object.name
         : null
-  if (propName && propsParams.some(p => p.name === propName)) {
-    return `in.${capitalizeFieldName(propName)}`
+  const param = propName ? propsParams.find(p => p.name === propName) : undefined
+  if (param) {
+    return `in.${capitalizeFieldName(param.sourceName ?? param.name)}`
   }
 
   if (object.kind === 'array-literal') {
@@ -376,7 +393,7 @@ export function mapJoinChainToGo(
   ctx: GoEmitContext,
   chain: { object: ParsedExpr; arrow: Extract<ParsedExpr, { kind: 'arrow' }>; sepArg?: ParsedExpr },
   signals: { getter: string; initialValue: string; type?: TypeInfo; parsed?: ParsedExpr }[],
-  propsParams: { name: string }[],
+  propsParams: { name: string; sourceName?: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar>,
 ): string | null {
   const itemsGo = resolveMapJoinBaseAsGo(ctx, chain.object, signals, propsParams)
@@ -393,11 +410,12 @@ export function mapJoinChainToGo(
   for (const name of freeVars) {
     const sig = signals.find(s => s.getter === name)
     let goExpr: string | null = null
+    const freeVarParam = propsParams.find(p => p.name === name)
     if (sig) {
       goExpr = getSignalInitialValueAsGo(ctx, sig.initialValue, propsParams, propFallbackVars, sig.type)
-    } else if (propsParams.some(p => p.name === name)) {
+    } else if (freeVarParam) {
       const hoisted = propFallbackVars.get(name)
-      goExpr = hoisted ? hoisted.varName : `in.${capitalizeFieldName(name)}`
+      goExpr = hoisted ? hoisted.varName : `in.${capitalizeFieldName(freeVarParam.sourceName ?? name)}`
     }
     if (goExpr === null) return null
     envEntries.push(`${JSON.stringify(name)}: ${goExpr}`)

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -12,6 +12,12 @@
  * fixture-divergences section of `ui/compat.lock.json` — surfaced on
  * the docs compatibility-matrix page. Graduating an entry means fixing
  * the adapter (or the shared compiler layer) and deleting the line.
+ *
+ * Empty — the file's last live entry (`aliased-destructured-prop`, #2525)
+ * graduated: the Input struct field is now keyed by `sourceName ?? name`
+ * (caller-facing), so the caller-side composite literal `go run`s clean.
+ * Keep the file (and this header) when the set is empty — the next
+ * divergence lands here, not in a re-created file.
  */
 
 import type { RenderDivergences } from '@barefootjs/jsx'
@@ -29,19 +35,4 @@ export const renderDivergences: RenderDivergences = {
   // production). `buildDynamicChildLoopSeeding` (this package's
   // `test-render.ts`) now replicates that documented contract for a
   // signal-backed dynamic child-component loop.
-
-  // Onboarding TSX-fidelity fixtures (PR #2461): `expectedHtml` was
-  // hand-authored to the CORRECT output while the emission bug lived in
-  // the shared compiler layer — every adapter, including the Hono
-  // reference, used to emit the broken form. That shared-layer defect
-  // (#2460) is now FIXED (b4f5075): `expectedHtml` is generated from the
-  // Hono reference like any other fixture. The remaining gap is
-  // Go-specific — the Input struct field stays keyed by the local
-  // binding instead of `sourceName ?? name`, so the caller-side struct
-  // literal fails `go run` outright — tracked by #2525 (go-template's
-  // `go run` exit-1 failure). Graduate by keying the Input struct field
-  // by `sourceName ?? name` and deleting this line (and the matching
-  // hono `skipJsx` entry, already gone).
-  'aliased-destructured-prop':
-    'aliased destructured prop `{ n: count }` loses its rename — the Input struct field is Count `json:"count"`, so the caller-side struct literal keyed by the real prop name fails `go run` outright (unknown field N, exit 1) (https://github.com/piconic-ai/barefootjs/issues/2525)',
 }

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -673,7 +673,12 @@ function buildGoPropsInit(
   // declared params are `className` / `type`) emits a top-level
   // `Placeholder:` initializer and Go fails with `unknown field Placeholder
   // in struct literal of type InputInput`. (#1467 Phase 2b)
-  const declaredParams = new Set((ir?.metadata.propsParams ?? []).map(p => p.name))
+  // `key` is caller-facing (what the fixture's caller supplied), so this
+  // set must be built from `sourceName ?? name` — a local-only set routes
+  // an aliased param into the rest bag.
+  const declaredParams = new Set(
+    (ir?.metadata.propsParams ?? []).map(p => p.sourceName ?? p.name),
+  )
   const restPropsName = ir?.metadata.restPropsName ?? null
   const restBagField = restPropsName ? capitalizeFieldName(restPropsName) : null
 

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -92,6 +92,16 @@
         "text"
       ]
     },
+    "aliased-prop-signal-tag-collision": {
+      "kinds": [
+        "call",
+        "identifier"
+      ],
+      "axes": [],
+      "contexts": [
+        "text"
+      ]
+    },
     "arithmetic-text": {
       "kinds": [
         "binary",
@@ -4945,9 +4955,9 @@
     "array-method": 67,
     "arrow": 64,
     "binary": 82,
-    "call": 200,
+    "call": 201,
     "conditional": 24,
-    "identifier": 288,
+    "identifier": 289,
     "index-access": 14,
     "literal": 238,
     "logical": 43,

--- a/packages/adapter-tests/fixtures/aliased-destructured-prop.ts
+++ b/packages/adapter-tests/fixtures/aliased-destructured-prop.ts
@@ -11,10 +11,11 @@ import { createFixture } from '../src/types'
  * `undefined`, `s1` rendered empty) — FIXED, Hono now emits
  * `{ text, n: count }` and this fixture is no longer skipped for it. The
  * template-string adapters used to key `ssrDefaults` / template vars as
- * `count` so props seeding missed; Go's Input struct field is `Count`
- * `json:"count"`, so the caller-side struct literal keyed by the real
- * prop name fails `go run` outright (unknown field N); the shared client
- * JS used to read `_p.count` too. All silent except Go's exit 1.
+ * `count` so props seeding missed — FIXED (#2524). Go's Input struct
+ * field used to be the local `Count`, so the caller-side struct literal
+ * failed `go run` (unknown field N) — FIXED (#2525). The shared client JS
+ * used to read `_p.count` too — FIXED (#2524). All of these were silent
+ * except Go's exit 1.
  * `ParamInfo.sourceName` carries the original property name precisely
  * for this; its docstring rule is "consumers keying into
  * `propsType.properties` must use `sourceName ?? name`".
@@ -39,10 +40,11 @@ import { createFixture } from '../src/types'
  *     local template var. `packages/jsx/src/ssr-defaults.ts`'s
  *     `deriveStashFromDefaults` is the shared TS twin of those runtime
  *     ports.
- *   - Go's `go run` exit-1 failure is STILL tracked by
- *     https://github.com/piconic-ai/barefootjs/issues/2525 — Go's `skipJsx`
- *     pin stays; graduating it means fixing the Go emission and deleting
- *     that pin.
+ *   - Go's `go run` exit-1 failure — FIXED (#2525): the Input struct
+ *     field is caller-facing while the Props field stays LOCAL with a
+ *     caller-facing json tag. Go's `render-divergences.ts` entry (and
+ *     `skipJsx` pin) is deleted; the fixture renders on Go like every
+ *     other adapter.
  */
 export const fixture = createFixture({
   id: 'aliased-destructured-prop',

--- a/packages/adapter-tests/fixtures/aliased-prop-signal-tag-collision.ts
+++ b/packages/adapter-tests/fixtures/aliased-prop-signal-tag-collision.ts
@@ -1,0 +1,33 @@
+import { createFixture } from '../src/types'
+
+/**
+ * An aliased destructured prop whose CALLER-facing name collides with a
+ * same-named signal getter: `{ count: initialCount }` +
+ * `createSignal(initialCount)`. With prop json tags caller-facing (#2525),
+ * the prop and the signal are different Go identifiers wanting the SAME
+ * tag — and `encoding/json` drops every field under an ambiguous tag, so
+ * without `claimJsonTag` the bf-p payload loses the key entirely. The prop
+ * must win the collision: on hono only props occupy `_p`; a signal seeds
+ * from the prop's key, never a key of its own.
+ *
+ * Normalization strips `bf-p`, so the Go struct-tag pin itself lives in
+ * go-template-adapter.test.ts ("an aliased prop's caller-facing tag wins
+ * over a same-named signal's"); this fixture holds the cross-adapter
+ * render surface for the shape.
+ */
+export const fixture = createFixture({
+  id: 'aliased-prop-signal-tag-collision',
+  description: "Aliased prop's caller-facing key collides with a same-named signal getter (#2525)",
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function Counter({ count: initialCount }: { count: number }) {
+  const [count, setCount] = createSignal(initialCount)
+  return <button onClick={() => setCount(count() + 1)}>Count: {count()}</button>
+}
+`,
+  props: { count: 5 },
+  expectedHtml: `
+    <button bf-s="test" bf="s1">Count: <!--bf:s0-->5<!--/--></button>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -458,6 +458,9 @@ import { fixture as objectCatalogued } from './object-catalogued'
 // Onboarding TSX-fidelity gaps (PR #2461): correct-output pins for
 // #2460/#2463/#2464/#2465 plus one documented React divergence.
 import { fixture as aliasedDestructuredProp } from './aliased-destructured-prop'
+// Aliased prop's caller-facing key colliding with a same-named signal
+// getter (#2525 — see the fixture's docstring).
+import { fixture as aliasedPropSignalTagCollision } from './aliased-prop-signal-tag-collision'
 import { fixture as selectValueSsr } from './select-value-ssr'
 import { fixture as textareaValueSsr } from './textarea-value-ssr'
 import { fixture as signalEarlyReturn } from './signal-early-return'
@@ -798,6 +801,7 @@ export const jsxFixtures: JSXFixture[] = [
   unionCatalogued,
   objectCatalogued,
   aliasedDestructuredProp,
+  aliasedPropSignalTagCollision,
   selectValueSsr,
   textareaValueSsr,
   signalEarlyReturn,

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -43,6 +43,26 @@
       }
     }
   ],
+  "aliased-prop-signal-tag-collision": [
+    {
+      "name": "gen:count:zero",
+      "props": {
+        "count": 0
+      }
+    },
+    {
+      "name": "gen:count:negative",
+      "props": {
+        "count": -7
+      }
+    },
+    {
+      "name": "gen:count:large",
+      "props": {
+        "count": 1234567890
+      }
+    }
+  ],
   "array-flat-dynamic-depth": [
     {
       "name": "gen:depth:zero",

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,14 +1814,8 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 307,
+    "totalFixtures": 308,
     "fixtures": {
-      "aliased-destructured-prop": {
-        "go-template": {
-          "kind": "render",
-          "reason": "aliased destructured prop `{ n: count }` loses its rename — the Input struct field is Count `json:\"count\"`, so the caller-side struct literal keyed by the real prop name fails `go run` outright (unknown field N, exit 1) (https://github.com/piconic-ai/barefootjs/issues/2525)"
-        }
-      },
       "date-method-uncatalogued": {
         "blade": {
           "kind": "refusal",
@@ -2785,10 +2779,6 @@
       }
     },
     "docs": {
-      "aliased-destructured-prop": {
-        "description": "Aliased destructured prop ({ n: count }) keeps the rename (#2524)",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/aliased-destructured-prop.ts"
-      },
       "date-method-uncatalogued": {
         "description": "Method call on a Date-typed prop refuses with BF021 (no catalogued lowering)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/date-method-uncatalogued.ts"

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 200,
+      "total": 201,
       "cells": {
         "hono": {
-          "pass": 199,
-          "total": 200,
+          "pass": 200,
+          "total": 201,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1433,8 +1433,8 @@
           ]
         },
         "blade": {
-          "pass": 185,
-          "total": 200,
+          "pass": 186,
+          "total": 201,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1509,8 +1509,8 @@
           ]
         },
         "erb": {
-          "pass": 186,
-          "total": 200,
+          "pass": 187,
+          "total": 201,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1579,8 +1579,8 @@
           ]
         },
         "go-template": {
-          "pass": 185,
-          "total": 200,
+          "pass": 186,
+          "total": 201,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1655,8 +1655,8 @@
           ]
         },
         "jinja": {
-          "pass": 185,
-          "total": 200,
+          "pass": 186,
+          "total": 201,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1731,8 +1731,8 @@
           ]
         },
         "minijinja": {
-          "pass": 185,
-          "total": 200,
+          "pass": 186,
+          "total": 201,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1807,8 +1807,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 186,
-          "total": 200,
+          "pass": 187,
+          "total": 201,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1877,8 +1877,8 @@
           ]
         },
         "twig": {
-          "pass": 185,
-          "total": 200,
+          "pass": 186,
+          "total": 201,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1953,8 +1953,8 @@
           ]
         },
         "xslate": {
-          "pass": 185,
-          "total": 200,
+          "pass": 186,
+          "total": 201,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2035,10 +2035,10 @@
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L166"
       },
       "example": {
-        "fixture": "client-only-loop",
-        "description": "Client-only directive suppresses SSR for a bare loop, keeping boundary markers",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/client-only-loop.ts",
-        "code": "items()"
+        "fixture": "aliased-prop-signal-tag-collision",
+        "description": "Aliased prop's caller-facing key collides with a same-named signal getter (#2525)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/aliased-prop-signal-tag-collision.ts",
+        "code": "count()"
       }
     },
     "conditional": {
@@ -2174,11 +2174,11 @@
       }
     },
     "identifier": {
-      "total": 288,
+      "total": 289,
       "cells": {
         "hono": {
-          "pass": 287,
-          "total": 288,
+          "pass": 288,
+          "total": 289,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2189,8 +2189,8 @@
           ]
         },
         "blade": {
-          "pass": 271,
-          "total": 288,
+          "pass": 272,
+          "total": 289,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2273,8 +2273,8 @@
           ]
         },
         "erb": {
-          "pass": 272,
-          "total": 288,
+          "pass": 273,
+          "total": 289,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2351,13 +2351,9 @@
           ]
         },
         "go-template": {
-          "pass": 270,
-          "total": 288,
+          "pass": 272,
+          "total": 289,
           "gaps": [
-            {
-              "fixture": "aliased-destructured-prop",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2439,8 +2435,8 @@
           ]
         },
         "jinja": {
-          "pass": 271,
-          "total": 288,
+          "pass": 272,
+          "total": 289,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2523,8 +2519,8 @@
           ]
         },
         "minijinja": {
-          "pass": 271,
-          "total": 288,
+          "pass": 272,
+          "total": 289,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2607,8 +2603,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 272,
-          "total": 288,
+          "pass": 273,
+          "total": 289,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2685,8 +2681,8 @@
           ]
         },
         "twig": {
-          "pass": 271,
-          "total": 288,
+          "pass": 272,
+          "total": 289,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2769,8 +2765,8 @@
           ]
         },
         "xslate": {
-          "pass": 271,
-          "total": 288,
+          "pass": 272,
+          "total": 289,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",


### PR DESCRIPTION
## Summary

Fixes #2525: for an aliased destructured prop (`{ n: count }`), the Go adapter's `Input` struct was keyed by the LOCAL binding (`Input.Count`), so the caller-facing composite literal `BadgeInput{N: 7}` failed `go run` with `unknown field N` — the only adapter where the aliased-prop defect was loud rather than silent.

Rebased onto main (single commit); the earlier WIP snapshots were rewritten into the real change.

## The split (two structs, two audiences)

| artifact | before | after |
|---|---|---|
| `Input` field (caller-facing composite literal) | `Count` | `N` = `capitalizeFieldName(sourceName ?? name)` |
| `Props` field (what `{{.Count}}` executes against) | `Count` | `Count` (unchanged — templates read the LOCAL name) |
| `Props` json tag (→ `bf-p` hydration payload) | `json:"count"` | `json:"n"` — required by the #2524 convention (client JS reads `_p.n`) |
| `NewProps` bridge | `Count: in.Count` | `Count: in.N` |

- The reprops spec regains the Props/Input field pair that 437f822 collapsed when the names were unified (case label = Props field, `&in.<X>` = Input field). `bf_with_props` / `bf_reprops` call sites stay keyed by the Props field.
- Every constructor-context `in.<Field>` read keyed by a possibly-aliased local prop name (memo-compute, value-lowering, spread-codegen) resolves the caller-facing field; `props.<X>` member-access paths were audited and correctly left alone (aliasing cannot exist there).

## Collision hardening (from adversarial review)

- **Shared `takenJsonTags` set** across all six Props-struct tag emitters, in declaration order: an aliased prop colliding with a same-named signal (`{ count: initialCount }` + `createSignal`) now serializes the prop's key once — matching Hono's wire shape, where the hydration blob is built only from props params — instead of Go's `encoding/json` silently dropping BOTH same-tagged fields.
- **`isNestedArrayShadowed`**: the nested-array shadow check now unions local + caller names at all four consumer sites (Input / Props / NewProps / reprops), so the structs can never disagree about whether a prop field exists.
- **`usesSearchParams` / context-consumer taken-sets**: same union treatment for every set that guards both namespaces.

## Coverage

- Graduated the Go `aliased-destructured-prop` `renderDivergences` pin — the fixture now renders through real `go run` as the regression test. `render-divergences.ts` is an empty map.
- New conformance fixture `aliased-prop-signal-tag-collision` (passes on every template adapter — nothing pinned).
- New Go unit tests pinning: `BadgeInput.N` / `BadgeProps.Count json:"n"` / `NewBadgeProps` bridge, the reprops pair, both nested-array alias directions, and the searchParams-local-alias shape.
- Changeset: patch bump `@barefootjs/go-template` (json-tag wire-format change documented).

## Verification

- `GOTOOLCHAIN=go1.25.6 bun test packages/adapter-go-template`: 1568 pass / 18 skip / 0 fail (real `go run` renders; aliased fixture 19/0, collision 10/0)
- `bun test packages/adapter-tests`: 1883 pass / 1 skip / 0 fail
- `packages/compat`: 183 pass / 0 fail; `packages/jsx`: 0 fail
- Locks regenerated: diff vs main is exactly the go-template divergence-cell removal, pass 270→271, plus the additive surface of the one new fixture (`totalFixtures` 307→308)
- Reviewed by Opus (REQUEST_CHANGES round: 2 blockers + 1 major + 6 minors/nits, all addressed; the blockers were collision regressions now covered by the new fixture/tests above)

## Stack context

Completes the aliased-prop series: #2531 (CSR half, merged) → #2534 (template SSR half, merged) → this PR (Go, targets main).

Closes #2525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANWdijiBRfuNqnACEPEyKD