### PR TITLE
fix(cli): override undici to clear npm audit vulns in Hono scaffold

### DIFF
--- a/.changeset/hono-scaffold-overrides-readme-note.md
+++ b/.changeset/hono-scaffold-overrides-readme-note.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/cli": patch
+---
+
+Adapters that inject a `package.json` dependency override (currently
+only the Hono adapter's `undici` override — see the previous release
+note) now also surface a "Dependency overrides" section in the
+scaffolded README explaining why the override exists and when it's
+safe to remove. `package.json` can't carry a comment, so without this
+the override was undiscoverable to whoever ends up maintaining the
+generated project.

--- a/.changeset/hono-scaffold-undici-override.md
+++ b/.changeset/hono-scaffold-undici-override.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/cli": patch
+---
+
+The Hono (Cloudflare Workers) scaffold now pins an `overrides.undici`
+entry in the generated `package.json`. `wrangler` pulls in `miniflare`,
+which pins `undici` to an exact (non-range) version that carries several
+known advisories — so even the latest resolvable `wrangler` left fresh
+scaffolds with `npm audit` reporting vulnerabilities that `npm audit fix`
+couldn't clear. Adapters that don't depend on `wrangler`/`miniflare`
+are unaffected.

--- a/packages/cli/src/__tests__/init-scaffold-deps.test.ts
+++ b/packages/cli/src/__tests__/init-scaffold-deps.test.ts
@@ -42,6 +42,7 @@ interface ScaffoldPkgJson {
   scripts: Record<string, string>
   dependencies: Record<string, string>
   devDependencies: Record<string, string>
+  overrides?: Record<string, string>
 }
 
 function scaffold(adapter: string): ScaffoldPkgJson {
@@ -115,5 +116,27 @@ describe('hono scaffold pins wrangler as a devDependency and invokes it directly
       expect(script).not.toContain('yarn dlx wrangler')
       expect(script).not.toContain('deno x npm:wrangler')
     }
+  })
+})
+
+describe('hono scaffold overrides the undici pulled in by wrangler/miniflare', () => {
+  test('package.json carries the undici override from the adapter template', () => {
+    // `wrangler` -> `miniflare` pins `undici` to an exact (non-range)
+    // version, so a vulnerable release stays wired in even at the
+    // latest resolvable `wrangler` and `npm audit fix` can't bump past
+    // it. Assert against the adapter template's own value (not a
+    // hardcoded version here) so a routine bump to the override in
+    // `../lib/adapters/hono.ts` doesn't also require touching this test.
+    const pkg = scaffold('hono')
+    expect(pkg.overrides).toEqual(ADAPTERS.hono.overrides)
+    expect(pkg.overrides?.undici).toBeTruthy()
+  })
+
+  test('adapters without a wrangler/miniflare chain carry no overrides', () => {
+    // Only the Hono (Cloudflare Workers) adapter depends on wrangler ->
+    // miniflare today. Every other adapter should scaffold without a
+    // stray `overrides` key.
+    const pkg = scaffold('csr')
+    expect(pkg.overrides).toBeUndefined()
   })
 })

--- a/packages/cli/src/__tests__/init-scaffold-deps.test.ts
+++ b/packages/cli/src/__tests__/init-scaffold-deps.test.ts
@@ -43,15 +43,27 @@ interface ScaffoldPkgJson {
   dependencies: Record<string, string>
   devDependencies: Record<string, string>
   overrides?: Record<string, string>
+  pnpm?: { overrides?: Record<string, string> }
+  resolutions?: Record<string, string>
 }
 
-function scaffold(adapter: string): ScaffoldPkgJson {
+// `userAgent`, when set, is forwarded as `npm_config_user_agent` so
+// `detectPackageManager` resolves to a PM other than the bun runtime
+// this test itself spawns under — see the UA-checked-before-`versions.bun`
+// order in `detectInvokingPackageManager` (`../lib/pm.ts`). Lets a single
+// test process exercise every PM's package.json shape without actually
+// having pnpm/yarn installed.
+function scaffold(adapter: string, userAgent?: string): ScaffoldPkgJson {
   const cwd = mktmp()
   const result = spawnSync(
     'bun',
     [CLI_ENTRY, 'init', '--name', 'scaffold-deps-test', '--adapter', adapter, '--css', 'none'],
     {
-      env: { ...process.env, BAREFOOT_INIT_VIA_CREATE: '1' },
+      env: {
+        ...process.env,
+        BAREFOOT_INIT_VIA_CREATE: '1',
+        ...(userAgent ? { npm_config_user_agent: userAgent } : {}),
+      },
       encoding: 'utf-8',
       cwd,
     },
@@ -138,5 +150,31 @@ describe('hono scaffold overrides the undici pulled in by wrangler/miniflare', (
     // stray `overrides` key.
     const pkg = scaffold('csr')
     expect(pkg.overrides).toBeUndefined()
+  })
+
+  // Verified empirically (bun 1.3.11 / pnpm 10.33.0 / yarn 1.22.22)
+  // before writing these: a top-level `overrides` key is silently a
+  // no-op under pnpm (installs the vulnerable version with zero
+  // warning — worse than omitting the key, since the package.json
+  // *looks* protected) and is not read by yarn at all (which wants
+  // `resolutions` instead). `overridesField` in `../commands/init.ts`
+  // exists specifically to render the PM-correct shape.
+  test('pnpm-detected scaffold nests the override under pnpm.overrides, not top-level', () => {
+    const pkg = scaffold('hono', 'pnpm/10.33.0 npm/? node/v22.0.0 linux x64')
+    expect(pkg.overrides).toBeUndefined()
+    expect(pkg.pnpm?.overrides).toEqual(ADAPTERS.hono.overrides)
+  })
+
+  test('yarn-detected scaffold uses top-level resolutions, not overrides', () => {
+    const pkg = scaffold('hono', 'yarn/1.22.22 npm/? node/v22.0.0 linux x64')
+    expect(pkg.overrides).toBeUndefined()
+    expect(pkg.resolutions).toEqual(ADAPTERS.hono.overrides)
+  })
+
+  test('npm-detected scaffold keeps the top-level overrides key', () => {
+    const pkg = scaffold('hono', 'npm/10.9.7 node/v22.0.0 linux x64')
+    expect(pkg.overrides).toEqual(ADAPTERS.hono.overrides)
+    expect(pkg.pnpm).toBeUndefined()
+    expect(pkg.resolutions).toBeUndefined()
   })
 })

--- a/packages/cli/src/__tests__/readme.test.ts
+++ b/packages/cli/src/__tests__/readme.test.ts
@@ -65,4 +65,20 @@ describe('generateReadmeMd', () => {
     expect(readme).toMatch(/regenerated on every build/i)
     expect(readme).toMatch(/don't edit it by hand/i)
   })
+
+  test('explains adapter.overrides in a dedicated section (package.json can\'t carry a comment)', () => {
+    // Hono is the one adapter that injects an override today (wrangler
+    // -> miniflare's exact undici pin) — see AdapterTemplate.overrides.
+    // The README is the only place a user maintaining the generated
+    // project can learn why the override exists or when it's safe to
+    // remove, since JSON has no comment syntax.
+    const readme = generateReadmeMd('my-app', ADAPTERS.hono, 'npm')
+    expect(readme).toContain('## Dependency overrides')
+    expect(readme).toContain(ADAPTERS.hono.overridesNote)
+  })
+
+  test('omits the overrides section for adapters that inject none', () => {
+    const readme = generateReadmeMd('my-app', ADAPTERS.csr, 'npm')
+    expect(readme).not.toContain('## Dependency overrides')
+  })
 })

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -543,6 +543,11 @@ async function scaffoldApp(
     // `^<CLI_VERSION>` here — see `pinBarefootDeps` above.
     dependencies: pinBarefootDeps({ ...adapter.dependencies }),
     devDependencies: pinBarefootDeps({ ...adapterDevDeps, ...pmDevDeps }),
+    // Only present when the adapter declares one (see the doc comment
+    // on `AdapterTemplate.overrides`) — most adapters carry no
+    // transitive-pin vulnerabilities to work around, and a stray empty
+    // `overrides: {}` in every scaffold's package.json would be noise.
+    ...(adapter.overrides ? { overrides: adapter.overrides } : {}),
   }
   if (!existsSync(pkgJsonPath)) {
     writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -97,6 +97,34 @@ function pinBarefootDeps(deps: Record<string, string>): Record<string, string> {
   return pinned
 }
 
+// Renders an `AdapterTemplate.overrides` map into whatever field shape
+// the detected package manager actually reads for "force this
+// transitive dependency's version" — the field name (and nesting)
+// differs per PM, and getting it wrong is worse than doing nothing: a
+// stray `overrides` key that a PM silently ignores looks like
+// protection in the generated package.json without providing any
+// (verified empirically — pnpm 10 silently no-ops on a top-level
+// `overrides` key; it only reads `pnpm.overrides`).
+//   - npm, bun, deno: top-level `overrides` (npm's own field; bun
+//     mirrors it — but only the FLAT form, see `AdapterTemplate.overrides`'s
+//     doc comment on why nested/scoped overrides are off the table).
+//   - pnpm: nested under `pnpm.overrides`.
+//   - yarn (classic and berry): top-level `resolutions`.
+function overridesField(
+  pm: PackageManager,
+  overrides: Record<string, string> | undefined,
+): Record<string, unknown> {
+  if (!overrides) return {}
+  switch (pm) {
+    case 'pnpm':
+      return { pnpm: { overrides } }
+    case 'yarn':
+      return { resolutions: overrides }
+    default:
+      return { overrides }
+  }
+}
+
 interface InitFlags {
   name?: string
   adapter?: string
@@ -547,7 +575,9 @@ async function scaffoldApp(
     // on `AdapterTemplate.overrides`) — most adapters carry no
     // transitive-pin vulnerabilities to work around, and a stray empty
     // `overrides: {}` in every scaffold's package.json would be noise.
-    ...(adapter.overrides ? { overrides: adapter.overrides } : {}),
+    // Rendered into the PM-appropriate field name/shape — see
+    // `overridesField` above.
+    ...overridesField(pm, adapter.overrides),
   }
   if (!existsSync(pkgJsonPath)) {
     writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -314,5 +314,15 @@ export const HONO_ADAPTER: AdapterTemplate = {
   overrides: {
     undici: '^7.29.0',
   },
+  // Surfaced in the scaffolded README (package.json can't carry a
+  // comment, so without this the override is undiscoverable to whoever
+  // ends up maintaining the generated project).
+  overridesNote:
+    '`overrides.undici` forces a patched `undici` version. `wrangler` depends on `miniflare`, ' +
+    'which pins `undici` to an exact vulnerable release (see ' +
+    '[GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) and related advisories) ' +
+    "rather than a range — so `npm audit fix` can't bump past it on its own. " +
+    'Safe to remove once `miniflare` re-pins `undici` upstream — tracked in ' +
+    '[barefootjs#2567](https://github.com/piconic-ai/barefootjs/issues/2567).',
   prereqWarnings: () => [],
 }

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -289,5 +289,18 @@ export const HONO_ADAPTER: AdapterTemplate = {
     // comment above — this is what makes the bare invocation safe).
     wrangler: '^4.0.0',
   },
+  // `wrangler` pulls in `miniflare`, which pins `undici` to an exact
+  // (non-range) version rather than a caret range — so a vulnerable
+  // `undici` release stays wired in even at the latest resolvable
+  // `wrangler`/`miniflare`, and `npm audit fix` can't bump past it
+  // (nothing to bump: the range is a single exact version). Overriding
+  // `undici` directly is the only way to clear the advisory
+  // (GHSA-8xcm-r25x-g524 and friends) without waiting on `miniflare` to
+  // re-pin. Verified clean (`npm audit` → 0 vulnerabilities) against
+  // wrangler@4.119.0 / miniflare@5.20260801.0-alpha, which pin
+  // undici@7.28.0.
+  overrides: {
+    undici: '^7.29.0',
+  },
   prereqWarnings: () => [],
 }

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -299,6 +299,18 @@ export const HONO_ADAPTER: AdapterTemplate = {
   // re-pin. Verified clean (`npm audit` → 0 vulnerabilities) against
   // wrangler@4.119.0 / miniflare@5.20260801.0-alpha, which pin
   // undici@7.28.0.
+  //
+  // Deliberately flat/unscoped (applies to every `undici` resolution in
+  // the scaffold, not just miniflare's) — see the `overrides` doc
+  // comment on `AdapterTemplate` in `../templates.ts` for why a
+  // `{ miniflare: { undici: ... } }` scoped form is off the table (bun
+  // doesn't support nested overrides). The Hono adapter has no other
+  // `undici` consumer today, so the wider blast radius is currently
+  // moot; revisit if that changes.
+  //
+  // Bridge, not a fix: drop this once `miniflare` re-pins past
+  // `undici@7.28.0` on its own — tracked in
+  // https://github.com/piconic-ai/barefootjs/issues/2567.
   overrides: {
     undici: '^7.29.0',
   },

--- a/packages/cli/src/lib/readme.ts
+++ b/packages/cli/src/lib/readme.ts
@@ -79,5 +79,15 @@ export function generateReadmeMd(
     '',
   )
 
+  // Only present when the adapter injects a dependency override (see
+  // `AdapterTemplate.overrides`/`overridesNote` in `./templates.ts`) —
+  // package.json can't carry a comment, so this is the only place the
+  // *why* survives past scaffold time for whoever maintains the
+  // generated project next.
+  if (adapter.overrides && adapter.overridesNote) {
+    lines.push('## Dependency overrides', '')
+    lines.push(adapter.overridesNote, '')
+  }
+
   return lines.join('\n')
 }

--- a/packages/cli/src/lib/templates.ts
+++ b/packages/cli/src/lib/templates.ts
@@ -52,6 +52,17 @@ export interface AdapterTemplate {
   /** package.json dev dependencies. */
   devDependencies: Record<string, string>
   /**
+   * Optional npm `overrides` entries the scaffold's package.json should
+   * carry. For deps that pin a *transitive* dependency to an exact
+   * (non-range) version, `npm audit fix` can't bump it even when a
+   * patched release exists — an override is the only way to force it
+   * without waiting on the upstream package to re-pin. Rendered
+   * verbatim into `package.json#overrides`; omitted entirely when an
+   * adapter needs none, so plain scaffolds don't carry a stray empty
+   * key.
+   */
+  overrides?: Record<string, string>
+  /**
    * Optional deploy hint surfaced as a dedicated "Deploy:" section in
    * the post-scaffold guide. Adapters that don't have an obvious one-
    * command deploy story (Echo, Mojolicious, CSR) leave this unset

--- a/packages/cli/src/lib/templates.ts
+++ b/packages/cli/src/lib/templates.ts
@@ -52,14 +52,23 @@ export interface AdapterTemplate {
   /** package.json dev dependencies. */
   devDependencies: Record<string, string>
   /**
-   * Optional npm `overrides` entries the scaffold's package.json should
-   * carry. For deps that pin a *transitive* dependency to an exact
-   * (non-range) version, `npm audit fix` can't bump it even when a
-   * patched release exists — an override is the only way to force it
-   * without waiting on the upstream package to re-pin. Rendered
-   * verbatim into `package.json#overrides`; omitted entirely when an
-   * adapter needs none, so plain scaffolds don't carry a stray empty
-   * key.
+   * Optional forced-version entries for *transitive* dependencies the
+   * scaffold's package.json should carry — e.g. a dep that pins its own
+   * dependency to an exact (non-range) vulnerable version, which leaves
+   * `npm audit fix` with nothing to bump even when a patched release
+   * exists upstream. Keys must be flat (`{ pkg: "range" }`), never
+   * nested/scoped (`{ parent: { pkg: "range" } }`) — bun does not
+   * support nested overrides (as of bun 1.3.11: it warns and silently
+   * ignores the entry, leaving the vulnerable version installed), and
+   * this repo treats bun as a first-class scaffold target. `bf init`
+   * (`../commands/init.ts`'s `overridesField`) renders this map into
+   * whichever field name/shape the *detected* package manager actually
+   * reads (npm/bun/deno: top-level `overrides`; pnpm: nested
+   * `pnpm.overrides`; yarn: top-level `resolutions`) — getting that
+   * per-PM shape wrong is worse than omitting it: an `overrides` key a
+   * PM silently no-ops on (verified: pnpm 10 does this) looks like
+   * protection without providing any. Omitted entirely when an adapter
+   * needs none, so plain scaffolds don't carry a stray empty key.
    */
   overrides?: Record<string, string>
   /**

--- a/packages/cli/src/lib/templates.ts
+++ b/packages/cli/src/lib/templates.ts
@@ -72,6 +72,18 @@ export interface AdapterTemplate {
    */
   overrides?: Record<string, string>
   /**
+   * Human-readable explanation of why `overrides` exists, rendered into
+   * the scaffolded README (see `generateReadmeMd` in `../lib/readme.ts`)
+   * rather than left undiscoverable in the framework's own source
+   * comments. `package.json` is JSON — it can't carry a comment — so
+   * without this, the override is a stray-looking block in a file the
+   * *user* now owns and maintains, with no way to learn why it's there
+   * or when it's safe to delete. Required whenever `overrides` is set;
+   * should name the upstream cause and link a tracking issue for
+   * removal once it's no longer needed.
+   */
+  overridesNote?: string
+  /**
    * Optional deploy hint surfaced as a dedicated "Deploy:" section in
    * the post-scaffold guide. Adapters that don't have an obvious one-
    * command deploy story (Echo, Mojolicious, CSR) leave this unset


### PR DESCRIPTION
## Summary

`npm create barefootjs@latest` (default Hono/Cloudflare Workers adapter) reports 3 `npm audit` vulnerabilities (2 moderate, 1 high) right after `npm install`, all rooted in the same advisory chain:

```
wrangler -> miniflare -> undici@7.28.0
```

`miniflare` pins `undici` to an **exact** version rather than a caret range, so even the newest resolvable `wrangler` (`4.119.0` at time of writing — confirmed no `5.x`/`next`/`beta` has ever been published) still pulls in a vulnerable `undici`, and `npm audit fix` has nothing to bump — there's no wider range to move within, and bumping the `wrangler` devDependency range doesn't help since nothing newer exists. The only way to clear it is a forced-version override.

### The fix

- Added an optional `overrides` field to `AdapterTemplate` (`packages/cli/src/lib/templates.ts`) — a flat `{ pkg: "range" }` map.
- Set `overrides: { undici: '^7.29.0' }` on the Hono adapter (`packages/cli/src/lib/adapters/hono.ts`), the only adapter that depends on `wrangler`/`miniflare`.
- `bf init` renders that map into whatever field shape the **detected package manager** actually reads (`overridesField()` in `packages/cli/src/commands/init.ts`): npm/bun/deno → top-level `overrides`; pnpm → nested `pnpm.overrides`; yarn → top-level `resolutions`.
- Since `package.json` can't carry a comment, added `AdapterTemplate.overridesNote` and a "Dependency overrides" section in the scaffolded README (`generateReadmeMd`) explaining *why* the override exists and linking the tracking issue, so it isn't undiscoverable debt to whoever maintains the generated project next.

Filed #2567 to track dropping the override once `miniflare` re-pins past `undici@7.28.0` on its own — this is a bridge, not a permanent fix.

### Review history on this PR

Two independent model reviews shaped the final design:
- One flagged that a single hardcoded `overrides` key doesn't work everywhere — verified empirically: **pnpm silently no-ops on a top-level `overrides` key** (installs the vulnerable version with zero warning — worse than omitting it) and **yarn doesn't read `overrides` at all** (wants `resolutions`). It also suggested scoping the override to `{ miniflare: { undici } }` to reduce blast radius; verified that's **not viable** — bun silently ignores nested/scoped overrides, which would break the fix under bun, a first-class target here. The flat, adapter-wide form is intentional and documented in code.
- A second raised that leaving an unexplained override in every generated user project reads as debt, since JSON can't hold a comment. Verdict: the override itself is the right default (a scaffold whose first `npm install` prints audit noise is worse than carrying a documented override), but the discoverability gap was real — closed via the README section above.

## Verification

- Reproduced the reported issue with a package.json mirroring the Hono adapter's deps: `npm audit` → **3 vulnerabilities (2 moderate, 1 high)**, matching the report.
- Confirmed via registry lookups there's no newer `wrangler`/`miniflare` release available that avoids the pin (checked dist-tags, recent alpha pre-releases).
- After the override: `npm audit` → **0 vulnerabilities** under npm, bun, **and pnpm** (`pnpm audit` → "No known vulnerabilities found"); yarn resolves `undici@7.29.0` directly.
- Ran the real scaffold end-to-end via `bf init --adapter hono --css none` under simulated npm/bun/pnpm/yarn user-agents; confirmed each produces the PM-correct override shape and that a real install with that PM actually pins the patched `undici`.
- Confirmed `wrangler --version` still resolves and runs with the overridden `undici`.
- Confirmed the scaffolded README renders the "Dependency overrides" section with the explanation + issue link.
- `bun test packages/cli` (with `@barefootjs/client` built, clearing an unrelated pre-existing flaky-baseline issue in this sandbox): 672 pass / 2 fail, both pre-existing and unrelated to this diff (`@barefootjs/vite` workspace resolution in `context.test.ts`/`vite-config-loader.test.ts`, present before this PR too).

## Test plan

- [x] `bun test packages/cli/src/__tests__/init-scaffold-deps.test.ts` and `readme.test.ts` pass
- [x] Scaffolded a real Hono project via `bf init` for npm, bun, pnpm, and yarn; ran each PM's real install + audit → 0 vulnerabilities (or patched `undici` confirmed directly)
- [x] Confirmed `wrangler --version` still works with the overridden `undici`
- [x] Confirmed other adapters (`csr`) scaffold without a stray `overrides`/`resolutions`/`pnpm.overrides` key or README section
- [x] Confirmed the scaffolded README explains the override and links #2567
