### PR TITLE
chore(cli): drop the scaffold's undici override — miniflare re-pinned upstream

### DIFF
--- a/.changeset/hono-scaffold-drop-undici-override.md
+++ b/.changeset/hono-scaffold-drop-undici-override.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/cli": patch
+---
+
+The Hono (Cloudflare Workers) scaffold no longer pins an
+`overrides.undici` entry in the generated `package.json`, and the
+scaffolded README no longer carries the "Dependency overrides" section
+explaining it. The override was a bridge over `miniflare` pinning an
+exact vulnerable `undici` release; `miniflare` re-pinned upstream
+(`undici@7.29.0` as of `miniflare@5.20260801.1-alpha`, resolved by the
+scaffold's `wrangler@^4.0.0`), so a fresh scaffold now passes
+`npm audit` with no override present. Existing projects that carry the
+override can safely delete it.

--- a/packages/cli/src/__tests__/init-scaffold-deps.test.ts
+++ b/packages/cli/src/__tests__/init-scaffold-deps.test.ts
@@ -131,50 +131,25 @@ describe('hono scaffold pins wrangler as a devDependency and invokes it directly
   })
 })
 
-describe('hono scaffold overrides the undici pulled in by wrangler/miniflare', () => {
-  test('package.json carries the undici override from the adapter template', () => {
-    // `wrangler` -> `miniflare` pins `undici` to an exact (non-range)
-    // version, so a vulnerable release stays wired in even at the
-    // latest resolvable `wrangler` and `npm audit fix` can't bump past
-    // it. Assert against the adapter template's own value (not a
-    // hardcoded version here) so a routine bump to the override in
-    // `../lib/adapters/hono.ts` doesn't also require touching this test.
-    const pkg = scaffold('hono')
-    expect(pkg.overrides).toEqual(ADAPTERS.hono.overrides)
-    expect(pkg.overrides?.undici).toBeTruthy()
-  })
-
-  test('adapters without a wrangler/miniflare chain carry no overrides', () => {
-    // Only the Hono (Cloudflare Workers) adapter depends on wrangler ->
-    // miniflare today. Every other adapter should scaffold without a
-    // stray `overrides` key.
-    const pkg = scaffold('csr')
-    expect(pkg.overrides).toBeUndefined()
-  })
-
-  // Verified empirically (bun 1.3.11 / pnpm 10.33.0 / yarn 1.22.22)
-  // before writing these: a top-level `overrides` key is silently a
-  // no-op under pnpm (installs the vulnerable version with zero
-  // warning — worse than omitting the key, since the package.json
-  // *looks* protected) and is not read by yarn at all (which wants
-  // `resolutions` instead). `overridesField` in `../commands/init.ts`
-  // exists specifically to render the PM-correct shape.
-  test('pnpm-detected scaffold nests the override under pnpm.overrides, not top-level', () => {
-    const pkg = scaffold('hono', 'pnpm/10.33.0 npm/? node/v22.0.0 linux x64')
-    expect(pkg.overrides).toBeUndefined()
-    expect(pkg.pnpm?.overrides).toEqual(ADAPTERS.hono.overrides)
-  })
-
-  test('yarn-detected scaffold uses top-level resolutions, not overrides', () => {
-    const pkg = scaffold('hono', 'yarn/1.22.22 npm/? node/v22.0.0 linux x64')
-    expect(pkg.overrides).toBeUndefined()
-    expect(pkg.resolutions).toEqual(ADAPTERS.hono.overrides)
-  })
-
-  test('npm-detected scaffold keeps the top-level overrides key', () => {
-    const pkg = scaffold('hono', 'npm/10.9.7 node/v22.0.0 linux x64')
-    expect(pkg.overrides).toEqual(ADAPTERS.hono.overrides)
-    expect(pkg.pnpm).toBeUndefined()
-    expect(pkg.resolutions).toBeUndefined()
+describe('scaffolds carry no dependency-override fields', () => {
+  // The Hono scaffold used to force `overrides.undici` because
+  // `wrangler` -> `miniflare` pinned an exact vulnerable `undici`
+  // release (#2566). `miniflare` re-pinned upstream (undici@7.29.0 as
+  // of miniflare 5.20260801.1-alpha), so the override — and the per-PM
+  // `overridesField` plumbing that rendered it — were removed (#2567).
+  // Pin the removal: no scaffold should carry a stray override key in
+  // any PM's shape.
+  test('hono scaffold has no overrides/resolutions in any PM shape', () => {
+    for (const userAgent of [
+      undefined,
+      'npm/10.9.7 node/v22.0.0 linux x64',
+      'pnpm/10.33.0 npm/? node/v22.0.0 linux x64',
+      'yarn/1.22.22 npm/? node/v22.0.0 linux x64',
+    ]) {
+      const pkg = scaffold('hono', userAgent)
+      expect(pkg.overrides).toBeUndefined()
+      expect(pkg.pnpm).toBeUndefined()
+      expect(pkg.resolutions).toBeUndefined()
+    }
   })
 })

--- a/packages/cli/src/__tests__/readme.test.ts
+++ b/packages/cli/src/__tests__/readme.test.ts
@@ -66,19 +66,12 @@ describe('generateReadmeMd', () => {
     expect(readme).toMatch(/don't edit it by hand/i)
   })
 
-  test('explains adapter.overrides in a dedicated section (package.json can\'t carry a comment)', () => {
-    // Hono is the one adapter that injects an override today (wrangler
-    // -> miniflare's exact undici pin) — see AdapterTemplate.overrides.
-    // The README is the only place a user maintaining the generated
-    // project can learn why the override exists or when it's safe to
-    // remove, since JSON has no comment syntax.
+  test('carries no dependency-overrides section (the undici override was removed in #2567)', () => {
+    // The Hono scaffold used to inject `overrides.undici` (and the
+    // README section explaining it) while miniflare pinned a vulnerable
+    // exact version; miniflare re-pinned upstream, the override is
+    // gone, and the section must not resurface without a new override.
     const readme = generateReadmeMd('my-app', ADAPTERS.hono, 'npm')
-    expect(readme).toContain('## Dependency overrides')
-    expect(readme).toContain(ADAPTERS.hono.overridesNote)
-  })
-
-  test('omits the overrides section for adapters that inject none', () => {
-    const readme = generateReadmeMd('my-app', ADAPTERS.csr, 'npm')
     expect(readme).not.toContain('## Dependency overrides')
   })
 })

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -97,34 +97,6 @@ function pinBarefootDeps(deps: Record<string, string>): Record<string, string> {
   return pinned
 }
 
-// Renders an `AdapterTemplate.overrides` map into whatever field shape
-// the detected package manager actually reads for "force this
-// transitive dependency's version" — the field name (and nesting)
-// differs per PM, and getting it wrong is worse than doing nothing: a
-// stray `overrides` key that a PM silently ignores looks like
-// protection in the generated package.json without providing any
-// (verified empirically — pnpm 10 silently no-ops on a top-level
-// `overrides` key; it only reads `pnpm.overrides`).
-//   - npm, bun, deno: top-level `overrides` (npm's own field; bun
-//     mirrors it — but only the FLAT form, see `AdapterTemplate.overrides`'s
-//     doc comment on why nested/scoped overrides are off the table).
-//   - pnpm: nested under `pnpm.overrides`.
-//   - yarn (classic and berry): top-level `resolutions`.
-function overridesField(
-  pm: PackageManager,
-  overrides: Record<string, string> | undefined,
-): Record<string, unknown> {
-  if (!overrides) return {}
-  switch (pm) {
-    case 'pnpm':
-      return { pnpm: { overrides } }
-    case 'yarn':
-      return { resolutions: overrides }
-    default:
-      return { overrides }
-  }
-}
-
 interface InitFlags {
   name?: string
   adapter?: string
@@ -571,13 +543,6 @@ async function scaffoldApp(
     // `^<CLI_VERSION>` here — see `pinBarefootDeps` above.
     dependencies: pinBarefootDeps({ ...adapter.dependencies }),
     devDependencies: pinBarefootDeps({ ...adapterDevDeps, ...pmDevDeps }),
-    // Only present when the adapter declares one (see the doc comment
-    // on `AdapterTemplate.overrides`) — most adapters carry no
-    // transitive-pin vulnerabilities to work around, and a stray empty
-    // `overrides: {}` in every scaffold's package.json would be noise.
-    // Rendered into the PM-appropriate field name/shape — see
-    // `overridesField` above.
-    ...overridesField(pm, adapter.overrides),
   }
   if (!existsSync(pkgJsonPath)) {
     writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -289,40 +289,5 @@ export const HONO_ADAPTER: AdapterTemplate = {
     // comment above — this is what makes the bare invocation safe).
     wrangler: '^4.0.0',
   },
-  // `wrangler` pulls in `miniflare`, which pins `undici` to an exact
-  // (non-range) version rather than a caret range — so a vulnerable
-  // `undici` release stays wired in even at the latest resolvable
-  // `wrangler`/`miniflare`, and `npm audit fix` can't bump past it
-  // (nothing to bump: the range is a single exact version). Overriding
-  // `undici` directly is the only way to clear the advisory
-  // (GHSA-8xcm-r25x-g524 and friends) without waiting on `miniflare` to
-  // re-pin. Verified clean (`npm audit` → 0 vulnerabilities) against
-  // wrangler@4.119.0 / miniflare@5.20260801.0-alpha, which pin
-  // undici@7.28.0.
-  //
-  // Deliberately flat/unscoped (applies to every `undici` resolution in
-  // the scaffold, not just miniflare's) — see the `overrides` doc
-  // comment on `AdapterTemplate` in `../templates.ts` for why a
-  // `{ miniflare: { undici: ... } }` scoped form is off the table (bun
-  // doesn't support nested overrides). The Hono adapter has no other
-  // `undici` consumer today, so the wider blast radius is currently
-  // moot; revisit if that changes.
-  //
-  // Bridge, not a fix: drop this once `miniflare` re-pins past
-  // `undici@7.28.0` on its own — tracked in
-  // https://github.com/piconic-ai/barefootjs/issues/2567.
-  overrides: {
-    undici: '^7.29.0',
-  },
-  // Surfaced in the scaffolded README (package.json can't carry a
-  // comment, so without this the override is undiscoverable to whoever
-  // ends up maintaining the generated project).
-  overridesNote:
-    '`overrides.undici` forces a patched `undici` version. `wrangler` depends on `miniflare`, ' +
-    'which pins `undici` to an exact vulnerable release (see ' +
-    '[GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) and related advisories) ' +
-    "rather than a range — so `npm audit fix` can't bump past it on its own. " +
-    'Safe to remove once `miniflare` re-pins `undici` upstream — tracked in ' +
-    '[barefootjs#2567](https://github.com/piconic-ai/barefootjs/issues/2567).',
   prereqWarnings: () => [],
 }

--- a/packages/cli/src/lib/readme.ts
+++ b/packages/cli/src/lib/readme.ts
@@ -79,15 +79,5 @@ export function generateReadmeMd(
     '',
   )
 
-  // Only present when the adapter injects a dependency override (see
-  // `AdapterTemplate.overrides`/`overridesNote` in `./templates.ts`) —
-  // package.json can't carry a comment, so this is the only place the
-  // *why* survives past scaffold time for whoever maintains the
-  // generated project next.
-  if (adapter.overrides && adapter.overridesNote) {
-    lines.push('## Dependency overrides', '')
-    lines.push(adapter.overridesNote, '')
-  }
-
   return lines.join('\n')
 }

--- a/packages/cli/src/lib/templates.ts
+++ b/packages/cli/src/lib/templates.ts
@@ -52,38 +52,6 @@ export interface AdapterTemplate {
   /** package.json dev dependencies. */
   devDependencies: Record<string, string>
   /**
-   * Optional forced-version entries for *transitive* dependencies the
-   * scaffold's package.json should carry — e.g. a dep that pins its own
-   * dependency to an exact (non-range) vulnerable version, which leaves
-   * `npm audit fix` with nothing to bump even when a patched release
-   * exists upstream. Keys must be flat (`{ pkg: "range" }`), never
-   * nested/scoped (`{ parent: { pkg: "range" } }`) — bun does not
-   * support nested overrides (as of bun 1.3.11: it warns and silently
-   * ignores the entry, leaving the vulnerable version installed), and
-   * this repo treats bun as a first-class scaffold target. `bf init`
-   * (`../commands/init.ts`'s `overridesField`) renders this map into
-   * whichever field name/shape the *detected* package manager actually
-   * reads (npm/bun/deno: top-level `overrides`; pnpm: nested
-   * `pnpm.overrides`; yarn: top-level `resolutions`) — getting that
-   * per-PM shape wrong is worse than omitting it: an `overrides` key a
-   * PM silently no-ops on (verified: pnpm 10 does this) looks like
-   * protection without providing any. Omitted entirely when an adapter
-   * needs none, so plain scaffolds don't carry a stray empty key.
-   */
-  overrides?: Record<string, string>
-  /**
-   * Human-readable explanation of why `overrides` exists, rendered into
-   * the scaffolded README (see `generateReadmeMd` in `../lib/readme.ts`)
-   * rather than left undiscoverable in the framework's own source
-   * comments. `package.json` is JSON — it can't carry a comment — so
-   * without this, the override is a stray-looking block in a file the
-   * *user* now owns and maintains, with no way to learn why it's there
-   * or when it's safe to delete. Required whenever `overrides` is set;
-   * should name the upstream cause and link a tracking issue for
-   * removal once it's no longer needed.
-   */
-  overridesNote?: string
-  /**
    * Optional deploy hint surfaced as a dedicated "Deploy:" section in
    * the post-scaffold guide. Adapters that don't have an obvious one-
    * command deploy story (Echo, Mojolicious, CSR) leave this unset


### PR DESCRIPTION
## Summary

#2567's removal condition is met: `miniflare` re-pinned `undici` upstream. The scaffold's forced override (added in #2566 as an explicit bridge) no longer has anything to fix, so this PR removes it and all of its plumbing, per the issue's action item.

Measured today against the npm registry: the scaffold's `wrangler@^4.0.0` resolves to `wrangler@4.120.0` → `miniflare@5.20260801.1-alpha`, which pins `undici@7.29.0` — at the `>=7.29.0` threshold the issue names.

## Changes

- `packages/cli/src/lib/adapters/hono.ts` — removed the `overrides: { undici: '^7.29.0' }` block and its `overridesNote`.
- `packages/cli/src/commands/init.ts` — removed the `overridesField` per-PM rendering helper and its use in the scaffolded `package.json` (no other adapter declares overrides).
- `packages/cli/src/lib/templates.ts` — removed the now-unused `AdapterTemplate.overrides` / `overridesNote` fields.
- `packages/cli/src/lib/readme.ts` — removed the "Dependency overrides" README section rendering.
- Tests: the override-shape describes in `init-scaffold-deps.test.ts` are replaced by a regression pin asserting no scaffold carries `overrides` / `pnpm.overrides` / `resolutions` in any PM shape; `readme.test.ts` now pins the absence of the "Dependency overrides" section.

## Verification (the issue's acceptance steps)

- Fresh `bf init --adapter hono` scaffold: `package.json` carries no override keys.
- `npm install` in that scaffold resolves `wrangler@4.120.0` → `miniflare@5.20260801.1-alpha` → `undici@7.29.0`.
- `npm audit` → **0 vulnerabilities** with no override present.
- `packages/cli` test suite: 667 pass; the 1 remaining failure (`context.test.ts`) reproduces on unmodified `main` in this environment and is unrelated.

Closes #2567

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_