### PR TITLE
fix(hono): resolve dangerouslySetInnerHTML into children for childless svg/head

### DIFF
--- a/.changeset/hono-dsih-svg-head-no-children.md
+++ b/.changeset/hono-dsih-svg-head-no-children.md
@@ -1,0 +1,33 @@
+---
+"@barefootjs/hono": patch
+---
+
+Fix `dangerouslySetInnerHTML` throwing on childless `<svg>`/`<head>` elements through `@barefootjs/hono/jsx` (#2557)
+
+`String(jsx('svg', { dangerouslySetInnerHTML: { __html: '...' } }))` threw
+`Error: Can only set one of \`children\` or \`props.dangerouslySetInnerHTML\`.`
+even though no children were passed at all.
+
+Root cause is in hono's own JSX runtime (`hono/dist/jsx/base.js`'s
+`jsxFn`), not in anything BarefootJS wrote: for `<svg>` and `<head>`
+specifically, `jsxFn` always wraps the real children in an internal
+namespace-context node — `[new JSXFunctionNode(nameSpaceContext, ...)]` —
+even when the caller passed zero children. That phantom wrapper makes the
+outer `JSXNode`'s `children.length > 0`, which trips hono's own
+`children`-vs-`dangerouslySetInnerHTML` conflict guard for every childless
+`<svg>`/`<head>` element using `dangerouslySetInnerHTML`. Ordinary tags
+(e.g. `<div>`) never hit this — only `svg`/`head` get the namespace
+wrapper — which is why the bug only reproduces on those two tags.
+
+`packages/adapter-hono/src/jsx/jsx-runtime/index.ts` (`jsx`/`jsxs`) and
+`packages/adapter-hono/src/jsx/jsx-dev-runtime/index.ts` (`jsxDEV`) now
+resolve `dangerouslySetInnerHTML` into real `children` themselves —
+mirroring what hono's guard expects — before delegating to hono's
+runtime, whenever no explicit `children` prop is present. A genuine
+conflict (both real children AND `dangerouslySetInnerHTML` passed
+together) is left untouched and still rejected by hono's own guard.
+
+Any compiled template whose element carries `dangerouslySetInnerHTML`
+previously crashed at SSR through this runtime if the element was an
+`<svg>` or `<head>` with no other children (a common shape for inlined
+icon markup).

--- a/packages/adapter-hono/src/__tests__/dangerously-set-inner-html.test.ts
+++ b/packages/adapter-hono/src/__tests__/dangerously-set-inner-html.test.ts
@@ -51,4 +51,20 @@ describe('dangerouslySetInnerHTML with no children (#2557)', () => {
       String(jsx('span', { dangerouslySetInnerHTML: { __html: 'x' }, children: 'real' }))
     ).toThrow('Can only set one of `children` or `props.dangerouslySetInnerHTML`.')
   })
+
+  test('function components receive the caller props untouched', () => {
+    // The workaround is scoped to intrinsic string tags: a user component
+    // must see exactly what the caller passed (it may forward
+    // `dangerouslySetInnerHTML` to an intrinsic element itself).
+    const seen: Record<string, unknown>[] = []
+    const Widget = (props: Record<string, unknown>) => {
+      seen.push(props)
+      return jsx('div', { dangerouslySetInnerHTML: props.dangerouslySetInnerHTML })
+    }
+    const html = String(jsx(Widget, { dangerouslySetInnerHTML: { __html: '<b>fwd</b>' } }))
+    expect(html).toBe('<div><b>fwd</b></div>')
+    expect(seen).toHaveLength(1)
+    expect(seen[0].dangerouslySetInnerHTML).toEqual({ __html: '<b>fwd</b>' })
+    expect('children' in seen[0]).toBe(false)
+  })
 })

--- a/packages/adapter-hono/src/__tests__/dangerously-set-inner-html.test.ts
+++ b/packages/adapter-hono/src/__tests__/dangerously-set-inner-html.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Hono adapter jsx-runtime: `dangerouslySetInnerHTML` with no children (#2557).
+ *
+ * hono's own `jsxFn` (see `hono/dist/jsx/base.js`) always wraps `<svg>` /
+ * `<head>` children in an internal namespace-context node, even when the
+ * caller passed no real children. That phantom wrapper makes hono's own
+ * `children.length > 0` guard true, so any *childless* `<svg>`/`<head>`
+ * element using `dangerouslySetInnerHTML` tripped hono's
+ * "Can only set one of `children` or `props.dangerouslySetInnerHTML`"
+ * error — even though there were no real children to conflict with.
+ *
+ * `../jsx/jsx-runtime/index.ts` and `../jsx/jsx-dev-runtime/index.ts` work
+ * around this by resolving `dangerouslySetInnerHTML` into real `children`
+ * themselves before delegating to hono, whenever no explicit `children`
+ * prop is present. This pins that fix at the runtime-function level (the
+ * layer BarefootJS's compiled SSR output actually calls into) and confirms
+ * genuine children+dangerouslySetInnerHTML conflicts are still rejected.
+ */
+import { describe, test, expect } from 'bun:test'
+import { jsx, jsxs } from '../jsx/jsx-runtime/index.ts'
+import { jsxDEV } from '../jsx/jsx-dev-runtime/index.ts'
+
+describe('dangerouslySetInnerHTML with no children (#2557)', () => {
+  test('jsx: <svg dangerouslySetInnerHTML> with no children does not throw', () => {
+    const html = String(jsx('svg', { dangerouslySetInnerHTML: { __html: '<path d="M1"/>' } }))
+    expect(html).toBe('<svg><path d="M1"/></svg>')
+  })
+
+  test('jsx: <head dangerouslySetInnerHTML> with no children does not throw', () => {
+    const html = String(jsx('head', { dangerouslySetInnerHTML: { __html: '<meta charset="utf-8">' } }))
+    expect(html).toBe('<head><meta charset="utf-8"></head>')
+  })
+
+  test('jsx: ordinary tags with dangerouslySetInnerHTML still work', () => {
+    const html = String(jsx('div', { dangerouslySetInnerHTML: { __html: '<b>hi</b>' } }))
+    expect(html).toBe('<div><b>hi</b></div>')
+  })
+
+  test('jsxs: <svg dangerouslySetInnerHTML> with no children does not throw', () => {
+    const html = String(jsxs('svg', { dangerouslySetInnerHTML: { __html: '<circle r="1"/>' } }))
+    expect(html).toBe('<svg><circle r="1"/></svg>')
+  })
+
+  test('jsxDEV: <svg dangerouslySetInnerHTML> with no children does not throw', () => {
+    const html = String(jsxDEV('svg', { dangerouslySetInnerHTML: { __html: '<rect/>' } }))
+    expect(html).toBe('<svg><rect/></svg>')
+  })
+
+  test('genuine conflict — both children and dangerouslySetInnerHTML — still throws', () => {
+    expect(() =>
+      String(jsx('span', { dangerouslySetInnerHTML: { __html: 'x' }, children: 'real' }))
+    ).toThrow('Can only set one of `children` or `props.dangerouslySetInnerHTML`.')
+  })
+})

--- a/packages/adapter-hono/src/jsx/jsx-dev-runtime/index.ts
+++ b/packages/adapter-hono/src/jsx/jsx-dev-runtime/index.ts
@@ -5,5 +5,15 @@
  * JSX namespace as the production runtime so dev builds see identical types.
  */
 
-export { jsxDEV, Fragment } from 'hono/jsx/jsx-dev-runtime'
+import { jsxDEV as honoJsxDEV, Fragment } from 'hono/jsx/jsx-dev-runtime'
+import { resolveDangerouslySetInnerHTML } from '../resolve-dangerously-set-inner-html.ts'
+
+export { Fragment }
 export type { JSX } from '../jsx-runtime/index.ts'
+
+// See `../resolve-dangerously-set-inner-html.ts` for why this is needed —
+// hono's own `jsxFn` throws for a childless `<svg>`/`<head>` element using
+// `dangerouslySetInnerHTML` (https://github.com/piconic-ai/barefootjs/issues/2557).
+export function jsxDEV(tag: string | Function, props: Record<string, unknown>, key?: string) {
+  return honoJsxDEV(tag, resolveDangerouslySetInnerHTML(props), key)
+}

--- a/packages/adapter-hono/src/jsx/jsx-dev-runtime/index.ts
+++ b/packages/adapter-hono/src/jsx/jsx-dev-runtime/index.ts
@@ -14,6 +14,8 @@ export type { JSX } from '../jsx-runtime/index.ts'
 // See `../resolve-dangerously-set-inner-html.ts` for why this is needed —
 // hono's own `jsxFn` throws for a childless `<svg>`/`<head>` element using
 // `dangerouslySetInnerHTML` (https://github.com/piconic-ai/barefootjs/issues/2557).
+// Intrinsic string tags only: a function component must receive the caller's
+// props untouched (it may forward `dangerouslySetInnerHTML` itself).
 export function jsxDEV(tag: string | Function, props: Record<string, unknown>, key?: string) {
-  return honoJsxDEV(tag, resolveDangerouslySetInnerHTML(props), key)
+  return honoJsxDEV(tag, typeof tag === 'string' ? resolveDangerouslySetInnerHTML(props) : props, key)
 }

--- a/packages/adapter-hono/src/jsx/jsx-runtime/index.ts
+++ b/packages/adapter-hono/src/jsx/jsx-runtime/index.ts
@@ -11,7 +11,28 @@
  */
 
 // Runtime functions from hono/jsx.
-export { jsx, jsxs, Fragment, jsxAttr, jsxEscape, jsxTemplate } from 'hono/jsx/jsx-runtime'
+import {
+  jsx as honoJsx,
+  jsxs as honoJsxs,
+  Fragment,
+  jsxAttr,
+  jsxEscape,
+  jsxTemplate,
+} from 'hono/jsx/jsx-runtime'
+import { resolveDangerouslySetInnerHTML } from '../resolve-dangerously-set-inner-html.ts'
+
+export { Fragment, jsxAttr, jsxEscape, jsxTemplate }
+
+// See `../resolve-dangerously-set-inner-html.ts` for why this is needed —
+// hono's own `jsxFn` throws for a childless `<svg>`/`<head>` element using
+// `dangerouslySetInnerHTML` (https://github.com/piconic-ai/barefootjs/issues/2557).
+export function jsx(tag: string | Function, props: Record<string, unknown>, key?: string) {
+  return honoJsx(tag, resolveDangerouslySetInnerHTML(props), key)
+}
+
+export function jsxs(tag: string | Function, props: Record<string, unknown>, key?: string) {
+  return honoJsxs(tag, resolveDangerouslySetInnerHTML(props), key)
+}
 
 // Re-export JSX namespace from @barefootjs/jsx, but override Element type for Hono.
 import type { JSX as BaseJSX } from '@barefootjs/jsx/jsx-runtime'

--- a/packages/adapter-hono/src/jsx/jsx-runtime/index.ts
+++ b/packages/adapter-hono/src/jsx/jsx-runtime/index.ts
@@ -26,12 +26,14 @@ export { Fragment, jsxAttr, jsxEscape, jsxTemplate }
 // See `../resolve-dangerously-set-inner-html.ts` for why this is needed —
 // hono's own `jsxFn` throws for a childless `<svg>`/`<head>` element using
 // `dangerouslySetInnerHTML` (https://github.com/piconic-ai/barefootjs/issues/2557).
+// Intrinsic string tags only: a function component must receive the caller's
+// props untouched (it may forward `dangerouslySetInnerHTML` itself).
 export function jsx(tag: string | Function, props: Record<string, unknown>, key?: string) {
-  return honoJsx(tag, resolveDangerouslySetInnerHTML(props), key)
+  return honoJsx(tag, typeof tag === 'string' ? resolveDangerouslySetInnerHTML(props) : props, key)
 }
 
 export function jsxs(tag: string | Function, props: Record<string, unknown>, key?: string) {
-  return honoJsxs(tag, resolveDangerouslySetInnerHTML(props), key)
+  return honoJsxs(tag, typeof tag === 'string' ? resolveDangerouslySetInnerHTML(props) : props, key)
 }
 
 // Re-export JSX namespace from @barefootjs/jsx, but override Element type for Hono.

--- a/packages/adapter-hono/src/jsx/resolve-dangerously-set-inner-html.ts
+++ b/packages/adapter-hono/src/jsx/resolve-dangerously-set-inner-html.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared by `./jsx-runtime/index.ts` and `./jsx-dev-runtime/index.ts`.
+ *
+ * hono's own `jsxFn` (`hono/dist/jsx/base.js`) always wraps `<svg>` /
+ * `<head>` children in an internal namespace-context node — even when the
+ * caller passed no children at all. That phantom wrapper makes the outer
+ * `JSXNode`'s `children.length > 0` true, which trips hono's own
+ * "Can only set one of `children` or `props.dangerouslySetInnerHTML`" guard
+ * for any childless `<svg>`/`<head>` element using `dangerouslySetInnerHTML`
+ * — see https://github.com/piconic-ai/barefootjs/issues/2557.
+ *
+ * Work around it at the one place BarefootJS's compiled output calls into
+ * hono's JSX runtime: when `dangerouslySetInnerHTML` is present and no real
+ * `children` prop was given, resolve it into `children` ourselves (mirroring
+ * what hono would do internally) before delegating to hono. If the caller
+ * supplied *both* real children and `dangerouslySetInnerHTML`, that's a
+ * genuine conflict — leave `props` untouched so hono's own guard still
+ * rejects it.
+ */
+import { raw } from 'hono/html'
+
+export function resolveDangerouslySetInnerHTML(props: Record<string, unknown>): Record<string, unknown> {
+  if (
+    props &&
+    'dangerouslySetInnerHTML' in props &&
+    props.dangerouslySetInnerHTML != null &&
+    !('children' in props)
+  ) {
+    const { dangerouslySetInnerHTML, ...rest } = props
+    const html = (dangerouslySetInnerHTML as { __html: string }).__html
+    return { ...rest, children: raw(html) }
+  }
+  return props
+}


### PR DESCRIPTION
**Stack 1/7** (base: `main`; next: #TBD). Seven mechanically-solvable open issues, one PR each, stacked in risk order.

## Summary

`String(jsx('svg', { dangerouslySetInnerHTML: { __html: '…' } }))` through `@barefootjs/hono/jsx/jsx-runtime` threw `Can only set one of \`children\` or \`props.dangerouslySetInnerHTML\`.` even with no children passed — so any compiled template with the prop on a childless `<svg>`/`<head>` crashed at SSR.

Root cause is upstream: hono's own `jsxFn` always wraps `<svg>`/`<head>` children in an internal namespace-context node, even for zero children. That phantom wrapper makes `children.length > 0`, tripping hono's conflict guard. Ordinary tags never hit it — only the two namespace-wrapped tags — which is why the one-liner repro is tag-specific.

## Fix

`jsx`/`jsxs`/`jsxDEV` now resolve `dangerouslySetInnerHTML` into `raw(html)` children themselves (shared helper `resolve-dangerously-set-inner-html.ts`) before delegating to hono — only when no explicit `children` prop is present. A genuine children-plus-prop conflict still reaches hono's own guard and is rejected (pinned by test).

## Coverage

- `packages/adapter-hono/src/__tests__/dangerously-set-inner-html.test.ts` — 6 pins: svg/head/div via `jsx`, `jsxs`, `jsxDEV`, plus the genuine-conflict rejection. This is SSR through the adapter runtime — the layer the issue reduced the bug to (it's independent of the compiler).
- Changeset: `@barefootjs/hono` patch.

## Verification

- New test: 6/6. Full `packages/adapter-hono` suite at the stack tip: 1364 pass; the single failure is `vite.test.ts`'s `Cannot find module '@barefootjs/vite'` — an unbuilt-workspace-package environment issue, proven by building `@barefootjs/vite` locally and rerunning (6/6 green), unrelated to this diff.

Closes #2557

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_