### PR TITLE
fix(hono): render nested ternary branches bare inside a non-reactive conditional

### DIFF
--- a/.changeset/hono-nested-ternary-bare-branch-2470.md
+++ b/.changeset/hono-nested-ternary-bare-branch-2470.md
@@ -1,0 +1,48 @@
+---
+"@barefootjs/hono": patch
+---
+
+Fix Hono adapter emitting invalid `.tsx` for a nested ternary chain nested in a non-reactive outer conditional's alternate (#2470)
+
+```tsx
+const MODE = 'b'
+export function Chain() {
+  return <div>{MODE === 'a' ? <span>A</span> : MODE === 'b' ? <span>B</span> : <span>C</span>}</div>
+}
+```
+
+used to emit
+
+```tsx
+{MODE === 'a' ? <span>A</span> : {MODE === 'b' ? <span>B</span> : <span>C</span>}}
+```
+
+— the nested conditional got re-wrapped in its own `{…}` while sitting in
+the ALTERNATE position of the outer ternary, where only a plain JS
+expression is legal, so the generated `.tsx` failed to parse
+(`Expected "}" but found "==="`) with zero diagnostics.
+
+Only reachable when the OUTER conditional's condition is non-reactive (no
+signal/prop/call — e.g. a module-level `const`), which takes the flat
+`cond ? whenTrue : whenFalse` path instead of the reactive marker-wrapping
+path (`wrapWithCondMarker`), so the existing `nested-ternary` fixture
+(reactive outer condition) never caught it.
+
+`renderConditional` now splits its output into `renderConditionalBody`
+(the bare ternary text) plus the enclosing `{…}` it alone adds. A new
+`renderBareBranch` helper renders a non-reactive conditional's branches
+through `renderConditionalBody` directly when a branch is itself a nested
+conditional, instead of falling through to the generic `renderNode`/
+`emitConditional` dispatch that re-wraps it. The reactive path (marker
+splicing via `wrapWithCondMarker`) is unchanged.
+
+New conformance fixture: `nested-ternary-bare-branch`
+(`packages/adapter-tests/fixtures/nested-ternary-bare-branch.ts`), modeled
+on `nested-ternary.ts` but with a non-reactive module-const outer
+condition — the shape the existing fixture doesn't exercise.
+
+Other adapters (Go template, ERB, Jinja, Twig, Mojolicious, Blade, Rust
+minijinja, Xslate) emit their own template-tag syntax (`{{ }}`, `<% %>`,
+etc.), not raw JS `{…}` expression containers, so they aren't exposed to
+this specific double-brace hazard — Hono is the only JSX-runtime adapter
+in the workspace.

--- a/packages/adapter-hono/src/__tests__/nested-ternary-bare-branch.test.ts
+++ b/packages/adapter-hono/src/__tests__/nested-ternary-bare-branch.test.ts
@@ -1,0 +1,70 @@
+/**
+ * #2470: a nested ternary chain (`a ? … : b ? … : …`) sitting in the
+ * ALTERNATE of a NON-reactive outer conditional (no signal/prop/call —
+ * a module-level `const`) used to emit
+ *
+ *   {MODE === 'a' ? <span>A</span> : {MODE === 'b' ? <span>B</span> : <span>C</span>}}
+ *
+ * — the nested conditional re-wrapped in its own `{…}` in a position where
+ * only a bare JS expression is legal, breaking the `.tsx` parse
+ * (`Expected "}" but found "==="`) with zero diagnostics. See
+ * `renderConditionalBody` / `renderBareBranch` in `hono-adapter.ts`.
+ */
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import ts from 'typescript'
+import { compileJSX } from '@barefootjs/jsx'
+import { HonoAdapter } from '../adapter/index.ts'
+
+const HERE = resolve(import.meta.dir)
+
+const SOURCE = `
+const MODE = 'b'
+export function Chain() {
+  return <div>{MODE === 'a' ? <span>A</span> : MODE === 'b' ? <span>B</span> : <span>C</span>}</div>
+}
+`
+
+describe('nested ternary under a non-reactive outer condition (#2470)', () => {
+  test('the emitted template has no double-braced nested conditional', () => {
+    const result = compileJSX(SOURCE, '/virtual/Chain.tsx', {
+      adapter: new HonoAdapter(),
+    })
+    expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
+    const template = result.files.find(f => f.type === 'markedTemplate')?.content
+    expect(template).toBeDefined()
+
+    // The nested conditional's branch must stay a bare `cond ? … : …`
+    // splice, not a second `{…}`-wrapped expression, inside the outer
+    // ternary's alternate.
+    expect(template).toContain(
+      "MODE === 'a' ? <span>A</span> : MODE === 'b' ? <span>B</span> : <span>C</span>",
+    )
+    expect(template).not.toContain(': {MODE ===')
+
+    // The template must actually PARSE as valid TSX — this is the
+    // regression the bug produced silently (no compiler diagnostic, just a
+    // downstream syntax error at build time). `getSyntacticDiagnostics` is
+    // the public API for this (mirrors `consumer-typecheck.test.ts`'s
+    // `ts.createProgram` usage, scoped to syntax only since this file has
+    // no import to resolve).
+    const tmp = mkdtempSync(join(HERE, '.nested-ternary-bare-branch-'))
+    try {
+      const file = join(tmp, 'Chain.tsx')
+      writeFileSync(file, template!)
+      const program = ts.createProgram([file], {
+        noEmit: true,
+        target: ts.ScriptTarget.ESNext,
+        jsx: ts.JsxEmit.ReactJSX,
+        jsxImportSource: '@barefootjs/hono/jsx',
+        allowImportingTsExtensions: true,
+        skipLibCheck: true,
+      })
+      const syntaxDiagnostics = program.getSyntacticDiagnostics(program.getSourceFile(file))
+      expect(syntaxDiagnostics.map(d => ts.flattenDiagnosticMessageText(d.messageText, ' '))).toEqual([])
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  }, 30_000)
+})

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -812,6 +812,39 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
       return `{bfComment("cond-start:${cond.slotId}")}{bfComment("cond-end:${cond.slotId}")}`
     }
 
+    return `{${this.renderConditionalBody(cond, ctx)}}`
+  }
+
+  /**
+   * The bare ternary text for `cond` — everything `renderConditional` would
+   * wrap in `{…}`, minus that wrapping. `renderConditional` is the ONLY
+   * place that should add the enclosing braces for a JSX-child position.
+   *
+   * The two branches below need genuinely different embedding rules, not
+   * just a brace/no-brace toggle:
+   *
+   * - Non-reactive (`cond.slotId` is null): the whole thing collapses to a
+   *   FLAT `cond ? whenTrue : whenFalse` — one JS expression, wrapped in
+   *   `{…}` exactly once by whichever caller owns that position (either
+   *   `renderConditional` for a JSX-child position, or an ENCLOSING
+   *   ternary's own bare-branch splice when this conditional is itself
+   *   nested — see `renderBareBranch`). So whenTrue/whenFalse must stay
+   *   bare all the way down: a nested conditional branch renders through
+   *   `renderConditionalBody` again (bare), never through the generic
+   *   `renderNode`/`emitConditional` dispatch, which would re-brace it and
+   *   break the .tsx parse where only a plain expression is legal (#2470).
+   *
+   * - Reactive (`cond.slotId` set): each branch is spliced through
+   *   `wrapWithCondMarker`, which expects a self-contained renderable
+   *   chunk — an HTML-element string it can tag with `bf-c`, or otherwise
+   *   text/JSX content it splices directly as JSX CHILDREN inside a
+   *   `<>…</>` fragment. A nested conditional branch here must keep going
+   *   through the ordinary `renderNode`/`emitConditional` dispatch (via
+   *   `renderNodeRawCtx`, unchanged) so it comes back as a complete,
+   *   already-`{…}`-wrapped JSX expression container — valid as fragment
+   *   children, which bare ternary text would not be.
+   */
+  private renderConditionalBody(cond: IRConditional, ctx?: HonoRenderCtx): string {
     // A conditional that is itself a loop item root (#1665 whole-item
     // conditional: `arr.map(t => cond && <li/>)`) makes its branch element the
     // loop item's root, so the `data-key` that reconciliation/hydration expect
@@ -819,26 +852,29 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
     // the flag through so `renderElement` emits `data-key`, matching the Go /
     // CSR adapters' generic `key`→`data-key` rewrite.
     const branchCtx: HonoRenderCtx | undefined = ctx?.isLoopItemRoot ? { isLoopItemRoot: true } : undefined
+
+    if (!cond.slotId) {
+      const whenTrue = this.renderBareBranch(cond.whenTrue, branchCtx)
+      let whenFalse = this.renderBareBranch(cond.whenFalse, branchCtx)
+      if (!whenFalse || whenFalse === '' || whenFalse === 'null') {
+        whenFalse = 'null'
+      }
+      return `${cond.condition} ? ${whenTrue} : ${whenFalse}`
+    }
+
     const whenTrue = this.renderNodeRawCtx(cond.whenTrue, branchCtx)
     let whenFalse = this.renderNodeRawCtx(cond.whenFalse, branchCtx)
-
-    // Handle empty/null whenFalse
     if (!whenFalse || whenFalse === '' || whenFalse === 'null') {
       whenFalse = 'null'
     }
 
-    // If reactive, wrap with markers
-    if (cond.slotId) {
-      const trueWithMarker = this.wrapWithCondMarker(cond.whenTrue, whenTrue, cond.slotId)
-      // For null false branch, render comment markers so client can insert content later
-      const falseWithMarker = cond.whenFalse.type === 'expression' && cond.whenFalse.expr === 'null'
-        ? `<>{bfComment("cond-start:${cond.slotId}")}{bfComment("cond-end:${cond.slotId}")}</>`
-        : this.wrapWithCondMarker(cond.whenFalse, whenFalse, cond.slotId)
+    const trueWithMarker = this.wrapWithCondMarker(cond.whenTrue, whenTrue, cond.slotId)
+    // For null false branch, render comment markers so client can insert content later
+    const falseWithMarker = cond.whenFalse.type === 'expression' && cond.whenFalse.expr === 'null'
+      ? `<>{bfComment("cond-start:${cond.slotId}")}{bfComment("cond-end:${cond.slotId}")}</>`
+      : this.wrapWithCondMarker(cond.whenFalse, whenFalse, cond.slotId)
 
-      return `{${cond.condition} ? ${trueWithMarker} : ${falseWithMarker}}`
-    }
-
-    return `{${cond.condition} ? ${whenTrue} : ${whenFalse}}`
+    return `${cond.condition} ? ${trueWithMarker} : ${falseWithMarker}`
   }
 
   /**
@@ -851,6 +887,30 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
     if (node.type === 'expression') {
       if (node.expr === 'null' || node.expr === 'undefined') return 'null'
       return node.expr
+    }
+    return this.renderNode(node, ctx)
+  }
+
+  /**
+   * A branch of a NON-reactive conditional's flat ternary (#2470) — the
+   * value must be a bare JS expression, since it's spliced directly into
+   * `cond ? whenTrue : whenFalse`. Mirrors `renderNodeRawCtx`'s existing
+   * `null`/`undefined` special case, extended to a nested conditional: that
+   * branch renders through `renderConditionalBody` itself (bare), instead
+   * of falling through to `renderNode`/`emitConditional`, which would wrap
+   * it in its own `{…}` and break the .tsx parse in this brace-free
+   * position. The `@client`-directive combination is excluded — its
+   * rendering is a pair of independent marker expressions, not a single JS
+   * expression, so it can't be spliced bare into a ternary branch either
+   * way; that shape falls through to the pre-existing (unrelated) behavior.
+   */
+  private renderBareBranch(node: IRNode, ctx?: HonoRenderCtx): string {
+    if (node.type === 'expression') {
+      if (node.expr === 'null' || node.expr === 'undefined') return 'null'
+      return node.expr
+    }
+    if (node.type === 'conditional' && !(node.clientOnly && node.slotId)) {
+      return this.renderConditionalBody(node, ctx)
     }
     return this.renderNode(node, ctx)
   }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -3203,6 +3203,20 @@
         "condition"
       ]
     },
+    "nested-ternary-bare-branch": {
+      "kinds": [
+        "binary",
+        "identifier",
+        "literal"
+      ],
+      "axes": [
+        "binary:===",
+        "literal:string"
+      ],
+      "contexts": [
+        "condition"
+      ]
+    },
     "nullish-coalescing-destructured": {
       "kinds": [
         "call",
@@ -4954,12 +4968,12 @@
     "array-literal": 70,
     "array-method": 67,
     "arrow": 64,
-    "binary": 82,
+    "binary": 83,
     "call": 201,
     "conditional": 24,
-    "identifier": 289,
+    "identifier": 290,
     "index-access": 14,
-    "literal": 238,
+    "literal": 239,
     "logical": 43,
     "member": 154,
     "object-literal": 55,
@@ -4999,13 +5013,13 @@
     "binary:-": 11,
     "binary:/": 1,
     "binary:<": 1,
-    "binary:===": 42,
+    "binary:===": 43,
     "binary:>": 11,
     "binary:>=": 1,
     "literal:boolean": 45,
     "literal:null": 23,
     "literal:number": 101,
-    "literal:string": 168,
+    "literal:string": 169,
     "logical:&&": 7,
     "logical:??": 38,
     "logical:||": 13,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -112,6 +112,12 @@ import { fixture as nestedElements } from './nested-elements'
 // Priority 3: Conditionals
 import { fixture as ternary } from './ternary'
 import { fixture as nestedTernary } from './nested-ternary'
+// #2470: nested ternary chain whose OUTER condition is non-reactive (module
+// const, not a signal) — the branch the reactive `nestedTernary` above
+// doesn't exercise. Hono used to double-wrap the nested ternary in `{…}`
+// while it sat in the outer ternary's bare alternate position, breaking the
+// emitted .tsx's parse.
+import { fixture as nestedTernaryBareBranch } from './nested-ternary-bare-branch'
 import { fixture as conditionPositionTernary } from './condition-position-ternary'
 import { fixture as topLevelTernary } from './top-level-ternary'
 import { fixture as logicalAnd } from './logical-and'
@@ -532,6 +538,7 @@ export const jsxFixtures: JSXFixture[] = [
   // Priority 3: Conditionals
   ternary,
   nestedTernary,
+  nestedTernaryBareBranch,
   conditionPositionTernary,
   topLevelTernary,
   logicalAnd,

--- a/packages/adapter-tests/fixtures/nested-ternary-bare-branch.ts
+++ b/packages/adapter-tests/fixtures/nested-ternary-bare-branch.ts
@@ -9,15 +9,16 @@ import { createFixture } from '../src/types'
  * `wrapWithCondMarker` fragment-embedding path and never exercised the bug.
  * Here the outer condition has no `slotId` (no signal/prop/call involved),
  * so the Hono adapter takes the non-reactive branch: `renderConditional`
- * renders the whenFalse branch — itself an `IRConditional` — through
- * `renderNodeRawCtx`, which used to fall through to the generic
- * `renderNode`/`emitConditional` dispatch and re-wrap the nested ternary in
- * its own `{…}`. That's correct for a JSX-child position but invalid where
- * this nested ternary actually sits: the ALTERNATE of the outer ternary,
- * where only a bare JS expression is legal. The extra brace pair broke the
- * emitted `.tsx`'s parse (`Expected "}" but found "==="`) with zero
- * diagnostics. `renderNodeRawCtx` now special-cases a nested `conditional`
- * node the same way it already special-cases a bare `null`/`undefined`
+ * used to render the whenFalse branch — itself an `IRConditional` — through
+ * `renderNodeRawCtx`, which fell through to the generic
+ * `renderNode`/`emitConditional` dispatch and re-wrapped the nested ternary
+ * in its own `{…}`. That's correct for a JSX-child position but invalid
+ * where this nested ternary actually sits: the ALTERNATE of the outer
+ * ternary, where only a bare JS expression is legal. The extra brace pair
+ * broke the emitted `.tsx`'s parse (`Expected "}" but found "==="`) with
+ * zero diagnostics. Non-reactive branches now render through
+ * `renderBareBranch`, which special-cases a nested `conditional` node the
+ * same way `renderNodeRawCtx` special-cases a bare `null`/`undefined`
  * expression branch, splicing in the bare ternary body
  * (`renderConditionalBody`) instead of a second `{…}`-wrapped copy.
  */

--- a/packages/adapter-tests/fixtures/nested-ternary-bare-branch.ts
+++ b/packages/adapter-tests/fixtures/nested-ternary-bare-branch.ts
@@ -1,0 +1,36 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Nested ternary chain (`a ? … : b ? … : …`) under a NON-reactive outer
+ * condition — a module-level `const`, not a signal read (#2470).
+ *
+ * `nested-ternary.ts` covers the same `a ? … : b ? … : …` shape but with a
+ * signal-conditioned OUTER condition, which routes through the reactive
+ * `wrapWithCondMarker` fragment-embedding path and never exercised the bug.
+ * Here the outer condition has no `slotId` (no signal/prop/call involved),
+ * so the Hono adapter takes the non-reactive branch: `renderConditional`
+ * renders the whenFalse branch — itself an `IRConditional` — through
+ * `renderNodeRawCtx`, which used to fall through to the generic
+ * `renderNode`/`emitConditional` dispatch and re-wrap the nested ternary in
+ * its own `{…}`. That's correct for a JSX-child position but invalid where
+ * this nested ternary actually sits: the ALTERNATE of the outer ternary,
+ * where only a bare JS expression is legal. The extra brace pair broke the
+ * emitted `.tsx`'s parse (`Expected "}" but found "==="`) with zero
+ * diagnostics. `renderNodeRawCtx` now special-cases a nested `conditional`
+ * node the same way it already special-cases a bare `null`/`undefined`
+ * expression branch, splicing in the bare ternary body
+ * (`renderConditionalBody`) instead of a second `{…}`-wrapped copy.
+ */
+export const fixture = createFixture({
+  id: 'nested-ternary-bare-branch',
+  description: 'Nested ternary chain under a non-reactive (module-const) outer condition (#2470)',
+  source: `
+const MODE = 'b'
+export function Chain() {
+  return <div>{MODE === 'a' ? <span>A</span> : MODE === 'b' ? <span>B</span> : <span>C</span>}</div>
+}
+`,
+  expectedHtml: `
+    <div bf-s="test"><span>B</span></div>
+  `,
+})

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 308,
+    "totalFixtures": 309,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1026,15 +1026,15 @@
       }
     },
     "binary": {
-      "total": 82,
+      "total": 83,
       "cells": {
         "hono": {
-          "pass": 82,
-          "total": 82
+          "pass": 83,
+          "total": 83
         },
         "blade": {
-          "pass": 73,
-          "total": 82,
+          "pass": 74,
+          "total": 83,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1081,8 +1081,8 @@
           ]
         },
         "erb": {
-          "pass": 74,
-          "total": 82,
+          "pass": 75,
+          "total": 83,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1123,8 +1123,8 @@
           ]
         },
         "go-template": {
-          "pass": 73,
-          "total": 82,
+          "pass": 74,
+          "total": 83,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1171,8 +1171,8 @@
           ]
         },
         "jinja": {
-          "pass": 73,
-          "total": 82,
+          "pass": 74,
+          "total": 83,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1219,8 +1219,8 @@
           ]
         },
         "minijinja": {
-          "pass": 73,
-          "total": 82,
+          "pass": 74,
+          "total": 83,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1267,8 +1267,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 74,
-          "total": 82,
+          "pass": 75,
+          "total": 83,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1309,8 +1309,8 @@
           ]
         },
         "twig": {
-          "pass": 73,
-          "total": 82,
+          "pass": 74,
+          "total": 83,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1357,8 +1357,8 @@
           ]
         },
         "xslate": {
-          "pass": 73,
-          "total": 82,
+          "pass": 74,
+          "total": 83,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2174,11 +2174,11 @@
       }
     },
     "identifier": {
-      "total": 289,
+      "total": 290,
       "cells": {
         "hono": {
-          "pass": 288,
-          "total": 289,
+          "pass": 289,
+          "total": 290,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2189,8 +2189,8 @@
           ]
         },
         "blade": {
-          "pass": 272,
-          "total": 289,
+          "pass": 273,
+          "total": 290,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2273,8 +2273,8 @@
           ]
         },
         "erb": {
-          "pass": 273,
-          "total": 289,
+          "pass": 274,
+          "total": 290,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2351,8 +2351,8 @@
           ]
         },
         "go-template": {
-          "pass": 272,
-          "total": 289,
+          "pass": 273,
+          "total": 290,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2435,8 +2435,8 @@
           ]
         },
         "jinja": {
-          "pass": 272,
-          "total": 289,
+          "pass": 273,
+          "total": 290,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2519,8 +2519,8 @@
           ]
         },
         "minijinja": {
-          "pass": 272,
-          "total": 289,
+          "pass": 273,
+          "total": 290,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2603,8 +2603,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 273,
-          "total": 289,
+          "pass": 274,
+          "total": 290,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2681,8 +2681,8 @@
           ]
         },
         "twig": {
-          "pass": 272,
-          "total": 289,
+          "pass": 273,
+          "total": 290,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2765,8 +2765,8 @@
           ]
         },
         "xslate": {
-          "pass": 272,
-          "total": 289,
+          "pass": 273,
+          "total": 290,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2914,15 +2914,15 @@
       }
     },
     "literal": {
-      "total": 238,
+      "total": 239,
       "cells": {
         "hono": {
-          "pass": 238,
-          "total": 238
+          "pass": 239,
+          "total": 239
         },
         "blade": {
-          "pass": 227,
-          "total": 238,
+          "pass": 228,
+          "total": 239,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2973,8 +2973,8 @@
           ]
         },
         "erb": {
-          "pass": 227,
-          "total": 238,
+          "pass": 228,
+          "total": 239,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3025,8 +3025,8 @@
           ]
         },
         "go-template": {
-          "pass": 227,
-          "total": 238,
+          "pass": 228,
+          "total": 239,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3077,8 +3077,8 @@
           ]
         },
         "jinja": {
-          "pass": 227,
-          "total": 238,
+          "pass": 228,
+          "total": 239,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3129,8 +3129,8 @@
           ]
         },
         "minijinja": {
-          "pass": 227,
-          "total": 238,
+          "pass": 228,
+          "total": 239,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3181,8 +3181,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 227,
-          "total": 238,
+          "pass": 228,
+          "total": 239,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3233,8 +3233,8 @@
           ]
         },
         "twig": {
-          "pass": 227,
-          "total": 238,
+          "pass": 228,
+          "total": 239,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3285,8 +3285,8 @@
           ]
         },
         "xslate": {
-          "pass": 227,
-          "total": 238,
+          "pass": 228,
+          "total": 239,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6836,15 +6836,15 @@
       }
     },
     "binary:===": {
-      "total": 42,
+      "total": 43,
       "cells": {
         "hono": {
-          "pass": 42,
-          "total": 42
+          "pass": 43,
+          "total": 43
         },
         "blade": {
-          "pass": 34,
-          "total": 42,
+          "pass": 35,
+          "total": 43,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6885,8 +6885,8 @@
           ]
         },
         "erb": {
-          "pass": 35,
-          "total": 42,
+          "pass": 36,
+          "total": 43,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6921,8 +6921,8 @@
           ]
         },
         "go-template": {
-          "pass": 34,
-          "total": 42,
+          "pass": 35,
+          "total": 43,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6963,8 +6963,8 @@
           ]
         },
         "jinja": {
-          "pass": 34,
-          "total": 42,
+          "pass": 35,
+          "total": 43,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7005,8 +7005,8 @@
           ]
         },
         "minijinja": {
-          "pass": 34,
-          "total": 42,
+          "pass": 35,
+          "total": 43,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7047,8 +7047,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 35,
-          "total": 42,
+          "pass": 36,
+          "total": 43,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7083,8 +7083,8 @@
           ]
         },
         "twig": {
-          "pass": 34,
-          "total": 42,
+          "pass": 35,
+          "total": 43,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7125,8 +7125,8 @@
           ]
         },
         "xslate": {
-          "pass": 34,
-          "total": 42,
+          "pass": 35,
+          "total": 43,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7173,10 +7173,10 @@
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L89"
       },
       "example": {
-        "fixture": "controlled-radio-checked",
-        "description": "Controlled radio group SSRs checked on the matching radio only",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/controlled-radio-checked.ts",
-        "code": "size() === 'sm'"
+        "fixture": "nested-ternary-bare-branch",
+        "description": "Nested ternary chain under a non-reactive (module-const) outer condition (#2470)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/nested-ternary-bare-branch.ts",
+        "code": "MODE === 'a'"
       }
     },
     "binary:>": {
@@ -7663,15 +7663,15 @@
       }
     },
     "literal:string": {
-      "total": 168,
+      "total": 169,
       "cells": {
         "hono": {
-          "pass": 168,
-          "total": 168
+          "pass": 169,
+          "total": 169
         },
         "blade": {
-          "pass": 160,
-          "total": 168,
+          "pass": 161,
+          "total": 169,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7710,8 +7710,8 @@
           ]
         },
         "erb": {
-          "pass": 160,
-          "total": 168,
+          "pass": 161,
+          "total": 169,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7750,8 +7750,8 @@
           ]
         },
         "go-template": {
-          "pass": 160,
-          "total": 168,
+          "pass": 161,
+          "total": 169,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7790,8 +7790,8 @@
           ]
         },
         "jinja": {
-          "pass": 160,
-          "total": 168,
+          "pass": 161,
+          "total": 169,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7830,8 +7830,8 @@
           ]
         },
         "minijinja": {
-          "pass": 160,
-          "total": 168,
+          "pass": 161,
+          "total": 169,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7870,8 +7870,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 160,
-          "total": 168,
+          "pass": 161,
+          "total": 169,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7910,8 +7910,8 @@
           ]
         },
         "twig": {
-          "pass": 160,
-          "total": 168,
+          "pass": 161,
+          "total": 169,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7950,8 +7950,8 @@
           ]
         },
         "xslate": {
-          "pass": 160,
-          "total": 168,
+          "pass": 161,
+          "total": 169,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",


### PR DESCRIPTION
**Stack 2/7** (base: #2577). Retarget to `main` when #2577 merges (GitHub does this automatically on base-branch deletion).

## Summary

A nested ternary chain under a NON-reactive outer condition emitted invalid `.tsx` — silently:

```tsx
const MODE = 'b'
export function Chain() {
  return <div>{MODE === 'a' ? <span>A</span> : MODE === 'b' ? <span>B</span> : <span>C</span>}</div>
}
```

emitted `{MODE === 'a' ? <span>A</span> : {MODE === 'b' ? … }}` — the nested conditional re-wrapped in `{…}` inside the outer ternary's alternate, where only a bare JS expression is legal. The file failed to parse (`Expected "}" but found "==="`), zero diagnostics. Reachable only when the outer condition has no `slotId` (module const, not a signal/prop) — the reactive path goes through `wrapWithCondMarker` and was always fine, which is why the existing `nested-ternary` fixture (signal-conditioned) never caught it.

## Fix

`renderConditional` now delegates to `renderConditionalBody` (the bare ternary text) and alone adds the enclosing `{…}`. A new `renderBareBranch` renders a non-reactive conditional's branches through `renderConditionalBody` directly when a branch is itself a conditional — mirroring `renderNodeRawCtx`'s existing `null`/`undefined` special case. The reactive marker-splicing path is unchanged, with a comment documenting why the two branches need genuinely different embedding rules. Other adapters emit their own template-tag syntax (`{{ }}`, `<% %>`, …), not raw JS expression containers, so Hono is the only adapter exposed to this hazard.

## Coverage

- New conformance fixture `nested-ternary-bare-branch` (all adapters; `expectedHtml` regenerated from the fixed reference) + `coverage-map.json` regenerated.
- Unit pin `packages/adapter-hono/src/__tests__/nested-ternary-bare-branch.test.ts` (emitted template parses; no double braces).
- Changeset: `@barefootjs/hono` patch.

## Verification

Full `packages/adapter-tests` at the stack tip: **1891 pass / 0 fail** (includes the new fixture across all adapters and the coverage-ledger freshness gate).

Closes #2470

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_