### PR TITLE
fix(compiler): prefix a referenced class constant's typedValue in lockstep with value

### DIFF
--- a/.changeset/css-layer-typed-value.md
+++ b/.changeset/css-layer-typed-value.md
@@ -1,0 +1,12 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix `layer-:` CSS layer prefixing dropping classes from a referenced class
+constant whose initializer carries TypeScript syntax (`as const`, a
+`satisfies`/`Record<...>` annotation, …). `applyCssLayerPrefixToFile`
+rewrote only `ConstantInfo.value`, but `preserveTypes` emitters (Hono)
+prefer `ConstantInfo.typedValue ?? value` when emitting a module-scope
+constant, so the type-carrying string it actually renders stayed
+unprefixed. `typedValue` is now prefixed in lockstep with `value` wherever
+a referenced constant is rewritten.

--- a/packages/jsx/src/__tests__/css-layer-prefixer.test.ts
+++ b/packages/jsx/src/__tests__/css-layer-prefixer.test.ts
@@ -13,6 +13,7 @@ import {
 import type { ComponentIR, IRElement, IRMetadata, IRTemplatePart, ConstantInfo, TemplateAttr, LiteralAttr } from '../types'
 import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
+import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
 
 describe('prefixClass', () => {
   test('prefixes a simple class', () => {
@@ -483,5 +484,44 @@ describe('applyCssLayerPrefix', () => {
     const declarations = template.match(/^const sharedClasses = .*$/gm) ?? []
     expect(declarations).toHaveLength(1)
     expect(declarations[0]).toContain('layer-components:flex')
+  })
+
+  test('prefixes a `Record`-shaped `as const` class map constant\'s typedValue (#2575)', () => {
+    // `preserveTypes` emitters (Hono) prefer `typedValue ?? value` when
+    // emitting a module-scope constant so `.tsx` output stays type-checked
+    // — see `generateModuleScopeDeclarations` in
+    // `packages/adapter-hono/src/adapter/hono-adapter.ts`'s base class.
+    // `applyCssLayerPrefixToFile` used to rewrite only `value`, leaving
+    // `typedValue` — the string Hono actually emits — unprefixed for any
+    // constant whose initializer carries type syntax (`as const`, a
+    // `satisfies`/`Record<...>` annotation, …). Regression for the fix:
+    // both strings must be prefixed together, and the `as const` assertion
+    // must survive the round trip verbatim.
+    const source = `
+      const toneClasses: Record<'info' | 'warn', string> = {
+        info: 'text-blue-500',
+        warn: 'text-amber-500',
+      } as const
+
+      export function Banner() {
+        return <div className={toneClasses.info}>hi</div>
+      }
+    `
+    const result = compileJSX(source, '/virtual/Banner.tsx', {
+      adapter: new HonoAdapter(),
+      cssLayerPrefix: 'components',
+    })
+    expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
+    const template = result.files.find(f => f.type === 'markedTemplate')!.content
+
+    const declarations = template.match(/^const toneClasses = [\s\S]*?\} as const$/m) ?? []
+    expect(declarations).toHaveLength(1)
+    const declaration = declarations[0]
+
+    // Classes are prefixed...
+    expect(declaration).toContain("info: 'layer-components:text-blue-500'")
+    expect(declaration).toContain("warn: 'layer-components:text-amber-500'")
+    // ...and the `as const` assertion survives the rewrite.
+    expect(declaration.trim().endsWith('} as const')).toBe(true)
   })
 })

--- a/packages/jsx/src/__tests__/css-layer-prefixer.test.ts
+++ b/packages/jsx/src/__tests__/css-layer-prefixer.test.ts
@@ -514,9 +514,9 @@ describe('applyCssLayerPrefix', () => {
     expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
     const template = result.files.find(f => f.type === 'markedTemplate')!.content
 
-    const declarations = template.match(/^const toneClasses = [\s\S]*?\} as const$/m) ?? []
+    const declarations = [...template.matchAll(/^const toneClasses = [\s\S]*?\} as const$/gm)]
     expect(declarations).toHaveLength(1)
-    const declaration = declarations[0]
+    const declaration = declarations[0][0]
 
     // Classes are prefixed...
     expect(declaration).toContain("info: 'layer-components:text-blue-500'")

--- a/packages/jsx/src/css-layer-prefixer.ts
+++ b/packages/jsx/src/css-layer-prefixer.ts
@@ -132,10 +132,24 @@ export function applyCssLayerPrefixToFile(irs: readonly ComponentIR[], layerName
   }
 
   // Apply prefixing to every IR's copy of each referenced constant.
+  //
+  // `typedValue` (the type-annotation-preserving initializer text used by
+  // `preserveTypes` emitters — Hono's `generateModuleScopeDeclarations` /
+  // SSR body block prefer `typedValue ?? value`) is a separate string that
+  // must be prefixed in lockstep with `value`, or an `as const` / annotated
+  // class-map constant is emitted unprefixed even though the class
+  // attributes referencing it were prefixed (#2575). `prefixConstantValue`
+  // only rewrites string-literal contents (see its docstring), so an `as
+  // const` suffix or type annotation elsewhere in the text passes through
+  // unchanged.
   for (const ir of irs) {
     for (const constant of ir.metadata.localConstants) {
-      if (referencedConstants.has(constant.name) && constant.value) {
+      if (!referencedConstants.has(constant.name)) continue
+      if (constant.value) {
         constant.value = prefixConstantValue(constant.value, layerName)
+      }
+      if (constant.typedValue) {
+        constant.typedValue = prefixConstantValue(constant.typedValue, layerName)
       }
     }
   }


### PR DESCRIPTION
**Stack 3/7** (base: #2578). Retarget to `main` as the stack merges.

## Summary

`applyCssLayerPrefixToFile` rewrote only `ConstantInfo.value` with the `layer-:` prefix, but `preserveTypes` emitters (Hono's module-scope declarations / SSR body block) prefer `typedValue ?? value` — so a class constant whose initializer carries type syntax (`as const`, a `Record<…>` annotation) was emitted **unprefixed** even though the class attributes referencing it were prefixed. Missing `layer-:` variants at runtime for that constant's classes. Surfaced by Copilot review on #2574; pre-existing (the old per-IR prefixer had the same `value`-only rewrite).

## Fix

Wherever a referenced constant's `value` is prefixed, `typedValue` is now prefixed in lockstep. `prefixConstantValue` already rewrites only string-literal contents via the TS AST, so `as const` and annotations pass through verbatim — asserted by the new test, not assumed.

## Coverage

- Regression test in `packages/jsx/src/__tests__/css-layer-prefixer.test.ts`: a `Record`-annotated `as const` class map compiled with the Hono adapter, asserting the emitted module-scope constant carries prefixed classes AND the `as const` survives.
- Changeset: `@barefootjs/jsx` patch.

## Verification

`css-layer-prefixer.test.ts`: 31 pass / 0 fail. Full adapter-tests at the stack tip: 1891 pass / 0 fail.

Closes #2575

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_