### PR TITLE
fix(compiler): carry SVG ref and local-var types through emitted templates (#2573)

### DIFF
--- a/.changeset/corpus-typecheck-svg-and-locals-2573.md
+++ b/.changeset/corpus-typecheck-svg-and-locals-2573.md
@@ -1,0 +1,34 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/hono": patch
+---
+
+Fix two type-level emission defects surfaced by the `ui/` corpus type-check gate (#2573)
+
+- **`<svg>`-rooted component props** (icons, spinner): a new `SVGSVGAttributes`
+  export (`@barefootjs/jsx`) gives components whose root is an `<svg>` a
+  properly-narrowed `ref?: (element: SVGSVGElement) => void`, instead of the
+  generic `HTMLBaseAttributes` whose `ref` targets `HTMLElement`. Spreading
+  `HTMLBaseAttributes`-typed rest-props onto an `<svg>` element failed to
+  type-check under `strictFunctionTypes` (`ref`'s param types are unrelated
+  DOM interfaces) — every `IconXxx`/`Icon`/`Spinner` component's emitted
+  `.tsx` template hit this (35 `TS2322` instances across the corpus). `ui/`'s
+  `icon` and `spinner` components now extend `SVGSVGAttributes`. Type-only —
+  no change to rendered output or runtime behavior.
+- **Uninitialized `let`/`const` locals lost their type annotation on emit**:
+  `generateSignalInitializers` (`packages/jsx/src/adapters/jsx-adapter.ts`,
+  shared by every JSX-runtime adapter incl. Hono) re-declared a local with no
+  initializer (e.g. `let emblaApi: EmblaCarouselType | undefined`) as a bare
+  `let emblaApi`, discarding the source's type annotation and forcing
+  implicit `any` (`TS7034`/`TS7005`) wherever the local was later read. Now
+  carries `ConstantInfo.type.raw` through when `preserveTypes` is set.
+- `ui/slider`: added an inline non-null assertion at the one genuine
+  possibly-`undefined` read (`currentValue()` in `percentage()`) — TS can't
+  see across `currentValue`'s own `isControlled() ? controlledValue() :
+  internalValue()` ternary that the controlled branch is only live when
+  `props.value` (and so `controlledValue()`) is defined. Type-only.
+
+Ratchets the `corpus-typecheck.test.ts` allowlist: `icon TS2322` (34),
+`spinner TS2322` (1), `carousel TS7005` (2), `carousel TS7034` (1), and
+`slider TS2532` (1) all drop to zero. `chart`/`xyflow` entries are
+unchanged — untouched by this PR (tracked in #2573).

--- a/packages/adapter-hono/src/__tests__/corpus-typecheck.test.ts
+++ b/packages/adapter-hono/src/__tests__/corpus-typecheck.test.ts
@@ -37,16 +37,11 @@ const UI_TYPES = join(REPO, 'ui/types/index.tsx')
  * pass.
  */
 const KNOWN_DIAGNOSTICS: Record<string, number> = {
-  'carousel TS7005': 2,
-  'carousel TS7034': 1,
   'chart TS17001': 6,
   'chart TS18046': 69,
   'chart TS2307': 2,
   'chart TS2322': 2,
   'chart TS7006': 34,
-  'icon TS2322': 34,
-  'slider TS2532': 1,
-  'spinner TS2322': 1,
   'xyflow TS2304': 7,
   'xyflow TS2307': 2,
 }

--- a/packages/adapter-tests/fixtures/__snapshots__/accordion.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/accordion.icon.ssr.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource hono/jsx */
-import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { SVGSVGAttributes } from '@barefootjs/jsx'
 
 export type IconSize = 'sm' | 'md' | 'lg' | 'xl'
 
-export interface IconProps extends HTMLBaseAttributes {
+export interface IconProps extends SVGSVGAttributes {
   size?: IconSize
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/carousel.carousel.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/carousel.carousel.ssr.tsx
@@ -96,7 +96,7 @@ export function Carousel(__allProps: CarouselProps & { __instanceId?: string; __
   const canScrollNext = () => false
   const setCanScrollNext = (..._args: any[]) => {}
   const orientation = () => props.orientation ?? 'horizontal'
-  let emblaApi
+  let emblaApi: EmblaCarouselType | undefined
   const scrollPrev = () => emblaApi?.scrollPrev()
   const scrollNext = () => emblaApi?.scrollNext()
 

--- a/packages/adapter-tests/fixtures/__snapshots__/carousel.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/carousel.icon.ssr.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource hono/jsx */
-import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { SVGSVGAttributes } from '@barefootjs/jsx'
 
 export type IconSize = 'sm' | 'md' | 'lg' | 'xl'
 
-export interface IconProps extends HTMLBaseAttributes {
+export interface IconProps extends SVGSVGAttributes {
   size?: IconSize
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/checkbox.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/checkbox.icon.ssr.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource hono/jsx */
-import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { SVGSVGAttributes } from '@barefootjs/jsx'
 
 export type IconSize = 'sm' | 'md' | 'lg' | 'xl'
 
-export interface IconProps extends HTMLBaseAttributes {
+export interface IconProps extends SVGSVGAttributes {
   size?: IconSize
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/combobox.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/combobox.icon.ssr.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource hono/jsx */
-import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { SVGSVGAttributes } from '@barefootjs/jsx'
 
 export type IconSize = 'sm' | 'md' | 'lg' | 'xl'
 
-export interface IconProps extends HTMLBaseAttributes {
+export interface IconProps extends SVGSVGAttributes {
   size?: IconSize
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/command.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.icon.ssr.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource hono/jsx */
-import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { SVGSVGAttributes } from '@barefootjs/jsx'
 
 export type IconSize = 'sm' | 'md' | 'lg' | 'xl'
 
-export interface IconProps extends HTMLBaseAttributes {
+export interface IconProps extends SVGSVGAttributes {
   size?: IconSize
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/data-table.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/data-table.icon.ssr.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource hono/jsx */
-import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { SVGSVGAttributes } from '@barefootjs/jsx'
 
 export type IconSize = 'sm' | 'md' | 'lg' | 'xl'
 
-export interface IconProps extends HTMLBaseAttributes {
+export interface IconProps extends SVGSVGAttributes {
   size?: IconSize
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.icon.ssr.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource hono/jsx */
-import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { SVGSVGAttributes } from '@barefootjs/jsx'
 
 export type IconSize = 'sm' | 'md' | 'lg' | 'xl'
 
-export interface IconProps extends HTMLBaseAttributes {
+export interface IconProps extends SVGSVGAttributes {
   size?: IconSize
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/pagination.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/pagination.icon.ssr.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource hono/jsx */
-import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { SVGSVGAttributes } from '@barefootjs/jsx'
 
 export type IconSize = 'sm' | 'md' | 'lg' | 'xl'
 
-export interface IconProps extends HTMLBaseAttributes {
+export interface IconProps extends SVGSVGAttributes {
   size?: IconSize
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/select.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/select.icon.ssr.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource hono/jsx */
-import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { SVGSVGAttributes } from '@barefootjs/jsx'
 
 export type IconSize = 'sm' | 'md' | 'lg' | 'xl'
 
-export interface IconProps extends HTMLBaseAttributes {
+export interface IconProps extends SVGSVGAttributes {
   size?: IconSize
 }
 

--- a/packages/jsx/src/__tests__/memo-deps-comments.test.ts
+++ b/packages/jsx/src/__tests__/memo-deps-comments.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Memo/effect dependency extraction must read the token stream, not the raw
+ * body text: a doc comment (or string literal) mentioning `otherSignal()`
+ * inside a computation body is not a read and must not become a dependency.
+ *
+ * Regression pin for the phantom deps surfaced in #2581's review: slider's
+ * `percentage` memo gained `internalValue`/`controlledValue` deps in the
+ * regenerated `ui/meta/slider.json` purely because an explanatory comment
+ * inside the memo body named those getters in call syntax.
+ */
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+
+describe('dependency extraction ignores comments and strings', () => {
+  test('a comment naming another getter in call syntax is not a dep', () => {
+    const source = `
+      "use client"
+      import { createSignal, createMemo } from '@barefootjs/client'
+      export function Slider() {
+        const [internalValue, setInternalValue] = createSignal(0)
+        const [controlledValue, setControlledValue] = createSignal<number | undefined>(undefined)
+        const [min, setMin] = createSignal(0)
+        const [max, setMax] = createSignal(100)
+        const currentValue = createMemo(() => controlledValue() ?? internalValue())
+        const percentage = createMemo(() => {
+          if (max() <= min()) return 0
+          // \`currentValue()\` mirrors \`controlledValue()\` and \`internalValue()\`
+          // in its type, so assert what's runtime-guaranteed.
+          return Math.max(0, Math.min(100, ((currentValue()! - min()) / (max() - min())) * 100))
+        })
+        return <div style={\`width: \${percentage()}%\`}>{currentValue()}</div>
+      }
+    `
+    const ctx = analyzeComponent(source, 'Slider.tsx')
+    const percentage = ctx.memos.find(m => m.name === 'percentage')
+    expect(percentage).toBeDefined()
+    expect(percentage!.deps.sort()).toEqual(['currentValue', 'max', 'min'])
+  })
+
+  test('a string literal naming a getter in call syntax is not a dep', () => {
+    const source = `
+      "use client"
+      import { createSignal, createMemo } from '@barefootjs/client'
+      export function Label() {
+        const [count, setCount] = createSignal(0)
+        const [label, setLabel] = createSignal('x')
+        const hint = createMemo(() => label() + ' (see count() for the number)')
+        return <span>{hint()}</span>
+      }
+    `
+    const ctx = analyzeComponent(source, 'Label.tsx')
+    const hint = ctx.memos.find(m => m.name === 'hint')
+    expect(hint).toBeDefined()
+    expect(hint!.deps).toEqual(['label'])
+  })
+
+  test('a read AFTER a template-literal substitution still registers', () => {
+    // Trap for token-scan implementations: without a parser driving
+    // `reScanTemplateToken`, the template tail after `\${...}` is mis-lexed
+    // as a new template opener and swallows the following statement —
+    // xyflow's `visibleClass` shape, where `animated()` follows a
+    // substitution line and silently lost its dep.
+    const source = `
+      "use client"
+      import { createSignal, createMemo } from '@barefootjs/client'
+      export function Edge() {
+        const [selected, setSelected] = createSignal(false)
+        const [animated, setAnimated] = createSignal(false)
+        const visibleClass = createMemo(() => {
+          let cls = 'edge'
+          if (selected()) cls += \` \${'edge-selected'}\`
+          if (animated()) cls += \` \${'edge-animated'}\`
+          return cls
+        })
+        return <div class={visibleClass()}>x</div>
+      }
+    `
+    const ctx = analyzeComponent(source, 'Edge.tsx')
+    const visibleClass = ctx.memos.find(m => m.name === 'visibleClass')
+    expect(visibleClass).toBeDefined()
+    expect(visibleClass!.deps.sort()).toEqual(['animated', 'selected'])
+  })
+
+  test('genuine reads inside template-literal substitutions still register', () => {
+    const source = `
+      "use client"
+      import { createSignal, createMemo } from '@barefootjs/client'
+      export function Badge() {
+        const [tone, setTone] = createSignal('info')
+        const cls = createMemo(() => \`badge badge-\${tone()}\`)
+        return <span class={cls()}>x</span>
+      }
+    `
+    const ctx = analyzeComponent(source, 'Badge.tsx')
+    const cls = ctx.memos.find(m => m.name === 'cls')
+    expect(cls).toBeDefined()
+    expect(cls!.deps).toEqual(['tone'])
+  })
+})

--- a/packages/jsx/src/adapters/jsx-adapter.ts
+++ b/packages/jsx/src/adapters/jsx-adapter.ts
@@ -194,7 +194,11 @@ export abstract class JsxAdapter extends BaseAdapter {
       if (moduleScopeNames.has(constant.name)) continue
       const keyword = constant.declarationKind ?? 'const'
       if (!constant.value) {
-        lines.push(`  ${keyword} ${constant.name}`)
+        // No initializer (e.g. `let emblaApi: EmblaCarouselType | undefined`)
+        // — carry the declared type annotation through so `.tsx` output
+        // doesn't fall back to implicit `any` (TS7034/TS7005, #2573).
+        const typeAnnotation = preserveTypes && constant.type ? `: ${constant.type.raw}` : ''
+        lines.push(`  ${keyword} ${constant.name}${typeAnnotation}`)
         continue
       }
       const value = constant.value.trim()

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -3647,21 +3647,47 @@ function inferTypeFromValue(value: string): TypeInfo {
   return { kind: 'unknown', raw: 'unknown' }
 }
 
+/**
+ * Identifiers that appear as a direct call (`name(...)`) in `code`,
+ * collected off a real TS parse — never a regex over the raw text, which
+ * false-matches inside comments and string literals (the repo-wide
+ * "no regex over JS syntax" rule). A doc comment mentioning
+ * `otherSignal()` inside a memo body must NOT become a dependency
+ * (phantom `internalValue`/`controlledValue` deps on slider's
+ * `percentage`, #2581 review). A raw token scan is not enough either:
+ * without a parser driving `reScanTemplateToken`, everything between a
+ * substitution's closing `}` and the next backtick is mis-lexed as code
+ * (and the template tail swallows real code after it), so a read
+ * following a `${...}` template — xyflow's `visibleClass` reading
+ * `animated()` after the `${BF_FLOW_EDGE_SELECTED}` line — would vanish.
+ */
+function collectCalledIdentifiers(code: string): Set<string> {
+  const called = new Set<string>()
+  const sf = ts.createSourceFile('__deps__.tsx', code, ts.ScriptTarget.Latest, false, ts.ScriptKind.TSX)
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      called.add(node.expression.text)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sf)
+  return called
+}
+
 function extractDependencies(code: string, ctx: AnalyzerContext): string[] {
+  const called = collectCalledIdentifiers(code)
   const deps: string[] = []
 
   // Find signal getter calls: signalName()
   for (const signal of ctx.signals) {
-    const pattern = new RegExp(`\\b${signal.getter}\\s*\\(`, 'g')
-    if (pattern.test(code)) {
+    if (called.has(signal.getter)) {
       deps.push(signal.getter)
     }
   }
 
   // Find memo calls: memoName()
   for (const memo of ctx.memos) {
-    const pattern = new RegExp(`\\b${memo.name}\\s*\\(`, 'g')
-    if (pattern.test(code)) {
+    if (called.has(memo.name)) {
       deps.push(memo.name)
     }
   }

--- a/packages/jsx/src/html-types.ts
+++ b/packages/jsx/src/html-types.ts
@@ -248,6 +248,29 @@ export interface SVGPresentationAttributes {
   filter?: string
 }
 
+// ============================================================================
+// SVG Root (`<svg>`) Attributes
+// ============================================================================
+
+/**
+ * Full attribute set for the root `<svg>` element, narrowed to
+ * `SVGSVGElement` for `ref`.
+ *
+ * Public so components that render an `<svg>` as their root and accept
+ * passthrough props (icons, spinners, and similar) can type their props with
+ * this instead of `HTMLBaseAttributes` — spreading `HTMLBaseAttributes` onto
+ * an `<svg>` fails to type-check because its `ref` is `(element: HTMLElement)
+ * => void`, incompatible with the `<svg>` intrinsic's
+ * `(element: SVGSVGElement) => void` (#2573).
+ */
+export type SVGSVGAttributes = SVGBaseAttributes & SVGPresentationAttributes & {
+  viewBox?: string
+  xmlns?: string
+  width?: number | string
+  height?: number | string
+  ref?: (element: SVGSVGElement) => void
+}
+
 /**
  * Marker reference attributes shared by `<path>`, `<line>`, `<polyline>`,
  * and `<polygon>`. Accepts both camelCase and kebab-case spellings.

--- a/packages/jsx/src/html-types.ts
+++ b/packages/jsx/src/html-types.ts
@@ -253,8 +253,9 @@ export interface SVGPresentationAttributes {
 // ============================================================================
 
 /**
- * Full attribute set for the root `<svg>` element, narrowed to
- * `SVGSVGElement` for `ref`.
+ * Attributes for the root `<svg>` element, narrowed to `SVGSVGElement` for
+ * `ref`. A curated subset mirroring the intrinsic `svg` entry — not the full
+ * SVG attribute surface.
  *
  * Public so components that render an `<svg>` as their root and accept
  * passthrough props (icons, spinners, and similar) can type their props with

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -361,4 +361,7 @@ export type {
   ImgHTMLAttributes,
   LabelHTMLAttributes,
   OptionHTMLAttributes,
+
+  // SVG attributes (for components whose root is an `<svg>`, e.g. icons)
+  SVGSVGAttributes,
 } from './html-types.ts'

--- a/packages/jsx/src/jsx-runtime/index.ts
+++ b/packages/jsx/src/jsx-runtime/index.ts
@@ -45,6 +45,7 @@ import type {
   SVGBaseAttributes,
   SVGPresentationAttributes,
   SVGMarkerReferenceAttributes,
+  SVGSVGAttributes,
 } from '../html-types.ts'
 
 // Stub function types (for type checking only - no runtime implementation)
@@ -208,13 +209,7 @@ export declare namespace JSX {
     // SVG (basic support).
     // Each entry uses `SVGBaseAttributes` so `ref` can be narrowed per-tag.
     // See `SVGBaseAttributes` JSDoc for why plain intersection doesn't work.
-    svg: SVGBaseAttributes & SVGPresentationAttributes & {
-      viewBox?: string
-      xmlns?: string
-      width?: number | string
-      height?: number | string
-      ref?: (element: SVGSVGElement) => void
-    }
+    svg: SVGSVGAttributes
     path: SVGBaseAttributes & SVGPresentationAttributes & SVGMarkerReferenceAttributes & {
       d?: string
       pathLength?: number | string

--- a/ui/components/ui/icon/index.tsx
+++ b/ui/components/ui/icon/index.tsx
@@ -28,11 +28,11 @@
  * ```
  */
 
-import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { SVGSVGAttributes } from '@barefootjs/jsx'
 
 export type IconSize = 'sm' | 'md' | 'lg' | 'xl'
 
-export interface IconProps extends HTMLBaseAttributes {
+export interface IconProps extends SVGSVGAttributes {
   size?: IconSize
 }
 

--- a/ui/components/ui/slider/index.tsx
+++ b/ui/components/ui/slider/index.tsx
@@ -104,7 +104,12 @@ function Slider(props: SliderProps) {
   // Compute percentage for positioning
   const percentage = createMemo(() => {
     if (max() <= min()) return 0
-    return Math.max(0, Math.min(100, ((currentValue() - min()) / (max() - min())) * 100))
+    // `currentValue()` is `number | undefined` in its type (mirrors
+    // `controlledValue()`), but it's only ever undefined when NOT
+    // controlled — and the uncontrolled branch (`internalValue()`) is
+    // always a `number`. TS can't see that across the two calls in
+    // `currentValue`'s own ternary, so assert what's runtime-guaranteed.
+    return Math.max(0, Math.min(100, ((currentValue()! - min()) / (max() - min())) * 100))
   })
 
   // Snap a raw value to the nearest step

--- a/ui/components/ui/spinner/index.tsx
+++ b/ui/components/ui/spinner/index.tsx
@@ -21,9 +21,9 @@
  * ```
  */
 
-import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { SVGSVGAttributes } from '@barefootjs/jsx'
 
-interface SpinnerProps extends HTMLBaseAttributes {
+interface SpinnerProps extends SVGSVGAttributes {
   /** Additional CSS classes to apply. */
   className?: string
 }

--- a/ui/meta/slider.json
+++ b/ui/meta/slider.json
@@ -135,8 +135,6 @@
     {
       "name": "percentage",
       "deps": [
-        "internalValue",
-        "controlledValue",
         "min",
         "max",
         "currentValue"

--- a/ui/meta/slider.json
+++ b/ui/meta/slider.json
@@ -135,6 +135,8 @@
     {
       "name": "percentage",
       "deps": [
+        "internalValue",
+        "controlledValue",
         "min",
         "max",
         "currentValue"


### PR DESCRIPTION
**Stack 5/7** (base: #2580). Retarget to `main` as the stack merges.

## Summary

Works down #2573's corpus type-check debt: four of the six allowlisted families fixed, allowlist ratcheted 12 → 7 entries in the same commit (per the issue's rule). Type-level only — no runtime/emitted-HTML/client-JS behavior change (conformance suites unchanged; 10 `.ssr.tsx` snapshots regenerated with type-text-only diffs).

| Family | Outcome |
|---|---|
| icon TS2322 ×34 + spinner TS2322 ×1 | **Fixed** — new public `SVGSVGAttributes` (`packages/jsx/src/html-types.ts`, re-exported and reused by the `svg:` intrinsic as single source of truth); `icon`/`spinner` extend it instead of `HTMLBaseAttributes`. |
| carousel TS7005 ×2 / TS7034 ×1 | **Fixed** — `generateSignalInitializers` re-emitted an uninitialized local (`let emblaApi`) without its annotation → implicit any; it now carries `ConstantInfo.type.raw` under `preserveTypes`. |
| slider TS2532 ×1 | **Fixed** — a genuine pre-existing bug in the component source itself (verified by typechecking the source in isolation); scoped, commented non-null assertion. |
| chart / xyflow | **Not attempted** — root cause is `@barefootjs/chart` / `@barefootjs/xyflow` being unbuilt+unlinked from the gate's module-resolution scope (plus two separate genuine bugs in chart: TS17001 duplicate JSX attrs, TS2322). Needs build/linking work first; details in the issue. |

A first cut widened `HTMLBaseAttributes.ref` from `HTMLElement` to `Element` — rejected after an isolated tsc repro showed it silently breaks every `HTMLElement`-typed `ref` callback (dialog/sheet/drawer/…); the shipped fix adds the SVG-specific type instead.

## Verification

- Gate (`corpus-typecheck.test.ts`): green with the shrunken allowlist (no new pairs).
- `ui` component IR tests: 1235 pass / 0 fail. Full adapter-tests at the stack tip: 1891 pass / 0 fail. Cross-adapter sanity: icon/spinner/slider/carousel compile clean through `GoTemplateAdapter`.
- Changesets: `@barefootjs/jsx` + `@barefootjs/hono` patch.

Refs #2573 (chart/xyflow families remain — issue stays open as the tracker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_