### PR TITLE
fix(compiler): refuse loudly (BF048) when a client file references an uncompiled sibling

### DIFF
--- a/.changeset/multi-return-sibling-diagnostic-2556.md
+++ b/.changeset/multi-return-sibling-diagnostic-2556.md
@@ -1,0 +1,26 @@
+---
+"@barefootjs/jsx": patch
+---
+
+A `'use client'` file where a component referenced a same-file sibling
+whose body is a multi-return JSX dispatch (`switch` / `if`-`else` chain,
+e.g. a `NavIcon` helper dispatched over an icon name) previously compiled
+with zero diagnostics, but the sibling produced no template — the compiler
+silently dropped it, and the emitted `renderChild`/`initChild`/
+`createComponent` call threw `ReferenceError: <Name> is not defined` at
+SSR/hydrate time (#2556).
+
+Root cause: `listComponentFunctions`'s #932 "preserve verbatim helper"
+bypass only applies to non-`'use client'` files. In a client file the
+multi-return sibling is instead asked to compile as a standalone
+component, and a top-level `switch` dispatch (unlike an `if`/`else`
+chain, which #1401 folds into a conditional template) is preserved as a
+verbatim init statement rather than yielding a template — so
+`compileMultipleComponents`'s Pass-1 loop silently skips it while the
+referencing sibling's IR still points at the dropped name.
+
+New diagnostic **BF048** detects this structurally, from the IR
+component-reference graph, and fails the compile instead of shipping the
+silent `ReferenceError`. Non-`'use client'` files (where #932's verbatim
+preservation applies) and siblings whose multi-return body does compile
+(`if`/`else` chains, #1401) are unaffected.

--- a/packages/jsx/src/__tests__/multi-return-sibling-diagnostic.test.ts
+++ b/packages/jsx/src/__tests__/multi-return-sibling-diagnostic.test.ts
@@ -124,6 +124,36 @@ describe('Sibling multi-return JSX dispatch produces no template in a client fil
     expect(markedTemplate!.content).toContain('function NavIcon')
   })
 
+  test('legal neighbor: a non-"use client" file never trips BF048, even when a sibling lands in componentNames', () => {
+    // The #932 bypass only skips NON-exported multi-return functions, so an
+    // exported switch-dispatch sibling in a non-client file IS in
+    // `componentNames` and produces no entry — the same set-difference shape
+    // BF048 keys on. But the diagnostic's premise (the 'use client' branch
+    // of #932, `ReferenceError` at hydrate time) doesn't apply outside
+    // client files, so BF048 is gated on a compiled client entry and must
+    // stay silent here.
+    const source = `
+      export function NavIcon({ name }: { name: string }) {
+        switch (name) {
+          case 'home': return <svg><path d="M1"/></svg>
+          case 'bell': return <svg><path d="M2"/></svg>
+          default: return null
+        }
+      }
+      export function Shell() {
+        return (
+          <nav>
+            {['home', 'bell'].map(item => <NavIcon key={item} name={item} />)}
+          </nav>
+        )
+      }
+    `
+
+    const result = compileJSX(source, 'Shell.tsx', { adapter })
+    const errs = result.errors.filter(e => e.severity === 'error')
+    expect(errs.filter(e => e.code === 'BF048')).toHaveLength(0)
+  })
+
   test('legal neighbor: a "use client" sibling whose multi-return body DOES compile (if/else chain, #1401) stays clean', () => {
     // if/else-if chains fold into `conditionalReturns` (#1401) and produce
     // a real ternary template, so the sibling ends up in `entries` and the

--- a/packages/jsx/src/__tests__/multi-return-sibling-diagnostic.test.ts
+++ b/packages/jsx/src/__tests__/multi-return-sibling-diagnostic.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Regression tests for #2556: a `'use client'` file where a component
+ * references a same-file sibling whose body is a multi-return JSX dispatch
+ * (`switch` / `if`-`else` chain) previously compiled clean with ZERO
+ * diagnostics, but the sibling produced no template — so the emitted
+ * `renderChild`/`initChild`/`createComponent` call referenced a component
+ * name with nothing registered under it, throwing
+ * `ReferenceError: <Name> is not defined` at SSR/hydrate time.
+ *
+ * Root cause: `listComponentFunctions`'s #932 "preserve verbatim helper"
+ * bypass is gated on `!hasUseClient` — in a `'use client'` file, a
+ * multi-return sibling like `NavIcon` below IS added to `componentNames`
+ * and asked to compile as a standalone component. But `visitComponentBody`
+ * only folds `if`/`else`-chain multi-return bodies into `conditionalReturns`
+ * (#1401); a top-level `switch` statement is preserved as a verbatim init
+ * statement instead, so `ctx.jsxReturn` stays null and
+ * `compileMultipleComponents`'s Pass-1 loop silently `continue`s past it —
+ * no entry, no template, no error. Meanwhile the referencing sibling's IR
+ * still holds a `component` reference to the dropped name.
+ *
+ * Fix: BF048 detects this structurally — after Pass 1, any name in
+ * `componentNames` that did not make it into `entries` is cross-referenced
+ * against every compiled sibling's IR component-reference graph (the same
+ * walk `@bf-child` import markers use, `collectComponentNamesFromIR`). A
+ * hit fails the compile instead of shipping a silent `ReferenceError`.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('Sibling multi-return JSX dispatch produces no template in a client file (#2556)', () => {
+  // Higher timeout: `.map()` in the source trips `needsTypeBasedDetection`,
+  // and building the one-time `ts.Program` for BF023/BF024's nullable-key
+  // check is slow the first time the TS API is touched in a fresh process
+  // (e.g. this file run in isolation) — well past bun's 5s default.
+  test('BF048: .map() loop child referencing a switch-dispatch sibling fails the compile', () => {
+    const source = `
+      "use client"
+      import { createSignal } from '@barefootjs/client'
+      function NavIcon({ name }: { name: string }) {
+        switch (name) {
+          case 'home': return <svg><path d="M1"/></svg>
+          case 'bell': return <svg><path d="M2"/></svg>
+          default: return null
+        }
+      }
+      export function Shell() {
+        const [n, setN] = createSignal(0)
+        return (
+          <nav onClick={() => setN(n() + 1)}>
+            {['home', 'bell'].map(item => <NavIcon key={item} name={item} />)}
+          </nav>
+        )
+      }
+    `
+
+    const result = compileJSX(source, 'Shell.tsx', { adapter })
+    const errs = result.errors.filter(e => e.severity === 'error')
+    expect(errs.length).toBeGreaterThan(0)
+    const bf048 = errs.find(e => e.code === 'BF048')
+    expect(bf048).toBeDefined()
+    expect(bf048!.message).toContain('NavIcon')
+    expect(bf048!.message).toContain('Shell')
+    expect(bf048!.message).toMatch(/did not compile to a template/)
+  }, 20000)
+
+  test('BF048: direct JSX tag (non-loop) referencing a switch-dispatch sibling fails the compile', () => {
+    const source = `
+      "use client"
+      import { createSignal } from '@barefootjs/client'
+      function StatusIcon({ status }: { status: string }) {
+        switch (status) {
+          case 'ok': return <span class="ok">OK</span>
+          case 'err': return <span class="err">ERR</span>
+          default: return null
+        }
+      }
+      export function Panel() {
+        const [n, setN] = createSignal(0)
+        return <div onClick={() => setN(n() + 1)}><StatusIcon status="ok" /></div>
+      }
+    `
+
+    const result = compileJSX(source, 'Panel.tsx', { adapter })
+    const errs = result.errors.filter(e => e.severity === 'error')
+    const bf048 = errs.find(e => e.code === 'BF048')
+    expect(bf048).toBeDefined()
+    expect(bf048!.message).toContain('StatusIcon')
+  })
+
+  test('legal neighbor: the identical switch-dispatch shape in a non-"use client" file compiles clean (#932)', () => {
+    // Same shape as the failing case above, but without the 'use client'
+    // directive: `listComponentFunctions`'s #932 bypass keeps NavIcon OFF
+    // `componentNames` entirely, so it is preserved verbatim in the marked
+    // template rather than compiled (and dropped) as a component. BF048
+    // must not fire here.
+    const source = `
+      function NavIcon({ name }: { name: string }) {
+        switch (name) {
+          case 'home': return <svg><path d="M1"/></svg>
+          case 'bell': return <svg><path d="M2"/></svg>
+          default: return null
+        }
+      }
+      export function Shell() {
+        return (
+          <nav>
+            {['home', 'bell'].map(item => <NavIcon key={item} name={item} />)}
+          </nav>
+        )
+      }
+    `
+
+    const result = compileJSX(source, 'Shell.tsx', { adapter })
+    const errs = result.errors.filter(e => e.severity === 'error')
+    expect(errs.filter(e => e.code === 'BF048')).toHaveLength(0)
+    expect(errs).toHaveLength(0)
+
+    const markedTemplate = result.files.find(f => f.type === 'markedTemplate')
+    expect(markedTemplate).toBeDefined()
+    expect(markedTemplate!.content).toContain('function NavIcon')
+  })
+
+  test('legal neighbor: a "use client" sibling whose multi-return body DOES compile (if/else chain, #1401) stays clean', () => {
+    // if/else-if chains fold into `conditionalReturns` (#1401) and produce
+    // a real ternary template, so the sibling ends up in `entries` and the
+    // reference resolves. BF048 must not fire.
+    const source = `
+      "use client"
+      import { createSignal } from '@barefootjs/client'
+      function Badge({ kind }: { kind: string }) {
+        if (kind === 'ok') return <span class="ok">ok</span>
+        if (kind === 'warn') return <span class="warn">warn</span>
+        return <span class="err">err</span>
+      }
+      export function Panel() {
+        const [n, setN] = createSignal(0)
+        return (
+          <div onClick={() => setN(n() + 1)}>
+            <Badge kind="ok" />
+          </div>
+        )
+      }
+    `
+
+    const result = compileJSX(source, 'Panel.tsx', { adapter })
+    const errs = result.errors.filter(e => e.severity === 'error')
+    expect(errs.filter(e => e.code === 'BF048')).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    // Both the Panel and Badge components' hydrate() registrations exist
+    // with real templates — the sibling reference resolves. Badge is a
+    // non-exported sibling so its runtime key is file-scoped
+    // (`Badge__<hash>`); match on the `name: 'Badge'` metadata instead of
+    // the registry key.
+    expect(clientJs!.content).toMatch(/hydrate\('Badge[^']*',\s*\{[^}]*template:/s)
+    expect(clientJs!.content).toContain("name: 'Badge'")
+  })
+
+  test('legal neighbor: single-component "use client" multi-return root (#1401) is unaffected', () => {
+    // Only one component in the file, so `compileJSX` never enters the
+    // multi-component path where BF048 is computed at all.
+    const source = `
+      "use client"
+      import { createSignal } from '@barefootjs/client'
+      export function Toggle(props: { asChild?: boolean }) {
+        const [open, setOpen] = createSignal(false)
+        if (props.asChild) {
+          return <span onClick={() => setOpen(!open())}>child</span>
+        }
+        return <button onClick={() => setOpen(!open())}>toggle</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Toggle.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('template:')
+  })
+
+  test('legal neighbor: a component-scope local JSX factory does not trip BF048', () => {
+    // `listComponentFunctions` recurses into function bodies, so a local
+    // factory like `Inner` below lands in `componentNames` and produces no
+    // standalone template — but its call sites are handled by the
+    // JSX-function-inlining pass, not `createComponent`, so it is NOT the
+    // dropped-sibling shape. BF048's uncompiled-sibling set is restricted
+    // to module top-level declarations precisely so this stays legal (the
+    // first BF048 cut flagged it and broke the ir-dynamic-tag corpus).
+    // Two components so the multi-component path (where BF048 runs) engages.
+    const source = `
+      "use client"
+      import { createSignal } from '@barefootjs/client'
+      export function Demo() {
+        const Inner = () => <span>x</span>
+        const [n, setN] = createSignal(0)
+        return <div onClick={() => setN(n() + 1)}><Inner /></div>
+      }
+      export function Other() {
+        return <p>other</p>
+      }
+    `
+
+    const result = compileJSX(source, 'demo.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  })
+})

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -191,7 +191,13 @@ function compileMultipleComponents(
   // here would fail legal programs (the ir-dynamic-tag / resolver-alias
   // corpus shapes). Only a name declared at module top level can be the
   // dropped-sibling shape this diagnostic exists for.
-  {
+  //
+  // Restricted to 'use client' FILES: only the 'use client' branch of #932
+  // widens `listComponentFunctions` to multi-return dispatch shapes; in a
+  // non-client file an uncompiled sibling is preserved verbatim (that is
+  // the escape hatch the message below recommends), so flagging it there
+  // would fail exactly the programs the fix tells users to write.
+  if (entries.some(e => e.componentIR.metadata.isClientComponent)) {
     const topLevelNames = new Set<string>()
     {
       const sf = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -27,7 +27,8 @@ import { preprocessInlineJsxCallbacks } from './preprocess-inline-jsx-callbacks.
 import { extractSsrDefaults } from './ssr-defaults.ts'
 import { computeSsrSeedPlan } from './ssr-seed-plan.ts'
 import { checkRichTypeMethodCalls } from './rich-type-refusal.ts'
-import { ErrorCodes } from './errors.ts'
+import { ErrorCodes, createError } from './errors.ts'
+import { collectComponentNamesFromIR } from './ir-to-client-js/child-components.ts'
 
 /**
  * Extended compile options with required adapter
@@ -165,6 +166,72 @@ function compileMultipleComponents(
     decideClientOnlyElision(componentIR.root)
 
     entries.push({ componentIR, ctx })
+  }
+
+  // BF048 — refuse loudly when an emitted component template references a
+  // same-file sibling that was in `componentNames` (so `listComponentFunctions`
+  // treated it as a component to compile — the 'use client' branch of #932
+  // does exactly that for multi-return JSX dispatch shapes) but never made
+  // it into `entries` (its own `analyzeComponent`/`jsxToIR` pass produced no
+  // usable IR — most commonly a top-level `switch` dispatch, which
+  // `visitComponentBody` preserves as a verbatim init statement rather than
+  // folding into `conditionalReturns`, so `ctx.jsxReturn` stays null).
+  // Pre-fix this compiled clean and the emitted `renderChild`/`initChild`/
+  // `createComponent` call threw `ReferenceError: <Name> is not defined` at
+  // SSR/hydrate time (#2556) — the silence itself is the bug. Detection
+  // walks the IR component-reference graph (the same walk that drives
+  // `@bf-child` import markers, `collectComponentNamesFromIR`), never the
+  // emitted template text.
+  //
+  // Restricted to TOP-LEVEL declarations: `listComponentFunctions` recurses
+  // into function bodies, so `componentNames` also carries component-scope
+  // local factories (`const Inner = () => <span/>` inside a component).
+  // Those never compile to standalone templates either, but their call
+  // sites are handled by the JSX-function-inlining pass — flagging them
+  // here would fail legal programs (the ir-dynamic-tag / resolver-alias
+  // corpus shapes). Only a name declared at module top level can be the
+  // dropped-sibling shape this diagnostic exists for.
+  {
+    const topLevelNames = new Set<string>()
+    {
+      const sf = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+      for (const stmt of sf.statements) {
+        if (ts.isFunctionDeclaration(stmt) && stmt.name) topLevelNames.add(stmt.name.text)
+        else if (ts.isVariableStatement(stmt)) {
+          for (const d of stmt.declarationList.declarations) {
+            if (ts.isIdentifier(d.name)) topLevelNames.add(d.name.text)
+          }
+        }
+      }
+    }
+    const compiledNames = new Set(entries.map(e => e.componentIR.metadata.componentName))
+    const uncompiledSiblings = new Set(
+      componentNames.filter(name => !compiledNames.has(name) && topLevelNames.has(name)),
+    )
+    if (uncompiledSiblings.size > 0) {
+      for (const { componentIR } of entries) {
+        const referenced = new Set<string>()
+        collectComponentNamesFromIR([componentIR.root], referenced)
+        for (const name of referenced) {
+          if (!uncompiledSiblings.has(name)) continue
+          errors.push(createError(
+            ErrorCodes.SIBLING_COMPONENT_NOT_COMPILED,
+            componentIR.root.loc,
+            {
+              message:
+                `Component '${componentIR.metadata.componentName}' references sibling ` +
+                `'<${name}>', which did not compile to a template in this 'use client' file ` +
+                `(likely a multi-return JSX dispatch — a \`switch\` or \`if\`/\`else\` chain ` +
+                `across multiple JSX-returning branches). This reference would throw ` +
+                `\`ReferenceError: ${name} is not defined\` at SSR/hydrate time. Extract '${name}' ` +
+                `to a separate non-"use client" file (where #932 preserves it verbatim), or ` +
+                `rewrite it as a single-return ternary/conditional chain so the component ` +
+                `pipeline can compile it.`,
+            },
+          ))
+        }
+      }
+    }
   }
 
   // CSS layer prefixing must be FILE-WIDE: per-IR application diverges the

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -43,6 +43,16 @@ export const ErrorCodes = {
   // ReferenceError at hydrate. Fail loud with workaround pointers
   // (#1414 cell 5).
   JSX_BRANCH_LOCAL_IN_CALLBACK: 'BF047',
+  // A `'use client'` file's emitted template references a same-file
+  // sibling component (`<NavIcon .../>`, a `.map()` child, …) whose own
+  // body never produced a template — most commonly a multi-return JSX
+  // dispatch (`switch` / `if`-`else` chain) that `compileMultipleComponents`
+  // silently dropped from its output. Pre-fix this compiled clean and threw
+  // `ReferenceError: <Name> is not defined` at SSR/hydrate time (#2556). The
+  // equivalent shape in a NON-"use client" file is fine — #932 preserves the
+  // helper verbatim instead of compiling it as a component — so this code
+  // fires only for the client-component compilation path.
+  SIBLING_COMPONENT_NOT_COMPILED: 'BF048',
 
   // Import errors (BF050-BF059)
   SHARED_PROGRAM_REQUIRED: 'BF050',
@@ -145,6 +155,14 @@ const errorMessages: Record<ErrorCode, string> = {
   [ErrorCodes.JSX_BRANCH_LOCAL_IN_CALLBACK]:
     "JSX-typed local declared inside an `if`-block cannot be referenced from a callback body (ref / event handler). " +
     "Render it as a child instead: `<div ref={...}>{local}</div>`.",
+
+  [ErrorCodes.SIBLING_COMPONENT_NOT_COMPILED]:
+    "Referenced component did not compile to a template, so this reference would throw " +
+    "`ReferenceError` at render time. Multi-return JSX dispatch (a `switch` or `if`/`else` " +
+    "chain across multiple JSX-returning branches) cannot compile as a component in a " +
+    "'use client' file. Extract it to a separate non-\"use client\" file (where it is preserved " +
+    "verbatim, see #932), or rewrite it as a single-return ternary/conditional chain so the " +
+    "component pipeline can compile it.",
 
   [ErrorCodes.SHARED_PROGRAM_REQUIRED]:
     'Shared ts.Program required for type-based reactivity classification. This source imports a Reactive<T>-branded library (e.g. @barefootjs/form) whose getters cannot be classified by regex alone. Pass `options.program` (built via `createProgramForCorpus`) so the analyzer can resolve the brand through the TypeChecker.',

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -843,6 +843,7 @@ symbol of each JSX tag through to the resolver; tracked as a follow-up.
 | BF025 | Unsupported destructure shape in `.map()` callback (computed property key — rest elements have been supported since #1244/#1309) |
 | BF043 | Props destructuring breaks reactivity |
 | BF044 | Signal/memo getter passed without calling it |
+| BF048 | `'use client'` file references a same-file sibling component that produced no template — typically a multi-return JSX `switch`/`if`-`else` dispatch, which only #932's non-client verbatim-preservation path can compile (#2556) |
 | BF060 | Reactive binding (signal/memo getter) referenced from template scope (staged-IR; opt-in diagnostic) |
 | BF061 | Init-scope local referenced from template scope (staged-IR; opt-in diagnostic) |
 | BF062 | AwaitExpression in template scope (staged-IR; reserved for Phase 1 dispatcher) |


### PR DESCRIPTION
**Stack 6/7** (base: #2581). Retarget to `main` as the stack merges.

## Summary

A `"use client"` file where a component references a same-file sibling whose body is a multi-return JSX dispatch compiled with **zero diagnostics** while silently dropping the sibling from the emitted output — the template still referenced it, so SSR threw `ReferenceError: <Name> is not defined` at render time (#2556, the crash that hit three gallery pages in #2554). The silence is the bug (sound-or-loud rule); this PR takes the issue's option (b): refuse loudly.

Root cause, sharpened from the issue: `listComponentFunctions`' #932 verbatim-preservation bypass is gated on `!hasUseClient`, so in a client file the sibling IS scheduled to compile — but a top-level `switch` dispatch never folds into `conditionalReturns` (#1401 covers `if`/`else` chains, which DO compile), `ctx.jsxReturn` stays null, and Pass 1 silently skips it.

## Fix

New diagnostic **BF048** (`errors.ts`, documented in `spec/compiler.md`'s error-code table): after Pass 1, every scheduled-but-uncompiled name is cross-referenced against each compiled sibling's IR component-reference graph — the same `collectComponentNamesFromIR` walk the `@bf-child` import markers use, never the emitted text. A hit fails the compile with extraction/rewrite guidance.

Detection is restricted to **module top-level declarations**: `listComponentFunctions` recurses into function bodies, so component-scope local factories (`const Inner = () => <span/>` inside a component) also land in `componentNames` and produce no standalone template — but their call sites are handled by the JSX-function-inlining pass and are legal. The first cut flagged them and broke the `ir-dynamic-tag` corpus; caught during stack verification, fixed, and pinned with a dedicated legal-neighbor test.

## Coverage

`multi-return-sibling-diagnostic.test.ts` — 6 tests: the `.map()` and direct-tag broken shapes fire BF048; four legal neighbors stay clean (non-client #932 shape, client `if`/`else` sibling that compiles (#1401), single-component multi-return root, component-scope local factory). Changeset: `@barefootjs/jsx` patch.

## Verification

Full `packages/jsx` suite in the stack worktree: 2930 pass / 2 fail — both `map-body-no-silent-divergence` "(JS-runtime)" cases that fail **identically on unmodified `main`** in this environment (a `BF_ASSERT_NO_JSX_IN_GETJS` strict-assertion path whose manifestation depends on whether `@barefootjs/client`'s `.d.ts` build output is present; not caused by this diff). Full adapter-tests at the stack tip: 1891 pass / 0 fail.

Closes #2556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_