### PR TITLE
fix(compiler): reactive per-row selected on controlled select option loops

### DIFF
--- a/.changeset/select-loop-reorder-selected-2466.md
+++ b/.changeset/select-loop-reorder-selected-2466.md
@@ -1,0 +1,33 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix controlled `<select>` losing its selection when an index-keyed
+`.map()`-rendered `<option>` loop reorders (#2466).
+
+`lowerFormControlValueSsr` (`jsx-to-ir.ts`) already distributed
+`selected={(value) === 'opt'}` onto statically-valued `<option>`s (#2464);
+a `.map()`-rendered `<option>` with an EXPRESSION value (`value={o.id}`,
+the shape every loop row uses) was left unhandled and silently froze at
+its SSR-time `selected` state. Reversing an index-keyed loop (`key={i}`)
+never moves the physical `<option>` nodes — `applyItem` rewrites
+`option.value` and its label text in place — so the previously-selected
+DOM node kept `selected` while the item underneath it changed, and
+`select.value` drifted from the controlled signal.
+
+`selected` is now distributed onto a loop-row `<option>` too, compared
+against the option's own value EXPRESSION (`(value) === (o.id)`) rather
+than a `JSON.stringify`'d literal. That makes it an ordinary per-row
+reactive attribute (a boolean DOM-property write, `isBooleanAttr`), so it
+rides the loop's existing per-row reactive-attribute machinery —
+`applyItem` (row rewritten under a stationary key) and `applyOuter` (the
+controlled signal itself changes) both recompute it, alongside the eager
+`mapArray` row effect for loops outside the lazy-row gate. Keyed loops
+(`key={o.id}`) were already correct (the DOM node itself moves) and are
+unaffected.
+
+New coverage: a compiler unit pin (`form-control-value-ssr.test.ts`)
+asserting `selected` rides both `applyItem` and `applyOuter` for an
+index-keyed loop, and a new `select-loop-selected` adapter-conformance
+fixture (SSR `expectedHtml` generated from the Hono reference, also
+exercised by `csr-conformance.test.ts`).

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -3952,6 +3952,26 @@
         "text"
       ]
     },
+    "select-loop-selected": {
+      "kinds": [
+        "array-literal",
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "binary:===",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "select-option-selected": {
       "kinds": [
         "binary",
@@ -4972,18 +4992,18 @@
     }
   },
   "kindCounts": {
-    "array-literal": 70,
+    "array-literal": 71,
     "array-method": 67,
     "arrow": 64,
-    "binary": 83,
-    "call": 201,
+    "binary": 84,
+    "call": 202,
     "conditional": 24,
-    "identifier": 290,
+    "identifier": 291,
     "index-access": 14,
-    "literal": 240,
+    "literal": 241,
     "logical": 43,
-    "member": 154,
-    "object-literal": 55,
+    "member": 155,
+    "object-literal": 56,
     "template-literal": 30,
     "unary": 23,
     "unsupported": 31
@@ -5020,13 +5040,13 @@
     "binary:-": 11,
     "binary:/": 1,
     "binary:<": 1,
-    "binary:===": 43,
+    "binary:===": 44,
     "binary:>": 11,
     "binary:>=": 1,
     "literal:boolean": 49,
     "literal:null": 23,
     "literal:number": 101,
-    "literal:string": 170,
+    "literal:string": 171,
     "logical:&&": 7,
     "logical:??": 38,
     "logical:||": 13,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -468,6 +468,11 @@ import { fixture as aliasedDestructuredProp } from './aliased-destructured-prop'
 // getter (#2525 — see the fixture's docstring).
 import { fixture as aliasedPropSignalTagCollision } from './aliased-prop-signal-tag-collision'
 import { fixture as selectValueSsr } from './select-value-ssr'
+// #2466: the loop half of #2464's controlled-select SSR projection —
+// `.map()`-rendered options get `selected` distributed against their own
+// (per-row) value expression, feeding the same per-row reactive-attribute
+// machinery `applyItem`/`applyOuter` already use.
+import { fixture as selectLoopSelected } from './select-loop-selected'
 import { fixture as textareaValueSsr } from './textarea-value-ssr'
 import { fixture as signalEarlyReturn } from './signal-early-return'
 // #2477: Record[key] class lookup keyed by a prop forwarded from a parent
@@ -810,6 +815,7 @@ export const jsxFixtures: JSXFixture[] = [
   aliasedDestructuredProp,
   aliasedPropSignalTagCollision,
   selectValueSsr,
+  selectLoopSelected,
   textareaValueSsr,
   signalEarlyReturn,
   branchRootPropAttr,

--- a/packages/adapter-tests/fixtures/select-loop-selected.ts
+++ b/packages/adapter-tests/fixtures/select-loop-selected.ts
@@ -1,0 +1,45 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `<select value={signal()}>` whose `<option>`s come from a `.map()` loop
+ * with a dynamic per-row `value` (e.g. `value={o.id}`) — the loop half of
+ * #2464's controlled-select SSR projection, and the shape #2466's compiler
+ * fix wires reactively.
+ *
+ * `lowerFormControlValueSsr` (`jsx-to-ir.ts`) distributes `selected` onto
+ * the loop's `<option>` element compared against its own value EXPRESSION
+ * (`selected={(value) === o.id}`), not a `JSON.stringify`'d literal — the
+ * option's value differs per row. That makes `selected` an ordinary
+ * per-row reactive attribute, so both SSR (this fixture) and the client
+ * loop plan's `applyItem` / `applyOuter` (pinned by the compiler unit test
+ * `index-keyed .map() loop option: selected rides applyItem AND
+ * applyOuter (#2466)` in `packages/jsx/src/__tests__/form-control-value-ssr.test.ts`)
+ * recompute it — fixing the bug where an INDEX-KEYED reorder left
+ * `selected` attached to whichever physical `<option>` happened to have
+ * its `value` rewritten in place, instead of following the controlled
+ * signal's value.
+ */
+export const fixture = createFixture({
+  id: 'select-loop-selected',
+  description: 'Controlled select distributes selected onto .map()-rendered options (#2466)',
+  source: `
+"use client"
+import { createSignal } from '@barefootjs/client'
+
+export function FruitPicker() {
+  const [fruits] = createSignal([{ id: 'apple', label: 'Apple' }, { id: 'banana', label: 'Banana' }])
+  const [picked, setPicked] = createSignal('banana')
+  return (
+    <select value={picked()} onChange={(e) => setPicked(e.target.value)}>
+      {fruits().map((f, i) => <option key={i} value={f.id}>{f.label}</option>)}
+    </select>
+  )
+}
+`,
+  expectedHtml: `
+    <select bf-s="test" bf="s2">
+      <option bf="s1" data-key="0" value="apple"><!--bf:s0-->Apple<!--/--></option>
+      <option bf="s1" data-key="1" selected value="banana"><!--bf:s0-->Banana<!--/--></option>
+    </select>
+  `,
+})

--- a/packages/adapter-tests/fixtures/select-value-ssr.ts
+++ b/packages/adapter-tests/fixtures/select-value-ssr.ts
@@ -9,9 +9,13 @@ import { createFixture } from '../src/types'
  * `clientOnly` (the hydrate-time `.value` binding is unchanged) and
  * distributes `selected={(value) === 'opt'}` onto each statically-valued
  * option — the per-option shape `select-option-selected` proves across
- * every adapter. Options rendered by a dynamic loop are left to the
- * hydrate-time effect (#2466 tracks the reorder interaction). This
- * fixture is the regression armor; `progress-meter-value` guards the
+ * every adapter. Options rendered by a `.map()` loop get the same
+ * treatment against the option's own value EXPRESSION (e.g.
+ * `selected={(value) === o.id}`), which rides the loop's existing per-row
+ * reactive-attribute machinery so `selected` is recomputed on both item
+ * change and outer-signal change — fixing the reorder-drops-selection bug
+ * (#2466; see the `select-loop-selected` fixture / conformance coverage).
+ * This fixture is the regression armor; `progress-meter-value` guards the
  * other direction (elements where `value` IS the legitimate attribute).
  */
 export const fixture = createFixture({

--- a/packages/jsx/src/__tests__/form-control-value-ssr.test.ts
+++ b/packages/jsx/src/__tests__/form-control-value-ssr.test.ts
@@ -1,5 +1,5 @@
 /**
- * SSR projection of controlled form-control `value` (#2464 / #2465).
+ * SSR projection of controlled form-control `value` (#2464 / #2465 / #2466).
  *
  * `value` is not an attribute on `<textarea>` or `<select>` — emitting it
  * verbatim ships invalid HTML that browsers ignore, so no-JS and
@@ -9,6 +9,15 @@
  * and projects the value into element content (textarea) or per-option
  * `selected` comparisons (select — the shape `select-option-selected`
  * already proves across every adapter).
+ *
+ * `<option>`s rendered by a `.map()` loop get the same `selected`
+ * distribution, compared against the option's own value EXPRESSION rather
+ * than a literal (#2466). That makes `selected` an ordinary per-row
+ * reactive attribute, so it rides the loop's existing `applyItem` /
+ * `applyOuter` (or eager `mapArray` per-row effect) machinery — fixing the
+ * bug where an INDEX-KEYED reorder left `selected` attached to whichever
+ * physical `<option>` happened to have its `value` rewritten in place,
+ * instead of following the controlled signal's value.
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -65,7 +74,7 @@ export function Pick() {
     expect(template).toContain(`((v()) === "b")`)
   })
 
-  test('an authored selected wins; dynamic option loops are left to hydrate', () => {
+  test('an authored selected wins; a `.map()` loop option gets a distributed selected binding (#2466)', () => {
     const { template } = compiled(`
 "use client"
 import { createSignal } from '@barefootjs/client'
@@ -89,7 +98,43 @@ export function Pick() {
     expect(template).toContain('selected={(false) || undefined}')
     expect(template).not.toContain('(v()) === "a"')
     expect(template).not.toMatch(/<select[^>]*value=/)
-  })
+    // The loop-rendered option compares against its own value EXPRESSION
+    // (the loop param `o`), not a literal — this is the #2466 half.
+    expect(template).toContain('((v()) === (o))')
+  }, 20000)
+
+  test('index-keyed .map() loop option: selected rides applyItem AND applyOuter (#2466)', () => {
+    const { clientJs } = compiled(`
+"use client"
+import { createSignal } from '@barefootjs/client'
+export function ReorderSelect() {
+  const [opts, setOpts] = createSignal([{ id: 'a', label: 'A' }, { id: 'b', label: 'B' }])
+  const [val, setVal] = createSignal('b')
+  return (
+    <div>
+      <select value={val()} onChange={(e) => setVal(e.target.value)}>
+        {opts().map((o, i) => <option key={i} value={o.id}>{o.label}</option>)}
+      </select>
+      <button onClick={() => setOpts([...opts()].reverse())}>Reverse</button>
+    </div>
+  )
+}
+`)
+    // `key={i}` is index-keyed: nothing MOVES on reorder, so `value`/text are
+    // rewritten in place by applyItem — `selected` must be recomputed there
+    // too (item changed under a stationary row), not just at row creation.
+    expect(clientJs).toContain('mapArrayLazy(')
+    expect(clientJs).toContain('applyItem:')
+    expect(clientJs).toContain('applyOuter:')
+    // Every apply body (createRow, applyItem, applyOuter) recomputes
+    // `selected` from the item AND the outer controlled signal…
+    const computed = clientJs.match(/const __x = \(val\(\)\) === \(o\(\)\.id\)/g) ?? []
+    expect(computed.length).toBe(3)
+    // …and writes it as a DOM PROPERTY (not just an HTML attribute
+    // presence, which would not affect a live, already-rendered <option>).
+    const writes = clientJs.match(/\.selected = !!\(__x\)/g) ?? []
+    expect(writes.length).toBe(3)
+  }, 20000)
 
   test('textarea with explicit children is left untouched', () => {
     const { template } = compiled(`

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1302,12 +1302,21 @@ function transformJsxElement(
  *  - `<textarea>` with no children gains a NON-reactive expression child
  *    (the initial value as element content — updates keep flowing through
  *    the `.value` effect, deliberately not a live text slot);
- *  - `<select>` distributes `selected={(value) === 'opt'}` onto each
- *    statically-valued `<option>` (incl. under `<optgroup>`/fragments) —
- *    the exact per-option comparison shape the `select-option-selected`
- *    fixture already proves across every adapter. Options rendered by a
- *    dynamic loop can't be statically distributed and are left to the
- *    hydrate-time effect (tracked with #2466 on the #2464 thread).
+ *  - `<select>` distributes `selected={(value) === optValue}` onto each
+ *    `<option>` (incl. under `<optgroup>`/fragments, and under a `.map()`
+ *    loop body) — the exact per-option comparison shape the
+ *    `select-option-selected` fixture already proves across every adapter.
+ *    A literal `optValue` (e.g. `value="banana"`) compares by
+ *    `JSON.stringify`; an expression `optValue` (a static dynamic value, or
+ *    a loop row reading its item — e.g. `value={o.id}`) compares against
+ *    the expression text directly. For a loop row this makes `selected` an
+ *    ordinary per-item reactive attribute like any other (`o.id`, the row's
+ *    text) — it rides the SAME loop-plan machinery
+ *    (`collectLoopChildReactiveAttrs` → `emitAttrUpdate`, which special-cases
+ *    `selected` as a boolean DOM PROPERTY write, not just an HTML attribute)
+ *    that already reruns per row on item change and per outer-signal change,
+ *    so selectedness is recomputed instead of staying attached to whichever
+ *    physical `<option>` a reorder happened to rewrite in place (#2466).
  */
 function lowerFormControlValueSsr(
   tagName: string,
@@ -1342,11 +1351,28 @@ function lowerFormControlValueSsr(
     return
   }
 
-  const selectedFor = (optValue: string): AttrValue =>
+  const selectedForLiteral = (optValue: string): AttrValue =>
     AttrValueOf.expression(
       `(${expr}) === ${JSON.stringify(optValue)}`,
       templateExpr !== undefined
         ? { templateExpr: `(${templateExpr}) === ${JSON.stringify(optValue)}` }
+        : undefined,
+    )
+  // An expression-valued `option value` — the shape every `.map()` loop row
+  // uses (`value={o.id}`) since the whole point of the loop is a per-item
+  // value. Compares the controlled value directly against the option's own
+  // value EXPRESSION TEXT (never JSON-stringified — it is JS, not a string
+  // literal). Inside a loop row this expression reads both the row item
+  // (`o.id`) and the outer controlled signal (`expr`, e.g. `val()`), which
+  // is exactly the "reads both" shape `collectLoopChildReactiveAttrs` /
+  // `classifyLazyBinding` already know how to place into both `applyItem`
+  // (row changed) and `applyOuter` (controlled value changed) — no new loop
+  // machinery, just one more per-row reactive attribute (#2466).
+  const selectedForExpr = (optExpr: string, optTemplateExpr: string | undefined): AttrValue =>
+    AttrValueOf.expression(
+      `(${expr}) === (${optExpr})`,
+      templateExpr !== undefined || optTemplateExpr !== undefined
+        ? { templateExpr: `(${templateExpr ?? expr}) === (${optTemplateExpr ?? optExpr})` }
         : undefined,
     )
   const distribute = (nodes: IRNode[]): void => {
@@ -1354,9 +1380,18 @@ function lowerFormControlValueSsr(
       if (n.type === 'element' && n.tag === 'option') {
         if (n.attrs.some(a => a.name === 'selected')) continue
         const optValue = n.attrs.find(a => a.name === 'value')
-        if (!optValue || optValue.value.kind !== 'literal') continue
-        n.attrs.push({ name: 'selected', value: selectedFor(optValue.value.value), loc: n.loc })
-      } else if (n.type === 'fragment' || (n.type === 'element' && n.tag === 'optgroup')) {
+        if (!optValue) continue
+        if (optValue.value.kind === 'literal') {
+          n.attrs.push({ name: 'selected', value: selectedForLiteral(optValue.value.value), loc: n.loc })
+        } else if (optValue.value.kind === 'expression') {
+          const selected = selectedForExpr(optValue.value.expr, optValue.value.templateExpr)
+          n.attrs.push({ name: 'selected', value: selected, loc: n.loc })
+        }
+      } else if (
+        n.type === 'fragment' ||
+        n.type === 'loop' ||
+        (n.type === 'element' && n.tag === 'optgroup')
+      ) {
         distribute(n.children)
       }
     }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 309,
+    "totalFixtures": 310,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 70,
+      "total": 71,
       "cells": {
         "hono": {
-          "pass": 70,
-          "total": 70
+          "pass": 71,
+          "total": 71
         },
         "blade": {
-          "pass": 58,
-          "total": 70,
+          "pass": 59,
+          "total": 71,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 59,
-          "total": 70,
+          "pass": 60,
+          "total": 71,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 58,
-          "total": 70,
+          "pass": 59,
+          "total": 71,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -189,8 +189,8 @@
           ]
         },
         "jinja": {
-          "pass": 58,
-          "total": 70,
+          "pass": 59,
+          "total": 71,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -247,8 +247,8 @@
           ]
         },
         "minijinja": {
-          "pass": 58,
-          "total": 70,
+          "pass": 59,
+          "total": 71,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -305,8 +305,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 59,
-          "total": 70,
+          "pass": 60,
+          "total": 71,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -357,8 +357,8 @@
           ]
         },
         "twig": {
-          "pass": 58,
-          "total": 70,
+          "pass": 59,
+          "total": 71,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -415,8 +415,8 @@
           ]
         },
         "xslate": {
-          "pass": 58,
-          "total": 70,
+          "pass": 59,
+          "total": 71,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1026,15 +1026,15 @@
       }
     },
     "binary": {
-      "total": 83,
+      "total": 84,
       "cells": {
         "hono": {
-          "pass": 83,
-          "total": 83
+          "pass": 84,
+          "total": 84
         },
         "blade": {
-          "pass": 74,
-          "total": 83,
+          "pass": 75,
+          "total": 84,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1081,8 +1081,8 @@
           ]
         },
         "erb": {
-          "pass": 75,
-          "total": 83,
+          "pass": 76,
+          "total": 84,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1123,8 +1123,8 @@
           ]
         },
         "go-template": {
-          "pass": 74,
-          "total": 83,
+          "pass": 75,
+          "total": 84,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1171,8 +1171,8 @@
           ]
         },
         "jinja": {
-          "pass": 74,
-          "total": 83,
+          "pass": 75,
+          "total": 84,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1219,8 +1219,8 @@
           ]
         },
         "minijinja": {
-          "pass": 74,
-          "total": 83,
+          "pass": 75,
+          "total": 84,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1267,8 +1267,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 75,
-          "total": 83,
+          "pass": 76,
+          "total": 84,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1309,8 +1309,8 @@
           ]
         },
         "twig": {
-          "pass": 74,
-          "total": 83,
+          "pass": 75,
+          "total": 84,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1357,8 +1357,8 @@
           ]
         },
         "xslate": {
-          "pass": 74,
-          "total": 83,
+          "pass": 75,
+          "total": 84,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 201,
+      "total": 202,
       "cells": {
         "hono": {
-          "pass": 200,
-          "total": 201,
+          "pass": 201,
+          "total": 202,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1433,8 +1433,8 @@
           ]
         },
         "blade": {
-          "pass": 186,
-          "total": 201,
+          "pass": 187,
+          "total": 202,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1509,8 +1509,8 @@
           ]
         },
         "erb": {
-          "pass": 187,
-          "total": 201,
+          "pass": 188,
+          "total": 202,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1579,8 +1579,8 @@
           ]
         },
         "go-template": {
-          "pass": 186,
-          "total": 201,
+          "pass": 187,
+          "total": 202,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1655,8 +1655,8 @@
           ]
         },
         "jinja": {
-          "pass": 186,
-          "total": 201,
+          "pass": 187,
+          "total": 202,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1731,8 +1731,8 @@
           ]
         },
         "minijinja": {
-          "pass": 186,
-          "total": 201,
+          "pass": 187,
+          "total": 202,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1807,8 +1807,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 187,
-          "total": 201,
+          "pass": 188,
+          "total": 202,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1877,8 +1877,8 @@
           ]
         },
         "twig": {
-          "pass": 186,
-          "total": 201,
+          "pass": 187,
+          "total": 202,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1953,8 +1953,8 @@
           ]
         },
         "xslate": {
-          "pass": 186,
-          "total": 201,
+          "pass": 187,
+          "total": 202,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2174,11 +2174,11 @@
       }
     },
     "identifier": {
-      "total": 290,
+      "total": 291,
       "cells": {
         "hono": {
-          "pass": 289,
-          "total": 290,
+          "pass": 290,
+          "total": 291,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2189,8 +2189,8 @@
           ]
         },
         "blade": {
-          "pass": 273,
-          "total": 290,
+          "pass": 274,
+          "total": 291,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2273,8 +2273,8 @@
           ]
         },
         "erb": {
-          "pass": 274,
-          "total": 290,
+          "pass": 275,
+          "total": 291,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2351,8 +2351,8 @@
           ]
         },
         "go-template": {
-          "pass": 273,
-          "total": 290,
+          "pass": 274,
+          "total": 291,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2435,8 +2435,8 @@
           ]
         },
         "jinja": {
-          "pass": 273,
-          "total": 290,
+          "pass": 274,
+          "total": 291,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2519,8 +2519,8 @@
           ]
         },
         "minijinja": {
-          "pass": 273,
-          "total": 290,
+          "pass": 274,
+          "total": 291,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2603,8 +2603,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 274,
-          "total": 290,
+          "pass": 275,
+          "total": 291,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2681,8 +2681,8 @@
           ]
         },
         "twig": {
-          "pass": 273,
-          "total": 290,
+          "pass": 274,
+          "total": 291,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2765,8 +2765,8 @@
           ]
         },
         "xslate": {
-          "pass": 273,
-          "total": 290,
+          "pass": 274,
+          "total": 291,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2914,15 +2914,15 @@
       }
     },
     "literal": {
-      "total": 240,
+      "total": 241,
       "cells": {
         "hono": {
-          "pass": 240,
-          "total": 240
+          "pass": 241,
+          "total": 241
         },
         "blade": {
-          "pass": 229,
-          "total": 240,
+          "pass": 230,
+          "total": 241,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2973,8 +2973,8 @@
           ]
         },
         "erb": {
-          "pass": 229,
-          "total": 240,
+          "pass": 230,
+          "total": 241,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3025,8 +3025,8 @@
           ]
         },
         "go-template": {
-          "pass": 229,
-          "total": 240,
+          "pass": 230,
+          "total": 241,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3077,8 +3077,8 @@
           ]
         },
         "jinja": {
-          "pass": 229,
-          "total": 240,
+          "pass": 230,
+          "total": 241,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3129,8 +3129,8 @@
           ]
         },
         "minijinja": {
-          "pass": 229,
-          "total": 240,
+          "pass": 230,
+          "total": 241,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3181,8 +3181,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 229,
-          "total": 240,
+          "pass": 230,
+          "total": 241,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3233,8 +3233,8 @@
           ]
         },
         "twig": {
-          "pass": 229,
-          "total": 240,
+          "pass": 230,
+          "total": 241,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3285,8 +3285,8 @@
           ]
         },
         "xslate": {
-          "pass": 229,
-          "total": 240,
+          "pass": 230,
+          "total": 241,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3498,11 +3498,11 @@
       }
     },
     "member": {
-      "total": 154,
+      "total": 155,
       "cells": {
         "hono": {
-          "pass": 153,
-          "total": 154,
+          "pass": 154,
+          "total": 155,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3513,8 +3513,8 @@
           ]
         },
         "blade": {
-          "pass": 137,
-          "total": 154,
+          "pass": 138,
+          "total": 155,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3597,8 +3597,8 @@
           ]
         },
         "erb": {
-          "pass": 138,
-          "total": 154,
+          "pass": 139,
+          "total": 155,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3675,8 +3675,8 @@
           ]
         },
         "go-template": {
-          "pass": 137,
-          "total": 154,
+          "pass": 138,
+          "total": 155,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3759,8 +3759,8 @@
           ]
         },
         "jinja": {
-          "pass": 137,
-          "total": 154,
+          "pass": 138,
+          "total": 155,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3843,8 +3843,8 @@
           ]
         },
         "minijinja": {
-          "pass": 137,
-          "total": 154,
+          "pass": 138,
+          "total": 155,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3927,8 +3927,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 138,
-          "total": 154,
+          "pass": 139,
+          "total": 155,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4005,8 +4005,8 @@
           ]
         },
         "twig": {
-          "pass": 137,
-          "total": 154,
+          "pass": 138,
+          "total": 155,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4089,8 +4089,8 @@
           ]
         },
         "xslate": {
-          "pass": 137,
-          "total": 154,
+          "pass": 138,
+          "total": 155,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4186,15 +4186,15 @@
       }
     },
     "object-literal": {
-      "total": 55,
+      "total": 56,
       "cells": {
         "hono": {
-          "pass": 55,
-          "total": 55
+          "pass": 56,
+          "total": 56
         },
         "blade": {
-          "pass": 53,
-          "total": 55,
+          "pass": 54,
+          "total": 56,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4209,8 +4209,8 @@
           ]
         },
         "erb": {
-          "pass": 53,
-          "total": 55,
+          "pass": 54,
+          "total": 56,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4225,8 +4225,8 @@
           ]
         },
         "go-template": {
-          "pass": 53,
-          "total": 55,
+          "pass": 54,
+          "total": 56,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4241,8 +4241,8 @@
           ]
         },
         "jinja": {
-          "pass": 53,
-          "total": 55,
+          "pass": 54,
+          "total": 56,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4257,8 +4257,8 @@
           ]
         },
         "minijinja": {
-          "pass": 53,
-          "total": 55,
+          "pass": 54,
+          "total": 56,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4273,8 +4273,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 53,
-          "total": 55,
+          "pass": 54,
+          "total": 56,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4289,8 +4289,8 @@
           ]
         },
         "twig": {
-          "pass": 53,
-          "total": 55,
+          "pass": 54,
+          "total": 56,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4305,8 +4305,8 @@
           ]
         },
         "xslate": {
-          "pass": 53,
-          "total": 55,
+          "pass": 54,
+          "total": 56,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -6836,15 +6836,15 @@
       }
     },
     "binary:===": {
-      "total": 43,
+      "total": 44,
       "cells": {
         "hono": {
-          "pass": 43,
-          "total": 43
+          "pass": 44,
+          "total": 44
         },
         "blade": {
-          "pass": 35,
-          "total": 43,
+          "pass": 36,
+          "total": 44,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6885,8 +6885,8 @@
           ]
         },
         "erb": {
-          "pass": 36,
-          "total": 43,
+          "pass": 37,
+          "total": 44,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6921,8 +6921,8 @@
           ]
         },
         "go-template": {
-          "pass": 35,
-          "total": 43,
+          "pass": 36,
+          "total": 44,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6963,8 +6963,8 @@
           ]
         },
         "jinja": {
-          "pass": 35,
-          "total": 43,
+          "pass": 36,
+          "total": 44,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7005,8 +7005,8 @@
           ]
         },
         "minijinja": {
-          "pass": 35,
-          "total": 43,
+          "pass": 36,
+          "total": 44,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7047,8 +7047,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 36,
-          "total": 43,
+          "pass": 37,
+          "total": 44,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7083,8 +7083,8 @@
           ]
         },
         "twig": {
-          "pass": 35,
-          "total": 43,
+          "pass": 36,
+          "total": 44,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7125,8 +7125,8 @@
           ]
         },
         "xslate": {
-          "pass": 35,
-          "total": 43,
+          "pass": 36,
+          "total": 44,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7663,15 +7663,15 @@
       }
     },
     "literal:string": {
-      "total": 170,
+      "total": 171,
       "cells": {
         "hono": {
-          "pass": 170,
-          "total": 170
+          "pass": 171,
+          "total": 171
         },
         "blade": {
-          "pass": 162,
-          "total": 170,
+          "pass": 163,
+          "total": 171,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7710,8 +7710,8 @@
           ]
         },
         "erb": {
-          "pass": 162,
-          "total": 170,
+          "pass": 163,
+          "total": 171,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7750,8 +7750,8 @@
           ]
         },
         "go-template": {
-          "pass": 162,
-          "total": 170,
+          "pass": 163,
+          "total": 171,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7790,8 +7790,8 @@
           ]
         },
         "jinja": {
-          "pass": 162,
-          "total": 170,
+          "pass": 163,
+          "total": 171,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7830,8 +7830,8 @@
           ]
         },
         "minijinja": {
-          "pass": 162,
-          "total": 170,
+          "pass": 163,
+          "total": 171,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7870,8 +7870,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 162,
-          "total": 170,
+          "pass": 163,
+          "total": 171,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7910,8 +7910,8 @@
           ]
         },
         "twig": {
-          "pass": 162,
-          "total": 170,
+          "pass": 163,
+          "total": 171,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7950,8 +7950,8 @@
           ]
         },
         "xslate": {
-          "pass": 162,
-          "total": 170,
+          "pass": 163,
+          "total": 171,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",


### PR DESCRIPTION
**Stack 7/7** (base: #2582). Retarget to `main` as the stack merges.

## Summary

A controlled `<select>` whose options come from an **index-keyed** loop (`key={i}`) lost its selection on reorder: reversing swaps the items but not the keys, so nothing moves — `mapArrayLazy`'s `applyItem` rewrites `option.value` in place, and the browser's selectedness stays attached to the physical element whose value just changed. DOM `select.value` silently diverged from the signal. (Keyed `key={o.id}` was measured correct all along: moved options carry their selectedness, and single-select re-insertion clears the others — the issue's original repro doesn't reproduce; the mechanism above, established by in-issue measurement, is what this fixes.) No runtime post-reconcile hook can fix a path where nothing moves — this is the compiler change that measurement called for.

## Fix

Extends #2464's SSR `selected` distribution (`lowerFormControlValueSsr`, `jsx-to-ir.ts`) to the loop half: the per-option comparison now supports expression-valued `value={o.id}` (compared against the option's value **expression**, not a stringified literal) and descends into loop bodies — making `selected` an ordinary per-row reactive attribute that reads both the loop item and the controlled signal. It rides the loop's existing per-row machinery (`applyItem`/`applyOuter` for lazy rows, the per-row effect for eager rows), so it re-evaluates on in-place row rewrites AND on controlled-signal changes. `selected` is a boolean attr, so the write is the live `option.selected` property. Stale `#2466 tracks…` comments in `jsx-to-ir.ts` / the `select-value-ssr` fixture updated.

## Browser proof (real Chromium, real compiled output, real runtime)

Both variants, 8 assertions: post-hydration `value='b'`; after Reverse still `'b'`; manual user selection of `'a'` then Reverse still `'a'` — with option order `["b","a"]` confirming the in-place rewrite actually happened. **Negative control:** the identical harness against unfixed `main` fails exactly the two index-keyed post-reorder assertions and passes keyed — confirming both the bug mechanism and that the harness isn't a false positive.

## Coverage

- Compiler pin: `form-control-value-ssr.test.ts` asserts `applyItem`/`applyOuter` both recompute `selected` for the index-keyed loop.
- Conformance fixture `select-loop-selected` (expectedHtml regenerated from the fixed reference; byte-identical to regen) — also exercised by csr-conformance. `coverage-map.json` regenerated.
- `map-body-no-silent-divergence`: 29 pass, known-hole set stays empty.
- Changeset: `@barefootjs/jsx` patch.

## Verification

`packages/client` 625 pass / 0 fail; full adapter-tests at this tip: **1891 pass / 0 fail**; jsx suite green modulo the two environment-dependent strict-assertion failures documented in #2582's PR body (identical on unmodified `main`).

The narrow fix sufficed — no #2482 Option B redesign was needed.

Closes #2466

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_