### PR TITLE
feat(jsx): add BindingScope, the shared scoped binding-resolution service (#2482 stage 0)

### DIFF
--- a/.changeset/binding-scope-2482-stage0.md
+++ b/.changeset/binding-scope-2482-stage0.md
@@ -1,0 +1,5 @@
+---
+'@barefootjs/jsx': patch
+---
+
+Add `BindingScope`, the shared scoped binding-resolution service for loop-callback-bound names (#2482 stage 0). New public export only — no existing code path is migrated yet; a shrink-only ratchet test pins the current inventory of the six legacy ad-hoc scope mechanisms it will replace.

--- a/packages/jsx/src/__tests__/binding-scope-ratchet.test.ts
+++ b/packages/jsx/src/__tests__/binding-scope-ratchet.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Shrink-only ledger of direct uses of the SIX legacy ad-hoc
+ * "names bound by a loop callback" mechanisms #2482 replaces with the one
+ * shared `BindingScope` service (`packages/jsx/src/scope/binding-scope.ts`).
+ * Modeled in spirit on `map-body-no-silent-divergence.test.ts`'s known-hole
+ * ledger: a known-inventory of the current reality that may only shrink as
+ * Stages 1-4 migrate call sites onto `BindingScope`, never grow.
+ *
+ * Scans every `.ts` file under `packages/jsx/src/` and each `packages/adapter-X/src/`
+ * (excluding `__tests__` directories, `*.test.ts` files, and
+ * `packages/jsx/src/scope/` itself — the new module legitimately mentions
+ * its own migration target names in doc comments) for five forbidden
+ * substrings:
+ *
+ *   - `localConstants.find(`   — ad-hoc linear scan for a shadowing local
+ *   - `staticLoopSourceBoundNames` — a per-adapter shadow-name Set
+ *   - `loopBoundNames`         — `collectLoopBoundNames`'s flat name Set
+ *   - `loopParamStack`         — the Go adapter's own loop-param stack
+ *   - `loopParams`             — `jsx-to-ir.ts`'s mutable `ctx.loopParams` Set
+ *
+ * ALLOWLIST pins the EXACT count of each pattern in each file as of Stage 0
+ * (#2482). Every assertion below must hold EXACTLY — not "at most" — so the
+ * ledger stays a live, precise record instead of a one-way ratchet that
+ * silently tolerates drift in either direction:
+ *
+ *   - A count ABOVE its allowlisted value means a NEW direct use of a
+ *     legacy scope device was added — use `BindingScope`
+ *     (`packages/jsx/src/scope/binding-scope.ts`) instead; see #2482.
+ *   - A count BELOW its allowlisted value means legacy use was removed
+ *     (progress!) — shrink the corresponding `ALLOWLIST` entry to keep the
+ *     ledger exact, don't leave a stale higher number sitting there.
+ *
+ * Counts are total substring OCCURRENCES per file (a line with the pattern
+ * twice counts twice), not matching-line counts.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+const REPO_ROOT = join(import.meta.dir, '..', '..', '..', '..')
+
+const PATTERNS = [
+  'localConstants.find(',
+  'staticLoopSourceBoundNames',
+  'loopBoundNames',
+  'loopParamStack',
+  'loopParams',
+] as const
+type Pattern = (typeof PATTERNS)[number]
+
+/**
+ * Exact per-file, per-pattern occurrence counts as of #2482 Stage 0. Only
+ * ever shrinks — see header comment. A missing file or missing pattern key
+ * means an expected count of 0.
+ */
+const ALLOWLIST: Record<string, Partial<Record<Pattern, number>>> = {
+  'packages/adapter-blade/src/adapter/blade-adapter.ts': { staticLoopSourceBoundNames: 8, loopBoundNames: 12 },
+  'packages/adapter-erb/src/adapter/erb-adapter.ts': { 'localConstants.find(': 1, loopBoundNames: 20 },
+  'packages/adapter-erb/src/adapter/expr/emitters.ts': { loopBoundNames: 1 },
+  'packages/adapter-go-template/src/adapter/expr/helper-inline.ts': { 'localConstants.find(': 1 },
+  'packages/adapter-go-template/src/adapter/go-template-adapter.ts': {
+    'localConstants.find(': 5,
+    staticLoopSourceBoundNames: 3,
+    loopParamStack: 35,
+  },
+  'packages/adapter-go-template/src/adapter/lib/compile-state.ts': { staticLoopSourceBoundNames: 1, loopParamStack: 1 },
+  'packages/adapter-go-template/src/adapter/memo/ctor-lowering.ts': { 'localConstants.find(': 3 },
+  'packages/adapter-go-template/src/adapter/memo/memo-value.ts': { 'localConstants.find(': 1 },
+  'packages/adapter-jinja/src/adapter/jinja-adapter.ts': { staticLoopSourceBoundNames: 8, loopBoundNames: 12 },
+  'packages/adapter-mojolicious/src/adapter/mojo-adapter.ts': {
+    'localConstants.find(': 1,
+    staticLoopSourceBoundNames: 1,
+    loopBoundNames: 23,
+  },
+  'packages/adapter-rust/src/adapter/minijinja-adapter.ts': { staticLoopSourceBoundNames: 8, loopBoundNames: 12 },
+  'packages/adapter-twig/src/adapter/twig-adapter.ts': { staticLoopSourceBoundNames: 8, loopBoundNames: 12 },
+  'packages/adapter-xslate/src/adapter/xslate-adapter.ts': { staticLoopSourceBoundNames: 8, loopBoundNames: 12 },
+  'packages/jsx/src/adapters/jsx-adapter.ts': { 'localConstants.find(': 1 },
+  'packages/jsx/src/augment-inherited-props.ts': { 'localConstants.find(': 1 },
+  'packages/jsx/src/css-layer-prefixer.ts': { 'localConstants.find(': 1 },
+  'packages/jsx/src/debug.ts': { loopParams: 18 },
+  'packages/jsx/src/free-refs.ts': { 'localConstants.find(': 1, loopParams: 4 },
+  'packages/jsx/src/ir-to-client-js/collect-elements.ts': { loopParams: 9 },
+  'packages/jsx/src/ir-to-client-js/compute-inlinability.ts': { 'localConstants.find(': 1 },
+  'packages/jsx/src/ir-to-client-js/control-flow/plan/build-event-delegation.ts': { loopParams: 4 },
+  'packages/jsx/src/ir-to-client-js/html-template.ts': { loopBoundNames: 3, loopParams: 16 },
+  'packages/jsx/src/ir-to-client-js/prop-handling.ts': { 'localConstants.find(': 2 },
+  'packages/jsx/src/ir-to-client-js/utils.ts': { loopParams: 3 },
+  'packages/jsx/src/jsx-to-ir.ts': { loopParams: 33 },
+  'packages/jsx/src/prop-rewrite.ts': { loopParams: 1 },
+}
+
+const SCOPE_MODULE_DIR = join(REPO_ROOT, 'packages', 'jsx', 'src', 'scope')
+
+function listTsFiles(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const st = statSync(full)
+    if (st.isDirectory()) {
+      if (entry === '__tests__') continue
+      if (full === SCOPE_MODULE_DIR) continue
+      listTsFiles(full, out)
+    } else if (st.isFile() && entry.endsWith('.ts') && !entry.endsWith('.test.ts')) {
+      out.push(full)
+    }
+  }
+}
+
+function countOccurrences(text: string, pattern: string): number {
+  let count = 0
+  let idx = 0
+  while (true) {
+    const found = text.indexOf(pattern, idx)
+    if (found === -1) break
+    count++
+    idx = found + pattern.length
+  }
+  return count
+}
+
+function scan(): Record<string, Partial<Record<Pattern, number>>> {
+  const roots: string[] = [join(REPO_ROOT, 'packages', 'jsx', 'src')]
+  const packagesDir = join(REPO_ROOT, 'packages')
+  for (const entry of readdirSync(packagesDir)) {
+    if (!entry.startsWith('adapter-')) continue
+    const srcDir = join(packagesDir, entry, 'src')
+    try {
+      if (statSync(srcDir).isDirectory()) roots.push(srcDir)
+    } catch {
+      // no src dir for this package — skip
+    }
+  }
+
+  const files: string[] = []
+  for (const root of roots) listTsFiles(root, files)
+
+  const result: Record<string, Partial<Record<Pattern, number>>> = {}
+  for (const file of files) {
+    const text = readFileSync(file, 'utf8')
+    const counts: Partial<Record<Pattern, number>> = {}
+    for (const pattern of PATTERNS) {
+      const c = countOccurrences(text, pattern)
+      if (c > 0) counts[pattern] = c
+    }
+    if (Object.keys(counts).length > 0) {
+      const rel = relative(REPO_ROOT, file).split(sep).join('/')
+      result[rel] = counts
+    }
+  }
+  return result
+}
+
+describe('legacy loop-scope device ledger (#2482) — shrink only', () => {
+  const actual = scan()
+
+  test('every scanned file matches its allowlisted counts exactly', () => {
+    const allFiles = new Set([...Object.keys(actual), ...Object.keys(ALLOWLIST)])
+    const mismatches: string[] = []
+
+    for (const file of allFiles) {
+      const actualCounts = actual[file] ?? {}
+      const expectedCounts = ALLOWLIST[file] ?? {}
+      const allPatterns = new Set<Pattern>([
+        ...(Object.keys(actualCounts) as Pattern[]),
+        ...(Object.keys(expectedCounts) as Pattern[]),
+      ])
+      for (const pattern of allPatterns) {
+        const got = actualCounts[pattern] ?? 0
+        const want = expectedCounts[pattern] ?? 0
+        if (got > want) {
+          mismatches.push(
+            `${file} [${pattern}]: found ${got}, allowlisted ${want} — new direct use of legacy ` +
+              `scope device — use BindingScope (packages/jsx/src/scope/binding-scope.ts) instead; see #2482`,
+          )
+        } else if (got < want) {
+          mismatches.push(
+            `${file} [${pattern}]: found ${got}, allowlisted ${want} — legacy use removed — ` +
+              `shrink the ALLOWLIST entry to keep the ledger exact`,
+          )
+        }
+      }
+    }
+
+    expect(mismatches).toEqual([])
+  })
+})

--- a/packages/jsx/src/__tests__/binding-scope-ratchet.test.ts
+++ b/packages/jsx/src/__tests__/binding-scope-ratchet.test.ts
@@ -1,7 +1,15 @@
 /**
- * Shrink-only ledger of direct uses of the SIX legacy ad-hoc
+ * Shrink-only ledger of direct uses of the legacy ad-hoc
  * "names bound by a loop callback" mechanisms #2482 replaces with the one
  * shared `BindingScope` service (`packages/jsx/src/scope/binding-scope.ts`).
+ *
+ * #2482 counts SIX such mechanisms; this ledger tracks FIVE textual
+ * patterns because two of the six have no greppable device name of their
+ * own: `csr-substitute.ts`'s `boundStack` is a function-local variable
+ * (migrated in Stage 1 by changing that one function, no ledger pattern
+ * needed), and `html-template.ts`'s `opts.loopBoundNames` shares the
+ * `loopBoundNames` spelling with the per-adapter ref-counted maps, so one
+ * pattern covers both.
  * Modeled in spirit on `map-body-no-silent-divergence.test.ts`'s known-hole
  * ledger: a known-inventory of the current reality that may only shrink as
  * Stages 1-4 migrate call sites onto `BindingScope`, never grow.

--- a/packages/jsx/src/__tests__/binding-scope.test.ts
+++ b/packages/jsx/src/__tests__/binding-scope.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for `BindingScope` (#2482 Stage 0). See
+ * `packages/jsx/src/scope/binding-scope.ts` for the service itself — this
+ * file pins its observable behavior, especially the destructure semantics
+ * mirrored from `jsx-to-ir.ts`'s `ctx.loopParams` add site and the
+ * immutability win over that Set-based design's nested-same-name hazard.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { BindingScope } from '../scope/binding-scope.ts'
+
+describe('BindingScope', () => {
+  test('EMPTY: nothing bound, lookup null, empty boundNames, shadow predicate false', () => {
+    const scope = BindingScope.EMPTY
+    expect(scope.isBound('x')).toBe(false)
+    expect(scope.lookup('x')).toBeNull()
+    expect(scope.boundNames().size).toBe(0)
+    expect(scope.asShadowPredicate()('x')).toBe(false)
+  })
+
+  test('simple loop row: param and index bound with sources item/index', () => {
+    const scope = BindingScope.EMPTY.enterLoopRow({ param: 'item', index: 'i' })
+    expect(scope.isBound('item')).toBe(true)
+    expect(scope.isBound('i')).toBe(true)
+    expect(scope.lookup('item')).toEqual({
+      depth: 0,
+      frame: scope.lookup('item')!.frame,
+      binding: { source: 'item' },
+    })
+    expect(scope.lookup('i')?.binding).toEqual({ source: 'index' })
+    expect(scope.lookup('item')?.frame.kind).toBe('loop-row')
+  })
+
+  test('loop row with no index: index name not bound', () => {
+    const scope = BindingScope.EMPTY.enterLoopRow({ param: 'item', index: null })
+    expect(scope.isBound('item')).toBe(true)
+    expect(scope.isBound('i')).toBe(false)
+  })
+
+  test('destructured row: paramBindings names bound as destructure; raw param NOT bound', () => {
+    // Mirrors jsx-to-ir.ts:4330-4335 exactly: when paramBindings is
+    // non-empty, ONLY the destructured binding names are added to
+    // ctx.loopParams — the else branch that adds the raw `param` text is
+    // skipped entirely. For a destructured callback `param` holds the
+    // original pattern source text (e.g. "{ id, name }"), which is not a
+    // usable identifier anyway, so not binding it is correct, not just
+    // an accident of mirroring.
+    const scope = BindingScope.EMPTY.enterLoopRow({
+      param: '{ id, name }',
+      index: null,
+      paramBindings: [{ name: 'id' }, { name: 'name' }],
+    })
+    expect(scope.isBound('id')).toBe(true)
+    expect(scope.isBound('name')).toBe(true)
+    expect(scope.lookup('id')?.binding).toEqual({ source: 'destructure' })
+    expect(scope.lookup('name')?.binding).toEqual({ source: 'destructure' })
+    // The raw pattern text is not a bound name.
+    expect(scope.isBound('{ id, name }')).toBe(false)
+  })
+
+  test('preamble locals: declaredNames bound as preamble', () => {
+    const scope = BindingScope.EMPTY.enterLoopRow({
+      param: 'row',
+      index: null,
+      preamble: { declaredNames: ['out', 'label'] },
+    })
+    expect(scope.isBound('row')).toBe(true)
+    expect(scope.lookup('out')?.binding).toEqual({ source: 'preamble' })
+    expect(scope.lookup('label')?.binding).toEqual({ source: 'preamble' })
+  })
+
+  test('nested loops with the SAME param name: inner lookup is depth 0; discarding the inner scope still leaves the parent bound', () => {
+    // Pins the immutability win over the old `ctx.loopParams` Set design:
+    // that mechanism `.add`s a nested loop's param and `.delete`s it on
+    // the way back out, so a caller that captured "the current set"
+    // reference before entering the nested loop observes the SAME
+    // mutable object both inside and after — there is no way to ask "what
+    // was bound one loop level up" once the same name has been added
+    // twice and deleted once. BindingScope's immutable child scopes make
+    // that question well-formed: `outer` below is never touched by
+    // `enterLoopRow` on `inner`, so it still resolves `item` after we
+    // stop using (conceptually "pop") the inner scope by simply going
+    // back to holding the `outer` reference.
+    const outer = BindingScope.EMPTY.enterLoopRow({ param: 'item', index: null })
+    const inner = outer.enterLoopRow({ param: 'item', index: null })
+
+    expect(inner.lookup('item')?.depth).toBe(0)
+    expect(outer.lookup('item')?.depth).toBe(0)
+    // "Discarding" the inner scope is just no longer holding its
+    // reference — `outer` was never mutated and still has `item` bound.
+    expect(outer.isBound('item')).toBe(true)
+  })
+
+  test('callback frame: enterCallback binds params as source param, frame kind callback; row bindings still visible beneath', () => {
+    const row = BindingScope.EMPTY.enterLoopRow({ param: 'item', index: null })
+    const withCallback = row.enterCallback(['a', 'b'])
+
+    expect(withCallback.lookup('a')).toEqual({
+      depth: 0,
+      frame: withCallback.lookup('a')!.frame,
+      binding: { source: 'param' },
+    })
+    expect(withCallback.lookup('a')?.frame.kind).toBe('callback')
+    expect(withCallback.lookup('b')?.binding).toEqual({ source: 'param' })
+
+    // The row binding is still visible, one frame further out.
+    const itemLookup = withCallback.lookup('item')
+    expect(itemLookup?.depth).toBe(1)
+    expect(itemLookup?.frame.kind).toBe('loop-row')
+    expect(itemLookup?.binding).toEqual({ source: 'item' })
+  })
+
+  test('shadowing: inner binding wins lookup (depth 0) over a same-named outer binding', () => {
+    const outer = BindingScope.EMPTY.enterLoopRow({ param: 'x', index: null })
+    const inner = outer.enterCallback(['x'])
+
+    const found = inner.lookup('x')
+    expect(found?.depth).toBe(0)
+    expect(found?.binding).toEqual({ source: 'param' })
+    expect(found?.frame.kind).toBe('callback')
+  })
+
+  test('boundNames unions across frames; asShadowPredicate matches isBound', () => {
+    const scope = BindingScope.EMPTY
+      .enterLoopRow({ param: 'item', index: 'i', preamble: { declaredNames: ['out'] } })
+      .enterCallback(['a'])
+
+    const names = scope.boundNames()
+    expect(names.has('item')).toBe(true)
+    expect(names.has('i')).toBe(true)
+    expect(names.has('out')).toBe(true)
+    expect(names.has('a')).toBe(true)
+    expect(names.size).toBe(4)
+
+    const shadowed = scope.asShadowPredicate()
+    for (const n of ['item', 'i', 'out', 'a', 'not-bound']) {
+      expect(shadowed(n)).toBe(scope.isBound(n))
+    }
+  })
+})

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -216,7 +216,7 @@ export { isLowerableLoopDestructure, isLowerableObjectRestDestructure } from './
 
 // Binding scope (#2482) — shared loop-bound-name resolution service
 export { BindingScope } from './scope/binding-scope.ts'
-export type { RowBindingSource, RowBinding, ScopeFrame, LoopBindingSource } from './scope/binding-scope.ts'
+export type { ScopeBindingSource, ScopeBinding, ScopeFrame, LoopBindingSource } from './scope/binding-scope.ts'
 
 // Debug analysis
 export {

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -214,6 +214,10 @@ export { buildLoopChainExpr } from './loop-chain.ts'
 export type { LoopChainInputs } from './loop-chain.ts'
 export { isLowerableLoopDestructure, isLowerableObjectRestDestructure } from './loop-destructure.ts'
 
+// Binding scope (#2482) — shared loop-bound-name resolution service
+export { BindingScope } from './scope/binding-scope.ts'
+export type { RowBindingSource, RowBinding, ScopeFrame, LoopBindingSource } from './scope/binding-scope.ts'
+
 // Debug analysis
 export {
   buildComponentGraph,

--- a/packages/jsx/src/scope/binding-scope.ts
+++ b/packages/jsx/src/scope/binding-scope.ts
@@ -1,0 +1,173 @@
+/**
+ * `BindingScope`: the one shared, immutable, stack-shaped model of "names
+ * bound by a loop callback" (#2482 Stage 0). Six independent ad-hoc
+ * mechanisms across the compiler currently answer this same question —
+ * `ctx.loopParams` (a mutated `Set<string>` in `jsx-to-ir.ts`),
+ * `collectLoopBoundNames` (`adapters/loop-bound-names.ts`),
+ * `resolveStaticLoopSource`'s `isNameShadowed` callback
+ * (`static-literal.ts`), and others — each reimplementing the same
+ * item/index/destructure/preamble-local bookkeeping with its own bugs and
+ * its own blind spots. This module is the single door those mechanisms
+ * migrate onto in later stages (Stage 0 only ships the service + tests;
+ * NO call site is migrated yet).
+ *
+ * Immutability is the point, not an incidental style choice:
+ * `ctx.loopParams` is `.add`/`.delete`-mutated as `jsx-to-ir.ts` walks in
+ * and back out of nested loops, so a caller that forgets (or races) a
+ * `.delete()` — or that holds a reference to the "current" set across a
+ * push/pop it didn't expect — silently observes the WRONG scope. A
+ * restore-bug of that shape is impossible by construction here:
+ * `enterLoopRow`/`enterCallback` never mutate `this`, they return a NEW
+ * `BindingScope` whose parent is untouched, so holding an old reference
+ * always sees the scope as it was, and there is no delete step to forget.
+ *
+ * Filter/sort callback params (`.filter(x => ...)`, `.sort((a, b) => ...)`,
+ * a nested arrow) are bound as `'callback'` frames via `enterCallback` —
+ * never folded into a `'loop-row'` frame's bindings. They are a distinct
+ * scope-introduction shape (an inner function's own parameter list, not a
+ * row's item/index/destructure/preamble names) even though both end up
+ * "just names you can't resolve against component-level state."
+ */
+
+/** How a name inside a `ScopeFrame` came to be bound. */
+export type RowBindingSource = 'item' | 'index' | 'destructure' | 'preamble' | 'param'
+
+export interface RowBinding {
+  readonly source: RowBindingSource
+}
+
+export interface ScopeFrame {
+  readonly kind: 'loop-row' | 'callback'
+  readonly bindings: ReadonlyMap<string, RowBinding>
+}
+
+/**
+ * Structural pick satisfied by BOTH `IRLoop` (`packages/jsx/src/types.ts`)
+ * and the client-JS `LoopCore` family (`packages/jsx/src/ir-to-client-js/types.ts`)
+ * without importing either — this module stays dependency-free and cannot
+ * form an import cycle with `types.ts` / `ir-to-client-js`.
+ */
+export interface LoopBindingSource {
+  readonly param: string
+  readonly index?: string | null
+  readonly paramBindings?: readonly { readonly name: string }[]
+  readonly preamble?: { readonly declaredNames: readonly string[] } | null
+}
+
+/**
+ * A stack of `ScopeFrame`s, innermost frame at index 0 of the internal
+ * array (i.e. `frames[0]` is what `enterLoopRow`/`enterCallback` most
+ * recently pushed). `lookup`'s `depth` counts from `frames[0]`, so depth 0
+ * always means "the innermost frame," independent of how many ancestor
+ * frames exist.
+ */
+export class BindingScope {
+  static readonly EMPTY: BindingScope = new BindingScope([])
+
+  private constructor(private readonly frames: readonly ScopeFrame[]) {}
+
+  /**
+   * Child scope with a new `'loop-row'` frame for one loop's per-item
+   * bindings. Parent (`this`) is not mutated; the returned scope is a
+   * NEW object with `frames = [newFrame, ...this.frames]`.
+   *
+   * Binding semantics mirror `jsx-to-ir.ts`'s `ctx.loopParams` add site
+   * EXACTLY (verified against lines ~4320-4345 and the matching delete
+   * site ~4695-4710 of `packages/jsx/src/jsx-to-ir.ts`):
+   *
+   *   - When `loop.paramBindings` is non-empty (a destructured callback
+   *     param, e.g. `.map(({ id, name }) => ...)`), each `paramBindings[i].name`
+   *     is bound with source `'destructure'` and the raw `param` text
+   *     (which for a destructured callback holds the ORIGINAL pattern
+   *     source, e.g. `"{ id, name }"`, not a usable identifier) is NOT
+   *     bound. This matches `jsx-to-ir.ts`:
+   *       `if (paramBindings) { for (const b of paramBindings) ctx.loopParams.add(b.name) }`
+   *     — the `else` branch (`ctx.loopParams.add(param)`) is skipped
+   *     entirely when `paramBindings` is present.
+   *   - Otherwise (a plain identifier param, e.g. `.map(item => ...)`),
+   *     `param` itself is bound with source `'item'`.
+   *   - `index` (the second callback param, e.g. `.map((item, i) => ...)`)
+   *     is bound with source `'index'` when non-null/non-undefined.
+   *   - Every name in `preamble.declaredNames` (a `.map()` callback's
+   *     pre-return `const`/`let`/`function` locals, #2447) is bound with
+   *     source `'preamble'`.
+   *
+   *   NOTE on a sibling mechanism this method does NOT mirror:
+   *   `adapters/loop-bound-names.ts`'s `collectLoopBoundNames` adds BOTH
+   *   `node.param` AND every `paramBindings[i].name` unconditionally
+   *   (never skipping `param` in the destructured case) — a deliberately
+   *   coarser, over-inclusive collection used only to subtract names from
+   *   a flat string-typing Set (safe to over-exclude there). This method
+   *   follows the precise `jsx-to-ir.ts` `ctx.loopParams` semantics, since
+   *   that is the mechanism actually doing scope-shadowed name RESOLUTION
+   *   (the behavior `BindingScope` replaces), not coarse exclusion.
+   */
+  enterLoopRow(loop: LoopBindingSource): BindingScope {
+    const bindings = new Map<string, RowBinding>()
+    if (loop.paramBindings && loop.paramBindings.length > 0) {
+      for (const b of loop.paramBindings) bindings.set(b.name, { source: 'destructure' })
+    } else {
+      bindings.set(loop.param, { source: 'item' })
+    }
+    if (loop.index) bindings.set(loop.index, { source: 'index' })
+    for (const name of loop.preamble?.declaredNames ?? []) bindings.set(name, { source: 'preamble' })
+
+    const frame: ScopeFrame = { kind: 'loop-row', bindings }
+    return new BindingScope([frame, ...this.frames])
+  }
+
+  /**
+   * Child scope with a new `'callback'` frame binding `params` (a filter
+   * predicate's `x`, a sort comparator's `(a, b)`, or a nested arrow's
+   * parameter list) with source `'param'`. Parent is not mutated.
+   */
+  enterCallback(params: readonly string[]): BindingScope {
+    const bindings = new Map<string, RowBinding>()
+    for (const name of params) bindings.set(name, { source: 'param' })
+    const frame: ScopeFrame = { kind: 'callback', bindings }
+    return new BindingScope([frame, ...this.frames])
+  }
+
+  /** Innermost-first membership check across every frame in the stack. */
+  isBound(name: string): boolean {
+    for (const frame of this.frames) {
+      if (frame.bindings.has(name)) return true
+    }
+    return false
+  }
+
+  /**
+   * Resolves `name` against the frame stack innermost-first. `depth 0`
+   * means the innermost (most recently entered) frame; `null` when `name`
+   * is not bound in any frame.
+   */
+  lookup(name: string): { readonly depth: number; readonly frame: ScopeFrame; readonly binding: RowBinding } | null {
+    for (let depth = 0; depth < this.frames.length; depth++) {
+      const frame = this.frames[depth]
+      const binding = frame.bindings.get(name)
+      if (binding) return { depth, frame, binding }
+    }
+    return null
+  }
+
+  /**
+   * Union of every frame's bound names, for migration interop with
+   * legacy `Set<string>`-shaped consumers (e.g. `collectLoopBoundNames`'s
+   * return type) as later stages migrate them onto `BindingScope`.
+   */
+  boundNames(): ReadonlySet<string> {
+    const names = new Set<string>()
+    for (const frame of this.frames) {
+      for (const name of frame.bindings.keys()) names.add(name)
+    }
+    return names
+  }
+
+  /**
+   * Drop-in for `resolveStaticLoopSource`'s `opts.isNameShadowed`
+   * (`packages/jsx/src/static-literal.ts:112-128`).
+   */
+  asShadowPredicate(): (name: string) => boolean {
+    return (name: string) => this.isBound(name)
+  }
+}

--- a/packages/jsx/src/scope/binding-scope.ts
+++ b/packages/jsx/src/scope/binding-scope.ts
@@ -29,16 +29,21 @@
  * "just names you can't resolve against component-level state."
  */
 
-/** How a name inside a `ScopeFrame` came to be bound. */
-export type RowBindingSource = 'item' | 'index' | 'destructure' | 'preamble' | 'param'
+/**
+ * How a name inside a `ScopeFrame` came to be bound — the row shapes
+ * (`'item'`/`'index'`/`'destructure'`/`'preamble'`) for `'loop-row'` frames,
+ * `'param'` for `'callback'` frames. One shared type because both frame
+ * kinds carry the same binding metadata.
+ */
+export type ScopeBindingSource = 'item' | 'index' | 'destructure' | 'preamble' | 'param'
 
-export interface RowBinding {
-  readonly source: RowBindingSource
+export interface ScopeBinding {
+  readonly source: ScopeBindingSource
 }
 
 export interface ScopeFrame {
   readonly kind: 'loop-row' | 'callback'
-  readonly bindings: ReadonlyMap<string, RowBinding>
+  readonly bindings: ReadonlyMap<string, ScopeBinding>
 }
 
 /**
@@ -103,13 +108,13 @@ export class BindingScope {
    *   (the behavior `BindingScope` replaces), not coarse exclusion.
    */
   enterLoopRow(loop: LoopBindingSource): BindingScope {
-    const bindings = new Map<string, RowBinding>()
+    const bindings = new Map<string, ScopeBinding>()
     if (loop.paramBindings && loop.paramBindings.length > 0) {
       for (const b of loop.paramBindings) bindings.set(b.name, { source: 'destructure' })
     } else {
       bindings.set(loop.param, { source: 'item' })
     }
-    if (loop.index) bindings.set(loop.index, { source: 'index' })
+    if (loop.index != null) bindings.set(loop.index, { source: 'index' })
     for (const name of loop.preamble?.declaredNames ?? []) bindings.set(name, { source: 'preamble' })
 
     const frame: ScopeFrame = { kind: 'loop-row', bindings }
@@ -122,7 +127,7 @@ export class BindingScope {
    * parameter list) with source `'param'`. Parent is not mutated.
    */
   enterCallback(params: readonly string[]): BindingScope {
-    const bindings = new Map<string, RowBinding>()
+    const bindings = new Map<string, ScopeBinding>()
     for (const name of params) bindings.set(name, { source: 'param' })
     const frame: ScopeFrame = { kind: 'callback', bindings }
     return new BindingScope([frame, ...this.frames])
@@ -141,7 +146,7 @@ export class BindingScope {
    * means the innermost (most recently entered) frame; `null` when `name`
    * is not bound in any frame.
    */
-  lookup(name: string): { readonly depth: number; readonly frame: ScopeFrame; readonly binding: RowBinding } | null {
+  lookup(name: string): { readonly depth: number; readonly frame: ScopeFrame; readonly binding: ScopeBinding } | null {
     for (let depth = 0; depth < this.frames.length; depth++) {
       const frame = this.frames[depth]
       const binding = frame.bindings.get(name)


### PR DESCRIPTION
**Stage 0 of #2482 Option A** (design recorded in https://github.com/piconic-ai/barefootjs/issues/2482#issuecomment-5224483715). Service + tests only — **no call site is migrated yet**; Stages 1–4 follow as stacked PRs.

## Summary

Introduces `packages/jsx/src/scope/binding-scope.ts`: ONE immutable, stack-shaped model of "names bound by a loop callback," replacing (over the coming stages) the six independently-implemented ad-hoc mechanisms that answer this question today — `ctx.loopParams`, `html-template.ts`'s `opts.loopBoundNames`, `csr-substitute.ts`'s `boundStack`, the per-adapter coarse `staticLoopSourceBoundNames` + live ref-counted `loopBoundNames` pair, erb/mojo's unified map, and go's `loopParamStack`.

Key semantics (each pinned by a unit test):

- **One canonical extractor**: a `'loop-row'` frame = item param (or destructured `paramBindings` names — the raw pattern text is NOT bound, exactly mirroring `jsx-to-ir.ts`'s `ctx.loopParams` add/delete sites) ∪ index ∪ preamble `declaredNames`. The doc comment records the deliberate divergence from `collectLoopBoundNames`' coarser over-inclusive collection.
- **Filter/sort/nested-arrow params are `'callback'` frames**, never row bindings — a distinction the ad-hoc code conflates.
- **Immutability kills the restore-bug class**: `enterLoopRow`/`enterCallback` return child scopes; there is no `delete`/ref-count/`inLoop` restore to forget (#2487's bug shape), and nested loops reusing a param name can't corrupt the outer scope (`ctx.loopParams`' latent flat-`Set.delete` hazard — pinned by test).
- `lookup()` reports frame depth (innermost = 0) so Go's `{{range}}` dot-rebinding ordering needs are servable; `asShadowPredicate()` is a drop-in for `resolveStaticLoopSource.isNameShadowed`.

## Ratchet

`binding-scope-ratchet.test.ts` pins the EXACT per-file occurrence counts of the five legacy patterns (`localConstants.find(` 19, `staticLoopSourceBoundNames` 45, `loopBoundNames` 107, `loopParamStack` 36, `loopParams` 88) across `packages/jsx/src` and every `packages/adapter-*/src`. Any count above its ledger entry fails with a pointer to `BindingScope`; any count below fails until the ledger is shrunk — the inventory stays live and may only shrink (same discipline as `map-body-no-silent-divergence`'s known-hole set).

## Verification

- New tests: 10 pass / 0 fail (ratchet run twice for stability).
- Full `packages/jsx` suite in the worktree: 2943 pass / 6 fail — 5 reproduce identically on unmodified `origin/main` in this environment (`primitive-resolver-all` ×3 / `primitive-resolver-alias` ×2, the resolver-migration checker-path family), the 6th is a load-flake timeout that passes in isolation; none touch loop-scope bookkeeping.
- `bunx biome check` clean on changed files.

Refs #2482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_