### PR TITLE
refactor(jsx): migrate ctx.loopParams onto BindingScope; bind preamble locals into scope (#2482 stage 1a)

### DIFF
--- a/.changeset/binding-scope-2482-stage1a.md
+++ b/.changeset/binding-scope-2482-stage1a.md
@@ -1,0 +1,5 @@
+---
+'@barefootjs/jsx': patch
+---
+
+Migrate the compiler's loop-callback scope tracking onto `BindingScope` (#2482 stage 1a) and bind `.map()` preamble locals into the scope, so a preamble-declared local shadowing a same-named module/component constant is no longer const-folded into every row. Adds `BindingScope.valueBoundNames()` for reactivity/slot classifiers.

--- a/packages/jsx/src/__tests__/binding-scope-preamble-shadowing.test.ts
+++ b/packages/jsx/src/__tests__/binding-scope-preamble-shadowing.test.ts
@@ -1,0 +1,115 @@
+/**
+ * #2482 Stage 1a Commit 2 — `ctx.scope` (`BindingScope`) must see a
+ * `.map()` callback's preamble-declared locals BEFORE the return
+ * expression's own child expressions are transformed, not only after
+ * (jsx-to-ir.ts's `transformMapCall` discovers the full structured
+ * `MapCallbackPreamble` well after `transformNode(returnExpr, ctx)` has
+ * already run for several body shapes — see the ordering comment ahead of
+ * the `returnStmt` pre-scan in `transformMapCall`).
+ *
+ * Without binding the preamble names early, a preamble-declared local
+ * shadowing a same-named module-level const gets const-folded by
+ * `tryResolveIdentifierAsTemplateLiteral` (`className={label}` here, the
+ * cva-style "identifier bound to a template literal" resolution) into the
+ * OUTER module value — baking one hard-coded value into every row instead
+ * of leaving the per-row local unresolved. Same bug class as #2222
+ * (loop-param shadowing), one level later: the shadowing name here is
+ * preamble-declared, not the callback's own item/index parameter.
+ *
+ * Modeled on `csr-template-loop-shadowing.test.ts` (the item/index-param
+ * shadowing pins) and `ir-const-resolution.test.ts`'s "function-scope
+ * const shadows a same-named module-level const" case (the non-loop
+ * shadowing pin this test is the loop-preamble analogue of).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import type { IRNode, IRElement, AttrValue } from '../types'
+
+const adapter = new TestAdapter()
+
+function compileToIR(source: string) {
+  const result = compileJSX(source, 'demo.tsx', { adapter, outputIR: true })
+  expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
+  const ir = result.files.find(f => f.type === 'ir')!
+  return JSON.parse(ir.content)
+}
+
+/** Walk the IR tree (including loop/conditional composites) for the first `class` attr. */
+function findClassValue(node: IRNode): AttrValue | null {
+  if (node.type === 'element') {
+    const el = node as IRElement
+    for (const attr of el.attrs) {
+      if (attr.name === 'class') return attr.value
+    }
+  }
+  const anyNode = node as IRNode & {
+    children?: IRNode[]
+    consequent?: IRNode
+    alternate?: IRNode
+    whenTrue?: IRNode
+    whenFalse?: IRNode
+  }
+  if (anyNode.children) {
+    for (const c of anyNode.children) {
+      const v = findClassValue(c)
+      if (v !== null) return v
+    }
+  }
+  if (anyNode.consequent) {
+    const v = findClassValue(anyNode.consequent)
+    if (v !== null) return v
+  }
+  if (anyNode.alternate) {
+    const v = findClassValue(anyNode.alternate)
+    if (v !== null) return v
+  }
+  if (anyNode.whenTrue) {
+    const v = findClassValue(anyNode.whenTrue)
+    if (v !== null) return v
+  }
+  if (anyNode.whenFalse) {
+    const v = findClassValue(anyNode.whenFalse)
+    if (v !== null) return v
+  }
+  return null
+}
+
+describe('BindingScope sees preamble locals before the return expression transforms (#2482)', () => {
+  test('a .map() preamble const shadowing a module-level template-literal const stays unresolved (row-local)', () => {
+    const ir = compileToIR(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+const label = \`row-MODULE\`
+
+export function Widget({ items }: { items: string[] }) {
+  const [n, setN] = createSignal(0)
+  return (
+    <div onClick={() => setN(n() + 1)}>
+      <ul>
+        {items.map((item) => {
+          const label = \`row-\${item}\`
+          return <li key={item} className={label}>{item}</li>
+        })}
+      </ul>
+    </div>
+  )
+}
+`)
+    const v = findClassValue(ir.root)
+    expect(v).not.toBeNull()
+    // The row-local `label` must survive as a bare expression reference —
+    // NOT get const-folded into the module-level `label`'s literal value.
+    expect(v!.kind).toBe('expression')
+    expect((v as Extract<AttrValue, { kind: 'expression' }>).expr).toBe('label')
+    if (v!.kind === 'template') {
+      // Negative assertion in case a future change routes this through the
+      // template-parts path instead: the module value must never appear.
+      const parts = (v as Extract<AttrValue, { kind: 'template' }>).parts
+      const concat = parts.map(p => (p.type === 'string' ? p.value : '')).join('')
+      expect(concat).not.toContain('MODULE')
+    }
+  })
+})

--- a/packages/jsx/src/__tests__/binding-scope-ratchet.test.ts
+++ b/packages/jsx/src/__tests__/binding-scope-ratchet.test.ts
@@ -95,8 +95,7 @@ const ALLOWLIST: Record<string, Partial<Record<Pattern, number>>> = {
   'packages/jsx/src/ir-to-client-js/html-template.ts': { loopBoundNames: 3, loopParams: 16 },
   'packages/jsx/src/ir-to-client-js/prop-handling.ts': { 'localConstants.find(': 2 },
   'packages/jsx/src/ir-to-client-js/utils.ts': { loopParams: 3 },
-  'packages/jsx/src/jsx-to-ir.ts': { loopParams: 33 },
-  'packages/jsx/src/prop-rewrite.ts': { loopParams: 1 },
+  'packages/jsx/src/jsx-to-ir.ts': { loopParams: 1 },
 }
 
 const SCOPE_MODULE_DIR = join(REPO_ROOT, 'packages', 'jsx', 'src', 'scope')

--- a/packages/jsx/src/__tests__/binding-scope.test.ts
+++ b/packages/jsx/src/__tests__/binding-scope.test.ts
@@ -137,4 +137,64 @@ describe('BindingScope', () => {
       expect(shadowed(n)).toBe(scope.isBound(n))
     }
   })
+
+  describe('valueBoundNames (#2482 Stage 1a Commit 2)', () => {
+    test('excludes preamble names that boundNames() includes', () => {
+      const scope = BindingScope.EMPTY.enterLoopRow({
+        param: 'item',
+        index: 'i',
+        preamble: { declaredNames: ['label', 'out'] },
+      })
+
+      // Shadow-guard query: sees everything, including preamble locals.
+      const all = scope.boundNames()
+      expect(all.has('item')).toBe(true)
+      expect(all.has('i')).toBe(true)
+      expect(all.has('label')).toBe(true)
+      expect(all.has('out')).toBe(true)
+      expect(all.size).toBe(4)
+
+      // Reactivity/slotId query: item/index/destructure only.
+      const values = scope.valueBoundNames()
+      expect(values.has('item')).toBe(true)
+      expect(values.has('i')).toBe(true)
+      expect(values.has('label')).toBe(false)
+      expect(values.has('out')).toBe(false)
+      expect(values.size).toBe(2)
+    })
+
+    test('destructured bindings count as value bindings', () => {
+      const scope = BindingScope.EMPTY.enterLoopRow({
+        param: '{ id, name }',
+        index: null,
+        paramBindings: [{ name: 'id' }, { name: 'name' }],
+        preamble: { declaredNames: ['formatted'] },
+      })
+
+      const values = scope.valueBoundNames()
+      expect(values.has('id')).toBe(true)
+      expect(values.has('name')).toBe(true)
+      expect(values.has('formatted')).toBe(false)
+      expect(values.size).toBe(2)
+    })
+
+    test('excludes enterCallback param-sourced names too', () => {
+      // A filter/sort/nested-arrow frame's own parameters are a distinct
+      // binding shape from a loop row's item/index/destructure names
+      // (see the class doc comment) — valueBoundNames() must not surface
+      // them either, only boundNames() does.
+      const scope = BindingScope.EMPTY
+        .enterLoopRow({ param: 'item', index: null })
+        .enterCallback(['a', 'b'])
+
+      expect(scope.boundNames().has('a')).toBe(true)
+      expect(scope.valueBoundNames().has('a')).toBe(false)
+      expect(scope.valueBoundNames().has('item')).toBe(true)
+    })
+
+    test('EMPTY scope: both queries return an empty set', () => {
+      expect(BindingScope.EMPTY.boundNames().size).toBe(0)
+      expect(BindingScope.EMPTY.valueBoundNames().size).toBe(0)
+    })
+  })
 })

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -840,9 +840,10 @@ function makeBindingEnv(ctx: TransformContext): BindingEnvironment {
     localFunctions: a.localFunctions,
     imports: a.imports,
     ambientGlobals: a.ambientGlobals,
-    // `valueBoundNames()` already returns a fresh Set per call — a stable
+    // `valueBoundNames()` returns a per-instance set that is never
+    // mutated (cached on the immutable `BindingScope`) — a stable
     // snapshot even if `ctx.scope` is later reassigned by an enclosing
-    // visitor frame.
+    // visitor frame, which swaps the instance rather than mutating it.
     loopParams: boundNames,
     checker: a.checker,
   }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -140,8 +140,9 @@ interface TransformContext {
   /**
    * Memoized free-refs binding environment. Built lazily by
    * `makeBindingEnv` and reused across every `resolveFreeRefs` call as
-   * long as `scope`'s bound names are unchanged. Invalidated by serializing
-   * `scope.boundNames()` into `_bindingEnvLoopKey` and comparing on read.
+   * long as `scope`'s bound VALUE names are unchanged. Invalidated by
+   * serializing `scope.valueBoundNames()` into `_bindingEnvLoopKey` and
+   * comparing on read.
    */
   _bindingEnv?: BindingEnvironment
   _bindingEnvLoopKey?: string
@@ -532,16 +533,21 @@ function rewriteBarePropRefs(text: string, expr: ts.Node, ctx: TransformContext)
   let propNames = getDestructuredPropNames(ctx)
   if (!propNames) return dateLowered === text ? undefined : dateLowered
   // #2222: a name bound as an enclosing loop callback's item/index param
-  // refers to the loop binding, not the prop, at THIS transform position —
-  // `ctx.scope` is the live loop-binding stack (destructured binding
-  // names and the index included), maintained by `transformMapCall` as it
-  // enters/leaves each callback, so this guard is scope-accurate rather
-  // than the coarse whole-component exclusion the SSR adapters use
-  // (#2221). Filter into a fresh set — `getDestructuredPropNames` caches
-  // its set on ctx and must not be mutated.
-  const boundNames = ctx.scope.boundNames()
-  if (boundNames.size > 0) {
-    const filtered = new Set([...propNames].filter(n => !boundNames.has(n)))
+  // (or, during the return-expression transform window, a preamble-
+  // declared local — #2482 Stage 1a Commit 2 re-enters `ctx.scope` with
+  // the preamble for that window) refers to the loop binding, not the
+  // prop, at THIS transform position — maintained by `transformMapCall`
+  // as it enters/leaves each callback, so this guard is scope-accurate
+  // rather than the coarse whole-component exclusion the SSR adapters use
+  // (#2221). This is a SHADOW-GUARD query — every `ScopeBindingSource`
+  // qualifies, so it reads all-sources `boundNames()`, not
+  // `valueBoundNames()` (see that method's doc comment on
+  // `BindingScope` for the two-consumer-classes split). Filter into a
+  // fresh set — `getDestructuredPropNames` caches its set on ctx and must
+  // not be mutated.
+  const shadowingNames = ctx.scope.boundNames()
+  if (shadowingNames.size > 0) {
+    const filtered = new Set([...propNames].filter(n => !shadowingNames.has(n)))
     if (filtered.size === 0) return dateLowered === text ? undefined : dateLowered
     propNames = filtered
   }
@@ -799,21 +805,24 @@ function generateSpreadSlotId(ctx: TransformContext): string {
 /**
  * Build the binding environment for `resolveFreeRefs` from the current
  * transform context. The analyzer's collected bindings (signals, memos,
- * props, locals, imports) plus the active loop-bound names form the
- * resolution frame; the TypeChecker, when available, is forwarded so
- * library getters carrying the Reactive<T> brand are recognised.
+ * props, locals, imports) plus the active loop-bound VALUE names (item/
+ * index/destructure — see `BindingScope.valueBoundNames`'s doc comment
+ * for why preamble locals are excluded here, #2482 Stage 1a Commit 2)
+ * form the resolution frame; the TypeChecker, when available, is
+ * forwarded so library getters carrying the Reactive<T> brand are
+ * recognised.
  *
  * Memoized on `ctx`: the returned env is identity-stable as long as
- * `ctx.scope`'s bound names are unchanged, which keeps the `WeakMap`-keyed
- * binding-table cache in `free-refs.ts` warm across every expression in
- * the same loop scope. `ctx.scope` is REASSIGNED (never mutated) as the
- * visitor enters / leaves `.map()` callbacks (#2482 Stage 1a), so we
- * serialize its bound names into a key rather than relying on object
- * identity — a sibling loop at the same nesting level would otherwise get
- * a spurious cache miss/hit mismatch across restores.
+ * `ctx.scope`'s bound VALUE names are unchanged, which keeps the
+ * `WeakMap`-keyed binding-table cache in `free-refs.ts` warm across every
+ * expression in the same loop scope. `ctx.scope` is REASSIGNED (never
+ * mutated) as the visitor enters / leaves `.map()` callbacks (#2482 Stage
+ * 1a), so we serialize its bound names into a key rather than relying on
+ * object identity — a sibling loop at the same nesting level would
+ * otherwise get a spurious cache miss/hit mismatch across restores.
  */
 function makeBindingEnv(ctx: TransformContext): BindingEnvironment {
-  const boundNames = ctx.scope.boundNames()
+  const boundNames = ctx.scope.valueBoundNames()
   const loopKey = boundNames.size === 0
     ? ''
     : Array.from(boundNames).sort().join('\0')
@@ -831,7 +840,7 @@ function makeBindingEnv(ctx: TransformContext): BindingEnvironment {
     localFunctions: a.localFunctions,
     imports: a.imports,
     ambientGlobals: a.ambientGlobals,
-    // `boundNames()` already returns a fresh Set per call — a stable
+    // `valueBoundNames()` already returns a fresh Set per call — a stable
     // snapshot even if `ctx.scope` is later reassigned by an enclosing
     // visitor frame.
     loopParams: boundNames,
@@ -2181,10 +2190,17 @@ function transformExpressionInner(
   const reactive = isReactiveExpression(exprText, ctx, expr) || isReactiveOrigin(origin)
   // @client expressions always need slotId and are treated as reactive for client-side evaluation
   // Expressions inside loops that reference the loop parameter need slotId
-  // so fine-grained effects can target them for per-item signal updates
-  const scopeBoundNames = ctx.scope.boundNames()
-  const refsLoopParam = scopeBoundNames.size > 0
-    && Array.from(scopeBoundNames).some(p => new RegExp(`\\b${p}\\b`).test(exprText))
+  // so fine-grained effects can target them for per-item signal updates.
+  // REACTIVITY/slotId classifier — value bindings only (item/index/
+  // destructure), NOT preamble locals: those already get their own
+  // dedicated slot/region-patch machinery (#2447), so folding them in
+  // here would double-allocate and (via `hasDynamicContent` reading this
+  // same `reactive`-adjacent signal) move an unrelated row-root slotId
+  // decision — see `BindingScope.valueBoundNames`'s doc comment
+  // (#2482 Stage 1a Commit 2).
+  const scopeValueNames = ctx.scope.valueBoundNames()
+  const refsLoopParam = scopeValueNames.size > 0
+    && Array.from(scopeValueNames).some(p => new RegExp(`\\b${p}\\b`).test(exprText))
 
   // Compute AST-derived flags. `callsReactive` recognises signal-getter / memo
   // calls even inside deeper expressions (e.g., `format(count())`); `hasCalls`
@@ -4034,8 +4050,13 @@ function transformMapCall(
   method: 'map' | 'flatMap' = 'map'
 ): IRLoop | null {
   // Capture nesting depth before we register this map's own params.
-  // ctx.scope is populated by the *outer* map; if any names are bound we are inside one.
-  const isNested = ctx.scope.boundNames().size > 0
+  // ctx.scope is populated by the *outer* map; if any VALUE names (item/
+  // index/destructure) are bound we are inside one. Reads
+  // `valueBoundNames()`, not `boundNames()`, for consistency with the
+  // other structural/reactivity consumers (#2482 Stage 1a Commit 2) —
+  // though a bound outer-loop row always carries at least one value
+  // binding regardless, so this can't actually change the answer.
+  const isNested = ctx.scope.valueBoundNames().size > 0
   // Diagnostic count at entry — the structural net at the scalar fallthrough
   // de-dups against refusals fired DURING this call (leaf-wiring, DSL gates),
   // never against unrelated diagnostics recorded before it.
@@ -4472,6 +4493,51 @@ function transformMapCall(
             (s): s is ts.ReturnStatement => ts.isReturnStatement(s) && s.expression != null
           )
         : undefined
+
+      // #2482 Stage 1a Commit 2 — ordering note: the STRUCTURED preamble
+      // (`MapCallbackPreamble`, built further down by
+      // `preambleFromValueStatements` / `buildPreambleSegments`, whichever
+      // branch below the return-expression shape takes) isn't known until
+      // well AFTER this point. But `transformNode(returnExpr, ctx)` just
+      // below walks the return expression's own child expressions RIGHT
+      // NOW — before that happens — so a preamble-declared local shadowing
+      // an outer const/prop must already be bound in `ctx.scope`, or
+      // `tryResolveTemplateSpanFromConst` / `tryResolveIdentifierAsTemplateLiteral`
+      // / `rewriteBarePropRefs` bake the OUTER value into every row instead
+      // of leaving the row-local unresolved (#2222-family, the const/prop-
+      // shadow bug class). Fix: a lightweight declared-names-only pre-scan
+      // — the exact same "statements before the return" shape
+      // `preambleFromValueStatements`/`buildPreambleSegments` scan below —
+      // re-enters the row's `BindingScope` frame (off `savedScope`, the
+      // pre-loop parent, so this REPLACES the param/index-only frame
+      // rather than stacking a second one) with the preamble included, for
+      // the duration of the return-expression transform. Restored back to
+      // the preamble-less row scope right after that window closes (see
+      // `rowScopeBeforePreamble` below) — everything past this window
+      // (the flatMap fallbacks, and the whole rest of `transformMapCall`
+      // after this `if (ts.isBlock(body))` branch) must keep observing
+      // EXACTLY the old (Commit 1) membership, since slotId-allocation
+      // classifiers there read `ctx.scope.valueBoundNames()`, which never
+      // included preamble names to begin with — only shadow guards need
+      // the widened view, and only for this window.
+      let rowScopeBeforePreamble: BindingScope | null = null
+      if (returnStmt) {
+        const preambleNames = new Set<string>()
+        for (const stmt of body.statements) {
+          if (stmt === returnStmt) break
+          collectPreambleDeclaredNames(stmt, preambleNames)
+        }
+        if (preambleNames.size > 0) {
+          rowScopeBeforePreamble = ctx.scope
+          ctx.scope = savedScope.enterLoopRow({
+            param,
+            index,
+            paramBindings,
+            preamble: { declaredNames: [...preambleNames] },
+          })
+        }
+      }
+
       if (returnStmt && returnStmt.expression) {
         let returnExpr = returnStmt.expression
         while (ts.isParenthesizedExpression(returnExpr)) {
@@ -4628,6 +4694,14 @@ function transformMapCall(
             }
           }
         }
+      }
+
+      // Window closed — restore the preamble-less row scope so every
+      // consumer past this point (the flatMap fallbacks immediately
+      // below, and the rest of `transformMapCall` after this branch)
+      // keeps observing EXACTLY the pre-rework membership.
+      if (rowScopeBeforePreamble) {
+        ctx.scope = rowScopeBeforePreamble
       }
 
       // flatMap block body fallback: compile JSX inline when children
@@ -6144,9 +6218,13 @@ function tryResolveTemplateSpanFromConst(
   // ${IDENT}
   if (ts.isIdentifier(expr)) {
     // #2222-family: inside a loop callback the name may be the loop's
-    // item/index binding shadowing a same-named const — resolving the
-    // const would bake the outer value into every row. Fall back to
-    // the bare-expression path, which sees the loop binding.
+    // item/index/preamble binding shadowing a same-named const —
+    // resolving the const would bake the outer value into every row.
+    // Fall back to the bare-expression path, which sees the loop
+    // binding. SHADOW-GUARD query — `isBound` (all sources), not
+    // `valueBoundNames()` — see `BindingScope.valueBoundNames`'s doc
+    // comment for the two-consumer-classes split (#2482 Stage 1a
+    // Commit 2).
     if (ctx.scope.isBound(expr.text)) return null
     const constInfo = findLocalConst(expr.text, ctx.analyzer)
     if (!constInfo) return null
@@ -6337,7 +6415,11 @@ function tryResolveIdentifierAsTemplateLiteral(
   // value into EVERY adapter's output (e.g. `key={label}` inside
   // `.map((label) => ...)` becoming a constant duplicate key).
   // `ctx.scope` is the live loop-binding stack (destructured binding
-  // names and index included), so the guard is scope-accurate.
+  // names and index included — plus, during the return-expression
+  // transform window, the preamble's declared names once
+  // `transformMapCall` re-enters the row scope with them, #2482 Stage 1a
+  // Commit 2), so the guard is scope-accurate. This is a SHADOW-GUARD
+  // query — reads `isBound` (all sources), not `valueBoundNames()`.
   if (ctx.scope.isBound(ident.text)) return null
   const constInfo = findLocalConst(ident.text, ctx.analyzer)
   if (!constInfo) return null
@@ -7012,9 +7094,13 @@ function isSignalOrMemoArray(array: string, ctx: TransformContext): boolean {
  * Used by conditional transforms to assign slotId for per-item signal reactivity.
  * NOT added to isReactiveExpression to avoid promoting text expressions
  * like {item.name} to reactive (they use a separate slotId path).
+ *
+ * REACTIVITY/slotId classifier — reads `valueBoundNames()` (item/index/
+ * destructure only), NOT preamble locals; see `BindingScope.valueBoundNames`'s
+ * doc comment (#2482 Stage 1a Commit 2).
  */
 function referencesLoopParam(expr: string, ctx: TransformContext): boolean {
-  const boundNames = ctx.scope.boundNames()
+  const boundNames = ctx.scope.valueBoundNames()
   if (boundNames.size === 0) return false
   for (const p of boundNames) {
     if (new RegExp(`\\b${p}\\b`).test(expr)) return true
@@ -7140,11 +7226,17 @@ function hasReactiveAttributes(attrs: IRAttribute[], ctx: TransformContext): boo
     if (isSignalOrMemoReference(valueToCheck, ctx) || isPropsReference(valueToCheck, ctx)) {
       return true
     }
-    // Check if attribute references any active loop-bound names —
-    // loop root elements need a slotId so className can be updated reactively.
-    const scopeBoundNames = ctx.scope.boundNames()
-    if (scopeBoundNames.size > 0) {
-      for (const p of scopeBoundNames) {
+    // Check if attribute references any active loop-bound VALUE names —
+    // loop root elements need a slotId so className can be updated
+    // reactively. REACTIVITY/slotId classifier — value bindings only
+    // (item/index/destructure), not preamble locals; see
+    // `BindingScope.valueBoundNames`'s doc comment (#2482 Stage 1a
+    // Commit 2) — this is the exact check whose over-widening flipped
+    // the `tag-cloud`/`preamble-cells` conformance fixtures before the
+    // source-filtered query existed.
+    const scopeValueNames = ctx.scope.valueBoundNames()
+    if (scopeValueNames.size > 0) {
+      for (const p of scopeValueNames) {
         if (new RegExp(`\\b${p}\\b`).test(valueToCheck)) return true
       }
     }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -62,6 +62,7 @@ import { iterateJsTokens, replaceInExprContexts } from './scanner/js-scanner.ts'
 import { reconstructAsSegments } from './strip-types.ts'
 import { templatePartsToJsExpr } from './template-parts.ts'
 import { toHTMLAttrName, decodeEntities } from '@barefootjs/shared'
+import { BindingScope } from './scope/binding-scope.ts'
 
 // =============================================================================
 // Transform Context
@@ -102,12 +103,18 @@ interface TransformContext {
    * `_p.<local>` (#2524 CSR half: `_p` is always caller-keyed).
    */
   _destructuredPropAliases?: Map<string, string> | null
-  /** Active loop parameter names for slotId assignment to loop-param-dependent expressions */
-  loopParams: Set<string>
+  /**
+   * The active `.map()`/callback binding stack (#2482 Stage 1a) — replaces
+   * the former mutable per-name `Set<string>` mutated in lockstep with
+   * `transformMapCall` entry/exit. `enterLoopRow`/`enterCallback` return a
+   * NEW `BindingScope`; restoring the saved parent reference on exit is
+   * the whole mechanism (no `.delete()` bookkeeping to get wrong).
+   */
+  scope: BindingScope
   /**
    * Count of enclosing `.map()` loops (0 = outermost), incremented/
    * decremented in lockstep with entering/leaving `transformMapCall`.
-   * Unlike `loopParams` (a name Set that can gain several entries for
+   * Unlike `scope` (a binding stack that can gain several bound names for
    * ONE loop level via destructuring), this is a plain per-level
    * counter — the single source of truth `IRLoop.depth` is stamped
    * from, so every adapter's `data-key`/`data-key-N` suffix derives
@@ -133,8 +140,8 @@ interface TransformContext {
   /**
    * Memoized free-refs binding environment. Built lazily by
    * `makeBindingEnv` and reused across every `resolveFreeRefs` call as
-   * long as `loopParams` content is unchanged. Invalidated by serializing
-   * `loopParams` into `_bindingEnvLoopKey` and comparing on read.
+   * long as `scope`'s bound names are unchanged. Invalidated by serializing
+   * `scope.boundNames()` into `_bindingEnvLoopKey` and comparing on read.
    */
   _bindingEnv?: BindingEnvironment
   _bindingEnvLoopKey?: string
@@ -526,14 +533,15 @@ function rewriteBarePropRefs(text: string, expr: ts.Node, ctx: TransformContext)
   if (!propNames) return dateLowered === text ? undefined : dateLowered
   // #2222: a name bound as an enclosing loop callback's item/index param
   // refers to the loop binding, not the prop, at THIS transform position —
-  // `ctx.loopParams` is the live loop-param set (destructured binding
+  // `ctx.scope` is the live loop-binding stack (destructured binding
   // names and the index included), maintained by `transformMapCall` as it
   // enters/leaves each callback, so this guard is scope-accurate rather
   // than the coarse whole-component exclusion the SSR adapters use
   // (#2221). Filter into a fresh set — `getDestructuredPropNames` caches
   // its set on ctx and must not be mutated.
-  if (ctx.loopParams.size > 0) {
-    const filtered = new Set([...propNames].filter(n => !ctx.loopParams.has(n)))
+  const boundNames = ctx.scope.boundNames()
+  if (boundNames.size > 0) {
+    const filtered = new Set([...propNames].filter(n => !boundNames.has(n)))
     if (filtered.size === 0) return dateLowered === text ? undefined : dateLowered
     propNames = filtered
   }
@@ -662,7 +670,7 @@ function createTransformContext(analyzer: AnalyzerContext): TransformContext {
     spreadIdCounter: 0,
     isRoot: true,
     insideComponentChildren: false,
-    loopParams: new Set(),
+    scope: BindingScope.EMPTY,
     loopDepth: 0,
     patterns: {
       signals: analyzer.signals.map(s => ({
@@ -791,21 +799,24 @@ function generateSpreadSlotId(ctx: TransformContext): string {
 /**
  * Build the binding environment for `resolveFreeRefs` from the current
  * transform context. The analyzer's collected bindings (signals, memos,
- * props, locals, imports) plus the active loop params form the resolution
- * frame; the TypeChecker, when available, is forwarded so library getters
- * carrying the Reactive<T> brand are recognised.
+ * props, locals, imports) plus the active loop-bound names form the
+ * resolution frame; the TypeChecker, when available, is forwarded so
+ * library getters carrying the Reactive<T> brand are recognised.
  *
  * Memoized on `ctx`: the returned env is identity-stable as long as
- * `loopParams` content is unchanged, which keeps the `WeakMap`-keyed
+ * `ctx.scope`'s bound names are unchanged, which keeps the `WeakMap`-keyed
  * binding-table cache in `free-refs.ts` warm across every expression in
- * the same loop scope. `loopParams` is `.add`/`.delete`-mutated as the
- * visitor enters / leaves `.map()` callbacks, so we serialize its
- * contents into a key rather than relying on Set identity.
+ * the same loop scope. `ctx.scope` is REASSIGNED (never mutated) as the
+ * visitor enters / leaves `.map()` callbacks (#2482 Stage 1a), so we
+ * serialize its bound names into a key rather than relying on object
+ * identity — a sibling loop at the same nesting level would otherwise get
+ * a spurious cache miss/hit mismatch across restores.
  */
 function makeBindingEnv(ctx: TransformContext): BindingEnvironment {
-  const loopKey = ctx.loopParams.size === 0
+  const boundNames = ctx.scope.boundNames()
+  const loopKey = boundNames.size === 0
     ? ''
-    : Array.from(ctx.loopParams).sort().join('\0')
+    : Array.from(boundNames).sort().join('\0')
   if (ctx._bindingEnv && ctx._bindingEnvLoopKey === loopKey) {
     return ctx._bindingEnv
   }
@@ -820,9 +831,10 @@ function makeBindingEnv(ctx: TransformContext): BindingEnvironment {
     localFunctions: a.localFunctions,
     imports: a.imports,
     ambientGlobals: a.ambientGlobals,
-    // Snapshot — the env must observe a stable view even if `ctx.loopParams`
-    // is later mutated by an enclosing visitor frame.
-    loopParams: new Set(ctx.loopParams),
+    // `boundNames()` already returns a fresh Set per call — a stable
+    // snapshot even if `ctx.scope` is later reassigned by an enclosing
+    // visitor frame.
+    loopParams: boundNames,
     checker: a.checker,
   }
   ctx._bindingEnv = env
@@ -2170,8 +2182,9 @@ function transformExpressionInner(
   // @client expressions always need slotId and are treated as reactive for client-side evaluation
   // Expressions inside loops that reference the loop parameter need slotId
   // so fine-grained effects can target them for per-item signal updates
-  const refsLoopParam = ctx.loopParams.size > 0
-    && Array.from(ctx.loopParams).some(p => new RegExp(`\\b${p}\\b`).test(exprText))
+  const scopeBoundNames = ctx.scope.boundNames()
+  const refsLoopParam = scopeBoundNames.size > 0
+    && Array.from(scopeBoundNames).some(p => new RegExp(`\\b${p}\\b`).test(exprText))
 
   // Compute AST-derived flags. `callsReactive` recognises signal-getter / memo
   // calls even inside deeper expressions (e.g., `format(count())`); `hasCalls`
@@ -4021,8 +4034,8 @@ function transformMapCall(
   method: 'map' | 'flatMap' = 'map'
 ): IRLoop | null {
   // Capture nesting depth before we register this map's own params.
-  // ctx.loopParams is populated by the *outer* map; if non-empty we are inside one.
-  const isNested = ctx.loopParams.size > 0
+  // ctx.scope is populated by the *outer* map; if any names are bound we are inside one.
+  const isNested = ctx.scope.boundNames().size > 0
   // Diagnostic count at entry — the structural net at the scalar fallthrough
   // de-dups against refusals fired DURING this call (leaf-wiring, DSL gates),
   // never against unrelated diagnostics recorded before it.
@@ -4322,17 +4335,17 @@ function transformMapCall(
       }
     }
 
-    // Register loop params so expressions referencing them get slotId.
-    // For destructured patterns, register the individual binding names —
-    // `\b${param}\b` never matches a bare name like `cfg` when `param` is
-    // `[, cfg]`, which would otherwise leave reactive-expression detection
-    // silently broken for destructured callbacks.
-    if (paramBindings) {
-      for (const b of paramBindings) ctx.loopParams.add(b.name)
-    } else {
-      ctx.loopParams.add(param)
-    }
-    if (index) ctx.loopParams.add(index)
+    // Register loop-bound names so expressions referencing them get slotId,
+    // by entering a new BindingScope frame for this row (#2482 Stage 1a).
+    // For destructured patterns, the frame binds the individual binding
+    // names — `\b${param}\b` never matches a bare name like `cfg` when
+    // `param` is `[, cfg]`, which would otherwise leave reactive-expression
+    // detection silently broken for destructured callbacks.
+    // `savedScope` is restored (not deleted-from) at the matching exit site
+    // below, so a nested loop reusing a param name can never corrupt the
+    // outer scope.
+    const savedScope = ctx.scope
+    ctx.scope = ctx.scope.enterLoopRow({ param, index, paramBindings })
     ctx.loopDepth++
 
     // Logical control flow (`cond && <X/>`, `a ?? themeLogo()`) as the map
@@ -4697,13 +4710,10 @@ function transformMapCall(
       )
     }
 
-    // Unregister loop params
-    if (paramBindings) {
-      for (const b of paramBindings) ctx.loopParams.delete(b.name)
-    } else {
-      ctx.loopParams.delete(param)
-    }
-    if (index) ctx.loopParams.delete(index)
+    // Restore the parent scope — the BindingScope twin of the old
+    // "unregister loop params" delete block, but by reference rather than
+    // by name, so it can never miss an entry the add-site added.
+    ctx.scope = savedScope
     ctx.loopDepth--
   }
 
@@ -6137,7 +6147,7 @@ function tryResolveTemplateSpanFromConst(
     // item/index binding shadowing a same-named const — resolving the
     // const would bake the outer value into every row. Fall back to
     // the bare-expression path, which sees the loop binding.
-    if (ctx.loopParams.has(expr.text)) return null
+    if (ctx.scope.isBound(expr.text)) return null
     const constInfo = findLocalConst(expr.text, ctx.analyzer)
     if (!constInfo) return null
     const ast = parseConstInitializer(constInfo)
@@ -6154,7 +6164,7 @@ function tryResolveTemplateSpanFromConst(
     // Same loop-shadowing guard as the ${IDENT} arm: `tone[k]` inside
     // `items.map((tone) => …)` must read the row's `tone`, not a
     // same-named module/component record const.
-    if (ctx.loopParams.has(expr.expression.text)) return null
+    if (ctx.scope.isBound(expr.expression.text)) return null
     const constInfo = findLocalConst(expr.expression.text, ctx.analyzer)
     if (!constInfo) return null
     const ast = parseConstInitializer(constInfo)
@@ -6326,9 +6336,9 @@ function tryResolveIdentifierAsTemplateLiteral(
   // outer const's literal into the IR here bakes the same hard-coded
   // value into EVERY adapter's output (e.g. `key={label}` inside
   // `.map((label) => ...)` becoming a constant duplicate key).
-  // `ctx.loopParams` is the live loop-param set (destructured binding
+  // `ctx.scope` is the live loop-binding stack (destructured binding
   // names and index included), so the guard is scope-accurate.
-  if (ctx.loopParams.has(ident.text)) return null
+  if (ctx.scope.isBound(ident.text)) return null
   const constInfo = findLocalConst(ident.text, ctx.analyzer)
   if (!constInfo) return null
   const ast = parseConstInitializer(constInfo)
@@ -7004,8 +7014,9 @@ function isSignalOrMemoArray(array: string, ctx: TransformContext): boolean {
  * like {item.name} to reactive (they use a separate slotId path).
  */
 function referencesLoopParam(expr: string, ctx: TransformContext): boolean {
-  if (ctx.loopParams.size === 0) return false
-  for (const p of ctx.loopParams) {
+  const boundNames = ctx.scope.boundNames()
+  if (boundNames.size === 0) return false
+  for (const p of boundNames) {
     if (new RegExp(`\\b${p}\\b`).test(expr)) return true
   }
   return false
@@ -7129,10 +7140,11 @@ function hasReactiveAttributes(attrs: IRAttribute[], ctx: TransformContext): boo
     if (isSignalOrMemoReference(valueToCheck, ctx) || isPropsReference(valueToCheck, ctx)) {
       return true
     }
-    // Check if attribute references any active loop parameters —
+    // Check if attribute references any active loop-bound names —
     // loop root elements need a slotId so className can be updated reactively.
-    if (ctx.loopParams.size > 0) {
-      for (const p of ctx.loopParams) {
+    const scopeBoundNames = ctx.scope.boundNames()
+    if (scopeBoundNames.size > 0) {
+      for (const p of scopeBoundNames) {
         if (new RegExp(`\\b${p}\\b`).test(valueToCheck)) return true
       }
     }

--- a/packages/jsx/src/prop-rewrite.ts
+++ b/packages/jsx/src/prop-rewrite.ts
@@ -14,7 +14,7 @@
  * stack, so `items.map((title) => title.a)` never turns into the
  * syntactically invalid `.map((_p.title) => _p.title.a)` when `title`
  * is also a prop. (Names bound by loop callbacks that ENCLOSE the
- * expression are the caller's job — see the `ctx.loopParams` filter in
+ * expression are the caller's job — see the `ctx.scope` filter in
  * `jsx-to-ir.ts`'s `rewriteBarePropRefs` wrapper, #2222.)
  */
 

--- a/packages/jsx/src/scope/binding-scope.ts
+++ b/packages/jsx/src/scope/binding-scope.ts
@@ -165,12 +165,21 @@ export class BindingScope {
    * other consumer class and why the two must not be conflated.
    */
   boundNames(): ReadonlySet<string> {
+    if (this.boundNamesCache) return this.boundNamesCache
     const names = new Set<string>()
     for (const frame of this.frames) {
       for (const name of frame.bindings.keys()) names.add(name)
     }
+    this.boundNamesCache = names
     return names
   }
+
+  // Both name queries are hot (shadow guards, slot/reactivity classifiers,
+  // binding-env memo keying) and the scope is immutable, so each computes
+  // once per instance. Callers receive the cached set as ReadonlySet —
+  // never mutate it.
+  private boundNamesCache: ReadonlySet<string> | undefined
+  private valueBoundNamesCache: ReadonlySet<string> | undefined
 
   /**
    * Union of names bound via `'item'`/`'index'`/`'destructure'` sources
@@ -206,6 +215,7 @@ export class BindingScope {
    *     These call `valueBoundNames()`.
    */
   valueBoundNames(): ReadonlySet<string> {
+    if (this.valueBoundNamesCache) return this.valueBoundNamesCache
     const names = new Set<string>()
     for (const frame of this.frames) {
       for (const [name, binding] of frame.bindings) {
@@ -214,6 +224,7 @@ export class BindingScope {
         }
       }
     }
+    this.valueBoundNamesCache = names
     return names
   }
 

--- a/packages/jsx/src/scope/binding-scope.ts
+++ b/packages/jsx/src/scope/binding-scope.ts
@@ -156,14 +156,63 @@ export class BindingScope {
   }
 
   /**
-   * Union of every frame's bound names, for migration interop with
-   * legacy `Set<string>`-shaped consumers (e.g. `collectLoopBoundNames`'s
-   * return type) as later stages migrate them onto `BindingScope`.
+   * Union of every frame's bound names (every `ScopeBindingSource`), for
+   * migration interop with legacy `Set<string>`-shaped consumers (e.g.
+   * `collectLoopBoundNames`'s return type) as later stages migrate them
+   * onto `BindingScope`.
+   *
+   * This is the SHADOW-GUARD query — see {@link valueBoundNames} for the
+   * other consumer class and why the two must not be conflated.
    */
   boundNames(): ReadonlySet<string> {
     const names = new Set<string>()
     for (const frame of this.frames) {
       for (const name of frame.bindings.keys()) names.add(name)
+    }
+    return names
+  }
+
+  /**
+   * Union of names bound via `'item'`/`'index'`/`'destructure'` sources
+   * only — the loop row's own per-item identity — excluding `'preamble'`
+   * (a `.map()` callback's pre-return `const`/`let`/`function` locals,
+   * #2447) and `'param'` (an `enterCallback` frame's filter/sort/nested-
+   * arrow parameters).
+   *
+   * `BindingScope` has exactly two consumer classes, and conflating them
+   * is the #2482 Stage 1a Commit 2 regression this split exists to
+   * prevent (a `ctx.scope`-wide preamble merge flipped `tag-cloud` and
+   * `preamble-cells` conformance fixtures before this method existed):
+   *
+   *   - SHADOW GUARDS (`tryResolveTemplateSpanFromConst`,
+   *     `tryResolveIdentifierAsTemplateLiteral`, `rewriteBarePropRefs`
+   *     in `jsx-to-ir.ts`) ask "is this name resolved to SOMETHING in
+   *     this scope, so an outer const/prop of the same name must not be
+   *     substituted here at this transform position" — every source
+   *     qualifies, including a preamble local shadowing a module const.
+   *     These call `isBound` / `boundNames()`.
+   *   - REACTIVITY / SLOT-ID CLASSIFIERS (`referencesLoopParam`,
+   *     `hasReactiveAttributes`, and the `BindingEnvironment.loopParams`
+   *     feed built from `makeBindingEnv`, all in `jsx-to-ir.ts`) ask
+   *     "does this expression read a value that changes per row and so
+   *     needs its own patchable slot" — a preamble local already gets
+   *     ITS OWN dedicated slot/region-patch machinery
+   *     (`preambleRegions` / `markPreambleAttrSlots`, #2447), so folding
+   *     it into this classification double-counts it. Worse: widening a
+   *     text child's `reactive` flag this way is read by
+   *     `hasDynamicContent` to decide whether the loop ROW's own root
+   *     element needs a slot — an unrelated, narrower decision that must
+   *     not move just because a preamble local is now scope-visible.
+   *     These call `valueBoundNames()`.
+   */
+  valueBoundNames(): ReadonlySet<string> {
+    const names = new Set<string>()
+    for (const frame of this.frames) {
+      for (const [name, binding] of frame.bindings) {
+        if (binding.source === 'item' || binding.source === 'index' || binding.source === 'destructure') {
+          names.add(name)
+        }
+      }
     }
     return names
   }


### PR DESCRIPTION
**Stage 1a of #2482 Option A** (design: https://github.com/piconic-ai/barefootjs/issues/2482#issuecomment-5224483715; Stage 0 = #2585, merged). Two commits, separately verifiable.

## Commit 1 — mechanical swap, zero behavior change

`TransformContext.loopParams: Set<string>` → `scope: BindingScope`. Loop entry/exit becomes `ctx.scope = ctx.scope.enterLoopRow(...)` / restore-by-reference — the flat-`Set.delete` hazard (nested loops reusing a param name clearing the still-active outer binding) is now impossible by construction. All readers switched (`.has` → `isBound`, set-shaped consumers → `boundNames()`, `makeBindingEnv`'s memo cache key kept correct). Ratchet ledger: `jsx-to-ir.ts` 33 → 1 (the remaining hit is `free-refs.ts`'s `BindingEnvironment.loopParams` field name, later stage), `prop-rewrite.ts` 1 → 0.

## Commit 2 — preamble locals join the scope (behavior fix, pinned)

`transformMapCall` transforms the return expression BEFORE the structured `MapCallbackPreamble` exists, so a preamble-declared local shadowing a same-named module/component const was still const-folded — every row baked the frozen module value (#2222-family, one binding layer deeper). A non-side-effecting pre-scan of the leading statements now re-enters the row `BindingScope` frame WITH the preamble for the return-transform window. Regression test red-without/green-with.

**Design finding encoded in the service**: shadow-fold guards and reactivity/slotId classifiers need *different* membership from the same scope. Folding preamble names into the classifiers' view flips `tag-cloud`/`preamble-cells` fixtures (preamble locals already have their own slot machinery, #2447). New `BindingScope.valueBoundNames()` (`'item' | 'index' | 'destructure'` only) serves the classifiers; all-sources `isBound`/`boundNames()` serves the three shadow guards. Every pre-existing consumer keeps exactly its prior membership by construction.

**Deferred (diagnosed, not shipped)**: scope-guarding the `isSignalOrMemoReference`/`isPropsReference` regex classifiers flips the `loop-param-shadows-outer-name` fixture — the #2222-era over-broad classification is inadvertently the only thing tripping `hasDynamicContent`'s row-root slot decision for rows whose sole dynamic content is loop-item text. Guard and compensation must be removed together in a later stage; full diagnosis in the commit message.

## Verification

- `bun test packages/jsx`: 2949 pass / 5 fail — the 5 are the `primitive-resolver-*` environment failures, identical on unmodified `main` in this container.
- `bun test packages/adapter-tests` (twice): 1882 pass / 9 fail — the 9 are the Carousel missing-build-artifact environment failures, identical on unmodified `main`. **Zero conformance-fixture divergence.**
- Ratchet ledger green at the shrunken counts; `binding-scope.test.ts` grows 4 `valueBoundNames()` cases.

Refs #2482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_