### PR TITLE
fix(compiler): preserve explicit let type annotations in emitted templates

### DIFF
--- a/.changeset/let-type-annotations-2589.md
+++ b/.changeset/let-type-annotations-2589.md
@@ -1,0 +1,5 @@
+---
+'@barefootjs/jsx': patch
+---
+
+Preserve explicit `let` type annotations in emitted `.tsx` templates (function scope and module scope), fixing TS7034/TS7005/TS2339-on-`never` under strict (#2589).

--- a/packages/jsx/src/__tests__/let-type-annotation.test.ts
+++ b/packages/jsx/src/__tests__/let-type-annotation.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Regression test for #2589: a `let` declaration's explicit type
+ * annotation was dropped in emitted `.tsx` SSR templates —
+ * `let x: HTMLTextAreaElement | null = null` emitted as `let x = null`,
+ * which TypeScript then infers as `null`/`never`, producing
+ * TS7034/TS7005 (and TS2339 via `never` narrowing) under strict mode.
+ * Runtime output (client JS) was always correct — this is a type-level
+ * emission defect in the SSR template only.
+ *
+ * `ConstantInfo.typeAnnotation` (verbatim `node.type.getText()`, only
+ * present when the author wrote an explicit annotation) is now threaded
+ * through and printed by the `HonoAdapter` (`JsxAdapter` base) for `let`
+ * declarations, both function-scope and module-scope, initialized and
+ * uninitialized. `const` declarations are deliberately left unchanged:
+ * their type always infers correctly from the (immutable) initializer,
+ * so emitting an annotation there would only churn output for no
+ * typecheck gain (see the design note in the class docstring / #2589).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
+
+describe('let type annotation preservation in emitted templates (#2589)', () => {
+  test('function-scope initialized let keeps its explicit type annotation', () => {
+    const honoAdapter = new HonoAdapter()
+    // `status()` is called directly from the returned JSX (unlike an
+    // `onXxx` event-handler prop, which the SSR template stubs to a
+    // no-op), so its body — and transitively `textareaEl`, which the
+    // effect-guard shape (`syncScroll`, mirroring the issue) also reads —
+    // stays reachable and survives into the emitted template.
+    const source = `
+      'use client'
+      import { createSignal, createEffect } from '@barefootjs/client'
+
+      export function Textarea() {
+        let textareaEl: HTMLTextAreaElement | null = null
+        const [value, setValue] = createSignal('')
+
+        const syncScroll = () => {
+          if (textareaEl) {
+            textareaEl.scrollTop = textareaEl.scrollHeight
+          }
+        }
+
+        const status = () => (textareaEl ? 'ready' : 'idle')
+
+        createEffect(() => {
+          value()
+          syncScroll()
+        })
+
+        return <div>{status()}</div>
+      }
+    `
+
+    const result = compileJSX(source, 'Textarea.tsx', { adapter: honoAdapter })
+    expect(result.errors).toHaveLength(0)
+
+    const template = result.files.find((f) => f.type === 'markedTemplate')!
+    expect(template).toBeDefined()
+    expect(template.content).toContain('let textareaEl: HTMLTextAreaElement | null = null')
+  })
+
+  test('module-scope initialized let keeps its explicit type annotation', () => {
+    const honoAdapter = new HonoAdapter()
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      let exportModulePromise: Promise<{ x: number }> | null = null
+
+      export function Loader() {
+        const [status, setStatus] = createSignal('idle')
+
+        const load = () => {
+          exportModulePromise = Promise.resolve({ x: 1 })
+          setStatus('loaded')
+        }
+
+        return <button onClick={load}>{status()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Loader.tsx', { adapter: honoAdapter })
+    expect(result.errors).toHaveLength(0)
+
+    const template = result.files.find((f) => f.type === 'markedTemplate')!
+    expect(template).toBeDefined()
+    expect(template.content).toContain(
+      'let exportModulePromise: Promise<{ x: number }> | null = null',
+    )
+  })
+
+  test('module-scope uninitialized let keeps its explicit type annotation', () => {
+    const honoAdapter = new HonoAdapter()
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      let pending: number
+
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+
+        const bump = () => {
+          pending = count() + 1
+          setCount(pending)
+        }
+
+        return <button onClick={bump}>{count()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter: honoAdapter })
+    expect(result.errors).toHaveLength(0)
+
+    const template = result.files.find((f) => f.type === 'markedTemplate')!
+    expect(template).toBeDefined()
+    expect(template.content).toContain('let pending: number')
+  })
+
+  test('unannotated let does NOT gain an inferred type annotation', () => {
+    const honoAdapter = new HonoAdapter()
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Toggle() {
+        let y = null
+        const [open, setOpen] = createSignal(false)
+
+        const flip = () => {
+          y = open() ? 1 : null
+          setOpen(!open())
+        }
+
+        return <button onClick={flip}>{open() ? 'on' : 'off'}{String(y)}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Toggle.tsx', { adapter: honoAdapter })
+    expect(result.errors).toHaveLength(0)
+
+    const template = result.files.find((f) => f.type === 'markedTemplate')!
+    expect(template).toBeDefined()
+    // No annotation must be synthesized from inference — only an
+    // explicit source annotation is ever printed (`typeAnnotation`,
+    // never `type` for an initialized declaration).
+    expect(template.content).toContain('let y = null')
+    expect(template.content).not.toMatch(/let y\s*:/)
+  })
+
+  test('const with an explicit annotation is unchanged (no annotation added at emit)', () => {
+    const honoAdapter = new HonoAdapter()
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Labelled() {
+        const label: string = 'hello'
+        const [count, setCount] = createSignal(0)
+        return <button onClick={() => setCount(count() + 1)}>{label}{count()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Labelled.tsx', { adapter: honoAdapter })
+    expect(result.errors).toHaveLength(0)
+
+    const template = result.files.find((f) => f.type === 'markedTemplate')!
+    expect(template).toBeDefined()
+    // By design (#2589 scoping decision) only `let` gets its annotation
+    // re-emitted — `const` infers correctly from its initializer already,
+    // so this stays `const label = 'hello'` with no annotation added.
+    expect(template.content).toContain("const label = 'hello'")
+    expect(template.content).not.toContain('const label: string')
+  })
+})

--- a/packages/jsx/src/__tests__/let-type-annotation.test.ts
+++ b/packages/jsx/src/__tests__/let-type-annotation.test.ts
@@ -175,4 +175,34 @@ describe('let type annotation preservation in emitted templates (#2589)', () => 
     expect(template.content).toContain("const label = 'hello'")
     expect(template.content).not.toContain('const label: string')
   })
+
+  test('ambient `declare let` is not re-emitted as a runtime binding', () => {
+    const honoAdapter = new HonoAdapter()
+    // `declare let` is a type-only contract: it has no initializer and
+    // carries NodeFlags.Let, so after the uninitialized-`let` collection
+    // fix it would match the module-scope collector unless ambient
+    // statements are excluded. Re-emitting it as a runtime `let` would
+    // shadow the real global with `undefined` in the SSR module.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      declare let __BF_AMBIENT__: string
+
+      export function Widget() {
+        const [n, setN] = createSignal(0)
+        const status = () => (__BF_AMBIENT__ ? 'set' : 'unset')
+        return <button onClick={() => setN(n() + 1)}>{status()}{n()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Widget.tsx', { adapter: honoAdapter })
+    expect(result.errors).toHaveLength(0)
+
+    const template = result.files.find((f) => f.type === 'markedTemplate')!
+    expect(template).toBeDefined()
+    // The reference inside `status` may survive, but no runtime `let`
+    // declaration for the ambient name may be emitted.
+    expect(template.content).not.toMatch(/^\s*let __BF_AMBIENT__/m)
+  })
 })

--- a/packages/jsx/src/adapters/jsx-adapter.ts
+++ b/packages/jsx/src/adapters/jsx-adapter.ts
@@ -197,7 +197,10 @@ export abstract class JsxAdapter extends BaseAdapter {
         // No initializer (e.g. `let emblaApi: EmblaCarouselType | undefined`)
         // — carry the declared type annotation through so `.tsx` output
         // doesn't fall back to implicit `any` (TS7034/TS7005, #2573).
-        const typeAnnotation = preserveTypes && constant.type ? `: ${constant.type.raw}` : ''
+        const typeAnnotation =
+          preserveTypes && (constant.typeAnnotation ?? constant.type)
+            ? `: ${constant.typeAnnotation ?? constant.type?.raw}`
+            : ''
         lines.push(`  ${keyword} ${constant.name}${typeAnnotation}`)
         continue
       }
@@ -213,7 +216,17 @@ export abstract class JsxAdapter extends BaseAdapter {
       const constValue = preserveTypes
         ? (constant.typedValue ?? constant.value)
         : constant.value
-      lines.push(`  ${keyword} ${constant.name} = ${constValue}`)
+      // Preserve an explicit `let` type annotation from source (#2589) —
+      // without it, TS infers the initializer's (often narrower) type and
+      // later reassignments/reads fail under strict (TS7034/TS7005, and
+      // TS2339 via `never` narrowing). `const` is left alone: its type
+      // always infers correctly from the (immutable) initializer, so
+      // adding annotations there would only churn snapshots.
+      const letTypeAnnotation =
+        preserveTypes && keyword === 'let' && constant.typeAnnotation
+          ? `: ${constant.typeAnnotation}`
+          : ''
+      lines.push(`  ${keyword} ${constant.name}${letTypeAnnotation} = ${constValue}`)
     }
 
     // Include local functions — skip unreachable ones (only used in event
@@ -412,14 +425,29 @@ export abstract class JsxAdapter extends BaseAdapter {
       const keyword = c.declarationKind ?? 'const'
       const exportKw = c.isExported ? 'export ' : ''
       if (!c.value) {
-        entries.push({ line: c.loc.start.line, text: `${exportKw}${keyword} ${c.name}` })
+        // No initializer (e.g. module-scope `let pending: number`) — carry
+        // the declared type annotation through, mirroring the function-scope
+        // fix above (#2573 / #2589).
+        const typeAnnotation =
+          preserveTypes && (c.typeAnnotation ?? c.type)
+            ? `: ${c.typeAnnotation ?? c.type?.raw}`
+            : ''
+        entries.push({ line: c.loc.start.line, text: `${exportKw}${keyword} ${c.name}${typeAnnotation}` })
         continue
       }
       const trimmed = c.value.trim()
       if (/^new WeakMap\b/.test(trimmed)) continue
       if (c.isExported && /^createContext\b/.test(trimmed)) continue
       const value = preserveTypes ? (c.typedValue ?? c.value) : c.value
-      entries.push({ line: c.loc.start.line, text: `${exportKw}${keyword} ${c.name} = ${value}` })
+      // Preserve an explicit module-scope `let` type annotation from source
+      // (#2589) — see the function-scope sibling above for rationale. `const`
+      // is left alone: its type always infers correctly from the (immutable)
+      // initializer.
+      const letTypeAnnotation =
+        preserveTypes && keyword === 'let' && c.typeAnnotation
+          ? `: ${c.typeAnnotation}`
+          : ''
+      entries.push({ line: c.loc.start.line, text: `${exportKw}${keyword} ${c.name}${letTypeAnnotation} = ${value}` })
     }
 
     for (const f of ir.metadata.localFunctions) {

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -525,9 +525,15 @@ function visit(
         }
         continue
       }
+      // An initializer is required for `const` (TS grammar enforces this),
+      // but an uninitialized module-scope `let` (e.g. `let pending: number`)
+      // is legal source and must still be collected — mirroring the
+      // component-scope path below (line ~687), which has never gated on
+      // `decl.initializer` — so its declared type carries into the emitted
+      // template instead of the declaration vanishing outright (#2589).
       if (
         ts.isIdentifier(decl.name) &&
-        decl.initializer &&
+        (decl.initializer || isLet) &&
         !isArrowComponentFunction(decl)
       ) {
         collectConstant(decl, ctx, true, isLet ? 'let' : 'const', isExported)
@@ -3203,6 +3209,7 @@ function collectConstant(
     value,
     parsed,
     typedValue: typedValue !== value ? typedValue : undefined,
+    typeAnnotation: node.type ? node.type.getText(ctx.sourceFile) : undefined,
     valueBranches,
     declarationKind,
     isExported,

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -504,8 +504,18 @@ function visit(
     collectAmbientGlobals(node, ctx)
   }
 
-  // Module-level constants (outside component)
-  if (ts.isVariableStatement(node) && !ctx.componentNode) {
+  // Module-level constants (outside component). Ambient statements
+  // (`declare let X: T`) are type-only contracts with no runtime binding —
+  // collectAmbientGlobals above already tracks them for BF052, and
+  // re-emitting one as a runtime `let` would shadow the real global, so
+  // they must not reach collectConstant. (Previously excluded only by
+  // accident: this path required an initializer, which `declare`
+  // statements never have — the #2589 uninitialized-`let` fix removed
+  // that gate, so the exclusion is now explicit.)
+  const isDeclareStatement =
+    ts.isVariableStatement(node) &&
+    (node.modifiers?.some(m => m.kind === ts.SyntaxKind.DeclareKeyword) ?? false)
+  if (ts.isVariableStatement(node) && !ctx.componentNode && !isDeclareStatement) {
     const isExported = node.modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
     const isLet = (node.declarationList.flags & ts.NodeFlags.Let) !== 0
     const isModuleClientDirective = hasLeadingClientDirectiveOnStatement(node, ctx.sourceFile)

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1882,6 +1882,14 @@ export interface ConstantInfo {
   parsed?: ParsedExpr
   /** Value with TypeScript type annotations preserved, for .tsx output */
   typedValue?: string
+  /**
+   * The declaration's explicit type annotation, verbatim from source
+   * (`node.type.getText()`), when the author wrote one. Distinct from
+   * `type`, which is also populated by inference from the initializer —
+   * emitters must only print THIS field, never an inferred type, onto a
+   * declaration (#2589).
+   */
+  typeAnnotation?: string
   valueBranches?: string[]
   declarationKind: 'const' | 'let'
   isExported?: boolean


### PR DESCRIPTION
## Summary

A `let` declaration's explicit type annotation was dropped in emitted `.tsx` SSR templates — `let x: HTMLTextAreaElement | null = null` became `let x = null` — so under `strict` the template failed with TS7034/TS7005, plus TS2339 where guard-narrowing collapsed the evolving-`any` to `never`. Both scopes from the issue's koma repro (function-scope `textareaEl`, module-scope `exportModulePromise`). Type-level only; emitted values unchanged.

## Root cause

`ConstantInfo.typedValue` only carries the initializer's text (`node.initializer.getText()`); the declaration's annotation lives on `node.type` and reached emitters only as `ConstantInfo.type` — which is **also populated by inference** from the initializer, so emitters could not safely print it. Four emission gaps in `packages/jsx/src/adapters/jsx-adapter.ts`: function-scope initialized, module-scope initialized, module-scope uninitialized (the module-scope sibling of #2573's function-scope fix), and — found during implementation — the module-level analyzer walk required an initializer, so an uninitialized module-scope `let pending: number` was never collected at all: the whole declaration vanished from the template, not just its type.

## Fix

- New `ConstantInfo.typeAnnotation`: the annotation **verbatim from source** (`node.type.getText()`), set only when the author wrote one — cleanly separated from the inference-populated `type`, so an unannotated `let y = null` can never leak an inferred type into output (pinned by a negative test).
- All four sites emit it under `preserveTypes` for `let` declarations. `const` is deliberately unchanged: its type always infers correctly from the immutable initializer, and annotating it would only churn snapshots (pinned by a negative test).
- Uninitialized branches prefer `typeAnnotation ?? type.raw` for verbatim fidelity (uninitialized declarations have no inference, so `type.raw` remains safe there, as #2573 established).
- Audited the remaining `ConstantInfo` printer (`module-exports.ts`'s `generateModuleExports`): unreachable for typed output (Hono sets `moduleConstantsIncludeExports: true`; the only adapter hitting it has `preserveTypes: false`) — left alone, noted here.

## Verification

- New `let-type-annotation.test.ts`: 5 cases — the issue's two shapes (function-scope `textareaEl` + guard, module-scope `exportModulePromise`), module-scope uninitialized `let pending: number`, and the two negatives (no inferred-type leak; `const` unchanged).
- After building workspace deps for true signal: `packages/jsx` **2954 pass / 0 fail**, `packages/adapter-hono` **1371 pass / 0 fail**, `packages/adapter-tests` **1891 pass / 0 fail**; corpus-typecheck gate green.
- Shared-component snapshot regeneration: **zero diff** — the one comparable existing pattern (accordion's `let nextIndex: number | null = null`) is handler-only and reachability-stripped from SSR templates, so no snapshot exercises the change; the new unit tests are the pins.
- Changeset: `@barefootjs/jsx` patch.

Closes #2589

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_