### PR TITLE
fix(compiler): re-anchor dynamic import() specifiers in emitted templates

### DIFF
--- a/.changeset/dynamic-import-reanchor-2588.md
+++ b/.changeset/dynamic-import-reanchor-2588.md
@@ -1,0 +1,6 @@
+---
+'@barefootjs/jsx': patch
+'@barefootjs/hono': patch
+---
+
+Re-anchor relative specifiers inside dynamic `import()` and `typeof import()` when emitting SSR templates (#2588). Those specifiers ride along inside declaration source text re-emitted verbatim (module-scope consts/functions, a component body's local handlers), so they never reach `metadata.templateImports` and were left pointing at the source file's directory — an unresolvable path once the template lands at a different depth, failing the backend bundler with `Could not resolve "…"`. Adds `rewriteDynamicImportsInSource` (TS AST + span splicing) to `@barefootjs/jsx`, applied by `HonoAdapter` alongside the existing static-import rewrite.

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -31,6 +31,7 @@ import {
   JsxAdapter,
   isBooleanAttr,
   rewriteImportsForTemplate,
+  rewriteDynamicImportsInSource,
   emitIRNode,
   emitAttrValue,
   buildLoopChainExpr,
@@ -195,9 +196,19 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
     // `generateModuleScopeDeclarations`; they join the scan text so a
     // helper referenced only from a hoisted declaration still pulls its
     // import.
-    const component = this.generateComponent(ir)
-    const types = this.generateTypes(ir)
-    const moduleConstants = this.generateModuleScopeDeclarations(ir)
+    // Re-anchor relative specifiers that ride along INSIDE emitted source
+    // text — dynamic `import('./x')` and `typeof import('./x')` — which
+    // never reach `metadata.templateImports` and so are invisible to
+    // `rewriteImportsForTemplate` below (#2588). Applied to every section
+    // that can carry verbatim source: module-scope declarations, the
+    // component body's local handlers, and type declarations.
+    const reanchor = this.rewriteRelativeImport
+    const withRewrittenDynamicImports = <T extends string | null>(text: T): T =>
+      reanchor && text ? (rewriteDynamicImportsInSource(text, reanchor) as T) : text
+
+    const component = withRewrittenDynamicImports(this.generateComponent(ir))
+    const types = withRewrittenDynamicImports(this.generateTypes(ir))
+    const moduleConstants = withRewrittenDynamicImports(this.generateModuleScopeDeclarations(ir))
     const componentCode = [moduleConstants, types, component].filter(Boolean).join('\n')
     const imports = this.generateImports(ir, componentCode)
 

--- a/packages/jsx/src/__tests__/rewrite-dynamic-imports.test.ts
+++ b/packages/jsx/src/__tests__/rewrite-dynamic-imports.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit coverage for `rewriteDynamicImportsInSource` (#2588) — the source-text
+ * counterpart to `rewriteImportsForTemplate`.
+ *
+ * The e2e half lives in `packages/vite/src/__tests__/dynamic-import-rewrite.test.ts`
+ * (real `vite build`, real emitted template). This half pins the cases that
+ * an e2e fixture can't isolate: which AST nodes count, and the false matches
+ * a regex-based implementation would produce. Those false-match cases are
+ * the entire reason this parses (CLAUDE.md: never parse JS/TS with regex) —
+ * without them, a regex rewrite would pass every other assertion here.
+ */
+import { describe, test, expect } from 'bun:test'
+import { rewriteDynamicImportsInSource } from '../adapters/template-imports.ts'
+
+/** Stand-in for `buildRelativeImportRewriter`: shifts one directory deeper. */
+const deeper = (spec: string): string => `../${spec}`
+
+describe('rewriteDynamicImportsInSource', () => {
+  test('rewrites a dynamic import call', () => {
+    expect(rewriteDynamicImportsInSource(`const m = import('./heavy')`, deeper))
+      .toBe(`const m = import('.././heavy')`)
+  })
+
+  test('rewrites an import type node (`typeof import(...)`)', () => {
+    expect(rewriteDynamicImportsInSource(`let p: Promise<typeof import('../lib/x')> | null = null`, deeper))
+      .toBe(`let p: Promise<typeof import('../../lib/x')> | null = null`)
+  })
+
+  test('rewrites a qualified import type (`import(...).Foo`)', () => {
+    expect(rewriteDynamicImportsInSource(`let v: import('../lib/x').Foo`, deeper))
+      .toBe(`let v: import('../../lib/x').Foo`)
+  })
+
+  test('rewrites every occurrence, keeping earlier spans intact', () => {
+    const out = rewriteDynamicImportsInSource(
+      `const a = import('./one'); const b = import('./two'); const c = import('./three')`,
+      deeper,
+    )
+    expect(out).toBe(
+      `const a = import('.././one'); const b = import('.././two'); const c = import('.././three')`,
+    )
+  })
+
+  test('leaves bare specifiers alone', () => {
+    const src = `const m = import('hono/jsx')`
+    expect(rewriteDynamicImportsInSource(src, deeper)).toBe(src)
+  })
+
+  test('leaves a non-literal specifier alone', () => {
+    const src = `const m = import(chunkPath)`
+    expect(rewriteDynamicImportsInSource(src, deeper)).toBe(src)
+  })
+
+  test('leaves static import statements to rewriteImportsForTemplate', () => {
+    // The adapter rewrites those from the parsed `templateImports` list; if
+    // this touched them too they would be rewritten twice.
+    const src = `import { x } from './sibling'`
+    expect(rewriteDynamicImportsInSource(src, deeper)).toBe(src)
+  })
+
+  test('does not touch `import(` inside a string literal', () => {
+    const src = `const code = "const m = import('./heavy')"`
+    expect(rewriteDynamicImportsInSource(src, deeper)).toBe(src)
+  })
+
+  test('does not touch `import(` inside a template literal', () => {
+    const src = 'const code = `await import(\'./heavy\')`'
+    expect(rewriteDynamicImportsInSource(src, deeper)).toBe(src)
+  })
+
+  test('does not touch `import(` inside a comment', () => {
+    const src = `// const m = import('./heavy')\nconst n = 1`
+    expect(rewriteDynamicImportsInSource(src, deeper)).toBe(src)
+  })
+
+  test('rewrites inside a TSX component body without disturbing the JSX', () => {
+    const src = [
+      `export function Lazy() {`,
+      `  const onClick = async () => { await import('./heavy') }`,
+      `  return <button onClick={onClick} data-x="import('./nope')">go</button>`,
+      `}`,
+    ].join('\n')
+    const out = rewriteDynamicImportsInSource(src, deeper)
+    expect(out).toContain(`await import('.././heavy')`)
+    // The attribute string is data, not a module reference.
+    expect(out).toContain(`data-x="import('./nope')"`)
+  })
+
+  test('returns the input unchanged when the rewriter is a no-op', () => {
+    const src = `const m = import('./heavy')`
+    expect(rewriteDynamicImportsInSource(src, (s) => s)).toBe(src)
+  })
+
+  test('returns the input unchanged when there is nothing to rewrite', () => {
+    const src = `export const answer = 42`
+    expect(rewriteDynamicImportsInSource(src, deeper)).toBe(src)
+  })
+})

--- a/packages/jsx/src/adapters/template-imports.ts
+++ b/packages/jsx/src/adapters/template-imports.ts
@@ -16,6 +16,7 @@
  * Adapters are responsible for calling this themselves before emitting any
  * import block. The compiler hands them `metadata.imports` unchanged.
  */
+import ts from 'typescript'
 import type { ImportInfo, ImportSpecifier } from '../types.ts'
 
 const CLIENT_PACKAGE_SOURCES = new Set([
@@ -76,4 +77,96 @@ export function rewriteImportsForTemplate(
 
 function specKey(s: ImportSpecifier): string {
   return `${s.isDefault ? 'd' : ''}${s.isNamespace ? 'n' : ''}:${s.name}:${s.alias ?? ''}`
+}
+
+/**
+ * Re-anchor relative specifiers carried inside emitted SOURCE TEXT — the
+ * counterpart to `rewriteImportsForTemplate`, which only sees the parsed
+ * static import list (`metadata.templateImports`).
+ *
+ * Declaration bodies re-emitted verbatim into a template
+ * (`generateModuleScopeDeclarations`' consts/functions, a component body's
+ * local handlers) can carry their own module references that never appear
+ * in that list:
+ *
+ * - `import('./x')` — a dynamic import expression
+ * - `typeof import('./x')` — an import TYPE node
+ *
+ * Those specifiers are written relative to the SOURCE file, so they break
+ * once the template is emitted to a directory at a different depth — the
+ * same depth shift `rewriteImportsForTemplate` already fixes for static
+ * imports (#1453, #2588).
+ *
+ * Only literal relative paths beginning with `.` are rewritten; bare
+ * specifiers pass through, matching `remap`'s guard above. A non-literal
+ * argument (`import(someVar)`) is left alone — there is no specifier to
+ * re-anchor, and guessing would be worse than leaving the source as-is.
+ *
+ * Parsed with the TS AST and applied by span splicing rather than by
+ * matching text: a regex would false-match `import(` inside a string or a
+ * comment, which is exactly the class of bug the repo-wide "never parse JS
+ * with regex" rule exists to prevent. Splices are applied back-to-front so
+ * earlier spans keep their offsets.
+ */
+export function rewriteDynamicImportsInSource(
+  sourceText: string,
+  rewriteRelative: (importPath: string) => string,
+): string {
+  // Cheap pre-check: skip the parse entirely for the overwhelmingly common
+  // case of text with no dynamic import at all. Substring presence is not
+  // used to LOCATE anything — the AST still does that — so a false positive
+  // here costs one wasted parse and a false negative is impossible.
+  if (!sourceText.includes('import')) return sourceText
+
+  const sf = ts.createSourceFile(
+    'bf-template-fragment.tsx',
+    sourceText,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ false,
+    ts.ScriptKind.TSX,
+  )
+
+  const edits: Array<{ start: number, end: number, text: string }> = []
+
+  const visit = (node: ts.Node): void => {
+    // `import('./x')` — the argument is the first (and only) call argument.
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length > 0 &&
+      ts.isStringLiteralLike(node.arguments[0])
+    ) {
+      collect(node.arguments[0] as ts.StringLiteralLike)
+    }
+    // `typeof import('./x')` / `import('./x').Foo` — a TYPE-position node
+    // whose argument is a literal type wrapping the string.
+    if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument)) {
+      const literal = node.argument.literal
+      if (ts.isStringLiteralLike(literal)) collect(literal)
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  const collect = (literal: ts.StringLiteralLike): void => {
+    const specifier = literal.text
+    if (!specifier.startsWith('.')) return
+    const next = rewriteRelative(specifier)
+    if (next === specifier) return
+    edits.push({
+      start: literal.getStart(sf),
+      end: literal.getEnd(),
+      // Re-quote rather than reusing the original delimiters: a rewritten
+      // POSIX-relative path never contains a quote to escape.
+      text: `'${next}'`,
+    })
+  }
+
+  ts.forEachChild(sf, visit)
+  if (edits.length === 0) return sourceText
+
+  let out = sourceText
+  for (const edit of edits.sort((a, b) => b.start - a.start)) {
+    out = out.slice(0, edit.start) + edit.text + out.slice(edit.end)
+  }
+  return out
 }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -89,7 +89,7 @@ export type {
 } from './adapters/interface.ts'
 export { JsxAdapter } from './adapters/jsx-adapter.ts'
 export type { JsxAdapterConfig } from './adapters/jsx-adapter.ts'
-export { rewriteImportsForTemplate } from './adapters/template-imports.ts'
+export { rewriteImportsForTemplate, rewriteDynamicImportsInSource } from './adapters/template-imports.ts'
 export { emitParsedExpr, groupBinaryOperand, isStringTypedOperand, isStringConcatBinary } from './adapters/parsed-expr-emitter.ts'
 export type { ParsedExprEmitter, HigherOrderMethod, ArrayMethod, SortMethod, LiteralType } from './adapters/parsed-expr-emitter.ts'
 export { collectLoopBoundNames } from './adapters/loop-bound-names.ts'

--- a/packages/vite/e2e-fixture-dynimport/components/Lazy.tsx
+++ b/packages/vite/e2e-fixture-dynimport/components/Lazy.tsx
@@ -1,0 +1,25 @@
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+// Module scope: a lazy loader whose dynamic `import()` reaches a sibling of
+// the `components` dir. Emitted verbatim into the template by
+// `generateModuleScopeDeclarations`.
+let modPromise: Promise<typeof import('../lib/heavy')> | null = null
+const loadHeavy = () => {
+  if (!modPromise) modPromise = import('../lib/heavy')
+  return modPromise
+}
+
+export function Lazy() {
+  const [n, setN] = createSignal(0)
+  // Component scope: the same specifier inside an event handler.
+  const onClick = async () => {
+    const mod = await import('../lib/heavy')
+    setN(mod.heavy())
+  }
+  const onDblClick = async () => {
+    const mod = await loadHeavy()
+    setN(mod.heavy())
+  }
+  return <button onClick={onClick} onDblClick={onDblClick}>{n()}</button>
+}

--- a/packages/vite/e2e-fixture-dynimport/lib/heavy.ts
+++ b/packages/vite/e2e-fixture-dynimport/lib/heavy.ts
@@ -1,0 +1,6 @@
+// Stand-in for an app module that lives OUTSIDE the `components` dir, so a
+// relative specifier reaching it has to be re-anchored when the template is
+// emitted to a directory at a different depth.
+export function heavy(): number {
+  return 42
+}

--- a/packages/vite/src/__tests__/dynamic-import-rewrite.test.ts
+++ b/packages/vite/src/__tests__/dynamic-import-rewrite.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression (#2588): a relative specifier inside a DYNAMIC `import()` must
+ * be re-anchored to the emitted template's directory, exactly like the
+ * static `import` statements `rewriteImportsForTemplate` already handles.
+ *
+ * Dynamic imports never reach `ir.metadata.templateImports` — they ride
+ * along inside declaration source text that the adapter re-emits verbatim
+ * (`generateModuleScopeDeclarations`' consts/functions, and a component
+ * body's local handlers). Before the fix they were emitted untouched, so a
+ * specifier written relative to `components/` still said `../lib/heavy`
+ * once the template landed in `app/dist/components/` — a path that does
+ * not exist. The backend bundler then hard-fails (`Could not resolve
+ * "../lib/heavy"`), so this is a build break, not a type-only defect.
+ *
+ * The fixture mirrors the layout that hits this in the wild (piconic-ai/koma):
+ * a `components` dir and a plain `lib` dir side by side, with templates
+ * emitted to a DEEPER directory — root-relative and template-relative only
+ * diverge when the two depths differ, so a flat layout would not reproduce.
+ * Lives under `packages/vite/` (not a system tmpdir) so `@barefootjs/client`
+ * resolves through the monorepo's real workspace symlinks — same reason
+ * `e2e-fixture`/`e2e-fixture-dev`/`e2e-fixture-relimport` do.
+ */
+import { describe, test, expect, afterAll } from 'bun:test'
+import { build } from 'vite'
+import { mkdtemp, rm, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { HonoAdapter } from '@barefootjs/hono/adapter'
+import { barefoot } from '../plugin.ts'
+
+const FIXTURE_ROOT = resolve(import.meta.dirname, '../../e2e-fixture-dynimport')
+const APP_ROOT = join(FIXTURE_ROOT, 'app')
+const COMPONENTS_DIR = join(FIXTURE_ROOT, 'components')
+
+// `app/dist/components/Lazy.tsx` → up three → the fixture root, where `lib/`
+// sits. The source says `../lib/heavy` from `components/`; the emitted
+// template has to say this instead.
+const REANCHORED = '../../../lib/heavy'
+
+describe('dynamic import() re-anchoring in emitted templates', () => {
+  let outDir: string
+  let templatesDir: string
+
+  afterAll(async () => {
+    await rm(outDir, { recursive: true, force: true })
+    await rm(join(APP_ROOT, 'dist'), { recursive: true, force: true })
+  })
+
+  test('re-anchors dynamic imports at module scope, in type position, and inside a component body', async () => {
+    outDir = await mkdtemp(join(tmpdir(), 'barefoot-vite-dynimport-dist-'))
+    templatesDir = join(APP_ROOT, 'dist/components')
+
+    await build({
+      configFile: false,
+      root: APP_ROOT,
+      base: '/static/',
+      logLevel: 'warn',
+      build: { outDir, emptyOutDir: true },
+      plugins: [
+        barefoot({
+          adapter: new HonoAdapter(),
+          components: [COMPONENTS_DIR],
+          templates: templatesDir,
+        }),
+      ],
+    })
+
+    const template = await readFile(join(templatesDir, 'Lazy.tsx'), 'utf8')
+
+    // Nothing anywhere may still carry the source-relative form. Asserted
+    // first and globally: a per-site check would pass while some fourth
+    // emission path silently leaked the old specifier.
+    expect(template).not.toContain("'../lib/heavy'")
+
+    // Module scope, TYPE position — `typeof import('…')` is an
+    // ImportTypeNode, a different AST node from the call expression below,
+    // and was missed independently.
+    expect(template).toContain(`typeof import('${REANCHORED}')`)
+
+    // Module scope, VALUE position — inside a re-emitted const's body.
+    expect(template).toContain(`modPromise = import('${REANCHORED}')`)
+
+    // Component scope — inside a local handler in the component body,
+    // which is emitted by a different code path than module declarations.
+    expect(template).toContain(`await import('${REANCHORED}')`)
+
+    // The re-anchored path must actually resolve on disk from the emitted
+    // template's own directory — the assertions above only pin the string.
+    const target = resolve(templatesDir, REANCHORED + '.ts')
+    expect(await readFile(target, 'utf8')).toContain('export function heavy')
+  }, 60_000)
+})


### PR DESCRIPTION
Fixes #2588.

## The bug

A relative specifier inside a dynamic `import()` was emitted into the SSR template untouched — still written relative to the **source** file. Once the template lands in a directory at a different depth the path no longer exists, and the backend bundler hard-fails:

```
✘ [ERROR] Could not resolve "../src/export/index"

    dist/components/AppHeader.tsx:21:33:
    21 │     exportModulePromise = import('../src/export/index')
       ╵                                  ~~~~~~~~~~~~~~~~~~~~~
```

This is a build break, not a type-only defect — `wrangler dev` / `wrangler deploy` refuse to start.

## Why the existing rewrite missed it

Static imports have been re-anchored since #1453, but only through `rewriteImportsForTemplate`, which reads the parsed `ir.metadata.templateImports` list. Dynamic imports never appear in that list. They ride along inside declaration **source text** the adapter re-emits verbatim:

- module-scope consts/functions (`generateModuleScopeDeclarations`, #2570)
- a component body's local handlers

The two sites end up inconsistent in the same emitted file — this is from the new fixture, before the fix:

```tsx
import type { Spec } from '../../src/model/types'   // static: re-anchored ../ → ../../
exportModulePromise = import('../src/export/index') // dynamic: untouched
```

`typeof import('…')` is affected the same way and is a **separate AST node** (`ImportTypeNode`, not a call expression), so it was missed independently of the value-position case.

## The fix

Adds `rewriteDynamicImportsInSource` to `@barefootjs/jsx`, applied by `HonoAdapter.generate()` to the module-constants, types, and component sections alongside the existing static-import rewrite.

Parsed with the TS AST and applied by span splicing, per CLAUDE.md's "never parse JS/TS with regex" rule — `import(` inside a string, a template literal, or a comment must not match. That is not hypothetical for this compiler: emitted component bodies routinely carry JSX attribute strings, and a regex would happily rewrite one.

Only literal relative specifiers are rewritten. Bare specifiers and non-literal arguments (`import(chunkPath)`) pass through, matching the guard `rewriteImportsForTemplate` already applies — for a non-literal there is no specifier to re-anchor, and guessing would be worse than leaving the source alone.

## Tests

Both halves land with the fix, per CLAUDE.md's "a reproducible defect lands as a fixture, not a prose report".

**e2e** — `packages/vite/src/__tests__/dynamic-import-rewrite.test.ts` with `packages/vite/e2e-fixture-dynimport/`. A real `vite build` over a layout that mirrors the wild reproduction ([piconic-ai/koma](https://github.com/piconic-ai/koma)): a `components` dir and a plain `lib` dir side by side, templates emitted to a **deeper** directory. Root-relative and template-relative only diverge when the depths differ, so a flat fixture would not reproduce this at all. It asserts all three sites (module-scope value, module-scope type, component body), asserts globally that the old specifier survives nowhere, and then **reads the re-anchored path off disk** so the test pins a working path rather than a matching string.

Verified it fails without the fix:

```
error: expect(received).not.toContain(expected)
(fail) dynamic import() re-anchoring in emitted templates > re-anchors dynamic imports at module scope, in type position, and inside a component body
```

**compiler unit** — `packages/jsx/src/__tests__/rewrite-dynamic-imports.test.ts`, 13 cases covering what an e2e fixture can't isolate: which AST nodes count (call expression, `typeof import()`, qualified `import().Foo`), the pass-through cases, and the false matches a regex implementation would produce. Those false-match cases are the entire reason this parses — without them a regex rewrite would pass every other assertion in the file.

## Suite status

`bun test packages/jsx packages/adapter-hono packages/vite`

| | pass | fail |
|---|---|---|
| before | 4428 | 5 |
| after | 4442 | 5 |

+14 = the 13 new unit tests and the new e2e test. The 5 failures are identical before and after (`ui corpus type-check gate`, two `.map()` body trichotomy cases) — pre-existing on `main`, untouched here.

## Note

While reproducing this I hit one more emitted-template divergence that is **not** in this PR: a `ref` on an intrinsic element is dropped from the template while a `ref` on a child component is kept, so the variable it assigns is declared and read but never written — TS then narrows it to `never` (`TS2339: Property 'scrollTop' does not exist on type 'never'`). It predates the Vite pipeline (reproduces on 0.11.0 under `bf build`). Happy to file it separately with a fixture.
