### PR TITLE
fix(compiler): $-safe identifier reference regexes via shared identifierPattern helper

### DIFF
--- a/.changeset/identifier-pattern-2592.md
+++ b/.changeset/identifier-pattern-2592.md
@@ -1,0 +1,5 @@
+---
+'@barefootjs/jsx': patch
+---
+
+Fix `$`-containing identifiers (`$item`, `count$`, `a$b`) being silently dropped from reactivity/loop-param classification and accessor-wrapping — the compiler's `new RegExp(`\\b${name}\\b`)` identifier-reference heuristic treated an unescaped `$` as a regex anchor and, even escaped, `\b` doesn't recognize `$` as identifier-like, so a leading/trailing `$` broke the boundary match (#2592).

--- a/packages/jsx/src/__tests__/identifier-pattern.test.ts
+++ b/packages/jsx/src/__tests__/identifier-pattern.test.ts
@@ -1,0 +1,160 @@
+/**
+ * #2592 — `$`-containing identifiers broke the compiler's
+ * `new RegExp(`\\b${name}\\b`)` "does this expression reference identifier
+ * X?" heuristic in two ways: an unescaped `$` acts as a regex end anchor
+ * (false negative anywhere but the very end of the pattern), and even once
+ * escaped, `\b` treats `$` as a non-word character, so it fails to find a
+ * boundary between e.g. `(` and a leading `$` (both non-word — no
+ * transition). See `../identifier-pattern.ts` for the fix.
+ */
+import { describe, test, expect } from 'bun:test'
+import { identifierPattern, identifierCallPattern } from '../identifier-pattern.ts'
+import { compileJSX } from '../compiler.ts'
+import { TestAdapter } from '../adapters/test-adapter.ts'
+
+describe('identifierPattern (#2592)', () => {
+  describe.each(['$item', 'item$', 'a$b', 'item'])('name = %p', (name) => {
+    test('matches a standalone parenthesized reference', () => {
+      expect(identifierPattern(name).test(`(${name})`)).toBe(true)
+    })
+
+    test('matches a reference after a binary operator', () => {
+      expect(identifierPattern(name).test(`x + ${name}`)).toBe(true)
+    })
+
+    test('matches as the base of a member-access expression', () => {
+      expect(identifierPattern(name).test(`${name}.foo`)).toBe(true)
+    })
+
+    test('does not match when it is a substring of a longer identifier (suffix)', () => {
+      expect(identifierPattern(name).test(`my${name}`)).toBe(false)
+    })
+
+    test('does not match when it is a substring of a longer identifier (prefix)', () => {
+      expect(identifierPattern(name).test(`${name}s`)).toBe(false)
+    })
+
+    test('does not match when it appears as a substring inside another identifier', () => {
+      // e.g. name="item" inside "xitem" / name="$item" inside "x$item"
+      expect(identifierPattern(name).test(`x${name}`)).toBe(false)
+    })
+  })
+
+  // Literal spellings from the issue, so the fixture reads without having
+  // to mentally substitute the parameterised %p name above.
+  test('$item: matches ($item), x + $item, $item.foo', () => {
+    const re = identifierPattern('$item')
+    expect(re.test('($item)')).toBe(true)
+    expect(re.test('x + $item')).toBe(true)
+    expect(re.test('$item.foo')).toBe(true)
+  })
+
+  test('$item: does not match my$item, $items, item$s, aitem, xitem', () => {
+    const re = identifierPattern('$item')
+    expect(re.test('my$item')).toBe(false)
+    expect(re.test('$items')).toBe(false)
+    expect(re.test('item$s')).toBe(false)
+    expect(re.test('aitem')).toBe(false)
+    expect(re.test('xitem')).toBe(false)
+  })
+
+  test('item (plain, no $) still matches only standalone references', () => {
+    const re = identifierPattern('item')
+    expect(re.test('(item)')).toBe(true)
+    expect(re.test('x + item')).toBe(true)
+    expect(re.test('item.foo')).toBe(true)
+    expect(re.test('my$item')).toBe(false)
+    expect(re.test('$items')).toBe(false)
+    expect(re.test('item$s')).toBe(false)
+    expect(re.test('aitem')).toBe(false)
+    expect(re.test('xitem')).toBe(false)
+  })
+
+  test('the `g` flag supports substitution scanning across multiple matches', () => {
+    const re = identifierPattern('$x', 'g')
+    expect('$x + $x'.replace(re, () => 'Y')).toBe('Y + Y')
+  })
+
+  test('regex-metacharacter identifiers are escaped, not interpreted', () => {
+    // Not a realistic JS identifier, but guards the escape step directly:
+    // an unescaped '.' would match any character.
+    const re = identifierPattern('a.b')
+    expect(re.test('a.b')).toBe(true)
+    expect(re.test('axb')).toBe(false)
+  })
+})
+
+describe('identifierCallPattern (#2592)', () => {
+  test('matches call syntax for a $-prefixed getter, with or without whitespace', () => {
+    expect(identifierCallPattern('$count').test('$count()')).toBe(true)
+    expect(identifierCallPattern('$count').test('$count ()')).toBe(true)
+    expect(identifierCallPattern('$count').test('1 + $count()')).toBe(true)
+  })
+
+  test('does not match a bare (non-call) reference', () => {
+    expect(identifierCallPattern('$count').test('$count')).toBe(false)
+  })
+
+  test('does not match when the name is a substring of a longer call', () => {
+    expect(identifierCallPattern('$count').test('my$count()')).toBe(false)
+    expect(identifierCallPattern('$count').test('$counter()')).toBe(false)
+  })
+
+  test('plain (non-$) getter names keep matching call syntax as before', () => {
+    expect(identifierCallPattern('count').test('count()')).toBe(true)
+    expect(identifierCallPattern('count').test('acount()')).toBe(false)
+    expect(identifierCallPattern('count').test('counter()')).toBe(false)
+  })
+})
+
+// -----------------------------------------------------------------------------
+// End-to-end: a `.map()` callback whose param is `$item` must classify
+// identically to one named `item` — same slotId allocation, same
+// `$item() ` accessor-wrapping in the emitted client JS. Before the fix,
+// `referencesLoopParam` / `wrapLoopParamAsAccessor`'s `\b$item\b` pattern
+// never matched, so the loop body silently lost slotId/reactive
+// classification for the `$item`-named param (wrong-but-silent: `bun test`
+// still passed because nothing asserted the accessor wrap for a `$`-param
+// until now). Verified red-without/green-with: reverting `identifier-
+// pattern.ts` to a plain `` new RegExp(`\\b${name}\\b`) ``-style
+// implementation fails this describe block while leaving the plain-`item`
+// sibling test green — see PR description for the local repro.
+// -----------------------------------------------------------------------------
+describe('$-prefixed loop param compiles identically to a plain-named one (#2592)', () => {
+  const adapter = new TestAdapter()
+
+  function compileMapBody(param: string): string {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Row = { id: number; label: string }
+      export function List() {
+        const [rows] = createSignal<Row[]>([])
+        return (
+          <ul>
+            {rows().map((${param}) => (
+              <Card key={${param}.id}>
+                <CardHeader>{${param}.label}</CardHeader>
+              </Card>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSX(source, 'List.tsx', { adapter })
+    const errors = result.errors.filter(e => e.severity === 'error')
+    if (errors.length > 0) throw new Error(errors.map(e => e.message).join('\n'))
+    return result.files.find(f => f.type === 'clientJs')!.content
+  }
+
+  test('a plain `item` param is wrapped as an accessor in the child component prop', () => {
+    const js = compileMapBody('item')
+    expect(js).toContain('item().label')
+  })
+
+  test('a `$item` param is wrapped as an accessor identically (was previously left bare)', () => {
+    const js = compileMapBody('$item')
+    expect(js).toContain('$item().label')
+    expect(js).toContain('$item().id')
+  })
+})

--- a/packages/jsx/src/__tests__/identifier-pattern.test.ts
+++ b/packages/jsx/src/__tests__/identifier-pattern.test.ts
@@ -158,3 +158,13 @@ describe('$-prefixed loop param compiles identically to a plain-named one (#2592
     expect(js).toContain('$item().id')
   })
 })
+
+describe('flags handling', () => {
+  test("passing flags that already include 'u' does not throw (no duplicate flag)", () => {
+    const p = identifierPattern('item', 'gu')
+    expect(p.flags).toBe('gu')
+    const c = identifierCallPattern('item', 'u')
+    expect(c.flags).toBe('u')
+    expect('a item b item'.replace(identifierPattern('item', 'gu'), 'x')).toBe('a x b x')
+  })
+})

--- a/packages/jsx/src/adapters/jsx-adapter.ts
+++ b/packages/jsx/src/adapters/jsx-adapter.ts
@@ -19,6 +19,7 @@ import type { CallbackBodyAcceptor } from './interface.ts'
 import { ENV_SIGNAL_CLIENT_FACTORY } from './env-signal.ts'
 import { formatParamWithType, findReachableNames } from '../module-exports.ts'
 import { extractFreeIdentifiersFromText } from '../ir-to-client-js/csr-substitute.ts'
+import { identifierPattern } from '../identifier-pattern.ts'
 
 export interface JsxAdapterConfig {
   /** Use typed versions (typedInitialValue, etc.) for type-safe .tsx output */
@@ -165,7 +166,7 @@ export abstract class JsxAdapter extends BaseAdapter {
 
       // Create a no-op setter for SSR — omit entirely if not referenced anywhere
       if (signal.setter) {
-        const setterUsed = new RegExp(`\\b${signal.setter}\\b`).test(setterRefText)
+        const setterUsed = identifierPattern(signal.setter).test(setterRefText)
         if (setterUsed) {
           lines.push(`  const ${signal.setter} = (..._args: any[]) => {}`)
         }

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -29,6 +29,7 @@ import { analyzeClientNeeds } from './ir-to-client-js/index.ts'
 import type { WrapReason } from './ir-to-client-js/reactivity.ts'
 import { decideWrapFromAstFlags } from './ir-to-client-js/reactivity.ts'
 import { tokenContainsIdent } from './ir-to-client-js/utils.ts'
+import { identifierCallPattern } from './identifier-pattern.ts'
 
 // =============================================================================
 // Types
@@ -1990,12 +1991,12 @@ function attrValueToString(value: AttrValue): string | null {
 function extractReactiveDeps(expr: string, signalGetters: Set<string>, memoNames: Set<string>): string[] {
   const deps: string[] = []
   for (const getter of signalGetters) {
-    if (new RegExp(`\\b${getter}\\s*\\(`).test(expr)) {
+    if (identifierCallPattern(getter).test(expr)) {
       deps.push(getter)
     }
   }
   for (const memo of memoNames) {
-    if (new RegExp(`\\b${memo}\\s*\\(`).test(expr)) {
+    if (identifierCallPattern(memo).test(expr)) {
       deps.push(memo)
     }
   }
@@ -2012,7 +2013,7 @@ function extractSetterRefs(expr: string, signalGetters: Set<string>): string[] {
   }
   // Also detect signal getter reads in handler
   for (const getter of signalGetters) {
-    if (new RegExp(`\\b${getter}\\s*\\(`).test(expr)) {
+    if (identifierCallPattern(getter).test(expr)) {
       refs.push(getter)
     }
   }

--- a/packages/jsx/src/identifier-pattern.ts
+++ b/packages/jsx/src/identifier-pattern.ts
@@ -1,0 +1,73 @@
+/**
+ * Single door for building "does this expression text reference identifier
+ * X?" regexes (#2592).
+ *
+ * The naive `new RegExp(`\\b${name}\\b`)` idiom used throughout the compiler
+ * breaks for `$`-containing identifiers (legal in JS: `$item`, `item$`,
+ * `a$b`) in two independent ways:
+ *
+ *   1. Unescaped: an interpolated `$` is a regex metacharacter (end-of-
+ *      input/line anchor), so `\b$item\b` / `\ba$b\b` can (almost) never
+ *      match mid-string — false negative.
+ *   2. Even escaped, `\b` requires a `\w`/non-`\w` transition and `$` is
+ *      not `\w` (`[A-Za-z0-9_]`) — so `\b\$item\b` still fails to match the
+ *      leading boundary in `($item)` (both `(` and `$` are non-word, so no
+ *      transition occurs there).
+ *
+ * `identifierPattern` / `identifierCallPattern` fix both: the identifier
+ * text is escaped before interpolation, and the boundary is asserted with
+ * lookaround against `\p{ID_Continue}` (Unicode "can continue an
+ * identifier") unioned with `$`, so `$` is correctly treated as
+ * identifier-like on both sides of the match.
+ *
+ * Scope: these remain the same *bounded lexical heuristic* the compiler has
+ * always used for expression-text scanning (not a general JS/TS parse —
+ * see CLAUDE.md's structural-parsing rule, which does not apply to this
+ * class of check). This module only fixes the `$` boundary bug; it does not
+ * change what the heuristic considers a "reference" (string literals,
+ * comments, and member-access tails are still opaque to it — callers that
+ * need that precision use `tokenContainsIdent` / `node.freeIdentifiers`
+ * instead, per #1267).
+ */
+
+/** Escape regex metacharacters in a literal identifier before interpolation. */
+export function escapeIdentifierForRegex(name: string): string {
+  return name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Lookaround fragments asserting "not preceded/followed by an identifier
+ * continuation character (including `$`)". `$` is a legal identifier char
+ * in JS but is not `\p{ID_Continue}`, so it's unioned in explicitly.
+ *
+ * Exported for the few call sites that must splice extra assertions
+ * between the identifier and the trailing boundary (e.g. "not followed by
+ * a call" as well as "not followed by an identifier char") — compose with
+ * these fragments rather than reintroducing a bare `\b`.
+ */
+export const ID_BOUNDARY_BEFORE = '(?<![\\p{ID_Continue}$])'
+export const ID_BOUNDARY_AFTER = '(?![\\p{ID_Continue}$])'
+
+/**
+ * Regex matching a standalone reference to identifier `name` — the `$`-safe
+ * replacement for `new RegExp(`\\b${name}\\b`)`. Always carries the `u`
+ * (unicode) flag, required for `\p{ID_Continue}`; pass additional flags
+ * (e.g. `'g'` for `String.replace`/`matchAll` substitution sites) via
+ * `flags`.
+ */
+export function identifierPattern(name: string, flags = ''): RegExp {
+  const esc = escapeIdentifierForRegex(name)
+  return new RegExp(`${ID_BOUNDARY_BEFORE}${esc}${ID_BOUNDARY_AFTER}`, `${flags}u`)
+}
+
+/**
+ * Regex matching identifier `name` used in call position (`name(...)`,
+ * allowing whitespace before the paren) — the `$`-safe replacement for
+ * `new RegExp(`\\b${name}\\s*\\(`)`. No trailing boundary assertion is
+ * needed: `\s`/`(` are already not `\p{ID_Continue}`/`$`, so they can't be
+ * mistaken for a continuation of `name`.
+ */
+export function identifierCallPattern(name: string, flags = ''): RegExp {
+  const esc = escapeIdentifierForRegex(name)
+  return new RegExp(`${ID_BOUNDARY_BEFORE}${esc}\\s*\\(`, `${flags}u`)
+}

--- a/packages/jsx/src/identifier-pattern.ts
+++ b/packages/jsx/src/identifier-pattern.ts
@@ -30,6 +30,12 @@
  * instead, per #1267).
  */
 
+// Duplicate regex flags throw at construction ('gu' + 'u' -> SyntaxError),
+// so `u` is added only when the caller didn't already pass it.
+function withUnicodeFlag(flags: string): string {
+  return flags.includes('u') ? flags : `${flags}u`
+}
+
 /** Escape regex metacharacters in a literal identifier before interpolation. */
 export function escapeIdentifierForRegex(name: string): string {
   return name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -57,7 +63,7 @@ export const ID_BOUNDARY_AFTER = '(?![\\p{ID_Continue}$])'
  */
 export function identifierPattern(name: string, flags = ''): RegExp {
   const esc = escapeIdentifierForRegex(name)
-  return new RegExp(`${ID_BOUNDARY_BEFORE}${esc}${ID_BOUNDARY_AFTER}`, `${flags}u`)
+  return new RegExp(`${ID_BOUNDARY_BEFORE}${esc}${ID_BOUNDARY_AFTER}`, withUnicodeFlag(flags))
 }
 
 /**
@@ -69,5 +75,5 @@ export function identifierPattern(name: string, flags = ''): RegExp {
  */
 export function identifierCallPattern(name: string, flags = ''): RegExp {
   const esc = escapeIdentifierForRegex(name)
-  return new RegExp(`${ID_BOUNDARY_BEFORE}${esc}\\s*\\(`, `${flags}u`)
+  return new RegExp(`${ID_BOUNDARY_BEFORE}${esc}\\s*\\(`, withUnicodeFlag(flags))
 }

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -11,6 +11,7 @@ import { templateRootIsSvg } from './control-flow/stringify/template-parse.ts'
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling.ts'
 import { walkIR, stopAt } from './walker.ts'
 import { buildLoopChainExpr } from '../loop-chain.ts'
+import { identifierPattern } from '../identifier-pattern.ts'
 
 /** Expressions that render nothing (0 DOM nodes) — `&&` / `?:` empty branches. */
 const EMPTY_RENDER_EXPRS = new Set(['null', 'undefined', 'false', "''", '""', '``'])
@@ -311,7 +312,7 @@ export function collectInnerLoops(
         const template = n.children.map(c => irToPlaceholderTemplate(c, undefined, emitDepth, loopParamsForTemplate)).join('')
         // Check if array expression references the outer loop param
         const refsOuter = outerLoopParam
-          ? new RegExp(`\\b${outerLoopParam}\\b`).test(n.array)
+          ? identifierPattern(outerLoopParam).test(n.array)
           : false
         // Per-item bindings for inner loop body, collected uniformly when
         // ctx is available: reactiveTexts / reactiveAttrs / refs are each

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-event-delegation.ts
@@ -11,6 +11,7 @@
 
 import type { TopLevelLoop, BranchLoop, LoopChildEvent } from '../../types.ts'
 import { buildChainedArrayExpr, varSlotId, substituteLoopBindings } from '../../utils.ts'
+import { identifierPattern } from '../../../identifier-pattern.ts'
 import { renderPreamble, irToHtmlTemplate } from '../../html-template.ts'
 import type {
   EventDelegationPlan,
@@ -138,7 +139,7 @@ function buildKeyedOrIndexLookup(args: {
     // we substitute bindings with `item.<path>` directly (#951).
     const keyWithItem = hasBindings
       ? substituteLoopBindings(args.key, args.paramBindings!, 'item')
-      : args.key.replace(new RegExp(`\\b${args.param}\\b`, 'g'), 'item')
+      : args.key.replace(identifierPattern(args.param, 'g'), 'item')
     return {
       kind: 'keyed',
       arrayExpr: args.array,

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/event-delegation.ts
@@ -34,6 +34,7 @@
 
 import { toDomEventName, varSlotId, substituteLoopBindings, buildLoopChildIndexSubtraction, DATA_KEY, keyAttrName } from '../../utils.ts'
 import { extractFreeIdentifiersFromText } from '../../csr-substitute.ts'
+import { identifierPattern } from '../../../identifier-pattern.ts'
 import type {
   EventDelegationPlan,
   KeyedItemLookup,
@@ -215,7 +216,7 @@ function emitKeyedLookup(
     const rawKey = nested.key ?? ''
     const innerKeyExpr = nested.paramBindings && nested.paramBindings.length > 0
       ? substituteLoopBindings(rawKey, nested.paramBindings, 'item')
-      : rawKey.replace(new RegExp(`\\b${nested.param}\\b`, 'g'), 'item')
+      : rawKey.replace(identifierPattern(nested.param, 'g'), 'item')
     const outerRef = hasBindings ? '__bfLoopItem' : param
     ls.push(`      const ${nested.param} = ${outerRef} && ${nested.array}.find(item => String(${innerKeyExpr}) === innerKey${nested.depth})`)
   }

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -5,6 +5,7 @@
 import type { ComponentIR, IRNode } from '../types.ts'
 import { isClientBuiltinName } from '../builtins.ts'
 import { collectValueReferencedNames } from '../value-references.ts'
+import { identifierCallPattern } from '../identifier-pattern.ts'
 
 // All exports from @barefootjs/client/runtime that may be used in generated code
 export const RUNTIME_IMPORT_CANDIDATES = [
@@ -57,7 +58,7 @@ export function detectUsedImports(code: string): Set<string> {
   const used = new Set<string>()
   for (const name of RUNTIME_IMPORT_CANDIDATES) {
     // Match function calls: name(
-    if (new RegExp(`\\b${name}\\s*\\(`).test(code)) {
+    if (identifierCallPattern(name).test(code)) {
       used.add(name)
     }
   }

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -18,6 +18,7 @@ import { attrValueToString, freeIdsFromRefs, tokenContainsIdent } from './utils.
 import { expandConstantForReactivity } from './prop-handling.ts'
 import { extractFreeIdentifiersFromText } from './csr-substitute.ts'
 import { walkIR, stopAt } from './walker.ts'
+import { identifierCallPattern } from '../identifier-pattern.ts'
 
 /**
  * Phase 2 reactivity detection: determines if a code expression needs `createEffect`
@@ -146,13 +147,13 @@ export function needsEffectWrapper(
   freeIdentifiers?: ReadonlySet<string>,
 ): boolean {
   for (const signal of ctx.signals) {
-    if (new RegExp(`\\b${signal.getter}\\s*\\(`).test(expr)) {
+    if (identifierCallPattern(signal.getter).test(expr)) {
       return true
     }
   }
 
   for (const memo of ctx.memos) {
-    if (new RegExp(`\\b${memo.name}\\s*\\(`).test(expr)) {
+    if (identifierCallPattern(memo.name).test(expr)) {
       return true
     }
   }

--- a/packages/jsx/src/ir-to-client-js/rewrite-props-object.ts
+++ b/packages/jsx/src/ir-to-client-js/rewrite-props-object.ts
@@ -24,6 +24,7 @@
 
 import ts from 'typescript'
 import { PROPS_PARAM } from './utils.ts'
+import { identifierPattern } from '../identifier-pattern.ts'
 
 /**
  * Rename every value-position reference to `propsObjectName` in `code`
@@ -36,7 +37,7 @@ export function rewritePropsObjectRef(code: string, propsObjectName: string | nu
   if (srcPropsName === PROPS_PARAM) return code
 
   // Quick exit when the name doesn't appear at all.
-  if (!new RegExp(`\\b${srcPropsName}\\b`).test(code)) return code
+  if (!identifierPattern(srcPropsName).test(code)) return code
 
   const sourceFile = ts.createSourceFile(
     'init-body.ts',

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -8,6 +8,7 @@ import type { AttrValue, IRTemplatePart, LoopParamBinding, FreeReference, IRNode
 import type { TopLevelLoop, BranchLoop, LoopOffset } from './types.ts'
 import { buildLoopChainExpr } from '../loop-chain.ts'
 import { templatePartsToJsExpr } from '../template-parts.ts'
+import { escapeIdentifierForRegex, ID_BOUNDARY_BEFORE, ID_BOUNDARY_AFTER } from '../identifier-pattern.ts'
 import {
   iterateJsTokens,
   isIdentifierLikeToken,
@@ -337,10 +338,6 @@ export function inferDefaultValue(type: { kind: string; primitive?: string }): s
   return 'undefined'
 }
 
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
 /**
  * Flatten an `OriginInfo.freeRefs` list to a plain `Set<string>` of free
  * identifier names (#1267). Skips `kind: 'reactive-brand'` entries whose
@@ -561,8 +558,12 @@ export function wrapLoopParamAsAccessor(expr: string, paramName: string, binding
   if (bindings && bindings.length > 0) {
     return rewriteLoopBindingRefs(expr, bindings, '__bfItem()')
   }
-  const re = new RegExp(`\\b${escapeRegExp(paramName)}\\b(?!\\s*\\()(?!-)`, 'g')
-  return replaceInExprContexts(expr, re, `${paramName}()`)
+  // `paramName` is a legal JS identifier and may itself start with `$`
+  // (`$1`, `$&`, …) — a plain string replacement would risk `String.replace`
+  // reading those as backreference/whole-match sequences, so use a replacer
+  // function to insert the accessor text literally (#2592).
+  const re = new RegExp(`${ID_BOUNDARY_BEFORE}${escapeIdentifierForRegex(paramName)}(?!\\s*\\()(?!-)${ID_BOUNDARY_AFTER}`, 'gu')
+  return replaceInExprContexts(expr, re, () => `${paramName}()`)
 }
 
 /**
@@ -588,8 +589,8 @@ function rewriteLoopBindingRefs(
   const byName = new Map<string, LoopParamBinding>()
   for (const b of bindings) byName.set(b.name, b)
   const preprocessed = expandShorthandBindings(expr, new Set(byName.keys()))
-  const alt = bindings.map(b => escapeRegExp(b.name)).join('|')
-  const re = new RegExp(`\\b(${alt})\\b`, 'g')
+  const alt = bindings.map(b => escapeIdentifierForRegex(b.name)).join('|')
+  const re = new RegExp(`${ID_BOUNDARY_BEFORE}(${alt})${ID_BOUNDARY_AFTER}`, 'gu')
   return replaceInExprContexts(preprocessed, re, (_m: string, name: string) =>
     renderLoopBindingAccess(byName.get(name)!, accessor),
   )

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -63,6 +63,7 @@ import { reconstructAsSegments } from './strip-types.ts'
 import { templatePartsToJsExpr } from './template-parts.ts'
 import { toHTMLAttrName, decodeEntities } from '@barefootjs/shared'
 import { BindingScope } from './scope/binding-scope.ts'
+import { identifierPattern, identifierCallPattern } from './identifier-pattern.ts'
 
 // =============================================================================
 // Transform Context
@@ -681,19 +682,19 @@ function createTransformContext(analyzer: AnalyzerContext): TransformContext {
     patterns: {
       signals: analyzer.signals.map(s => ({
         getter: s.getter,
-        pattern: new RegExp(`\\b${s.getter}\\s*\\(`),
+        pattern: identifierCallPattern(s.getter),
       })),
       memos: analyzer.memos.map(m => ({
         name: m.name,
-        pattern: new RegExp(`\\b${m.name}\\s*\\(`),
+        pattern: identifierCallPattern(m.name),
       })),
       props: analyzer.propsParams
         .filter(p => p.name !== 'children')
-        .map(p => ({ name: p.name, pattern: new RegExp(`\\b${p.name}\\b`) })),
+        .map(p => ({ name: p.name, pattern: identifierPattern(p.name) })),
       constants: analyzer.localConstants.map(c => ({
         name: c.name,
         value: c.value,
-        pattern: new RegExp(`\\b${c.name}\\b`),
+        pattern: identifierPattern(c.name),
       })),
     },
     getJS(node: ts.Node): string {
@@ -2201,7 +2202,7 @@ function transformExpressionInner(
   // (#2482 Stage 1a Commit 2).
   const scopeValueNames = ctx.scope.valueBoundNames()
   const refsLoopParam = scopeValueNames.size > 0
-    && Array.from(scopeValueNames).some(p => new RegExp(`\\b${p}\\b`).test(exprText))
+    && Array.from(scopeValueNames).some(p => identifierPattern(p).test(exprText))
 
   // Compute AST-derived flags. `callsReactive` recognises signal-getter / memo
   // calls even inside deeper expressions (e.g., `format(count())`); `hasCalls`
@@ -2267,7 +2268,11 @@ function transformJsxFunctionCall(
   const substitutedGetJS = (node: ts.Node) => {
     let text = baseGetJS(node)
     for (const [paramName, argExpr] of substitutions) {
-      text = text.replace(new RegExp(`\\b${paramName}\\b`, 'g'), argExpr)
+      // Replacer function, not the string form: `argExpr` is arbitrary
+      // caller-supplied JS text and may itself contain `$` sequences
+      // (`$&`, `$1`, …) that `String.replace`'s string-replacement form
+      // would interpret specially instead of inserting literally (#2592).
+      text = text.replace(identifierPattern(paramName, 'g'), () => argExpr)
     }
     return text
   }
@@ -2319,7 +2324,11 @@ function transformMultiReturnJsxFunctionCall(
   const substitutedGetJS = (node: ts.Node) => {
     let text = baseGetJS(node)
     for (const [paramName, argExpr] of substitutions) {
-      text = text.replace(new RegExp(`\\b${paramName}\\b`, 'g'), argExpr)
+      // Replacer function, not the string form: `argExpr` is arbitrary
+      // caller-supplied JS text and may itself contain `$` sequences
+      // (`$&`, `$1`, …) that `String.replace`'s string-replacement form
+      // would interpret specially instead of inserting literally (#2592).
+      text = text.replace(identifierPattern(paramName, 'g'), () => argExpr)
     }
     return text
   }
@@ -7104,7 +7113,7 @@ function referencesLoopParam(expr: string, ctx: TransformContext): boolean {
   const boundNames = ctx.scope.valueBoundNames()
   if (boundNames.size === 0) return false
   for (const p of boundNames) {
-    if (new RegExp(`\\b${p}\\b`).test(expr)) return true
+    if (identifierPattern(p).test(expr)) return true
   }
   return false
 }
@@ -7238,7 +7247,7 @@ function hasReactiveAttributes(attrs: IRAttribute[], ctx: TransformContext): boo
     const scopeValueNames = ctx.scope.valueBoundNames()
     if (scopeValueNames.size > 0) {
       for (const p of scopeValueNames) {
-        if (new RegExp(`\\b${p}\\b`).test(valueToCheck)) return true
+        if (identifierPattern(p).test(valueToCheck)) return true
       }
     }
   }

--- a/packages/jsx/src/module-exports.ts
+++ b/packages/jsx/src/module-exports.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ComponentIR, ParamInfo } from './types.ts'
+import { identifierPattern } from './identifier-pattern.ts'
 
 /**
  * Emit module-level exports for local declarations and `export { ... } [from '...']`
@@ -140,7 +141,7 @@ export function findReachableNames(
   const queue: string[] = []
 
   for (const name of allNames) {
-    if (new RegExp(`\\b${name}\\b`).test(primaryRefs)) {
+    if (identifierPattern(name).test(primaryRefs)) {
       reachable.add(name)
       queue.push(name)
     }
@@ -150,7 +151,7 @@ export function findReachableNames(
     const current = queue.shift()!
     const body = bodyMap.get(current) || ''
     for (const name of allNames) {
-      if (!reachable.has(name) && new RegExp(`\\b${name}\\b`).test(body)) {
+      if (!reachable.has(name) && identifierPattern(name).test(body)) {
         reachable.add(name)
         queue.push(name)
       }

--- a/packages/jsx/src/relocate.ts
+++ b/packages/jsx/src/relocate.ts
@@ -22,6 +22,7 @@ import type {
 } from './adapters/interface.ts'
 import { tsNodeToParsedExpr, type ParsedExpr } from './expression-parser.ts'
 import { prepareLoweringMatchers, type LoweringMatcher } from './lowering-registry.ts'
+import { identifierPattern } from './identifier-pattern.ts'
 
 export interface RelocateEnv {
   /**
@@ -713,7 +714,7 @@ function scanRefsByName(
 ): Map<string, ts.Identifier[]> {
   const result = new Map<string, ts.Identifier[]>()
   for (const name of bindings.keys()) {
-    const re = new RegExp(`\\b${name}\\b`)
+    const re = identifierPattern(name)
     if (re.test(text)) result.set(name, [])
   }
   return result


### PR DESCRIPTION
## Summary

The `new RegExp(`\\b${name}\\b`)` idiom used for "does this expression text reference identifier X" breaks for `$`-containing identifiers (legal JS: `$item`, `item$`, `a$b`) two ways: unescaped `$` is a regex anchor (false negatives), and even escaped, `\b` can't assert a boundary next to `$` since `$` isn't a word character (`\b\$item\b` never matches `($item)`). A `.map(($item) => ...)` body was therefore misclassified by the loop-param reactivity/slot classifiers.

Surfaced by Copilot review on #2590; specified in #2592. The tree-wide sweep found the idiom is much more widespread than the issue's estimate: **26 sites across 13 files** (several `ir-to-client-js` emission paths had independently reimplemented it).

## Fix

New single door `packages/jsx/src/identifier-pattern.ts`:
- `identifierPattern(name, flags?)` — escape + `\p{ID_Continue}`∪`$` lookaround boundaries (with `u` flag), replacing `\b…\b`.
- `identifierCallPattern(name, flags?)` — call-position variant replacing `\b…\s*\(` (the `\s*\(` itself enforces the trailing boundary).
- `ID_BOUNDARY_BEFORE`/`ID_BOUNDARY_AFTER` fragments for sites composing extra assertions.

All 26 sites migrated (`jsx-to-ir.ts`'s 9, plus `debug.ts`, `jsx-adapter.ts`, `relocate.ts`, `module-exports.ts`, and 8 `ir-to-client-js` files). **Bonus fix in the same class**: 3 substitution sites used the string form of `String.replace` where the replacement is arbitrary caller JS — a `$&`/`$1` in that text would be interpreted as a substitution pattern; switched to replacer functions.

Deliberately left (flagged for follow-up, distinct composed-pattern family): the `\b${propsObjectName}\.` prefix-rewrite sites and the CSS-hyphen-exclusion family (`csr-substitute.ts`, `html-template.ts`, `init-declarations.ts`, `reactivity.ts:173`, `relocate.ts:276`, `prop-rewrite.ts:196`, `emit-reactive.ts`, `emit-registration.ts`) — same latent leading-`$` limitation, but a third composition shape outside this PR's two variants. Notably the codebase already had 3 correct precedents (`loop-destructure.ts`, `analyzer.ts`, `augment-inherited-props.ts` use explicit `$`-aware classes) — this PR makes that the enforced idiom for the simple-boundary family.

The heuristic's scope is unchanged: this is the same bounded lexical scan as before (string literals/comments remain opaque to it) — only the identifier-boundary correctness is fixed, per the issue's framing.

## Verification

- New `identifier-pattern.test.ts`: 35 tests — direct helper coverage (`$item`/`item$`/`a$b`/plain; standalone-match + substring non-match; `g`-flag substitution; escaping; call-syntax), plus an end-to-end compile asserting `.map(($item) => ...)` produces accessor-wrapping identical to `.map((item) => ...)`. Red/green verified: temporarily reverting the helper to the `\b` implementation fails 14 of 35.
- `packages/jsx` **2995 pass / 0 fail** (baseline 2959/1-flaky), `packages/adapter-tests` **1891 / 0 fail**, `packages/adapter-hono` **1371 / 0 fail** — zero conformance divergence for non-`$` code.
- Changeset: `@barefootjs/jsx` patch.

Closes #2592

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_