### PR TITLE
refactor(jsx): migrate ir-to-client-js loop scope onto BindingScope (#2482 stage 1b)

### DIFF
--- a/.changeset/binding-scope-2482-stage1b.md
+++ b/.changeset/binding-scope-2482-stage1b.md
@@ -1,0 +1,5 @@
+---
+'@barefootjs/jsx': patch
+---
+
+Migrate the client-JS emitter's loop-callback scope tracking onto `BindingScope` (#2482 stage 1b): `html-template.ts`'s CSR materialize template (`opts.loopBoundNames`) and `csr-substitute.ts`'s `csrSubstitute` now thread a `BindingScope` instead of an ad-hoc flat name set, so a `.map()` callback preamble local (#2447) shadowing a same-named module/component constant is no longer const-folded into the CSR-only hydrate template. Also guards `prop-handling.ts`'s `expandDynamicPropValue` / `expandConstantForReactivity` against the same class of bug for per-item reactive attribute effects (`reactivity.ts`'s loop-child collectors and `collect-elements.ts`'s loop-child conditionals) — a loop row binding (item / index / destructured / preamble) that shadows a component const no longer resolves to the outer const's value inside a per-row `createEffect`.

--- a/packages/jsx/src/__tests__/binding-scope-ratchet.test.ts
+++ b/packages/jsx/src/__tests__/binding-scope-ratchet.test.ts
@@ -92,7 +92,7 @@ const ALLOWLIST: Record<string, Partial<Record<Pattern, number>>> = {
   'packages/jsx/src/ir-to-client-js/collect-elements.ts': { loopParams: 9 },
   'packages/jsx/src/ir-to-client-js/compute-inlinability.ts': { 'localConstants.find(': 1 },
   'packages/jsx/src/ir-to-client-js/control-flow/plan/build-event-delegation.ts': { loopParams: 4 },
-  'packages/jsx/src/ir-to-client-js/html-template.ts': { loopBoundNames: 3, loopParams: 16 },
+  'packages/jsx/src/ir-to-client-js/html-template.ts': { loopParams: 16 },
   'packages/jsx/src/ir-to-client-js/prop-handling.ts': { 'localConstants.find(': 2 },
   'packages/jsx/src/ir-to-client-js/utils.ts': { loopParams: 3 },
   'packages/jsx/src/jsx-to-ir.ts': { loopParams: 1 },

--- a/packages/jsx/src/__tests__/csr-materialize-loop-preamble-shadow.test.ts
+++ b/packages/jsx/src/__tests__/csr-materialize-loop-preamble-shadow.test.ts
@@ -1,0 +1,76 @@
+/**
+ * #2482 Stage 1b — `generateCsrTemplateWithOpts`'s (`html-template.ts`)
+ * CSR "materialize" template lambda (the `hydrate(..., { template })`
+ * function used to render a loop's rows client-side with no SSR markup to
+ * hydrate against) const-folded a `.map()` callback preamble local (#2447)
+ * into an outer, same-named module-level const, instead of leaving the
+ * row-local binding unresolved.
+ *
+ * Root cause: the `loop` case's `opts.loopBoundNames` — a flat
+ * `Set<string>` re-unioned per recursion level — only ever accumulated
+ * the loop's item / index / destructured-binding names, never the
+ * callback's preamble-declared locals (#2447 postdates the original
+ * `loopBoundNames` shadow fix, #2222). Migrating onto `BindingScope`'s
+ * `enterLoopRow` (which binds item ∪ index ∪ destructure ∪ preamble
+ * `declaredNames` uniformly) closes the gap.
+ *
+ * Observable failure mode before the fix: every row's branch condition
+ * evaluated the constant's fixed truthiness instead of the row's own
+ * preamble-computed value — e.g. every `<li>` rendered its "true" branch
+ * regardless of the actual per-item condition.
+ *
+ * Modeled on `csr-template-loop-shadowing.test.ts` (the pre-#2447
+ * item/index/destructured-param shadowing pins for this same template
+ * lambda) and `binding-scope-preamble-shadowing.test.ts` (the IR-level
+ * preamble-shadowing analogue this test is the CSR-codegen-level sibling
+ * of).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsFor(source: string): string {
+  const result = compileJSX(source, 'Repro.tsx', { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+function templateLambda(content: string): string {
+  const line = content.split('\n').find(l => l.includes('hydrate('))
+  expect(line).toBeDefined()
+  return line!
+}
+
+describe('CSR materialize template vs .map() preamble-local shadowing a module const (#2482)', () => {
+  test('a preamble local shadowing a module const stays row-local in the hydrate template lambda', () => {
+    const tpl = templateLambda(clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Widget({ items }: { items: { name: string; active: boolean }[] }) {
+        const label = 'MODULE_CONST'
+        const [on, setOn] = createSignal(true)
+        return (
+          <div onClick={() => setOn(false)}>
+            <ul>
+              {items.map((item) => {
+                const label = item.active && on()
+                return <li key={item.name}>{label ? <span>yes</span> : <span>no</span>}</li>
+              })}
+            </ul>
+          </div>
+        )
+      }
+    `))
+
+    // The row-local `label` (the preamble's OWN computed value) must
+    // drive the branch — never the outer module const's literal.
+    expect(tpl).toContain('label ? `<span>yes</span>`')
+    expect(tpl).not.toContain("('MODULE_CONST')")
+    expect(tpl).not.toContain('MODULE_CONST')
+  })
+})

--- a/packages/jsx/src/__tests__/csr-substitute-enclosing-scope.test.ts
+++ b/packages/jsx/src/__tests__/csr-substitute-enclosing-scope.test.ts
@@ -1,0 +1,77 @@
+/**
+ * #2482 Stage 1b — `csrSubstitute`'s `enclosingScope` parameter.
+ *
+ * `csrSubstitute`'s `boundStack` only ever learns about bindings found
+ * while walking the substituted expression's OWN AST (nested arrow/
+ * function parameters and block-scoped locals inside `value` itself) — it
+ * has no way to see a binding introduced OUTSIDE that expression, e.g. an
+ * enclosing `.map()` row's item/index/destructured/preamble binding.
+ * `enclosingScope` (a `BindingScope`) seeds those outer frames so
+ * `isBound` treats them identically to an in-expression arrow param.
+ *
+ * Direct unit coverage, not a full-pipeline conformance fixture: every
+ * current call site (`html-template.ts`'s `generateCsrTemplateWithOpts`)
+ * already pre-filters `env.substitutions` to remove loop-shadowed names
+ * BEFORE calling in (see the `loop` case's `childEnv` construction, itself
+ * migrated onto `BindingScope.enterLoopRow` in this same stage) — so by
+ * the time `csrSubstitute` runs inside a loop body today, the shadowed
+ * name is already absent from `env.substitutions` and `enclosingScope`
+ * never gets a chance to matter. This test exercises the module function
+ * directly, bypassing that pre-filtering, to pin the parameter's own
+ * contract in isolation: SHOULD a future call site ever hand `csrSubstitute`
+ * an unfiltered env alongside a loop's `BindingScope` (e.g. a caller that
+ * wants substitution and shadow-guarding as one step instead of two), the
+ * shadow guard already works correctly.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { csrSubstitute, type CsrEnv } from '../ir-to-client-js/csr-substitute.ts'
+import { BindingScope } from '../scope/binding-scope.ts'
+
+describe('csrSubstitute enclosingScope (#2482)', () => {
+  test('a name bound by the enclosing loop scope is left unsubstituted, even though the env still has an entry for it', () => {
+    // Deliberately UNFILTERED env — in real call sites this would already
+    // have `label` removed by the caller's own loop-scope filtering; here
+    // we keep it to isolate what `enclosingScope` alone contributes.
+    const env: CsrEnv = {
+      substitutions: new Map([
+        ['label', { kind: 'identifier', replacement: "'MODULE_CONST'", freeIdentifiers: new Set() }],
+      ]),
+      propsObjectName: null,
+    }
+    const scope = BindingScope.EMPTY.enterLoopRow({ param: 'label' })
+
+    const withoutScope = csrSubstitute('label', env)
+    const withScope = csrSubstitute('label', env, scope)
+
+    expect(withoutScope.rewritten).toBe("('MODULE_CONST')")
+    expect(withScope.rewritten).toBe('label')
+  })
+
+  test('a name NOT bound by the enclosing scope still substitutes normally', () => {
+    const env: CsrEnv = {
+      substitutions: new Map([
+        ['label', { kind: 'identifier', replacement: "'MODULE_CONST'", freeIdentifiers: new Set() }],
+      ]),
+      propsObjectName: null,
+    }
+    // Scope binds a DIFFERENT name (`item`) — `label` stays substitutable.
+    const scope = BindingScope.EMPTY.enterLoopRow({ param: 'item' })
+
+    const { rewritten } = csrSubstitute('label', env, scope)
+    expect(rewritten).toBe("('MODULE_CONST')")
+  })
+
+  test('a preamble-bound name (not item/index/destructure) is also guarded', () => {
+    const env: CsrEnv = {
+      substitutions: new Map([
+        ['label', { kind: 'identifier', replacement: "'MODULE_CONST'", freeIdentifiers: new Set() }],
+      ]),
+      propsObjectName: null,
+    }
+    const scope = BindingScope.EMPTY.enterLoopRow({ param: 'item', preamble: { declaredNames: ['label'] } })
+
+    const { rewritten } = csrSubstitute('label', env, scope)
+    expect(rewritten).toBe('label')
+  })
+})

--- a/packages/jsx/src/__tests__/loop-child-reactive-attr-const-shadow.test.ts
+++ b/packages/jsx/src/__tests__/loop-child-reactive-attr-const-shadow.test.ts
@@ -1,0 +1,68 @@
+/**
+ * #2482 Stage 1b — `prop-handling.ts`'s `expandConstantForReactivity` /
+ * `expandDynamicPropValue` run on `ClientJsContext`, a per-component object
+ * with no loop-scope field at all. Both do a flat
+ * `ctx.localConstants.find((c) => c.name === trimmedValue)` lookup with no
+ * awareness that the expression being expanded might be sitting inside a
+ * `.map()` row whose OWN item/index/destructured/preamble binding shadows
+ * that same-named module/component-level const — the lookup resolves to
+ * the OUTER const's value regardless.
+ *
+ * This test pins the reachable, currently-shipping instance: a per-item
+ * reactive DOM attribute (forced via `/* @client *\/`, so it bypasses the
+ * loop-param-only reactivity classifier and always reaches
+ * `collectLoopChildReactiveAttrs` → `expandConstantForReactivity`) whose
+ * value is a bare reference to the loop's OWN item parameter, which
+ * shares a name with a module-level const. Before the fix, the per-item
+ * `createEffect`-equivalent (`applyItem`/`createRow` in the lazy-row
+ * runtime) baked in the outer const's fixed literal for every row instead
+ * of reading the row's own item value — every row rendered the SAME
+ * `data-label`, and it never diverged from that one baked value.
+ *
+ * Modeled on `csr-template-loop-shadowing.test.ts` (the sibling shadowing
+ * fix for the CSR *template* lambda, #2222) — this is the analogous fix
+ * for the per-item *reactive attribute effect* body, a different codegen
+ * path (`reactivity.ts`'s `collectLoopChildReactiveAttrs`, not
+ * `html-template.ts`).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsFor(source: string): string {
+  const result = compileJSX(source, 'Repro.tsx', { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('loop-child reactive attr vs a loop-param shadowing a module const (#2482)', () => {
+  test('a /* @client */ attr reading the shadowing item param reads the row value, not the outer const', () => {
+    const js = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Widget({ items }: { items: string[] }) {
+        const label = 'MODULE_CONST'
+        const [n, setN] = createSignal(0)
+        return (
+          <div onClick={() => setN(n() + 1)}>
+            <ul>
+              {items.map((label) => (
+                <li key={label} data-label={/* @client */ label}>{n()}</li>
+              ))}
+            </ul>
+          </div>
+        )
+      }
+    `)
+
+    // The per-item attribute effect must read the row's OWN item
+    // accessor — never the outer module const's baked literal.
+    expect(js).toContain('const __x = label()')
+    expect(js).not.toContain("const __x = 'MODULE_CONST'")
+  })
+})

--- a/packages/jsx/src/__tests__/loop-child-reactive-attr-const-shadow.test.ts
+++ b/packages/jsx/src/__tests__/loop-child-reactive-attr-const-shadow.test.ts
@@ -24,6 +24,18 @@
  * for the per-item *reactive attribute effect* body, a different codegen
  * path (`reactivity.ts`'s `collectLoopChildReactiveAttrs`, not
  * `html-template.ts`).
+ *
+ * A second describe block below pins the INDEX-param shadowing case
+ * (Copilot review on PR #2595): `buildLoopRowScope` initially omitted
+ * the loop's second callback param (`.map((item, i) => ...)`'s `i`) from
+ * the `BindingScope` it builds, so an `i`-shadows-a-module-const attr
+ * const-folded the outer value exactly like the item-param case above,
+ * empirically confirmed reachable through the same
+ * `collectLoopChildReactiveAttrs` → `expandConstantForReactivity` path.
+ * Fixed by threading the IR loop's `index` field through
+ * `collectLoopChildBindings` / `collectLoopChildConditionals` /
+ * `summarizeLoopChildBranch` / `collectLoopChildReactiveAttrs` /
+ * `collectLoopChildReactiveTexts` into `buildLoopRowScope`.
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -64,5 +76,32 @@ describe('loop-child reactive attr vs a loop-param shadowing a module const (#24
     // accessor — never the outer module const's baked literal.
     expect(js).toContain('const __x = label()')
     expect(js).not.toContain("const __x = 'MODULE_CONST'")
+  })
+})
+
+describe('loop-child reactive attr vs a loop INDEX param shadowing a module const (#2482 / #2595)', () => {
+  test('a /* @client */ attr reading the shadowing index param reads the row index, not the outer const', () => {
+    const js = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Widget({ items }: { items: string[] }) {
+        const i = 'MODULE_CONST'
+        const [n, setN] = createSignal(0)
+        return (
+          <div onClick={() => setN(n() + 1)}>
+            <ul>
+              {items.map((item, i) => (
+                <li key={item} data-idx={/* @client */ i}>{n()}</li>
+              ))}
+            </ul>
+          </div>
+        )
+      }
+    `)
+
+    // The per-item attribute effect must read the row's OWN index
+    // closure variable — never the outer module const's baked literal.
+    expect(js).toContain("const __v = i;")
+    expect(js).not.toContain("const __v = 'MODULE_CONST';")
   })
 })

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -5,7 +5,7 @@
 import { type IRNode, type IRElement, type IRComponent, type IRLoop, type IRProp, pickAttrMetaFromIR } from '../types.ts'
 import type { ClientJsContext, ConditionalBranchChildComponent, ConditionalBranchReactiveAttr, BranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildBindings, LoopChildBranchSummary, LoopChildConditional, LoopOffset, NestedLoop } from './types.ts'
 import { attrValueToString, freeIdsFromRefs, quotePropName, PROPS_PARAM } from './utils.ts'
-import { classifyReactivity, decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts, collectLoopChildRefs, emptyLoopChildBindings } from './reactivity.ts'
+import { classifyReactivity, decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts, collectLoopChildRefs, emptyLoopChildBindings, buildLoopRowScope } from './reactivity.ts'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr, buildLoopSkeletonTemplate, computeSkeletonSlotPaths, renderFlatMapClientBody, renderFlatMapProjectionClientBody, flatMapCallbackHasKeyedLeaf, type SkeletonSlotPaths } from './html-template.ts'
 import { templateRootIsSvg } from './control-flow/stringify/template-parse.ts'
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling.ts'
@@ -332,7 +332,7 @@ export function collectInnerLoops(
         const innerPreambleNames = preambleNamesOf(n)
         if (ctx) {
           for (const child of n.children) {
-            bindings.reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param, n.paramBindings))
+            bindings.reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param, n.paramBindings, false, innerPreambleNames))
             bindings.reactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param, n.paramBindings, false, innerPreambleNames))
             bindings.refs.push(...collectLoopChildRefs(child))
           }
@@ -375,6 +375,7 @@ export function collectInnerLoops(
               siblingOffsets,
               n.param,
               n.paramBindings,
+              innerPreambleNames,
             ))
           }
         }
@@ -1356,9 +1357,9 @@ export function collectLoopChildBindings(
     // arm-scoped attrs/texts (`LoopChildBranchSummary.reactiveAttrs` /
     // `.reactiveTexts`) — descending into them here too would double-bind.
     bindings.reactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, loopParam, loopParamBindings, true, preambleNames))
-    bindings.reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, loopParam, loopParamBindings, true))
+    bindings.reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, loopParam, loopParamBindings, true, preambleNames))
     bindings.refs.push(...collectLoopChildRefs(child))
-    bindings.conditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, loopParam, loopParamBindings))
+    bindings.conditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, loopParam, loopParamBindings, preambleNames))
   }
   return bindings
 }
@@ -1369,8 +1370,19 @@ export function collectLoopChildConditionals(
   siblingOffsets: Map<IRLoop, IRNode[]>,
   loopParam?: string,
   loopParamBindings?: readonly import('../types.ts').LoopParamBinding[],
+  /**
+   * The enclosing loop's `.map()` callback preamble locals (#2447), when
+   * known — folded into the `expandConstantForReactivity` shadow guard
+   * (#2482 Stage 1b) so a preamble local shadowing a component/module
+   * const doesn't get const-folded into the condition, which would
+   * corrupt `classifyReactivity`'s verdict below (a substituted literal
+   * reads as "not reactive," silently freezing the branch at its initial
+   * value instead of wiring an `insert()`).
+   */
+  preambleNames?: ReadonlySet<string>,
 ): LoopChildConditional[] {
   const conditionals: LoopChildConditional[] = []
+  const scope = buildLoopRowScope(loopParam, loopParamBindings, preambleNames)
 
   // Widen the source-level "references loop param" check so destructured
   // callbacks fire too — the pattern text `[, cfg]` never word-matches on
@@ -1402,7 +1414,7 @@ export function collectLoopChildConditionals(
       // Pre-gate using AST `reactive` flag on the source condition before
       // paying for constant expansion — matches the legacy short-circuit.
       if (!n.reactive && !refsLoopParamInSource) return
-      const expanded = expandConstantForReactivity(n.condition, ctx, sourceFreeIds)
+      const expanded = expandConstantForReactivity(n.condition, ctx, sourceFreeIds, scope)
       // Loop-param conditionals are reactive via per-item signal accessors;
       // classifyReactivity sees both paths (signal/memo/prop + loop-param).
       if (classifyReactivity(expanded.expr, ctx, loopParam, loopParamBindings, expanded.freeIds).kind === 'none') return
@@ -1421,8 +1433,8 @@ export function collectLoopChildConditionals(
         condition: expanded.expr,
         whenTrueHtml,
         whenFalseHtml,
-        whenTrue: summarizeLoopChildBranch(n.whenTrue, ctx, siblingOffsets, loopParam, loopParamBindings),
-        whenFalse: summarizeLoopChildBranch(n.whenFalse, ctx, siblingOffsets, loopParam, loopParamBindings),
+        whenTrue: summarizeLoopChildBranch(n.whenTrue, ctx, siblingOffsets, loopParam, loopParamBindings, preambleNames),
+        whenFalse: summarizeLoopChildBranch(n.whenFalse, ctx, siblingOffsets, loopParam, loopParamBindings, preambleNames),
         ...(expanded.freeIds !== undefined && { conditionFreeIdentifiers: expanded.freeIds }),
       })
     },
@@ -1444,19 +1456,21 @@ function summarizeLoopChildBranch(
   siblingOffsets: Map<IRLoop, IRNode[]>,
   loopParam?: string,
   loopParamBindings?: readonly import('../types.ts').LoopParamBinding[],
+  /** Enclosing loop's preamble locals (#2447) — see `collectLoopChildConditionals`. */
+  preambleNames?: ReadonlySet<string>,
 ): LoopChildBranchSummary {
   const inner = collectInnerLoops([node], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
   return {
     childComponents: collectConditionalBranchChildComponents(node),
     innerLoops: inner.length > 0 ? inner : undefined,
-    conditionals: collectLoopChildConditionals(node, ctx, siblingOffsets, loopParam, loopParamBindings),
+    conditionals: collectLoopChildConditionals(node, ctx, siblingOffsets, loopParam, loopParamBindings, preambleNames),
     events: collectConditionalBranchEvents(node),
     // Loop-param-aware — reuses the flat loop-item collectors scoped to just
     // this branch's subtree. Both already stop descending into any further
     // nested reactive conditional (own insert()/arm), so calling them here
     // on the branch root yields exactly this branch's direct bindings
     // without re-collecting what a nested arm already owns (#2347).
-    reactiveAttrs: collectLoopChildReactiveAttrs(node, ctx, loopParam, loopParamBindings, true),
+    reactiveAttrs: collectLoopChildReactiveAttrs(node, ctx, loopParam, loopParamBindings, true, preambleNames),
     // Skip ONLY when the branch's entire content is a single bare
     // `expression` (no wrapping element) that MAY yield a live DOM node —
     // i.e. it contains a call anywhere (`node.hasFunctionCalls`, computed
@@ -1506,6 +1520,6 @@ function summarizeLoopChildBranch(
     // two can't disagree on shape).
     reactiveTexts: node.type === 'expression' && node.hasFunctionCalls
       ? []
-      : collectLoopChildReactiveTexts(node, ctx, loopParam, loopParamBindings, true),
+      : collectLoopChildReactiveTexts(node, ctx, loopParam, loopParamBindings, true, preambleNames),
   }
 }

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -332,8 +332,8 @@ export function collectInnerLoops(
         const innerPreambleNames = preambleNamesOf(n)
         if (ctx) {
           for (const child of n.children) {
-            bindings.reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param, n.paramBindings, false, innerPreambleNames))
-            bindings.reactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param, n.paramBindings, false, innerPreambleNames))
+            bindings.reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param, n.paramBindings, false, innerPreambleNames, n.index))
+            bindings.reactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param, n.paramBindings, false, innerPreambleNames, n.index))
             bindings.refs.push(...collectLoopChildRefs(child))
           }
         }
@@ -376,6 +376,7 @@ export function collectInnerLoops(
               n.param,
               n.paramBindings,
               innerPreambleNames,
+              n.index,
             ))
           }
         }
@@ -672,7 +673,7 @@ export function collectElements(
       const childHandlers: string[] = []
       const bindings = projectionInner
         ? emptyLoopChildBindings()
-        : collectLoopChildBindings(l.children, ctx, siblingOffsets, l.param, l.paramBindings, preambleNamesOf(l))
+        : collectLoopChildBindings(l.children, ctx, siblingOffsets, l.param, l.paramBindings, preambleNamesOf(l), l.index)
       if (!projectionInner) {
         for (const child of l.children) {
           childHandlers.push(...collectEventHandlersFromIR(child))
@@ -1147,7 +1148,7 @@ function collectBranchLoops(
       // which caused reactive reads inside simple loop bodies to silently
       // no-op for existing items.
       const branchBindings = ctx && !projectionInner
-        ? collectLoopChildBindings(n.children, ctx, siblingOffsets, n.param, n.paramBindings, preambleNamesOf(n))
+        ? collectLoopChildBindings(n.children, ctx, siblingOffsets, n.param, n.paramBindings, preambleNamesOf(n), n.index)
         : emptyLoopChildBindings()
 
       loops.push({
@@ -1347,6 +1348,12 @@ export function collectLoopChildBindings(
    * `collectLoopChildReactiveAttrs`. Omitted for a loop with no preamble.
    */
   preambleNames?: ReadonlySet<string>,
+  /**
+   * The loop's index param name (`.map((item, i) => ...)`'s `i`), when
+   * present — folded into the shadow guard (Copilot review on #2595) so
+   * an index-shadowing const doesn't get const-folded either.
+   */
+  loopIndex?: string | null,
 ): LoopChildBindings {
   const bindings = emptyLoopChildBindings()
   for (const child of children) {
@@ -1356,10 +1363,10 @@ export function collectLoopChildBindings(
     // `collectLoopChildConditionals`, which gives each its own insert() +
     // arm-scoped attrs/texts (`LoopChildBranchSummary.reactiveAttrs` /
     // `.reactiveTexts`) — descending into them here too would double-bind.
-    bindings.reactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, loopParam, loopParamBindings, true, preambleNames))
-    bindings.reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, loopParam, loopParamBindings, true, preambleNames))
+    bindings.reactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, loopParam, loopParamBindings, true, preambleNames, loopIndex))
+    bindings.reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, loopParam, loopParamBindings, true, preambleNames, loopIndex))
     bindings.refs.push(...collectLoopChildRefs(child))
-    bindings.conditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, loopParam, loopParamBindings, preambleNames))
+    bindings.conditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, loopParam, loopParamBindings, preambleNames, loopIndex))
   }
   return bindings
 }
@@ -1380,9 +1387,14 @@ export function collectLoopChildConditionals(
    * value instead of wiring an `insert()`).
    */
   preambleNames?: ReadonlySet<string>,
+  /**
+   * The loop's index param name, when present — see
+   * `collectLoopChildBindings`'s doc comment (Copilot review on #2595).
+   */
+  loopIndex?: string | null,
 ): LoopChildConditional[] {
   const conditionals: LoopChildConditional[] = []
-  const scope = buildLoopRowScope(loopParam, loopParamBindings, preambleNames)
+  const scope = buildLoopRowScope(loopParam, loopParamBindings, preambleNames, loopIndex)
 
   // Widen the source-level "references loop param" check so destructured
   // callbacks fire too — the pattern text `[, cfg]` never word-matches on
@@ -1433,8 +1445,8 @@ export function collectLoopChildConditionals(
         condition: expanded.expr,
         whenTrueHtml,
         whenFalseHtml,
-        whenTrue: summarizeLoopChildBranch(n.whenTrue, ctx, siblingOffsets, loopParam, loopParamBindings, preambleNames),
-        whenFalse: summarizeLoopChildBranch(n.whenFalse, ctx, siblingOffsets, loopParam, loopParamBindings, preambleNames),
+        whenTrue: summarizeLoopChildBranch(n.whenTrue, ctx, siblingOffsets, loopParam, loopParamBindings, preambleNames, loopIndex),
+        whenFalse: summarizeLoopChildBranch(n.whenFalse, ctx, siblingOffsets, loopParam, loopParamBindings, preambleNames, loopIndex),
         ...(expanded.freeIds !== undefined && { conditionFreeIdentifiers: expanded.freeIds }),
       })
     },
@@ -1458,19 +1470,21 @@ function summarizeLoopChildBranch(
   loopParamBindings?: readonly import('../types.ts').LoopParamBinding[],
   /** Enclosing loop's preamble locals (#2447) — see `collectLoopChildConditionals`. */
   preambleNames?: ReadonlySet<string>,
+  /** Enclosing loop's index param name — see `collectLoopChildConditionals` (Copilot review on #2595). */
+  loopIndex?: string | null,
 ): LoopChildBranchSummary {
   const inner = collectInnerLoops([node], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
   return {
     childComponents: collectConditionalBranchChildComponents(node),
     innerLoops: inner.length > 0 ? inner : undefined,
-    conditionals: collectLoopChildConditionals(node, ctx, siblingOffsets, loopParam, loopParamBindings, preambleNames),
+    conditionals: collectLoopChildConditionals(node, ctx, siblingOffsets, loopParam, loopParamBindings, preambleNames, loopIndex),
     events: collectConditionalBranchEvents(node),
     // Loop-param-aware — reuses the flat loop-item collectors scoped to just
     // this branch's subtree. Both already stop descending into any further
     // nested reactive conditional (own insert()/arm), so calling them here
     // on the branch root yields exactly this branch's direct bindings
     // without re-collecting what a nested arm already owns (#2347).
-    reactiveAttrs: collectLoopChildReactiveAttrs(node, ctx, loopParam, loopParamBindings, true, preambleNames),
+    reactiveAttrs: collectLoopChildReactiveAttrs(node, ctx, loopParam, loopParamBindings, true, preambleNames, loopIndex),
     // Skip ONLY when the branch's entire content is a single bare
     // `expression` (no wrapping element) that MAY yield a live DOM node —
     // i.e. it contains a call anywhere (`node.hasFunctionCalls`, computed
@@ -1520,6 +1534,6 @@ function summarizeLoopChildBranch(
     // two can't disagree on shape).
     reactiveTexts: node.type === 'expression' && node.hasFunctionCalls
       ? []
-      : collectLoopChildReactiveTexts(node, ctx, loopParam, loopParamBindings, true, preambleNames),
+      : collectLoopChildReactiveTexts(node, ctx, loopParam, loopParamBindings, true, preambleNames, loopIndex),
   }
 }

--- a/packages/jsx/src/ir-to-client-js/csr-substitute.ts
+++ b/packages/jsx/src/ir-to-client-js/csr-substitute.ts
@@ -28,6 +28,7 @@ import ts from 'typescript'
 import { PROPS_PARAM, inferDefaultValue } from './utils.ts'
 import { extractFreeIdentifiersFromNode } from '../analyzer.ts'
 import type { MemoInfo, SignalInfo } from '../types.ts'
+import type { BindingScope } from '../scope/binding-scope.ts'
 
 /**
  * CSR-substituted const value: the const's initializer with every
@@ -94,10 +95,21 @@ export interface CsrEnv {
  * so chained inline expansions (const A inlines to a form that mentions
  * const B's already-rewritten value) stay accurate without analytical
  * bookkeeping.
+ *
+ * `enclosingScope` (#2482 Stage 1b): an optional `BindingScope` for loop
+ * bindings ENCLOSING this expression — names bound outside the
+ * expression's own AST, which the internal `boundStack` (built purely
+ * from arrow/function scopes found while walking `value` itself) can
+ * never see on its own. Every current call site already pre-filters
+ * `env.substitutions` for loop-shadowed names before calling in (see
+ * `html-template.ts`'s `loop` case), so this is defense-in-depth, not a
+ * currently-observable behavior change: the two mechanisms should agree
+ * on what's shadowed regardless of which one runs first.
  */
 export function csrSubstitute(
   value: string,
   env: CsrEnv,
+  enclosingScope?: BindingScope,
 ): { rewritten: string; freeIdentifiers: ReadonlySet<string> } {
   if (!value || value.trim().length === 0) {
     return { rewritten: value, freeIdentifiers: new Set() }
@@ -111,7 +123,7 @@ export function csrSubstitute(
   let current = value
   let lastFreeIdentifiers: ReadonlySet<string> = new Set()
   for (let i = 0; i < maxIter; i++) {
-    const step = csrSubstituteOnce(current, env)
+    const step = csrSubstituteOnce(current, env, enclosingScope)
     lastFreeIdentifiers = step.freeIdentifiers
     if (step.rewritten === current) break
     current = step.rewritten
@@ -122,6 +134,7 @@ export function csrSubstitute(
 function csrSubstituteOnce(
   value: string,
   env: CsrEnv,
+  enclosingScope?: BindingScope,
 ): { rewritten: string; freeIdentifiers: ReadonlySet<string> } {
   if (!value || value.trim().length === 0) {
     return { rewritten: value, freeIdentifiers: new Set() }
@@ -151,12 +164,16 @@ function csrSubstituteOnce(
 
   // Track the bound names in nested arrow/function scopes so we don't
   // substitute identifiers shadowed by a parameter or local binding.
+  // `enclosingScope` seeds the OUTER frames — loop bindings introduced
+  // outside `value`'s own AST (item / index / destructure / preamble) —
+  // so a name bound there is treated identically to one bound by an
+  // arrow/function found while walking `value` itself.
   const boundStack: Array<Set<string>> = []
   const isBound = (name: string): boolean => {
     for (let i = boundStack.length - 1; i >= 0; i--) {
       if (boundStack[i].has(name)) return true
     }
-    return false
+    return enclosingScope?.isBound(name) ?? false
   }
 
   const recordSubstitution = (start: number, end: number, sub: CsrSubstitution): void => {

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -13,6 +13,7 @@ import type { ClientJsContext } from './types.ts'
 import { BF_PARENT_SCOPE_PLACEHOLDER, BF_SCOPE, escapeHtml } from '@barefootjs/shared'
 import { buildLoopChainExpr } from '../loop-chain.ts'
 import { derivesScopeFromSlot } from '../adapters/child-scope.ts'
+import { BindingScope } from '../scope/binding-scope.ts'
 
 /**
  * Protect string literals from regex-based replacements.
@@ -1572,19 +1573,26 @@ export interface TemplateOptions {
   csrEnv?: CsrEnv
   loopDepth?: number
   /**
-   * Names bound by the ENCLOSING loops' callback params (item / index /
-   * destructured binding names), accumulated by the `loop` case as the
-   * recursion descends (#2222). Inside a loop body, `csrSubstitute`
-   * receives each expression in isolation — no enclosing arrow text — so
-   * its own bound-name tracking can't see the loop binding; the `loop`
-   * case instead filters these names out of the child recursion's
-   * `csrEnv`, so an inlinable const / signal / memo whose name is
-   * shadowed by a loop param never substitutes at the shadowed
-   * occurrence. Scope-accurate per nesting level (the CURRENT level's
-   * own `transformExpr` — e.g. the loop's array-source expression —
-   * keeps the unfiltered env).
+   * `BindingScope` for the ENCLOSING loops' callback bindings (item /
+   * index / destructured names / preamble locals), threaded through the
+   * recursion one `enterLoopRow` per nesting level (#2482 Stage 1b —
+   * migrated from the ad-hoc flat loop-bound-names `ReadonlySet<string>`
+   * this field replaces). Inside a loop body, `csrSubstitute` receives each
+   * expression in isolation — no enclosing arrow text — so its own
+   * bound-name tracking can't see the loop binding; the `loop` case
+   * instead filters these names out of the child recursion's `csrEnv`
+   * (via `scope.boundNames()`, the SHADOW-GUARD query — see
+   * `BindingScope.valueBoundNames`'s doc comment for why this must stay
+   * the all-sources query, not the value-only one), so an inlinable
+   * const / signal / memo whose name is shadowed by a loop-row binding —
+   * including a `.map()` callback preamble local (#2447) — never
+   * substitutes at the shadowed occurrence. Scope-accurate per nesting
+   * level (the CURRENT level's own `transformExpr` — e.g. the loop's
+   * array-source expression — keeps the unfiltered env). `undefined` at
+   * the top of the recursion means "no enclosing loop" (treated as
+   * `BindingScope.EMPTY`).
    */
-  loopBoundNames?: ReadonlySet<string>
+  scope?: BindingScope
   /** Emit `bf-s` placeholder on scoped elements inside a jsx-children prop (#1320). */
   inHoistedChildren?: boolean
   /**
@@ -2226,7 +2234,7 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     // the IR — emit does no string transformation of its own (#1277).
     const source = templateExpr ?? expr
     if (!source) return source
-    const { rewritten, freeIdentifiers } = csrSubstitute(source, env)
+    const { rewritten, freeIdentifiers } = csrSubstitute(source, env, opts.scope)
 
     // The CSR template runs at module scope, so any post-substitution
     // free identifier that lands in `unsafeLocalNames` (init-body-only
@@ -2458,23 +2466,21 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     }
 
     case 'loop': {
-      // Accumulate this loop's callback-bound names and filter them out
-      // of the child recursion's substitution env (#2222): an inlinable
-      // const / signal / memo whose name the callback shadows must never
-      // substitute inside the body. Destructured callbacks contribute
-      // their individual binding names; a raw pattern-text `param` (the
-      // BF025 fallback shapes, detected by the same leading-`[`/`{` check
-      // `destructureLoopParam` uses — NOT an ASCII-identifier regex, which
-      // would drop Unicode param names like `π` and re-enable the shadow
-      // bug for that body) contributes nothing — conservatively
-      // unfiltered rather than mis-filtered.
-      const boundHere = new Set(opts.loopBoundNames ?? [])
-      if (node.paramBindings && node.paramBindings.length > 0) {
-        for (const b of node.paramBindings) boundHere.add(b.name)
-      } else if (!node.param.startsWith('[') && !node.param.startsWith('{')) {
-        boundHere.add(node.param)
-      }
-      if (node.index) boundHere.add(node.index)
+      // Enter this loop's row frame and filter its bound names out of the
+      // child recursion's substitution env (#2222, #2482 Stage 1b): an
+      // inlinable const / signal / memo whose name the callback shadows —
+      // item, index, a destructured binding, OR a `.map()` callback
+      // preamble local (#2447) — must never substitute inside the body.
+      // `enterLoopRow` mirrors `jsx-to-ir.ts`'s legacy mutable loop-param
+      // set semantics exactly (see its doc comment): a raw pattern-text `param` (the
+      // BF025 fallback shapes) with no `paramBindings` still gets added,
+      // but as non-identifier pattern text it can never collide with a
+      // real const/signal/memo name, so it's a harmless no-op for this
+      // filter. `boundNames()` (not `valueBoundNames()`) is the correct
+      // query here — this is a SHADOW GUARD (every binding source must
+      // hide an outer same-named const), not a reactivity classifier.
+      const childScope = (opts.scope ?? BindingScope.EMPTY).enterLoopRow(node)
+      const boundHere = childScope.boundNames()
       const childEnv: CsrEnv = {
         ...env,
         substitutions: new Map([...env.substitutions].filter(([name]) => !boundHere.has(name))),
@@ -2483,7 +2489,7 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
         ...opts,
         loopDepth: loopDepth + 1,
         inHoistedChildren: false,
-        loopBoundNames: boundHere,
+        scope: childScope,
         csrEnv: childEnv,
       })
       let childTemplate = node.children.map(recurseInLoopBody).join('')

--- a/packages/jsx/src/ir-to-client-js/prop-handling.ts
+++ b/packages/jsx/src/ir-to-client-js/prop-handling.ts
@@ -4,6 +4,7 @@
 
 import type { ParamInfo, SignalInfo } from '../types.ts'
 import type { ClientJsContext } from './types.ts'
+import type { BindingScope } from '../scope/binding-scope.ts'
 
 /**
  * Expand dynamic prop value by resolving local constants.
@@ -11,9 +12,22 @@ import type { ClientJsContext } from './types.ts'
  * Per spec/compiler.md, no prop reference transformation is needed:
  * - Destructured props are captured once at hydration, used as-is
  * - Props object already uses props.xxx syntax
+ *
+ * `scope` (#2482 Stage 1b): the enclosing loop row's `BindingScope`, when
+ * `value` is being expanded from inside a `.map()` row. `ClientJsContext`
+ * itself carries no loop-scope field — it's a per-component object, built
+ * once and shared across the whole tree — so without this guard a loop
+ * row binding (item / index / destructured / preamble local) that shares
+ * a name with a component/module-level const resolves to the OUTER
+ * const's value instead of staying an unresolved reference to the row's
+ * own binding. `isBound` (not `valueBoundNames`) is the correct query —
+ * this is a SHADOW GUARD (every binding source hides an outer same-named
+ * const), not a reactivity classifier — see `BindingScope.valueBoundNames`'s
+ * doc comment.
  */
-export function expandDynamicPropValue(value: string, ctx: ClientJsContext): string {
+export function expandDynamicPropValue(value: string, ctx: ClientJsContext, scope?: BindingScope): string {
   const trimmedValue = value.trim()
+  if (scope?.isBound(trimmedValue)) return value
 
   const constant = ctx.localConstants.find((c) => c.name === trimmedValue)
   if (constant && constant.value) {
@@ -35,16 +49,29 @@ export function expandDynamicPropValue(value: string, ctx: ClientJsContext): str
  * Otherwise it is `originalFreeIds` passed by the caller (typically derived
  * from the IR node's `origin.freeRefs`) — `undefined` when the caller has
  * no precomputed set.
+ *
+ * `scope` (#2482 Stage 1b): see `expandDynamicPropValue` — same guard, same
+ * reasoning. Without it, a loop row's own binding (bare identifier, e.g. a
+ * `.map()` callback preamble local or the item param itself) that shares a
+ * name with a component/module-level const gets const-folded into the
+ * OUTER value here, which then corrupts BOTH the emitted expression AND
+ * downstream reactivity classification (`classifyReactivity` sees a
+ * literal instead of a live reference and concludes "not reactive" — the
+ * observable failure mode is a reactive attribute/conditional that
+ * silently freezes at its initial value instead of updating).
  */
 export function expandConstantForReactivity(
   expr: string,
   ctx: ClientJsContext,
   originalFreeIds?: ReadonlySet<string>,
+  scope?: BindingScope,
 ): { expr: string; freeIds: ReadonlySet<string> | undefined } {
   // Stateful components use props.xxx directly — reactivity is already detected.
   if (ctx.propsObjectName) return { expr, freeIds: originalFreeIds }
 
   const trimmedValue = expr.trim()
+  if (scope?.isBound(trimmedValue)) return { expr, freeIds: originalFreeIds }
+
   const constant = ctx.localConstants.find((c) => c.name === trimmedValue)
   if (constant && constant.value) {
     return { expr: constant.value, freeIds: constant.freeIdentifiers }

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -22,24 +22,33 @@ import { BindingScope } from '../scope/binding-scope.ts'
 
 /**
  * Build the `BindingScope` for one loop row's own bindings — item /
- * destructured param names plus (when supplied) the `.map()` callback's
- * preamble locals (#2447) — for the `expandConstantForReactivity` shadow
- * guard (#2482 Stage 1b). `undefined` when there's no enclosing loop
+ * destructured param / index names plus (when supplied) the `.map()`
+ * callback's preamble locals (#2447) — for the `expandConstantForReactivity`
+ * shadow guard (#2482 Stage 1b). `undefined` when there's no enclosing loop
  * (`loopParam` unset), matching every caller's existing "no loop" shape.
- * Loop `index` is intentionally NOT included — none of these collectors
- * carry it separately, matching `classifyReactivity`'s own
- * `loopParam`/`loopParamBindings`-only signature (index shadowing a
- * const is comparatively rare and out of scope for this pass).
+ *
+ * `loopIndex` (Copilot review on #2595): a `.map((item, i) => ...)`
+ * callback's second param is a real row-scoped binding exactly like
+ * `item` — an `i`-shadows-a-module-const attr/text (e.g.
+ * `data-idx={/* @client *\/ i}`) const-folds to the outer value exactly
+ * like an item-param shadow does when the index name isn't in scope.
+ * Only guarded when the CALLER passes it in, though — none of the
+ * `collectLoopChild*` collectors' own callers threaded the IR loop's
+ * `index` field through before this fix (see each call site's own
+ * `undefined`/omitted-arg default), so `undefined` here still means "not
+ * guarded," not "no index param."
  */
 export function buildLoopRowScope(
   loopParam?: string,
   loopParamBindings?: readonly LoopParamBinding[],
   preambleNames?: ReadonlySet<string>,
+  loopIndex?: string | null,
 ): BindingScope | undefined {
   if (!loopParam) return undefined
   return BindingScope.EMPTY.enterLoopRow({
     param: loopParam,
     paramBindings: loopParamBindings,
+    index: loopIndex,
     preamble: preambleNames && preambleNames.size > 0 ? { declaredNames: [...preambleNames] } : undefined,
   })
 }
@@ -585,6 +594,9 @@ function traverseForComponents(
  * preamble locals (#2447), when known — folded into the `expandConstantForReactivity`
  * shadow guard via `buildLoopRowScope` so a preamble local shadowing a
  * component/module const doesn't get const-folded here.
+ *
+ * `loopIndex` (Copilot review on #2595): the loop's index param name
+ * (`.map((item, i) => ...)`'s `i`), when known — see `buildLoopRowScope`.
  */
 export function collectLoopChildReactiveTexts(
   node: IRNode,
@@ -593,9 +605,10 @@ export function collectLoopChildReactiveTexts(
   loopParamBindings?: readonly LoopParamBinding[],
   stopAtReactiveConditionals = false,
   preambleNames?: ReadonlySet<string>,
+  loopIndex?: string | null,
 ): LoopChildReactiveText[] {
   const texts: LoopChildReactiveText[] = []
-  const scope = buildLoopRowScope(loopParam, loopParamBindings, preambleNames)
+  const scope = buildLoopRowScope(loopParam, loopParamBindings, preambleNames, loopIndex)
   walkIR(node, false, {
     // Skip loop/async/if-statement subtrees — the original walker omitted
     // them; they have their own scopes (inner-loop reconciliation, async
@@ -653,6 +666,8 @@ export function collectLoopChildReactiveTexts(
  * `stopAtReactiveConditionals` (#2347): see `collectLoopChildReactiveTexts` —
  * same semantics. Pass true only when the caller also separately collects
  * nested reactive conditionals and gives each its own `insert()`.
+ *
+ * `loopIndex` (Copilot review on #2595): see `collectLoopChildReactiveTexts`.
  */
 /** Does any name in `names` appear in `set`? Iterates rather than
  *  spreading — this runs per attribute (Copilot review). */
@@ -668,9 +683,10 @@ export function collectLoopChildReactiveAttrs(
   loopParamBindings?: readonly LoopParamBinding[],
   stopAtReactiveConditionals = false,
   preambleNames?: ReadonlySet<string>,
+  loopIndex?: string | null,
 ): LoopChildReactiveAttr[] {
   const attrs: LoopChildReactiveAttr[] = []
-  const scope = buildLoopRowScope(loopParam, loopParamBindings, preambleNames)
+  const scope = buildLoopRowScope(loopParam, loopParamBindings, preambleNames, loopIndex)
   traverseElements(node, (el) => {
     if (el.slotId) {
       for (const attr of el.attrs) {

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -18,6 +18,31 @@ import { attrValueToString, freeIdsFromRefs, tokenContainsIdent } from './utils.
 import { expandConstantForReactivity } from './prop-handling.ts'
 import { extractFreeIdentifiersFromText } from './csr-substitute.ts'
 import { walkIR, stopAt } from './walker.ts'
+import { BindingScope } from '../scope/binding-scope.ts'
+
+/**
+ * Build the `BindingScope` for one loop row's own bindings — item /
+ * destructured param names plus (when supplied) the `.map()` callback's
+ * preamble locals (#2447) — for the `expandConstantForReactivity` shadow
+ * guard (#2482 Stage 1b). `undefined` when there's no enclosing loop
+ * (`loopParam` unset), matching every caller's existing "no loop" shape.
+ * Loop `index` is intentionally NOT included — none of these collectors
+ * carry it separately, matching `classifyReactivity`'s own
+ * `loopParam`/`loopParamBindings`-only signature (index shadowing a
+ * const is comparatively rare and out of scope for this pass).
+ */
+export function buildLoopRowScope(
+  loopParam?: string,
+  loopParamBindings?: readonly LoopParamBinding[],
+  preambleNames?: ReadonlySet<string>,
+): BindingScope | undefined {
+  if (!loopParam) return undefined
+  return BindingScope.EMPTY.enterLoopRow({
+    param: loopParam,
+    paramBindings: loopParamBindings,
+    preamble: preambleNames && preambleNames.size > 0 ? { declaredNames: [...preambleNames] } : undefined,
+  })
+}
 
 /**
  * Phase 2 reactivity detection: determines if a code expression needs `createEffect`
@@ -555,6 +580,11 @@ function traverseForComponents(
  * Defaults to false: some callers (e.g. a plain nested `.map()`'s own
  * per-item bindings) have no sibling conditional collector, so a slotId'd
  * conditional's inlined content is only ever reachable by descending here.
+ *
+ * `preambleNames` (#2482 Stage 1b): the enclosing loop's `.map()` callback
+ * preamble locals (#2447), when known — folded into the `expandConstantForReactivity`
+ * shadow guard via `buildLoopRowScope` so a preamble local shadowing a
+ * component/module const doesn't get const-folded here.
  */
 export function collectLoopChildReactiveTexts(
   node: IRNode,
@@ -562,8 +592,10 @@ export function collectLoopChildReactiveTexts(
   loopParam?: string,
   loopParamBindings?: readonly LoopParamBinding[],
   stopAtReactiveConditionals = false,
+  preambleNames?: ReadonlySet<string>,
 ): LoopChildReactiveText[] {
   const texts: LoopChildReactiveText[] = []
+  const scope = buildLoopRowScope(loopParam, loopParamBindings, preambleNames)
   walkIR(node, false, {
     // Skip loop/async/if-statement subtrees — the original walker omitted
     // them; they have their own scopes (inner-loop reconciliation, async
@@ -579,7 +611,7 @@ export function collectLoopChildReactiveTexts(
       // (a `joinArrayChild` region's value is raw HTML, not text).
       if (n.preambleRegion) return
       const originFreeIds = freeIdsFromRefs(n.origin?.freeRefs)
-      const expanded = expandConstantForReactivity(n.expr, ctx, originFreeIds)
+      const expanded = expandConstantForReactivity(n.expr, ctx, originFreeIds, scope)
       // Include if expression reads signals OR references the loop parameter
       // (loop param becomes a signal accessor via per-item signals). Falls
       // back to the Solid-style AST-flag wrap decision — mirroring
@@ -638,6 +670,7 @@ export function collectLoopChildReactiveAttrs(
   preambleNames?: ReadonlySet<string>,
 ): LoopChildReactiveAttr[] {
   const attrs: LoopChildReactiveAttr[] = []
+  const scope = buildLoopRowScope(loopParam, loopParamBindings, preambleNames)
   traverseElements(node, (el) => {
     if (el.slotId) {
       for (const attr of el.attrs) {
@@ -653,7 +686,7 @@ export function collectLoopChildReactiveAttrs(
         if (attr.name === 'key') continue
         const valueStr = attrValueToString(attr.value)
         if (!valueStr) continue
-        const expanded = expandConstantForReactivity(valueStr, ctx, attr.freeIdentifiers)
+        const expanded = expandConstantForReactivity(valueStr, ctx, attr.freeIdentifiers, scope)
         // `/* @client */` always defers via per-item createEffect
         // regardless of the reactivity classifier — matches the
         // top-level `collectElements.element` and the conditional


### PR DESCRIPTION
**Stage 1b of #2482 Option A** (design: https://github.com/piconic-ai/barefootjs/issues/2482#issuecomment-5224483715; Stage 0 = #2585, Stage 1a = #2590, both merged). Completes Stage 1's compiler-core scope: the `ir-to-client-js` (Phase 2) half.

## What changed

1. **`html-template.ts`**: `TemplateOptions.loopBoundNames` (a Set re-unioned per recursion level, predating #2447 so preamble names were never in it) → `scope?: BindingScope`. The `loop` case derives `childScope = scope.enterLoopRow(node)` and filters `csrEnv.substitutions` via all-sources `boundNames()` (shadow-guard membership, per Stage 1a's two-consumer-classes split).
2. **`csr-substitute.ts`**: `csrSubstitute`/`csrSubstituteOnce` accept an optional `enclosingScope?: BindingScope`; the internal `boundStack` lookup falls back to it. On today's live call graph every caller pre-filters its `CsrEnv`, so this is wired per the design mandate and pinned by unit test only — stated plainly rather than pretending an end-to-end repro exists.
3. **`prop-handling.ts`**: the two flat `ctx.localConstants.find` lookups (a context type with no loop-scope field — the unguarded sites named in the design comment) now take a `scope` and skip const resolution when the name `isBound`.
4. **`reactivity.ts` / `collect-elements.ts`**: new `buildLoopRowScope()` helper; `preambleNames` threaded through `collectLoopChildReactiveTexts` / `collectLoopChildConditionals` / `summarizeLoopChildBranch` (mirroring the parameter `collectLoopChildReactiveAttrs` already had).

## Behavior fixes shipped (both pinned red-without/green-with)

- **Preamble local shadowing a module const leaked into the CSR-only materialize hydrate template** — every row baked the frozen module value (`csr-materialize-loop-preamble-shadow.test.ts`). Direct consequence of preamble names finally joining the scope; previously-shipping bug, found while probing.
- **Loop-row reactive attribute reading an item param that shadows a module const resolved to the outer const** (`loop-child-reactive-attr-const-shadow.test.ts`, via `expandConstantForReactivity` — the genuinely reachable path; the "child-component prop" route from the design table turned out to be unreachable, always going through the already-scope-safe `wrapLoopParamAsAccessor` mechanism; guarded anyway).

## Found, out of scope (Phase 1, filed separately)

A `.map()` row conditional whose condition is a bare preamble-local reference never gets its IR `reactive` flag set — a `jsx-to-ir.ts` (Phase 1) gap upstream of this stage. Issue to follow.

## Ratchet & verification

- Allowlist: `html-template.ts` `loopBoundNames: 3` → **entry deleted** (0 occurrences); `prop-handling.ts` entries unchanged (guarded in place). Shrink-only invariant holds.
- `packages/jsx` **2965 pass / 0 fail** (baseline 2959 + 1 flaky timeout; +6 = the new tests), `packages/adapter-tests` **1891 / 0 fail** (unchanged), `packages/adapter-hono` **1371 / 0 fail**.
- Shared-component snapshot regeneration: **zero diff**.
- Deferred, untouched per plan: the `isSignalOrMemoReference`/`isPropsReference` classifier guards (Stage 1a's explicit deferral, guard+compensation must move together), `BindingEnvironment.loopParams` rename.

Refs #2482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_