### PR TITLE
fix(compiler): keep the writers of surviving mutable bindings

### DIFF
--- a/.changeset/mutable-binding-writers-2598.md
+++ b/.changeset/mutable-binding-writers-2598.md
@@ -1,0 +1,5 @@
+---
+'@barefootjs/jsx': patch
+---
+
+Keep the declarations that WRITE a mutable binding when that binding survives into an emitted SSR template (#2598). Reachability is seeded from the rendered JSX, which has already had client-only attributes stripped, so a handler reachable only through `ref={setRef}` (or `onClick={handleClick}`) is pruned — deliberate, since it is client-only. The hole was a `let` that outlives its writer: it survives because another surviving declaration reads it, leaving the template to declare and read a binding it never assigns, which TypeScript narrows to `never` at every guarded use (TS2339). `findReachableNames` now closes over writers of surviving mutable bindings, detected via the TS AST so a read, a comparison, or a property write through the binding does not count.

--- a/packages/jsx/src/__tests__/mutable-binding-writers.test.ts
+++ b/packages/jsx/src/__tests__/mutable-binding-writers.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit coverage for `findAssignedNames` / `closeOverWritersOfMutableBindings`
+ * (#2598).
+ *
+ * The e2e half lives in `packages/vite/src/__tests__/mutable-binding-writers.test.ts`
+ * (real `vite build`, emitted template type-checked). This half pins what an
+ * e2e fixture can't isolate: which syntactic forms count as a WRITE, and the
+ * reads/false matches that must not. Those negative cases are why this uses
+ * the AST — a regex for `name\s*=` would match every one of them.
+ */
+import { describe, test, expect } from 'bun:test'
+import { findAssignedNames, closeOverWritersOfMutableBindings } from '../module-exports.ts'
+
+const candidates = (...names: string[]) => new Set(names)
+
+describe('findAssignedNames', () => {
+  test('plain assignment', () => {
+    expect([...findAssignedNames(`el = node`, candidates('el'))]).toEqual(['el'])
+  })
+
+  test('compound assignment', () => {
+    expect([...findAssignedNames(`seq += 1`, candidates('seq'))]).toEqual(['seq'])
+  })
+
+  test('logical assignment', () => {
+    expect([...findAssignedNames(`cached ??= build()`, candidates('cached'))]).toEqual(['cached'])
+  })
+
+  test('postfix and prefix update', () => {
+    expect([...findAssignedNames(`a++`, candidates('a'))]).toEqual(['a'])
+    expect([...findAssignedNames(`--b`, candidates('b'))]).toEqual(['b'])
+  })
+
+  test('assignment nested inside a function body', () => {
+    const body = `(el) => { if (el) { highlightEl = el } }`
+    expect([...findAssignedNames(body, candidates('highlightEl'))]).toEqual(['highlightEl'])
+  })
+
+  test('reports only the candidates asked about', () => {
+    const body = `a = 1; b = 2; c = 3`
+    expect([...findAssignedNames(body, candidates('b'))]).toEqual(['b'])
+  })
+
+  test('a read is not a write', () => {
+    expect([...findAssignedNames(`const x = el`, candidates('el'))]).toEqual([])
+  })
+
+  test('a comparison is not a write', () => {
+    expect([...findAssignedNames(`if (el == null) {}`, candidates('el'))]).toEqual([])
+    expect([...findAssignedNames(`if (el === other) {}`, candidates('el'))]).toEqual([])
+  })
+
+  test('a property write through the binding is not a write TO it', () => {
+    // `el` keeps whatever it already held — this cannot be what gives a
+    // never-narrowed binding its value.
+    expect([...findAssignedNames(`el.scrollTop = 0`, candidates('el'))]).toEqual([])
+  })
+
+  test('a same-named property key is not a write', () => {
+    expect([...findAssignedNames(`const o = { el: 1 }`, candidates('el'))]).toEqual([])
+  })
+
+  test('`name=` inside a string or JSX attribute is not a write', () => {
+    expect([...findAssignedNames(`const s = "el = node"`, candidates('el'))]).toEqual([])
+    expect([...findAssignedNames(`<div data-x="el = node" />`, candidates('el'))]).toEqual([])
+  })
+
+  test('no candidates means no parse and no results', () => {
+    expect([...findAssignedNames(`el = node`, candidates())]).toEqual([])
+  })
+})
+
+describe('closeOverWritersOfMutableBindings', () => {
+  // `declarations` carries the local `let` bindings themselves alongside the
+  // functions, exactly as the adapter builds it (localConstants +
+  // localFunctions) — a binding only counts as "surviving" if it is in this
+  // list and reachable.
+  const decls = [
+    { name: 'binding', body: `null` },
+    // Reachable from the rendered JSX below.
+    { name: 'reader', body: `() => { if (binding) return binding.x; return 0 }` },
+    // Reachable ONLY through a stripped attribute — the writer.
+    { name: 'writer', body: `(el) => { binding = el }` },
+    // Reachable from nothing at all; must stay pruned.
+    { name: 'orphan', body: `() => { unrelated = 1 }` },
+  ]
+  const rendered = `<div onScroll={reader} />`
+
+  test('pulls in the writer of a surviving mutable binding', () => {
+    const out = closeOverWritersOfMutableBindings(rendered, decls, new Set(['binding']))
+    expect(out.has('reader')).toBe(true)
+    expect(out.has('writer')).toBe(true)
+  })
+
+  test('leaves declarations that write nothing reachable alone', () => {
+    const out = closeOverWritersOfMutableBindings(rendered, decls, new Set(['binding']))
+    expect(out.has('orphan')).toBe(false)
+  })
+
+  test('does not retain a writer when the binding itself was pruned', () => {
+    // Nothing references `binding`, so it is not emitted and its writer is
+    // dead client-only code — the pruning this feature must not undo.
+    const out = closeOverWritersOfMutableBindings(`<div />`, decls, new Set(['binding']))
+    expect(out.has('writer')).toBe(false)
+    expect(out.has('reader')).toBe(false)
+  })
+
+  test('is a no-op when nothing is mutable', () => {
+    const withMutables = closeOverWritersOfMutableBindings(rendered, decls, new Set(['binding']))
+    const withoutMutables = closeOverWritersOfMutableBindings(rendered, decls, new Set())
+    expect(withoutMutables.has('writer')).toBe(false)
+    expect(withMutables.has('writer')).toBe(true)
+  })
+
+  test('reaches a writer that is only retained transitively', () => {
+    // `outerWriter` writes `a`; retaining it makes `b` reachable, whose own
+    // writer must then come along too — one round is not enough.
+    const chained = [
+      { name: 'a', body: `null` },
+      { name: 'b', body: `null` },
+      { name: 'reader', body: `() => (a ? a.x : 0)` },
+      { name: 'outerWriter', body: `(el) => { a = el; touch(b) }` },
+      { name: 'innerWriter', body: `(el) => { b = el }` },
+    ]
+    const out = closeOverWritersOfMutableBindings(
+      `<div onScroll={reader} />`,
+      chained,
+      new Set(['a', 'b']),
+    )
+    expect(out.has('outerWriter')).toBe(true)
+    expect(out.has('innerWriter')).toBe(true)
+  })
+})

--- a/packages/jsx/src/adapters/jsx-adapter.ts
+++ b/packages/jsx/src/adapters/jsx-adapter.ts
@@ -17,7 +17,7 @@ import { BF_SCOPE, BF_SLOT, BF_COND } from '@barefootjs/shared'
 import { BaseAdapter } from './interface.ts'
 import type { CallbackBodyAcceptor } from './interface.ts'
 import { ENV_SIGNAL_CLIENT_FACTORY } from './env-signal.ts'
-import { formatParamWithType, findReachableNames } from '../module-exports.ts'
+import { formatParamWithType, closeOverWritersOfMutableBindings } from '../module-exports.ts'
 import { extractFreeIdentifiersFromText } from '../ir-to-client-js/csr-substitute.ts'
 import { identifierPattern } from '../identifier-pattern.ts'
 
@@ -113,7 +113,15 @@ export abstract class JsxAdapter extends BaseAdapter {
     ]
 
     // Find reachable declarations via transitive dependency analysis
-    const reachable = findReachableNames(primaryRefText, declarations)
+    const reachable = closeOverWritersOfMutableBindings(
+      primaryRefText,
+      declarations,
+      new Set(
+        ir.metadata.localConstants
+          .filter(c => (c.declarationKind ?? 'const') !== 'const')
+          .map(c => c.name),
+      ),
+    )
 
     // Also check which signal setters are referenced
     const reachableBodies = [...reachable].map(name => {

--- a/packages/jsx/src/module-exports.ts
+++ b/packages/jsx/src/module-exports.ts
@@ -5,6 +5,7 @@
  * This is a compiler-layer concern, not adapter-specific.
  */
 
+import ts from 'typescript'
 import type { ComponentIR, ParamInfo } from './types.ts'
 import { identifierPattern } from './identifier-pattern.ts'
 
@@ -159,6 +160,142 @@ export function findReachableNames(
   }
 
   return reachable
+}
+
+/**
+ * Which of `candidates` does `bodyText` ASSIGN to?
+ *
+ * Reachability above answers "is this declaration referenced?", which is
+ * the right question for pruning SSR-irrelevant code. It is the wrong
+ * question for a MUTABLE binding: a surviving `let` whose only writer got
+ * pruned is left declared-and-read but never assigned, and TypeScript's
+ * control-flow analysis then narrows it to `never` at every guarded use
+ * (#2598). `closeOverWritersOfMutableBindings` uses this to restore the
+ * missing half of that pair.
+ *
+ * Recognizes the forms that actually write a local binding:
+ *   `x = …`, `x += …` (and every other compound operator), `x++`, `--x`
+ * Destructuring assignment (`[x] = …`, `({ x } = …)`) is deliberately NOT
+ * recognized: it never appears in the ref/handler shapes this exists for,
+ * and a wrong guess here over-retains rather than fails loudly, so leaving
+ * it out keeps the retained set honest. If one shows up, it will present
+ * as this same `never` narrowing and can be added with a fixture.
+ *
+ * Parsed with the TS AST, not matched as text: `identifierPattern` (used
+ * for reference detection above) cannot tell a write from a read, and a
+ * regex for `name\s*=` would match `name == x`, a `name=` inside a string
+ * or JSX attribute, and a property write `obj.name = x` that assigns
+ * nothing of the sort.
+ */
+export function findAssignedNames(
+  bodyText: string,
+  candidates: ReadonlySet<string>,
+): Set<string> {
+  const assigned = new Set<string>()
+  if (candidates.size === 0) return assigned
+
+  const sf = ts.createSourceFile(
+    'bf-assignment-scan.tsx',
+    bodyText,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ false,
+    ts.ScriptKind.TSX,
+  )
+
+  // A bare Identifier on the left of an assignment — `obj.x = …` is a
+  // PropertyAccessExpression and writes through the binding rather than to
+  // it, so it does not count.
+  const record = (target: ts.Node): void => {
+    if (ts.isIdentifier(target) && candidates.has(target.text)) {
+      assigned.add(target.text)
+    }
+  }
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isBinaryExpression(node) && isAssignmentOperator(node.operatorToken.kind)) {
+      record(node.left)
+    } else if (
+      (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+      (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken)
+    ) {
+      record(node.operand)
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  ts.forEachChild(sf, visit)
+  return assigned
+}
+
+/**
+ * `findReachableNames`, plus the invariant it cannot express on its own:
+ * **a mutable binding that survives keeps the declarations that write it.**
+ *
+ * Reachability is seeded from the RENDERED JSX, which has already had the
+ * client-only attributes stripped — `ref={setRef}` leaves no `setRef`
+ * behind, and `onClick={handleClick}` is rendered as `onClick={() => {}}`.
+ * That is deliberate: code reachable only from a handler is client-only
+ * and should not be emitted into an SSR template.
+ *
+ * It goes wrong when a `let` outlives its writer. The binding survives
+ * because some OTHER surviving declaration reads it, while its only
+ * assignment lived in a pruned handler — so the emitted template declares
+ * it, reads it, and never assigns it. TypeScript's control-flow analysis
+ * concludes it is permanently `null`, narrows every guarded use to `never`,
+ * and each member access on it fails:
+ *
+ *     let highlightEl: HTMLElement | null = null      // writer was pruned
+ *     const syncScroll = () => {
+ *       if (highlightEl && textareaEl) {
+ *         highlightEl.scrollTop = textareaEl.scrollTop   // TS2339 on `never`
+ *       }
+ *     }
+ *
+ * Pulling the writers back in restores the source's shape for exactly the
+ * bindings that survived — nothing else. The retained writer is dead code
+ * at SSR (it only ever runs from a hydrated event), which is the same
+ * harmless-unused-declaration trade `generateModuleScopeDeclarations`
+ * already makes deliberately.
+ *
+ * Iterates to a fixpoint because a newly retained writer can read further
+ * declarations, and can itself write another mutable binding. Bounded by
+ * the declaration count: each round either adds a name or stops.
+ */
+export function closeOverWritersOfMutableBindings(
+  primaryRefs: string,
+  declarations: { name: string; body: string }[],
+  mutableNames: ReadonlySet<string>,
+): Set<string> {
+  let reachable = findReachableNames(primaryRefs, declarations)
+  if (mutableNames.size === 0) return reachable
+
+  let seedText = primaryRefs
+  for (let round = 0; round <= declarations.length; round++) {
+    const survivingMutables = new Set(
+      [...reachable].filter(name => mutableNames.has(name)),
+    )
+    if (survivingMutables.size === 0) return reachable
+
+    const added = declarations
+      .filter(d => !reachable.has(d.name))
+      .filter(d => findAssignedNames(d.body, survivingMutables).size > 0)
+      .map(d => d.name)
+    if (added.length === 0) return reachable
+
+    // Re-seed by NAME rather than merging sets directly, so each retained
+    // writer's own transitive dependencies come along through the same
+    // traversal instead of a second, divergent one.
+    seedText += '\n' + added.join('\n')
+    reachable = findReachableNames(seedText, declarations)
+  }
+  return reachable
+}
+
+function isAssignmentOperator(kind: ts.SyntaxKind): boolean {
+  return (
+    kind >= ts.SyntaxKind.FirstAssignment &&
+    kind <= ts.SyntaxKind.LastAssignment
+  )
 }
 
 /**

--- a/packages/vite/e2e-fixture-refwriter/components/Editable.tsx
+++ b/packages/vite/e2e-fixture-refwriter/components/Editable.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+// A child component. Its props — `ref` included — are emitted into the SSR
+// template verbatim, unlike an intrinsic element's, which is what keeps the
+// handler passed to it alive through reachability.
+export function Editable(props: { ref?: (el: HTMLTextAreaElement) => void }) {
+  return <textarea ref={props.ref} />
+}

--- a/packages/vite/e2e-fixture-refwriter/components/ScrollSync.tsx
+++ b/packages/vite/e2e-fixture-refwriter/components/ScrollSync.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { Editable } from './Editable'
+
+// Mirrors piconic-ai/koma's FrameEditor: a highlight layer painted behind a
+// textarea, both captured by `ref`, kept scrolled in lockstep.
+export function ScrollSync() {
+  let textareaEl: HTMLTextAreaElement | null = null
+  let highlightEl: HTMLElement | null = null
+  let renderSeq = 0
+
+  const syncScroll = () => {
+    if (highlightEl && textareaEl) {
+      highlightEl.scrollTop = textareaEl.scrollTop
+      renderSeq++
+    }
+  }
+
+  // Reachable: passed to a CHILD component, whose props survive verbatim.
+  const handleTextareaRef = (el: HTMLTextAreaElement) => {
+    textareaEl = el
+    el.addEventListener('scroll', syncScroll)
+  }
+
+  // The only writer of `highlightEl` — reachable ONLY through the `ref` on an
+  // INTRINSIC element below, which the SSR renderer strips.
+  const handleHighlightRef = (el: HTMLElement) => {
+    highlightEl = el
+  }
+
+  return (
+    <div>
+      <pre ref={handleHighlightRef} />
+      <Editable ref={handleTextareaRef} />
+    </div>
+  )
+}

--- a/packages/vite/src/__tests__/mutable-binding-writers.test.ts
+++ b/packages/vite/src/__tests__/mutable-binding-writers.test.ts
@@ -42,11 +42,14 @@ const APP_ROOT = join(FIXTURE_ROOT, 'app')
 const COMPONENTS_DIR = join(FIXTURE_ROOT, 'components')
 
 describe('writers of surviving mutable bindings', () => {
-  let outDir: string
+  let outDir: string | undefined
   const templatesDir = join(APP_ROOT, 'dist/components')
 
   afterAll(async () => {
-    await rm(outDir, { recursive: true, force: true })
+    // Guarded: if the test throws before `mkdtemp` returns, `outDir` is still
+    // undefined and an unguarded `rm` would throw here, replacing the real
+    // failure with a cleanup TypeError.
+    if (outDir) await rm(outDir, { recursive: true, force: true })
     await rm(join(APP_ROOT, 'dist'), { recursive: true, force: true })
   })
 
@@ -83,9 +86,9 @@ describe('writers of surviving mutable bindings', () => {
     expect(template).toContain('renderSeq++')
 
     // The symptom itself, not a proxy for it: type-check the emitted
-    // template and assert the `never` narrowing is gone. Asserting on the
-    // retained source line alone would still pass if some later change made
-    // the binding un-narrowable for a different reason.
+    // template. Asserting on the retained source line alone would still pass
+    // if some later change made the binding un-narrowable for a different
+    // reason.
     const program = ts.createProgram([templatePath], {
       strict: true,
       noEmit: true,
@@ -98,10 +101,16 @@ describe('writers of surviving mutable bindings', () => {
       allowImportingTsExtensions: true,
       skipLibCheck: true,
     })
-    const neverNarrowings = ts
+    // Asserted over the WHOLE error set, not a TS2339-only filter: this
+    // fixture's emitted template compiles completely clean today, so any
+    // error at all — a syntax break, an unresolved import, a wrong JSX
+    // setting — is a real regression, and a narrow filter would let those
+    // through while still claiming the template type-checks. TS2339 on
+    // `never` is simply the member of that set this PR is about.
+    const errors = ts
       .getPreEmitDiagnostics(program)
-      .filter((d) => d.code === 2339)
-      .map((d) => ts.flattenDiagnosticMessageText(d.messageText, ' '))
-    expect(neverNarrowings).toEqual([])
+      .filter((d) => d.category === ts.DiagnosticCategory.Error)
+      .map((d) => `TS${d.code}: ${ts.flattenDiagnosticMessageText(d.messageText, ' ')}`)
+    expect(errors).toEqual([])
   }, 60_000)
 })

--- a/packages/vite/src/__tests__/mutable-binding-writers.test.ts
+++ b/packages/vite/src/__tests__/mutable-binding-writers.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression (#2598): a mutable binding that survives into the emitted SSR
+ * template must keep the declarations that WRITE it.
+ *
+ * Reachability is seeded from the RENDERED JSX, after the client-only
+ * attributes are stripped — `ref={setRef}` leaves no `setRef` behind, and
+ * `onClick={handleClick}` renders as `onClick={() => {}}`. Pruning code
+ * reachable only from a handler is deliberate; it is client-only.
+ *
+ * The hole is a `let` that outlives its writer. It survives because some
+ * OTHER surviving declaration reads it, while its only assignment sat in a
+ * pruned handler — so the template declares it, reads it, and never assigns
+ * it. TypeScript then concludes it is permanently `null`, narrows every
+ * guarded use to `never`, and each member access fails with TS2339.
+ *
+ * The fixture reproduces the shape from the wild (piconic-ai/koma's
+ * FrameEditor), and the asymmetry that makes it reachable at all:
+ *
+ *   <pre ref={handleHighlightRef} />   intrinsic — `ref` is STRIPPED, so
+ *                                      the handler is pruned
+ *   <Editable ref={handleTextareaRef}/> child component — props survive
+ *                                      VERBATIM, so its handler is kept,
+ *                                      which keeps `syncScroll`, which
+ *                                      keeps `highlightEl` alive with no
+ *                                      writer left
+ *
+ * A fixture with only intrinsic elements does NOT reproduce: the whole
+ * cluster is pruned together and nothing is left to narrow. The child
+ * component is load-bearing.
+ */
+import { describe, test, expect, afterAll } from 'bun:test'
+import { build } from 'vite'
+import { mkdtemp, rm, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import ts from 'typescript'
+import { HonoAdapter } from '@barefootjs/hono/adapter'
+import { barefoot } from '../plugin.ts'
+
+const FIXTURE_ROOT = resolve(import.meta.dirname, '../../e2e-fixture-refwriter')
+const APP_ROOT = join(FIXTURE_ROOT, 'app')
+const COMPONENTS_DIR = join(FIXTURE_ROOT, 'components')
+
+describe('writers of surviving mutable bindings', () => {
+  let outDir: string
+  const templatesDir = join(APP_ROOT, 'dist/components')
+
+  afterAll(async () => {
+    await rm(outDir, { recursive: true, force: true })
+    await rm(join(APP_ROOT, 'dist'), { recursive: true, force: true })
+  })
+
+  test('retains a ref handler whose binding survives, and the template type-checks', async () => {
+    outDir = await mkdtemp(join(tmpdir(), 'barefoot-vite-refwriter-dist-'))
+
+    await build({
+      configFile: false,
+      root: APP_ROOT,
+      base: '/static/',
+      logLevel: 'warn',
+      build: { outDir, emptyOutDir: true },
+      plugins: [
+        barefoot({
+          adapter: new HonoAdapter(),
+          components: [COMPONENTS_DIR],
+          templates: templatesDir,
+        }),
+      ],
+    })
+
+    const templatePath = join(templatesDir, 'ScrollSync.tsx')
+    const template = await readFile(templatePath, 'utf8')
+
+    // The binding survives (some surviving declaration reads it) …
+    expect(template).toContain('let highlightEl')
+    // … so its writer must survive with it. This is the line the bug dropped.
+    expect(template).toContain('highlightEl = el')
+
+    // `renderSeq` is written with `++` rather than `=`, from a declaration
+    // retained only by this same closure — pins that update expressions
+    // count as writes, not just assignment operators.
+    expect(template).toContain('let renderSeq')
+    expect(template).toContain('renderSeq++')
+
+    // The symptom itself, not a proxy for it: type-check the emitted
+    // template and assert the `never` narrowing is gone. Asserting on the
+    // retained source line alone would still pass if some later change made
+    // the binding un-narrowable for a different reason.
+    const program = ts.createProgram([templatePath], {
+      strict: true,
+      noEmit: true,
+      target: ts.ScriptTarget.ESNext,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      jsx: ts.JsxEmit.ReactJSX,
+      jsxImportSource: '@barefootjs/hono/jsx',
+      lib: ['lib.esnext.d.ts', 'lib.dom.d.ts'],
+      allowImportingTsExtensions: true,
+      skipLibCheck: true,
+    })
+    const neverNarrowings = ts
+      .getPreEmitDiagnostics(program)
+      .filter((d) => d.code === 2339)
+      .map((d) => ts.flattenDiagnosticMessageText(d.messageText, ' '))
+    expect(neverNarrowings).toEqual([])
+  }, 60_000)
+})


### PR DESCRIPTION
Fixes #2598. This is the divergence I flagged at the end of #2593.

## The bug

A mutable binding could survive into an emitted SSR template while the declaration that **writes** it was pruned. The template then declares the binding, reads it, and never assigns it — so TypeScript concludes it is permanently `null`, narrows every guarded use to `never`, and each member access fails:

```tsx
let highlightEl: HTMLElement | null = null      // writer was pruned
const syncScroll = () => {
  if (highlightEl && textareaEl) {
    highlightEl.scrollTop = textareaEl.scrollTop   // TS2339 on `never`
  }
}
```

## Why it happens

Reachability is seeded from the **rendered** JSX, after the client-only attributes are stripped — `ref={setRef}` leaves no `setRef` behind, and `onClick={handleClick}` renders as `onClick={() => {}}`. Instrumented, for a minimal `<div ref={setRef} onClick={onClick}><span ref={setChildRef}/></div>`:

```
=== primaryRefText ===
<div onClick={() => {}} bf-s={__scopeId} …><span bf="s0">x</span></div>
=== declarations === [ "el", "childEl", "setRef", "setChildRef", "read", "onClick" ]
=== reachable    === [ "onClick", "read", "el", "childEl" ]
```

Pruning handler-only code is deliberate and correct — it never runs at SSR — and this PR does not change that.

What lets a binding outlive its writer is that **a child component's props are emitted verbatim**. `<Textarea ref={handleTextareaRef}>` keeps that handler alive, which keeps `syncScroll`, which keeps `highlightEl` — whose own writer sat on an intrinsic `<pre ref={…}>` and did not survive. A component built only from intrinsic elements does **not** reproduce this: the whole cluster prunes together and nothing is left to narrow. The fixture leans on that asymmetry deliberately.

(Worth noting separately: `onClick` above is "reachable" only because the string `onClick` occurs as the *attribute name* in the rendered JSX. Rename the handler and it prunes. That accident is not what this PR changes, but it is the same seeding weakness.)

## The fix

`findReachableNames` now closes over the writers of surviving mutable bindings (`closeOverWritersOfMutableBindings`), iterating to a fixpoint since a retained writer can read further declarations and write further bindings. **Only writers come back** — not every handler — so templates do not grow beyond the bindings that actually survived. In koma that is one four-line ref handler.

Retaining the writer, rather than dropping the binding, keeps the source module's shape and is dead code at SSR — the same harmless-unused-declaration trade `generateModuleScopeDeclarations` already documents as deliberate.

Writes are detected with the TS AST (`findAssignedNames`) per CLAUDE.md's "never parse JS/TS with regex" rule. A regex for `name\s*=` would match every one of these, none of which is a write to the binding:

| form | is it a write? |
|---|---|
| `el = node`, `seq += 1`, `cached ??= …`, `a++`, `--b` | yes |
| `const x = el` (read) | no |
| `el == null`, `el === other` (comparison) | no |
| `el.scrollTop = 0` (property write **through** it) | no |
| `{ el: 1 }` (same-named key) | no |
| `"el = node"`, `<div data-x="el = node" />` | no |

Destructuring assignment (`[x] = …`) is deliberately not recognized — it does not appear in the ref/handler shapes this exists for, and leaving it out under-retains rather than over-retains, so the set stays honest. It would present as this same narrowing and can be added with a fixture.

## Tests

Both halves land with the fix, per CLAUDE.md's "a reproducible defect lands as a fixture, not a prose report".

**e2e** — `packages/vite/src/__tests__/mutable-binding-writers.test.ts` with `packages/vite/e2e-fixture-refwriter/`. A real `vite build` over koma's `FrameEditor` shape (intrinsic `<pre ref>` + child `<Editable ref>`). It asserts the writer is retained, that `renderSeq++` counts as a write, and then **type-checks the emitted template with `ts.createProgram` and asserts zero TS2339** — the symptom itself, not a proxy. Asserting only on the retained source line would keep passing if a later change made the binding un-narrowable for some unrelated reason.

Verified it fails without the fix:

```
error: expect(received).toContain(expected)
Expected to contain: "highlightEl = el"
(fail) writers of surviving mutable bindings > retains a ref handler whose binding survives, and the template type-checks
```

**compiler unit** — `packages/jsx/src/__tests__/mutable-binding-writers.test.ts`, 17 cases: every row of the table above, plus the closure's own behaviour — it must **not** retain a writer when the binding itself was pruned (that is the client-only pruning this must not undo), must be a no-op when nothing is mutable, and must reach a writer that only becomes relevant on a second round.

## Suite status

`bun test packages/jsx packages/adapter-hono packages/vite packages/adapter-tests`

| | pass | fail |
|---|---|---|
| before | 6373 | 7 |
| after | 6391 | 7 |

+18 = the 17 new unit tests and the new e2e test. The 7 failures are identical before and after, and each was confirmed pre-existing on `main` individually (`ui corpus type-check gate` — same single `chart TS2345` violation either way; two `Carousel cross-adapter` conformance cases; two `.map()` body trichotomy cases).

## Not a regression

Predates the Vite pipeline — reproduces on 0.11.0 under `bf build`. It only became visible after #2559, #2565 and #2589 cleared the surrounding noise; koma's emitted-template diagnostics went 209 → 125 → 85 across 0.31.0–0.31.4, and these two TS2339s were among what was left.
