### PR TITLE
refactor(adapters): migrate 7 template-string adapters onto BindingScope (#2482 stage 2)

### DIFF
--- a/.changeset/binding-scope-2482-stage2.md
+++ b/.changeset/binding-scope-2482-stage2.md
@@ -1,0 +1,16 @@
+---
+'@barefootjs/jsx': patch
+'@barefootjs/twig': patch
+'@barefootjs/jinja': patch
+'@barefootjs/blade': patch
+'@barefootjs/xslate': patch
+'@barefootjs/rust': patch
+'@barefootjs/erb': patch
+'@barefootjs/mojolicious': patch
+---
+
+Migrate the seven template-string adapters (Twig, Jinja, Blade, Xslate, Rust/minijinja, ERB, Mojolicious) onto `BindingScope` for loop-callback shadow guards (#2482 stage 2). Each adapter's ad-hoc device pair — a coarse whole-component shadow-name `Set` plus a ref-counted, position-accurate `Map<string, number>` (or, for ERB/Mojolicious, a single already-live map) — collapses into one threaded, immutable `this.scope: BindingScope`, entered/exited by reference around `renderLoop`'s body exactly like the Stage 1a/1b `ctx.scope` precedent in `jsx-to-ir.ts`. `IRLoop` already structurally satisfies `LoopBindingSource`, so `renderLoop` passes the loop node straight to `enterLoopRow`.
+
+This ends a real coarse/live drift: `resolveStaticLoopSource`'s `isNameShadowed` callback previously received the coarse whole-component set from five adapters (twig/jinja/blade/xslate/rust) but the live, position-accurate map from ERB/Mojolicious — same shared function, two different meanings depending on caller. All seven adapters now feed the same canonical, position-accurate predicate (`scope.asShadowPredicate()`). The five Twig-family adapters' `_resolveLiteralConst`/`_resolveStaticRecordLiteral` module-const-inlining guards are also canonicalized from a coarse whole-component exclusion to the position-accurate scope, matching ERB/Mojolicious's existing (already-correct) behavior: a same-named const outside any shadowing loop now inlines even when a same-named loop param exists elsewhere in the component — previously an accepted-but-imprecise trade-off, now fixed.
+
+`@barefootjs/jsx`: `lookupStaticRecordLiteral` (`augment-inherited-props.ts`) gains a required `isShadowed` guard parameter instead of leaving the shadow check to caller discipline — every one of the seven call sites now passes its threaded scope's `isBound` predicate.

--- a/packages/adapter-blade/src/__tests__/blade-adapter-unit.test.ts
+++ b/packages/adapter-blade/src/__tests__/blade-adapter-unit.test.ts
@@ -410,10 +410,11 @@ export function Parent() {
 // `ir.metadata.localConstants` with no notion of AST scope — it used to
 // substitute an outer const's literal value even at an occurrence that is
 // actually an enclosing loop callback's own (shadowing) parameter, so every
-// iteration rendered the same hard-coded literal. Guarded with the same
-// coarse `collectLoopBoundNames` exclusion as #2212: any name a loop binds
-// anywhere in the component never inlines, falling back to the bare
-// identifier.
+// iteration rendered the same hard-coded literal. Guarded via the threaded,
+// position-accurate `BindingScope` (#2482 Stage 2 — previously a coarse
+// whole-component exclusion, same as #2212's, that also suppressed a
+// genuinely non-shadowed occurrence outside the loop; the threaded scope
+// only shadows AT the enclosing loop's own body).
 describe('BladeAdapter - const inlining vs loop-param shadowing (#2221)', () => {
   test('a loop param shadowing an outer literal const emits the identifier, not the const value', () => {
     const { template } = compileAndGenerate(`
@@ -452,11 +453,11 @@ function Widget({ values }: { values: number[] }) {
     expect(template).toContain('1 + 5')
   })
 
-  // The accepted coarse-exclusion trade-off (same as #2212): a name that is
-  // loop-bound ANYWHERE in the component never inlines, even at a genuinely
-  // non-shadowed occurrence outside the loop — the bare identifier is
-  // emitted instead of the value.
-  test('a const referenced outside the loop whose name is loop-bound elsewhere falls back to the identifier (accepted trade-off)', () => {
+  // Position-accurate scope (#2482 Stage 2): a name that is loop-bound
+  // elsewhere in the component but NOT at THIS occurrence still inlines
+  // here — the coarse whole-component exclusion this used to hit (and
+  // accept as a trade-off) is gone; only the loop's own body shadows.
+  test('a const referenced outside the loop whose name is loop-bound elsewhere still inlines outside, stays the identifier inside', () => {
     const { template } = compileAndGenerate(`
 function Widget({ values }: { values: number[] }) {
   const label: string = 'x'
@@ -466,7 +467,7 @@ function Widget({ values }: { values: number[] }) {
   </div>
 }
 `)
-    expect(template).not.toContain("1 + 'x'")
+    expect(template).toContain("1 + 'x'")
     expect(template).toContain('2 + $label')
   })
 })
@@ -478,10 +479,8 @@ function Widget({ values }: { values: number[] }) {
 // substitute the outer const's member value even at an occurrence that is
 // actually an enclosing loop callback's own (shadowing) parameter, so every
 // iteration rendered the same hard-coded literal instead of the per-item
-// value. Guarded with the same coarse `staticLoopSourceBoundNames`
-// exclusion as #2221: any name a loop binds anywhere in the component
-// never inlines, falling back to the bare `data_get($cfg, 'x')` member
-// expression.
+// value. Guarded via the threaded, position-accurate `BindingScope` (#2482
+// Stage 2), same as #2221's fix above.
 describe('BladeAdapter - record-literal member lookup vs loop-param shadowing (#2237)', () => {
   test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
     const { template } = compileAndGenerate(`
@@ -506,12 +505,12 @@ function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
     expect(template).toContain("bf->string('bg-ghost')")
   })
 
-  // The accepted coarse-exclusion trade-off (same as #2221/#2212): an
-  // object name that is loop-bound ANYWHERE in the component never
-  // inlines its member lookups, even at a genuinely non-shadowed
-  // occurrence outside the loop — the bare member expression is emitted
-  // instead of the value.
-  test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
+  // Position-accurate scope (#2482 Stage 2): an object name that is
+  // loop-bound elsewhere in the component but NOT at THIS occurrence still
+  // inlines its member lookup here — the coarse whole-component exclusion
+  // this used to hit (and accept as a trade-off) is gone; only the loop's
+  // own body shadows.
+  test('a record member referenced outside the loop whose object name is loop-bound elsewhere still inlines outside, stays the member expression inside', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
 function Widget({ rows }: { rows: { x: string }[] }) {
@@ -521,7 +520,7 @@ function Widget({ rows }: { rows: { x: string }[] }) {
   </div>
 }
 `)
-    expect(template).not.toContain("bf->string('outer-lit')")
+    expect(template).toContain("bf->string('outer-lit')")
     expect(template).toContain("bf->string(data_get($cfg, 'x'))")
   })
 })

--- a/packages/adapter-blade/src/__tests__/blade-adapter-unit.test.ts
+++ b/packages/adapter-blade/src/__tests__/blade-adapter-unit.test.ts
@@ -525,6 +525,44 @@ function Widget({ rows }: { rows: { x: string }[] }) {
   })
 })
 
+// Copilot review on #2600 (#2482 Stage 2 follow-up): the position-accurate
+// `this.scope` (replacing the old coarse `staticLoopSourceBoundNames` set)
+// was only threaded around `renderChildren(loop.children)` in `renderLoop`
+// — narrower than the coarse set's always-on coverage. Two row-context
+// conversions sit OUTSIDE that window: a `.map()` preamble local's own
+// initializer, and the whole-item-conditional `loop-i:` key anchor
+// (`loop.key`). Both genuinely evaluate PER ROW and must see the row's own
+// bindings — a loop param shadowing a same-named outer const must resolve
+// to the row value there too, exactly as it already does inside the loop
+// body proper. `renderLoop` now enters the row scope before converting
+// either and pops it after, closing the gap.
+describe('BladeAdapter - row scope covers preamble/key conversions outside renderChildren (#2482 Stage 2 Copilot follow-up)', () => {
+  test('a loop param shadowing an outer const resolves to the row value inside a whole-item-conditional loop-i: key anchor', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <ul>{values.map((label) => (label > 0 ? <li key={label}>{label}</li> : null))}</ul>
+}
+`)
+    expect(template).toContain("bf->comment('loop-i:' . $bf->string($label))")
+    expect(template).not.toContain("bf->comment('loop-i:' . $bf->string('x'))")
+  })
+
+  test('a loop param shadowing an outer const resolves to the row value inside a .map() preamble local initializer', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <ul>{values.map((label) => {
+    const cls = label
+    return <li key={label} class={cls}>{label}</li>
+  })}</ul>
+}
+`)
+    expect(template).toContain('@php($cls = $label)')
+    expect(template).not.toContain("@php($cls = 'x')")
+  })
+})
+
 // #2038 nested-callback-predicate loudness is pinned at the shared
 // conformance layer (workstream C): `filter-nested-callback-predicate` /
 // `filter-nested-find-predicate` (BF101 via `expectedDiagnostics`) and

--- a/packages/adapter-blade/src/adapter/blade-adapter.ts
+++ b/packages/adapter-blade/src/adapter/blade-adapter.ts
@@ -1089,14 +1089,6 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
 
-    // Per-row locals for a `.map()` callback preamble (#2447), in source
-    // order so a later initializer sees an earlier local — same as the
-    // source block. Phase 1 refuses the loop outright when the preamble
-    // isn't fully declarable, so there is no partial-lowering case: either
-    // every statement is lowered here, or the build already failed.
-    const preambleLines = (loop.preamble?.declarations ?? []).map(
-      d => `@php(${bladeVar(d.name)} = ${this.convertExpressionToBlade(d.raw, d.valueParsed)})`,
-    )
     // This loop's row scope, for the position-accurate shadow guard
     // (#2488/#2489, canonicalized on `BindingScope` in #2482 Stage 2).
     // `IRLoop` already structurally satisfies `LoopBindingSource`
@@ -1105,11 +1097,35 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     // the index (when present), and the `.map()` preamble's declared
     // locals, mirroring what THIS renderLoop's for-header + `indexLocalLines`
     // actually introduce. Restored by reference (immutable — no ref-count
-    // bookkeeping) so nested loops compose for free.
+    // bookkeeping) so nested loops compose for free. Entered BEFORE
+    // `preambleLines`/`bodyChildren` are converted and popped AFTER, not
+    // just around `renderChildren` — Copilot review on #2600 caught that
+    // the narrower window silently regressed the module-const shadow guard
+    // (`_resolveLiteralConst`/`_resolveStaticRecordLiteral`, now
+    // scope-driven instead of the old coarse whole-component set) for two
+    // row-context conversions that sit OUTSIDE `renderChildren`: a
+    // `.map()` preamble local's own initializer (`d.raw`, below) and the
+    // whole-item-conditional `loop-i:` key anchor (`loop.key`, in
+    // `bodyChildren` below) — both genuinely evaluate PER ROW and must see
+    // the row's own bindings. `loop.filterPredicate` deliberately stays
+    // OUTSIDE this window (further down, after the pop): per the Stage 0
+    // design a filter/sort callback's own param is a separate `callback`
+    // frame, never folded into the `.map()` row — and empirically
+    // `BladeFilterEmitter` (the filter predicate's dedicated,
+    // self-contained emitter) never consults `this.scope` at all, so its
+    // position relative to the pop is inert either way.
     const prevScope = this.scope
     this.scope = prevScope.enterLoopRow(loop)
+
+    // Per-row locals for a `.map()` callback preamble (#2447), in source
+    // order so a later initializer sees an earlier local — same as the
+    // source block. Phase 1 refuses the loop outright when the preamble
+    // isn't fully declarable, so there is no partial-lowering case: either
+    // every statement is lowered here, or the build already failed.
+    const preambleLines = (loop.preamble?.declarations ?? []).map(
+      d => `@php(${bladeVar(d.name)} = ${this.convertExpressionToBlade(d.raw, d.valueParsed)})`,
+    )
     const childrenUnderLoop = this.renderChildren(loop.children)
-    this.scope = prevScope
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -1117,11 +1133,13 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     // Whole-item conditional: prepend an always-present `<!--bf-loop-i:KEY-->`
     // anchor before each item's (possibly empty) conditional content so the
     // client's `mapArrayAnchored` can hydrate every SSR-rendered item by its
-    // anchor.
+    // anchor. Still under the row scope (see above) — `loop.key` is a
+    // per-row expression.
     const bodyChildren =
       loop.bodyIsItemConditional && loop.key
         ? `{!! $bf->comment('loop-i:' . $bf->string(${this.convertExpressionToBlade(loop.key)})) !!}\n${childrenUnderLoop}`
         : childrenUnderLoop
+    this.scope = prevScope
 
     const lines: string[] = []
     // Scoped per-call-site marker so sibling `.map()`s under the same parent

--- a/packages/adapter-blade/src/adapter/blade-adapter.ts
+++ b/packages/adapter-blade/src/adapter/blade-adapter.ts
@@ -294,8 +294,8 @@ import {
   dangerousInnerHtmlMetacharViolation,
   dangerousInnerHtmlDiagnostic,
   resolveStaticLoopSource,
-  collectLoopBoundNames,
   derivesScopeFromSlot,
+  BindingScope,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr, isExplicitStringCall } from './boolean-result.ts'
 import type { ParsedExpr, LoweringMatcher } from '@barefootjs/jsx'
@@ -423,30 +423,24 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
   private localConstants: IRMetadata['localConstants'] = []
 
   /**
-   * Every name a `.map()`/`.filter()` loop callback binds as its item/index
-   * parameter anywhere in the component (#2208 fable review). A static
-   * loop-SOURCE name (e.g. a function-scope `const items = [...]`) must
-   * never resolve through `resolveStaticLoopSource` at a use site where a
-   * DIFFERENT, enclosing loop's own callback param shadows it — same
-   * shadowing hazard, and same coarse-but-safe mitigation, as #2212's
-   * `collectLoopBoundNames` use in `collectStringValueNames`.
+   * The one canonical, position-accurate "names bound by an enclosing loop
+   * callback" service (#2482 Stage 2) — replaces the two ad-hoc devices
+   * this adapter used to carry side by side: a coarse whole-component
+   * shadow-name Set (built once at `generate()` entry, used only to guard
+   * static-const inlining) and a ref-counted, position-accurate live map
+   * (pushed/popped around `renderLoop`'s body, used for the boolean-prop/
+   * nullable-optional classification sites (#2488) and `emitSpread`'s
+   * local-const fallback (#2489)). Both consulted the "is this name
+   * loop-bound" question with DIFFERENT meanings — the coarse/live drift
+   * #2482 Stage 2 ends. Every shadow-guard site now reads this ONE
+   * threaded, immutable scope: `enterLoopRow`/pop-by-reference around
+   * `renderChildren(loop.children)` in `renderLoop`, mirroring the Stage
+   * 1a/1b `ctx.scope` precedent in `jsx-to-ir.ts`. `IRLoop` already
+   * structurally satisfies `LoopBindingSource`
+   * (`param`/`index`/`paramBindings`/`preamble`), so `renderLoop` passes
+   * the loop node straight to `enterLoopRow`.
    */
-  private staticLoopSourceBoundNames: Set<string> = new Set()
-
-  /**
-   * Names currently bound by an enclosing loop body — the block-param
-   * locals `renderLoop` introduces (item, index, per-binding destructure
-   * fields, `.map()` preamble declarations) — ref-counted so nested loops
-   * compose. This is the POSITION-ACCURATE twin of the coarse
-   * `staticLoopSourceBoundNames` above: that set is a whole-component
-   * union used only to guard static-const inlining (safe to over-suppress
-   * there — the fallback is just "don't inline"), whereas the boolean-prop
-   * and nullable-optional classification sites (#2488) and `emitSpread`'s
-   * local-const fallback (#2489) need to know whether a name is loop-bound
-   * AT THIS POSITION, because for those the coarse fallback would silently
-   * mis-render a genuine occurrence of the same name outside the loop too.
-   */
-  private loopBoundNames: Map<string, number> = new Map()
+  private scope: BindingScope = BindingScope.EMPTY
 
   /**
    * Optional, no-default props that are `None` when the caller omits them.
@@ -480,8 +474,7 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     // ("1"/"") (#1897, pagination's data-active).
     this.booleanTypedProps = collectBooleanTypedProps(ir)
     this.localConstants = ir.metadata.localConstants ?? []
-    this.staticLoopSourceBoundNames = collectLoopBoundNames(ir)
-    this.loopBoundNames.clear()
+    this.scope = BindingScope.EMPTY
     this.nullableOptionalProps = collectNullableOptionalProps(ir)
     this.stringValueNames = collectStringValueNames(ir)
     this.moduleStringConsts = collectModuleStringConsts(ir.metadata.localConstants)
@@ -981,9 +974,11 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     // bare identifier expression below, same as before #2208 — which
     // still trips the pre-existing BF101 gate for an unresolvable local
     // const reference (a loud, conservative refusal, not a silent wrong
-    // value).
+    // value). Canonical, position-accurate predicate (#2482 Stage 2) — the
+    // enclosing loop scope's own membership, not a coarse whole-component
+    // union.
     const staticItems = resolveStaticLoopSource(loop.arrayParsed, this.localConstants, {
-      isNameShadowed: name => this.staticLoopSourceBoundNames.has(name),
+      isNameShadowed: this.scope.asShadowPredicate(),
     })
     const staticArray = staticItems !== null ? staticValueToBlade(staticItems) : null
 
@@ -1102,39 +1097,19 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     const preambleLines = (loop.preamble?.declarations ?? []).map(
       d => `@php(${bladeVar(d.name)} = ${this.convertExpressionToBlade(d.raw, d.valueParsed)})`,
     )
-    // Names this loop binds in body scope, for the position-accurate
-    // `loopBoundNames` guard (#2488) — mirrors the ERB adapter's `loopBound`
-    // derivation, adapted to what THIS renderLoop actually binds: the
-    // for-header target(s) (`loopVar` / `objectIteration` key+value /
-    // `iterationShape === 'keys'`'s `param`), each `indexLocalLines` name
-    // (explicit index, or a destructure binding), and the `.map()`
-    // preamble's declared locals. Ref-counted so nested loops compose.
-    const loopBound: string[] = []
-    if (loop.objectIteration === 'entries') {
-      loopBound.push(loop.index ?? param, param)
-    } else if (loop.objectIteration === 'keys' || loop.objectIteration === 'values') {
-      loopBound.push(param)
-    } else if (loop.iterationShape === 'keys') {
-      // The header still binds the throwaway loop var; `param` is only the
-      // index alias set beneath it (#2488).
-      loopBound.push('__bf_item', param)
-    } else if (supportableDestructure) {
-      loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
-      if (loop.index) loopBound.push(loop.index)
-    } else {
-      loopBound.push(param)
-      if (loop.index) loopBound.push(loop.index)
-    }
-    for (const d of loop.preamble?.declarations ?? []) loopBound.push(d.name)
-    for (const n of loopBound) {
-      this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
-    }
+    // This loop's row scope, for the position-accurate shadow guard
+    // (#2488/#2489, canonicalized on `BindingScope` in #2482 Stage 2).
+    // `IRLoop` already structurally satisfies `LoopBindingSource`
+    // (`param`/`index`/`paramBindings`/`preamble`) — `enterLoopRow(loop)`
+    // binds exactly the for-header target(s), each destructure binding,
+    // the index (when present), and the `.map()` preamble's declared
+    // locals, mirroring what THIS renderLoop's for-header + `indexLocalLines`
+    // actually introduce. Restored by reference (immutable — no ref-count
+    // bookkeeping) so nested loops compose for free.
+    const prevScope = this.scope
+    this.scope = prevScope.enterLoopRow(loop)
     const childrenUnderLoop = this.renderChildren(loop.children)
-    for (const n of loopBound) {
-      const c = (this.loopBoundNames.get(n) ?? 1) - 1
-      if (c <= 0) this.loopBoundNames.delete(n)
-      else this.loopBoundNames.set(n, c)
-    }
+    this.scope = prevScope
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -1646,13 +1621,13 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
       // function-scope (`!isModule`) consts whose value is NOT itself a bare
       // identifier (loop guard) are considered.
       //
-      // `loopBoundNames` guard (#2489): an enclosing `.map()` callback's own
-      // param can shadow this outer const's name (`.map((attrs) => <p
+      // `this.scope` shadow guard (#2489): an enclosing `.map()` callback's
+      // own param can shadow this outer const's name (`.map((attrs) => <p
       // {...attrs} />)`) — without the guard this forwarded the OUTER
       // const's value at every iteration instead of the per-item value.
-      // Must be the LIVE map, not `staticLoopSourceBoundNames` — the same
-      // name spread at ROOT must still resolve the const.
-      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.loopBoundNames.has(trimmed)) {
+      // Must be the threaded, position-accurate scope — the same name
+      // spread at ROOT (no enclosing loop) must still resolve the const.
+      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.scope.isBound(trimmed)) {
         const localConst = (this.localConstants ?? []).find(
           c => c.name === trimmed && !c.isModule,
         )
@@ -2075,9 +2050,9 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     return this.booleanTypedProps.has(bare)
   }
 
-  /** Position-accurate loop-bound-name check — see `loopBoundNames`'s docstring. */
+  /** Position-accurate loop-bound-name check — see `this.scope`'s docstring. */
   private isLoopBoundName(name: string): boolean {
-    return this.loopBoundNames.has(name)
+    return this.scope.isBound(name)
   }
 
   /**
@@ -2104,17 +2079,16 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
    * context, so a bare reference would resolve to an undefined variable.
    *
    * The lookup is a flat name match with no notion of AST scope, so a
-   * name that any loop callback binds as its item/index param never
-   * inlines (#2221) — the occurrence may be the loop's own (shadowing)
-   * binding, and substituting the outer const's value there renders every
-   * iteration with the same hard-coded literal. Coarse (a genuinely
-   * non-shadowed same-named const elsewhere in the component also stops
-   * inlining, falling back to the bare identifier) but safe — the same
-   * trade-off as #2212's `collectLoopBoundNames` use in
-   * `collectStringValueNames`.
+   * name bound by the CURRENTLY ENCLOSING loop's item/index/destructure/
+   * preamble param never inlines (#2221) — the occurrence may be the
+   * loop's own (shadowing) binding, and substituting the outer const's
+   * value there renders every iteration with the same hard-coded literal.
+   * Position-accurate via the threaded `this.scope` (#2482 Stage 2) — a
+   * same-named const elsewhere in the component, outside any loop that
+   * shadows it, still inlines.
    */
   private _resolveLiteralConst(name: string): string | null {
-    if (this.staticLoopSourceBoundNames.has(name)) return null
+    if (this.scope.isBound(name)) return null
     const c = (this.localConstants ?? []).find(lc => lc.name === name)
     if (c?.value === undefined) return null
     const v = c.value.trim()
@@ -2132,15 +2106,16 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
    * scope, so an enclosing loop callback's own param of the same name
    * (`.map((cfg) => <li>{cfg.x}</li>)` shadowing a module `const cfg = {…}`)
    * still resolved to the OUTER const's member value at every iteration
-   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`. Same
-   * coarse-but-safe `staticLoopSourceBoundNames` guard: any name a loop
-   * binds anywhere in the component never inlines, falling back to the bare
+   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`.
+   * Position-accurate via the threaded `this.scope` (#2482 Stage 2), passed
+   * as `lookupStaticRecordLiteral`'s required guard: a name the CURRENTLY
+   * ENCLOSING loop binds never inlines, falling back to the bare
    * `data_get($cfg, 'x')` member expression (which a Blade `@foreach`
-   * binds correctly at the shadowed occurrences).
+   * binds correctly at the shadowed occurrence); a same-named const
+   * elsewhere, outside any loop that shadows it, still inlines.
    */
   private _resolveStaticRecordLiteral(objectName: string, key: string): string | null {
-    if (this.staticLoopSourceBoundNames.has(objectName)) return null
-    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants)
+    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants, name => this.scope.isBound(name))
     if (!hit) return null
     return hit.kind === 'number'
       ? hit.text

--- a/packages/adapter-erb/src/adapter/erb-adapter.ts
+++ b/packages/adapter-erb/src/adapter/erb-adapter.ts
@@ -94,6 +94,7 @@ import {
   dangerousInnerHtmlDiagnostic,
   resolveStaticLoopSource,
   derivesScopeFromSlot,
+  BindingScope,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr, isExplicitStringCall } from './boolean-result.ts'
 import type { ParsedExpr, LoweringMatcher, LoopBindingPathSegment } from '@barefootjs/jsx'
@@ -248,17 +249,23 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
    */
   private localConstants: IRMetadata['localConstants'] = []
   /**
-   * Names currently bound by an enclosing loop body — the block-param
-   * locals `renderLoop` introduces (item, index, per-binding destructure
-   * fields) — ref-counted so nested loops compose. This is load-bearing
-   * for TWO things in the ERB adapter (more than the Mojo original, which
-   * only used it to guard const-inlining): it also decides the
-   * fundamental `v[:name]` vs bare-Ruby-local rendering choice in
-   * `ErbTopLevelEmitter.identifier` — see `emit-context.ts`'s
-   * `isLoopBoundName` docstring for why ERB's two-locals model needs this
-   * where Perl's uniform `$name` sigil does not.
+   * The one canonical, position-accurate "names bound by an enclosing loop
+   * callback" service (#2482 Stage 2) — replaces the ref-counted
+   * `Map<string, number>` this adapter used to push/pop around
+   * `renderLoop`'s body. Load-bearing for TWO things in the ERB adapter
+   * (more than the Mojo original, which only used it to guard
+   * const-inlining): it also decides the fundamental `v[:name]` vs
+   * bare-Ruby-local rendering choice in `ErbTopLevelEmitter.identifier` —
+   * see `emit-context.ts`'s `isLoopBoundName` docstring for why ERB's
+   * two-locals model needs this where Perl's uniform `$name` sigil does
+   * not. Threaded via save/restore-by-reference around
+   * `renderChildren(loop.children)` in `renderLoop` (immutable — no
+   * ref-count bookkeeping), mirroring the Stage 1a/1b `ctx.scope`
+   * precedent in `jsx-to-ir.ts`. `IRLoop` already structurally satisfies
+   * `LoopBindingSource` (`param`/`index`/`paramBindings`/`preamble`), so
+   * `renderLoop` passes the loop node straight to `enterLoopRow`.
    */
-  private loopBoundNames: Map<string, number> = new Map()
+  private scope: BindingScope = BindingScope.EMPTY
   /**
    * Prop names whose value is `nil` in the template body when the caller
    * omits them — so a bare-reference attribute should be dropped rather
@@ -298,7 +305,7 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
     this._searchParamsLocals = searchParamsLocalNames(ir.metadata)
     this._loweringMatchers = prepareLoweringMatchers(ir.metadata)
     this.localConstants = ir.metadata.localConstants ?? []
-    this.loopBoundNames.clear()
+    this.scope = BindingScope.EMPTY
     this.errors = []
     this.childrenCaptureCounter = 0
 
@@ -440,7 +447,7 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
    * would read nil.
    */
   private resolveLiteralConst(name: string): string | null {
-    if (this.loopBoundNames?.has?.(name)) return null
+    if (this.scope.isBound(name)) return null
     const c = (this.localConstants ?? []).find(lc => lc.name === name)
     if (c?.value === undefined) return null
     const v = c.value.trim()
@@ -451,8 +458,7 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
   }
 
   private resolveStaticRecordLiteral(objectName: string, key: string): string | null {
-    if (this.loopBoundNames?.has?.(objectName)) return null
-    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants)
+    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants, name => this.scope.isBound(name))
     if (!hit) return null
     return hit.kind === 'number' ? hit.text : rubyStringLiteral(hit.text)
   }
@@ -460,7 +466,7 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
   private resolveModuleStringConst(name: string): string | null {
     // A loop body introduces block-param bindings that shadow a module
     // const of the same name — never inline inside one.
-    if (this.loopBoundNames.has(name)) return null
+    if (this.scope.isBound(name)) return null
     const value = this.moduleStringConsts.get(name)
     if (value === undefined) return null
     return rubyStringLiteral(value)
@@ -469,7 +475,7 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
   /** Whether `name` currently names a loop-bound Ruby local. See
    *  `ErbEmitContext.isLoopBoundName`'s docstring. */
   private isLoopBoundName(name: string): boolean {
-    return this.loopBoundNames.has(name)
+    return this.scope.isBound(name)
   }
 
   // ===========================================================================
@@ -957,15 +963,17 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
     // `unsupported` object-literal path (BF101, "Expression not
     // supported"), which is what this loop-specific check now also does
     // deliberately, up front, for both shapes.
+    // Canonical, position-accurate predicate (#2482 Stage 2) — the
+    // enclosing loop scope's own membership.
     const staticItems = resolveStaticLoopSource(loop.arrayParsed, this.localConstants, {
-      isNameShadowed: name => this.loopBoundNames.has(name),
+      isNameShadowed: this.scope.asShadowPredicate(),
     })
     const staticArray = staticItems !== null ? staticValueToRuby(staticItems) : null
 
     if (staticArray === null && loop.arrayParsed?.kind === 'identifier') {
       const arrayName = loop.arrayParsed.name
       const isUnresolvableLocalConst =
-        !this.loopBoundNames.has(arrayName) &&
+        !this.scope.isBound(arrayName) &&
         this.resolveModuleStringConst(arrayName) === null &&
         this.resolveLiteralConst(arrayName) === null &&
         this.localConstants.some(c => c.name === arrayName && !c.isModule)
@@ -994,29 +1002,22 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
     const indexVar = loop.iterationShape === 'keys'
       ? rubyLocal(param)
       : rubyLocal(loop.index ?? '_i')
-    // Names this loop binds in body scope. Guard module-const inlining (and,
-    // in ERB, the fundamental v[:name]-vs-local rendering choice) for the
-    // whole body (children + key + filter) so a same-named loop variable
-    // isn't replaced by the const literal / a vars-Hash read. Ref-counted
-    // for nested loops; released after the body lines are assembled below.
-    const loopBound = loop.objectIteration === 'entries'
-      ? [param, loop.index ?? '_k']
-      : loop.objectIteration === 'keys' || loop.objectIteration === 'values' || loop.iterationShape === 'keys'
-        ? [param]
-        : supportableDestructure
-          ? ['__bf_item', ...(loop.paramBindings ?? []).map(b => b.name), loop.index ?? '_i']
-          : [param, loop.index ?? '_i']
-    // A `.map()` callback preamble lowers to one per-row Ruby local per
-    // declaration (#2447). The names must be loop-bound for the whole body,
-    // or `ErbTopLevelEmitter.identifier` renders each read as `v[:cls]` —
-    // a vars-Hash key nothing ever seeds, i.e. the empty attribute this
-    // fixes. Phase 1 guarantees `declarations` is present or the loop was
-    // already refused, so there is no partial-lowering case here.
+    // This loop's row scope. Guards module-const inlining (and, in ERB, the
+    // fundamental v[:name]-vs-local rendering choice) for the whole body
+    // (children + key + filter) so a same-named loop variable isn't
+    // replaced by the const literal / a vars-Hash read. `IRLoop` already
+    // structurally satisfies `LoopBindingSource`
+    // (`param`/`index`/`paramBindings`/`preamble`) — `enterLoopRow(loop)`
+    // binds exactly what this renderLoop's header + preamble locals
+    // introduce (#2482 Stage 2 — replaces the ref-counted `Map` this
+    // adapter used to carry). Restored by reference (immutable — no
+    // ref-count bookkeeping) at the matching pop below, once the WHOLE
+    // body (including the filter predicate) has been rendered — except for
+    // one temporary drop-to-outer window around the hoisted sort-comparator
+    // emission below, since that runs OUTSIDE this loop.
     const preambleDecls = loop.preamble?.declarations ?? []
-    for (const d of preambleDecls) loopBound.push(d.name)
-    for (const n of loopBound) {
-      this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
-    }
+    const prevScope = this.scope
+    this.scope = prevScope.enterLoopRow(loop)
     const prevLoopKeyDepth = this.currentLoopKeyDepth
     this.currentLoopKeyDepth = loop.depth
     const renderedChildren = this.renderChildren(loop.children)
@@ -1042,18 +1043,16 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
       // fall back to the structured `bf.sort` for a comparator the
       // evaluator can't model (e.g. `localeCompare`).
       //
-      // The hoisted sort runs OUTSIDE this loop, so this loop's bound names
+      // The hoisted sort runs OUTSIDE this loop, so this loop's row scope
       // must not shadow the comparator's captured free vars while emitting
       // the env — otherwise a captured var that happens to share a
       // loop-param name is blocked from inlining its module const / from
       // reading `v[:name]` and instead resolves to the (out-of-scope) loop
-      // local. Drop this loop's bound names for the sort emit, then
-      // restore (a nested loop's outer bindings, ref-counted, stay in effect).
-      for (const n of loopBound) {
-        const c = (this.loopBoundNames.get(n) ?? 1) - 1
-        if (c <= 0) this.loopBoundNames.delete(n)
-        else this.loopBoundNames.set(n, c)
-      }
+      // local. Drop back to the outer (pre-row) scope for the sort emit,
+      // then restore the row scope below (a nested loop's own outer
+      // bindings stay in effect throughout, since `prevScope` already
+      // carries them).
+      this.scope = prevScope
       const sortEmit = (e: ParsedExpr) => this.convertExpressionToRuby('', e)
       const sortArrow = loop.sortComparator.arrow
       let sorted: string | null = null
@@ -1074,9 +1073,7 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
         )
         sorted = rawArray
       }
-      for (const n of loopBound) {
-        this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
-      }
+      this.scope = prevScope.enterLoopRow(loop)
       lines.push(`<%- ${sortedHoist} = ${sorted} -%>`)
     }
     if (loop.objectIteration) {
@@ -1184,12 +1181,8 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
       lines.push(children)
     }
 
-    // Body fully rendered — release the loop-bound names.
-    for (const n of loopBound) {
-      const c = (this.loopBoundNames.get(n) ?? 1) - 1
-      if (c <= 0) this.loopBoundNames.delete(n)
-      else this.loopBoundNames.set(n, c)
-    }
+    // Body fully rendered — restore the outer (pre-row) scope.
+    this.scope = prevScope
 
     lines.push(`<%- end -%>`)
     lines.push(`<%= bf.comment("/loop:${loop.markerId}") %>`)
@@ -1558,11 +1551,11 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
       // function-scope (`!isModule`) consts whose value is NOT itself a
       // bare identifier (loop guard) are considered.
       //
-      // `loopBoundNames` guard (#2489): an enclosing `.map()` callback's own
-      // param can shadow this outer const's name (`.map((attrs) => <p
+      // `this.scope` shadow guard (#2489): an enclosing `.map()` callback's
+      // own param can shadow this outer const's name (`.map((attrs) => <p
       // {...attrs} />)`) — without the guard this forwarded the OUTER
       // const's value at every iteration instead of the per-item value.
-      if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed) && !this.loopBoundNames.has(trimmed)) {
+      if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed) && !this.scope.isBound(trimmed)) {
         const localConst = this.localConstants.find(
           c => c.name === trimmed && !c.isModule,
         )

--- a/packages/adapter-erb/src/adapter/expr/emitters.ts
+++ b/packages/adapter-erb/src/adapter/expr/emitters.ts
@@ -352,11 +352,11 @@ export class ErbTopLevelEmitter implements ParsedExprEmitter {
     if (name === 'undefined' || name === 'null') return 'nil'
     // A loop-bound name (this identifier resolves to a bare Ruby local
     // introduced by an enclosing loop, not a vars-Hash entry) takes
-    // priority over const inlining — mirrors the Mojo adapter's
-    // `loopBoundNames` shadow guard, but here it ALSO decides the
-    // fundamental v[:name]-vs-bare-local rendering, not just the const
-    // fast path (ERB's two-locals variable model needs this distinction;
-    // Perl's uniform `$name` sigil does not — see `ErbEmitContext`).
+    // priority over const inlining — mirrors the Mojo adapter's threaded
+    // scope shadow guard, but here it ALSO decides the fundamental
+    // v[:name]-vs-bare-local rendering, not just the const fast path
+    // (ERB's two-locals variable model needs this distinction; Perl's
+    // uniform `$name` sigil does not — see `ErbEmitContext`).
     if (this.ctx.isLoopBoundName(name)) return rubyLocal(name)
     // Module pure-string const (e.g. `const baseClasses = '...'` used in a
     // className template literal): inline the literal value rather than

--- a/packages/adapter-jinja/src/__tests__/jinja-adapter-unit.test.ts
+++ b/packages/adapter-jinja/src/__tests__/jinja-adapter-unit.test.ts
@@ -530,6 +530,44 @@ function Widget({ rows }: { rows: { x: string }[] }) {
   })
 })
 
+// Copilot review on #2600 (#2482 Stage 2 follow-up): the position-accurate
+// `this.scope` (replacing the old coarse `staticLoopSourceBoundNames` set)
+// was only threaded around `renderChildren(loop.children)` in `renderLoop`
+// — narrower than the coarse set's always-on coverage. Two row-context
+// conversions sit OUTSIDE that window: a `.map()` preamble local's own
+// initializer, and the whole-item-conditional `loop-i:` key anchor
+// (`loop.key`). Both genuinely evaluate PER ROW and must see the row's own
+// bindings — a loop param shadowing a same-named outer const must resolve
+// to the row value there too, exactly as it already does inside the loop
+// body proper. `renderLoop` now enters the row scope before converting
+// either and pops it after, closing the gap.
+describe('JinjaAdapter - row scope covers preamble/key conversions outside renderChildren (#2482 Stage 2 Copilot follow-up)', () => {
+  test('a loop param shadowing an outer const resolves to the row value inside a whole-item-conditional loop-i: key anchor', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <ul>{values.map((label) => (label > 0 ? <li key={label}>{label}</li> : null))}</ul>
+}
+`)
+    expect(template).toContain('bf.comment("loop-i:" ~ bf.string(label))')
+    expect(template).not.toContain("bf.comment(\"loop-i:\" ~ bf.string('x'))")
+  })
+
+  test('a loop param shadowing an outer const resolves to the row value inside a .map() preamble local initializer', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <ul>{values.map((label) => {
+    const cls = label
+    return <li key={label} class={cls}>{label}</li>
+  })}</ul>
+}
+`)
+    expect(template).toContain('{% set cls = label %}')
+    expect(template).not.toContain("{% set cls = 'x' %}")
+  })
+})
+
 // A fragment-rooted component (top-level `<>...</>` return) has no single
 // wrapping element to bound the client's scope query, so `renderFragment`
 // brackets its children with a comment-based scope marker pair instead of

--- a/packages/adapter-jinja/src/__tests__/jinja-adapter-unit.test.ts
+++ b/packages/adapter-jinja/src/__tests__/jinja-adapter-unit.test.ts
@@ -414,11 +414,12 @@ export function Parent() {
 // `ir.metadata.localConstants` with no notion of AST scope — it used to
 // substitute an outer const's literal value even at an occurrence that is
 // actually an enclosing loop callback's own (shadowing) parameter, so every
-// iteration rendered the same hard-coded literal. Guarded with the same
-// coarse `collectLoopBoundNames` exclusion as #2212: any name a loop binds
-// anywhere in the component never inlines, falling back to the bare
-// identifier. SSR-only tests for the same #2222 reason as the #2212
-// describe below.
+// iteration rendered the same hard-coded literal. Guarded via the threaded,
+// position-accurate `BindingScope` (#2482 Stage 2 — previously a coarse
+// whole-component exclusion, same as #2212's, that also suppressed a
+// genuinely non-shadowed occurrence outside the loop; the threaded scope
+// only shadows AT the enclosing loop's own body). SSR-only tests for the
+// same #2222 reason as the #2212 describe below.
 describe('JinjaAdapter - const inlining vs loop-param shadowing (#2221)', () => {
   test('a loop param shadowing an outer literal const emits the identifier, not the const value', () => {
     const { template } = compileAndGenerate(`
@@ -457,11 +458,11 @@ function Widget({ values }: { values: number[] }) {
     expect(template).toContain('1 + 5')
   })
 
-  // The accepted coarse-exclusion trade-off (same as #2212): a name that is
-  // loop-bound ANYWHERE in the component never inlines, even at a genuinely
-  // non-shadowed occurrence outside the loop — the bare identifier is
-  // emitted instead of the value.
-  test('a const referenced outside the loop whose name is loop-bound elsewhere falls back to the identifier (accepted trade-off)', () => {
+  // Position-accurate scope (#2482 Stage 2): a name that is loop-bound
+  // elsewhere in the component but NOT at THIS occurrence still inlines
+  // here — the coarse whole-component exclusion this used to hit (and
+  // accept as a trade-off) is gone; only the loop's own body shadows.
+  test('a const referenced outside the loop whose name is loop-bound elsewhere still inlines outside, stays the identifier inside', () => {
     const { template } = compileAndGenerate(`
 function Widget({ values }: { values: number[] }) {
   const label: string = 'x'
@@ -471,7 +472,7 @@ function Widget({ values }: { values: number[] }) {
   </div>
 }
 `)
-    expect(template).not.toContain("1 + 'x'")
+    expect(template).toContain("1 + 'x'")
     expect(template).toContain('2 + label')
   })
 })
@@ -483,9 +484,8 @@ function Widget({ values }: { values: number[] }) {
 // substitute the outer const's member value even at an occurrence that is
 // actually an enclosing loop callback's own (shadowing) parameter, so every
 // iteration rendered the same hard-coded literal instead of the per-item
-// value. Guarded with the same coarse `staticLoopSourceBoundNames`
-// exclusion as #2221: any name a loop binds anywhere in the component
-// never inlines, falling back to the bare `cfg['x']` member expression.
+// value. Guarded via the threaded, position-accurate `BindingScope` (#2482
+// Stage 2), same as #2221's fix above.
 describe('JinjaAdapter - record-literal member lookup vs loop-param shadowing (#2237)', () => {
   test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
     const { template } = compileAndGenerate(`
@@ -510,12 +510,12 @@ function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
     expect(template).toContain("bf.string('bg-ghost')")
   })
 
-  // The accepted coarse-exclusion trade-off (same as #2221/#2212): an
-  // object name that is loop-bound ANYWHERE in the component never
-  // inlines its member lookups, even at a genuinely non-shadowed
-  // occurrence outside the loop — the bare member expression is emitted
-  // instead of the value.
-  test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
+  // Position-accurate scope (#2482 Stage 2): an object name that is
+  // loop-bound elsewhere in the component but NOT at THIS occurrence still
+  // inlines its member lookup here — the coarse whole-component exclusion
+  // this used to hit (and accept as a trade-off) is gone; only the loop's
+  // own body shadows.
+  test('a record member referenced outside the loop whose object name is loop-bound elsewhere still inlines outside, stays the member expression inside', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
 function Widget({ rows }: { rows: { x: string }[] }) {
@@ -525,7 +525,7 @@ function Widget({ rows }: { rows: { x: string }[] }) {
   </div>
 }
 `)
-    expect(template).not.toContain("bf.string('outer-lit')")
+    expect(template).toContain("bf.string('outer-lit')")
     expect(template).toContain("bf.string(cfg['x'])")
   })
 })

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -936,14 +936,6 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
 
-    // Per-row locals for a `.map()` callback preamble (#2447), in source
-    // order so a later initializer sees an earlier local — same as the
-    // source block. Phase 1 refuses the loop outright when the preamble
-    // isn't fully declarable, so there is no partial-lowering case: either
-    // every statement is lowered here, or the build already failed.
-    const preambleLines = (loop.preamble?.declarations ?? []).map(
-      d => `{% set ${jinjaIdent(d.name)} = ${this.convertExpressionToJinja(d.raw, d.valueParsed)} %}`,
-    )
     // This loop's row scope, for the position-accurate shadow guard
     // (#2488/#2489, canonicalized on `BindingScope` in #2482 Stage 2).
     // `IRLoop` already structurally satisfies `LoopBindingSource`
@@ -952,11 +944,35 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     // the index (when present), and the `.map()` preamble's declared
     // locals, mirroring what THIS renderLoop's for-header + `indexLocalLines`
     // actually introduce. Restored by reference (immutable — no ref-count
-    // bookkeeping) so nested loops compose for free.
+    // bookkeeping) so nested loops compose for free. Entered BEFORE
+    // `preambleLines`/`bodyChildren` are converted and popped AFTER, not
+    // just around `renderChildren` — Copilot review on #2600 caught that
+    // the narrower window silently regressed the module-const shadow guard
+    // (`_resolveLiteralConst`/`_resolveStaticRecordLiteral`, now
+    // scope-driven instead of the old coarse whole-component set) for two
+    // row-context conversions that sit OUTSIDE `renderChildren`: a
+    // `.map()` preamble local's own initializer (`d.raw`, below) and the
+    // whole-item-conditional `loop-i:` key anchor (`loop.key`, in
+    // `bodyChildren` below) — both genuinely evaluate PER ROW and must see
+    // the row's own bindings. `loop.filterPredicate` deliberately stays
+    // OUTSIDE this window (further down, after the pop): per the Stage 0
+    // design a filter/sort callback's own param is a separate `callback`
+    // frame, never folded into the `.map()` row — and empirically
+    // `JinjaFilterEmitter` (the filter predicate's dedicated,
+    // self-contained emitter) never consults `this.scope` at all, so its
+    // position relative to the pop is inert either way.
     const prevScope = this.scope
     this.scope = prevScope.enterLoopRow(loop)
+
+    // Per-row locals for a `.map()` callback preamble (#2447), in source
+    // order so a later initializer sees an earlier local — same as the
+    // source block. Phase 1 refuses the loop outright when the preamble
+    // isn't fully declarable, so there is no partial-lowering case: either
+    // every statement is lowered here, or the build already failed.
+    const preambleLines = (loop.preamble?.declarations ?? []).map(
+      d => `{% set ${jinjaIdent(d.name)} = ${this.convertExpressionToJinja(d.raw, d.valueParsed)} %}`,
+    )
     const childrenUnderLoop = this.renderChildren(loop.children)
-    this.scope = prevScope
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -964,11 +980,13 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     // Whole-item conditional: prepend an always-present `<!--bf-loop-i:KEY-->`
     // anchor before each item's (possibly empty) conditional content so the
     // client's `mapArrayAnchored` can hydrate every SSR-rendered item by its
-    // anchor.
+    // anchor. Still under the row scope (see above) — `loop.key` is a
+    // per-row expression.
     const bodyChildren =
       loop.bodyIsItemConditional && loop.key
         ? `{{ bf.comment("loop-i:" ~ bf.string(${this.convertExpressionToJinja(loop.key)})) | safe }}\n${childrenUnderLoop}`
         : childrenUnderLoop
+    this.scope = prevScope
 
     const lines: string[] = []
     // Scoped per-call-site marker so sibling `.map()`s under the same parent

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -145,8 +145,8 @@ import {
   dangerousInnerHtmlMetacharViolation,
   dangerousInnerHtmlDiagnostic,
   resolveStaticLoopSource,
-  collectLoopBoundNames,
   derivesScopeFromSlot,
+  BindingScope,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr, isExplicitStringCall } from './boolean-result.ts'
 import type { ParsedExpr, LoweringMatcher } from '@barefootjs/jsx'
@@ -272,30 +272,24 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
   private localConstants: IRMetadata['localConstants'] = []
 
   /**
-   * Every name a `.map()`/`.filter()` loop callback binds as its item/index
-   * parameter anywhere in the component (#2208 fable review). A static
-   * loop-SOURCE name (e.g. a function-scope `const items = [...]`) must
-   * never resolve through `resolveStaticLoopSource` at a use site where a
-   * DIFFERENT, enclosing loop's own callback param shadows it — same
-   * shadowing hazard, and same coarse-but-safe mitigation, as #2212's
-   * `collectLoopBoundNames` use in `collectStringValueNames`.
+   * The one canonical, position-accurate "names bound by an enclosing loop
+   * callback" service (#2482 Stage 2) — replaces the two ad-hoc devices
+   * this adapter used to carry side by side: a coarse whole-component
+   * shadow-name Set (built once at `generate()` entry, used only to guard
+   * static-const inlining) and a ref-counted, position-accurate live map
+   * (pushed/popped around `renderLoop`'s body, used for the boolean-prop/
+   * nullable-optional classification sites (#2488) and `emitSpread`'s
+   * local-const fallback (#2489)). Both consulted the "is this name
+   * loop-bound" question with DIFFERENT meanings — the coarse/live drift
+   * #2482 Stage 2 ends. Every shadow-guard site now reads this ONE
+   * threaded, immutable scope: `enterLoopRow`/pop-by-reference around
+   * `renderChildren(loop.children)` in `renderLoop`, mirroring the Stage
+   * 1a/1b `ctx.scope` precedent in `jsx-to-ir.ts`. `IRLoop` already
+   * structurally satisfies `LoopBindingSource`
+   * (`param`/`index`/`paramBindings`/`preamble`), so `renderLoop` passes
+   * the loop node straight to `enterLoopRow`.
    */
-  private staticLoopSourceBoundNames: Set<string> = new Set()
-
-  /**
-   * Names currently bound by an enclosing loop body — the block-param
-   * locals `renderLoop` introduces (item, index, per-binding destructure
-   * fields, `.map()` preamble declarations) — ref-counted so nested loops
-   * compose. This is the POSITION-ACCURATE twin of the coarse
-   * `staticLoopSourceBoundNames` above: that set is a whole-component
-   * union used only to guard static-const inlining (safe to over-suppress
-   * there — the fallback is just "don't inline"), whereas the boolean-prop
-   * and nullable-optional classification sites (#2488) and `emitSpread`'s
-   * local-const fallback (#2489) need to know whether a name is loop-bound
-   * AT THIS POSITION, because for those the coarse fallback would silently
-   * mis-render a genuine occurrence of the same name outside the loop too.
-   */
-  private loopBoundNames: Map<string, number> = new Map()
+  private scope: BindingScope = BindingScope.EMPTY
 
   /**
    * Optional, no-default props that are `None` when the caller omits them.
@@ -329,8 +323,7 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     // ("True"/"False") (#1897, pagination's data-active).
     this.booleanTypedProps = collectBooleanTypedProps(ir)
     this.localConstants = ir.metadata.localConstants ?? []
-    this.staticLoopSourceBoundNames = collectLoopBoundNames(ir)
-    this.loopBoundNames.clear()
+    this.scope = BindingScope.EMPTY
     this.nullableOptionalProps = collectNullableOptionalProps(ir)
     this.stringValueNames = collectStringValueNames(ir)
     this.moduleStringConsts = collectModuleStringConsts(ir.metadata.localConstants)
@@ -829,9 +822,11 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     // bare identifier expression below, same as before #2208 — which
     // still trips the pre-existing BF101 gate for an unresolvable local
     // const reference (a loud, conservative refusal, not a silent wrong
-    // value).
+    // value). Canonical, position-accurate predicate (#2482 Stage 2) — the
+    // enclosing loop scope's own membership, not a coarse whole-component
+    // union.
     const staticItems = resolveStaticLoopSource(loop.arrayParsed, this.localConstants, {
-      isNameShadowed: name => this.staticLoopSourceBoundNames.has(name),
+      isNameShadowed: this.scope.asShadowPredicate(),
     })
     const staticArray = staticItems !== null ? staticValueToJinja(staticItems) : null
 
@@ -949,39 +944,19 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     const preambleLines = (loop.preamble?.declarations ?? []).map(
       d => `{% set ${jinjaIdent(d.name)} = ${this.convertExpressionToJinja(d.raw, d.valueParsed)} %}`,
     )
-    // Names this loop binds in body scope, for the position-accurate
-    // `loopBoundNames` guard (#2488) — mirrors the ERB adapter's `loopBound`
-    // derivation, adapted to what THIS renderLoop actually binds: the
-    // for-header target(s) (`loopVar` / `objectIteration` key+value /
-    // `iterationShape === 'keys'`'s `param`), each `indexLocalLines` name
-    // (explicit index, or a destructure binding), and the `.map()`
-    // preamble's declared locals. Ref-counted so nested loops compose.
-    const loopBound: string[] = []
-    if (loop.objectIteration === 'entries') {
-      loopBound.push(loop.index ?? param, param)
-    } else if (loop.objectIteration === 'keys' || loop.objectIteration === 'values') {
-      loopBound.push(param)
-    } else if (loop.iterationShape === 'keys') {
-      // The header still binds the throwaway loop var; `param` is only the
-      // index alias set beneath it (#2488).
-      loopBound.push('__bf_item', param)
-    } else if (supportableDestructure) {
-      loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
-      if (loop.index) loopBound.push(loop.index)
-    } else {
-      loopBound.push(param)
-      if (loop.index) loopBound.push(loop.index)
-    }
-    for (const d of loop.preamble?.declarations ?? []) loopBound.push(d.name)
-    for (const n of loopBound) {
-      this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
-    }
+    // This loop's row scope, for the position-accurate shadow guard
+    // (#2488/#2489, canonicalized on `BindingScope` in #2482 Stage 2).
+    // `IRLoop` already structurally satisfies `LoopBindingSource`
+    // (`param`/`index`/`paramBindings`/`preamble`) — `enterLoopRow(loop)`
+    // binds exactly the for-header target(s), each destructure binding,
+    // the index (when present), and the `.map()` preamble's declared
+    // locals, mirroring what THIS renderLoop's for-header + `indexLocalLines`
+    // actually introduce. Restored by reference (immutable — no ref-count
+    // bookkeeping) so nested loops compose for free.
+    const prevScope = this.scope
+    this.scope = prevScope.enterLoopRow(loop)
     const childrenUnderLoop = this.renderChildren(loop.children)
-    for (const n of loopBound) {
-      const c = (this.loopBoundNames.get(n) ?? 1) - 1
-      if (c <= 0) this.loopBoundNames.delete(n)
-      else this.loopBoundNames.set(n, c)
-    }
+    this.scope = prevScope
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -1472,13 +1447,13 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
       // function-scope (`!isModule`) consts whose value is NOT itself a bare
       // identifier (loop guard) are considered.
       //
-      // `loopBoundNames` guard (#2489): an enclosing `.map()` callback's own
-      // param can shadow this outer const's name (`.map((attrs) => <p
+      // `this.scope` shadow guard (#2489): an enclosing `.map()` callback's
+      // own param can shadow this outer const's name (`.map((attrs) => <p
       // {...attrs} />)`) — without the guard this forwarded the OUTER
       // const's value at every iteration instead of the per-item value.
-      // Must be the LIVE map, not `staticLoopSourceBoundNames` — the same
-      // name spread at ROOT must still resolve the const.
-      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.loopBoundNames.has(trimmed)) {
+      // Must be the threaded, position-accurate scope — the same name
+      // spread at ROOT (no enclosing loop) must still resolve the const.
+      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.scope.isBound(trimmed)) {
         const localConst = (this.localConstants ?? []).find(
           c => c.name === trimmed && !c.isModule,
         )
@@ -1894,9 +1869,9 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     return this.booleanTypedProps.has(bare)
   }
 
-  /** Position-accurate loop-bound-name check — see `loopBoundNames`'s docstring. */
+  /** Position-accurate loop-bound-name check — see `this.scope`'s docstring. */
   private isLoopBoundName(name: string): boolean {
-    return this.loopBoundNames.has(name)
+    return this.scope.isBound(name)
   }
 
   /**
@@ -1923,17 +1898,16 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
    * context, so a bare reference would resolve to Undefined.
    *
    * The lookup is a flat name match with no notion of AST scope, so a
-   * name that any loop callback binds as its item/index param never
-   * inlines (#2221) — the occurrence may be the loop's own (shadowing)
-   * binding, and substituting the outer const's value there renders every
-   * iteration with the same hard-coded literal. Coarse (a genuinely
-   * non-shadowed same-named const elsewhere in the component also stops
-   * inlining, falling back to the bare identifier) but safe — the same
-   * trade-off as #2212's `collectLoopBoundNames` use in
-   * `collectStringValueNames`.
+   * name bound by the CURRENTLY ENCLOSING loop's item/index/destructure/
+   * preamble param never inlines (#2221) — the occurrence may be the
+   * loop's own (shadowing) binding, and substituting the outer const's
+   * value there renders every iteration with the same hard-coded literal.
+   * Position-accurate via the threaded `this.scope` (#2482 Stage 2) — a
+   * same-named const elsewhere in the component, outside any loop that
+   * shadows it, still inlines.
    */
   private _resolveLiteralConst(name: string): string | null {
-    if (this.staticLoopSourceBoundNames.has(name)) return null
+    if (this.scope.isBound(name)) return null
     const c = (this.localConstants ?? []).find(lc => lc.name === name)
     if (c?.value === undefined) return null
     const v = c.value.trim()
@@ -1951,15 +1925,16 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
    * scope, so an enclosing loop callback's own param of the same name
    * (`.map((cfg) => <li>{cfg.x}</li>)` shadowing a module `const cfg = {…}`)
    * still resolved to the OUTER const's member value at every iteration
-   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`. Same
-   * coarse-but-safe `staticLoopSourceBoundNames` guard: any name a loop
-   * binds anywhere in the component never inlines, falling back to the bare
+   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`.
+   * Position-accurate via the threaded `this.scope` (#2482 Stage 2), passed
+   * as `lookupStaticRecordLiteral`'s required guard: a name the CURRENTLY
+   * ENCLOSING loop binds never inlines, falling back to the bare
    * `cfg['x']` member expression (which a Jinja for-loop binds correctly
-   * at the shadowed occurrences).
+   * at the shadowed occurrence); a same-named const elsewhere, outside any
+   * loop that shadows it, still inlines.
    */
   private _resolveStaticRecordLiteral(objectName: string, key: string): string | null {
-    if (this.staticLoopSourceBoundNames.has(objectName)) return null
-    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants)
+    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants, name => this.scope.isBound(name))
     if (!hit) return null
     return hit.kind === 'number'
       ? hit.text

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -65,6 +65,7 @@ import {
   dangerousInnerHtmlDiagnostic,
   resolveStaticLoopSource,
   derivesScopeFromSlot,
+  BindingScope,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result.ts'
 import type { ParsedExpr, LoweringMatcher } from '@barefootjs/jsx'
@@ -238,14 +239,22 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    */
   private localConstants: IRMetadata['localConstants'] = []
   /**
-   * Names currently bound by an enclosing loop body — the `my $<param>` and
-   * `my $<index>` bindings `renderLoop` introduces — ref-counted so nested
-   * loops compose. `resolveModuleStringConst` consults this so a loop
+   * The one canonical, position-accurate "names bound by an enclosing loop
+   * callback" service (#2482 Stage 2) — replaces the ref-counted
+   * `Map<string, number>` this adapter used to push/pop around
+   * `renderLoop`'s body (the `my $<param>` / `my $<index>` bindings it
+   * introduces). `resolveModuleStringConst` consults this so a loop
    * variable whose name happens to match a module string const is NOT
    * inlined as the const literal (mirrors the Go adapter's loop-param /
-   * loop-var shadowing guards). (#1749 review)
+   * loop-var shadowing guards). (#1749 review) Threaded via
+   * save/restore-by-reference around `renderChildren(loop.children)` in
+   * `renderLoop` (immutable — no ref-count bookkeeping), mirroring the
+   * Stage 1a/1b `ctx.scope` precedent in `jsx-to-ir.ts`. `IRLoop` already
+   * structurally satisfies `LoopBindingSource`
+   * (`param`/`index`/`paramBindings`/`preamble`), so `renderLoop` passes
+   * the loop node straight to `enterLoopRow`.
    */
-  private loopBoundNames: Map<string, number> = new Map()
+  private scope: BindingScope = BindingScope.EMPTY
   /**
    * Prop names whose value is `undef` in the template body when the caller
    * omits them — so a bare-reference attribute should be dropped rather
@@ -293,7 +302,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     this._searchParamsLocals = searchParamsLocalNames(ir.metadata)
     this._loweringMatchers = prepareLoweringMatchers(ir.metadata)
     this.localConstants = ir.metadata.localConstants ?? []
-    this.loopBoundNames.clear()
+    this.scope = BindingScope.EMPTY
     this.errors = []
     this.childrenCaptureCounter = 0
 
@@ -388,7 +397,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // Inside a `.map()` callback, a param that shares a boolean prop's name
     // is the ROW binding, not the prop — route it through plain string
     // emission instead of `bf->bool_str` (#2488).
-    if (this.loopBoundNames.has(bare)) return false
+    if (this.scope.isBound(bare)) return false
     return this.booleanTypedProps.has(bare)
   }
 
@@ -423,16 +432,15 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * function-scope consts never reach the per-render stash, so a bare
    * `$totalPages` faults under strict mode.
    *
-   * The `loopBoundNames` guard also covers the #2221 hazard (a loop
-   * callback's own param shadowing this outer const's name): unlike the
-   * Twig-family adapters' coarse, whole-component `collectLoopBoundNames(ir)`
-   * static set, this adapter's `loopBoundNames` is a LIVE ref-counted map
-   * `renderLoop` populates/depopulates as it descends/ascends into each
-   * loop body (#1749) — so it's already scope-precise for this call site;
-   * no separate `staticLoopSourceBoundNames`-style field is needed here.
+   * The threaded scope's shadow guard also covers the #2221 hazard (a loop
+   * callback's own param shadowing this outer const's name): `this.scope`
+   * is position-accurate (#2482 Stage 2) — pushed/popped by reference as
+   * `renderLoop` descends/ascends into each loop body — so it's already
+   * scope-precise for this call site; no separate coarse whole-component
+   * field is needed here.
    */
   private resolveLiteralConst(name: string): string | null {
-    if (this.loopBoundNames?.has?.(name)) return null
+    if (this.scope.isBound(name)) return null
     const c = (this.localConstants ?? []).find(lc => lc.name === name)
     if (c?.value === undefined) return null
     const v = c.value.trim()
@@ -443,8 +451,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   }
 
   private resolveStaticRecordLiteral(objectName: string, key: string): string | null {
-    if (this.loopBoundNames?.has?.(objectName)) return null
-    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants)
+    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants, name => this.scope.isBound(name))
     if (!hit) return null
     return hit.kind === 'number'
       ? hit.text
@@ -454,7 +461,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   private resolveModuleStringConst(name: string): string | null {
     // A loop body introduces `my $<param>` / `my $<index>` bindings that
     // shadow a module const of the same name — never inline inside one.
-    if (this.loopBoundNames.has(name)) return null
+    if (this.scope.isBound(name)) return null
     const value = this.moduleStringConsts.get(name)
     if (value === undefined) return null
     return `'${value.replace(/[\\']/g, m => `\\${m}`)}'`
@@ -902,10 +909,10 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // `Object.entries(props.tags).filter(...)`) still refuses below.
     // `isNameShadowed` guards a DIFFERENT, enclosing loop's own callback
     // param shadowing this identifier (fable review) — reuses the same
-    // live `loopBoundNames` ref-counted tracking `resolveModuleStringConst`
-    // already consults for this hazard class (#1749).
+    // threaded, position-accurate `this.scope` `resolveModuleStringConst`
+    // already consults for this hazard class (#1749/#2482 Stage 2).
     const staticItems = resolveStaticLoopSource(loop.arrayParsed, this.localConstants, {
-      isNameShadowed: name => this.loopBoundNames.has(name),
+      isNameShadowed: this.scope.asShadowPredicate(),
     })
     const staticArray = staticItems !== null ? staticValueToPerl(staticItems) : null
 
@@ -951,26 +958,21 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     const indexVar = loop.iterationShape === 'keys'
       ? `$${param}`
       : loop.index ? `$${loop.index}` : '$_i'
-    // Names this loop binds in body scope. Guard module-const inlining for
-    // the whole body (children + key + filter) so a same-named loop variable
-    // isn't replaced by the const literal (#1749 review). Ref-counted for
-    // nested loops; released after the body lines are assembled below.
-    const loopBound = loop.objectIteration === 'entries'
-      ? [param, loop.index ?? '_k']
-      : loop.objectIteration === 'keys' || loop.objectIteration === 'values' || loop.iterationShape === 'keys'
-        ? [param]
-        : supportableDestructure
-          ? ['__bf_item', ...(loop.paramBindings ?? []).map(b => b.name), loop.index ?? '_i']
-          : [param, loop.index ?? '_i']
-    // A `.map()` callback preamble lowers to one per-row `my` local per
-    // declaration (#2447). Loop-binding the names keeps a same-named module
-    // const from inlining over the local the loop just declared — the same
-    // hazard class `resolveModuleStringConst` already consults this map for.
+    // This loop's row scope. Guards module-const inlining for the whole
+    // body (children + key + filter) so a same-named loop variable isn't
+    // replaced by the const literal (#1749 review). `IRLoop` already
+    // structurally satisfies `LoopBindingSource`
+    // (`param`/`index`/`paramBindings`/`preamble`) — `enterLoopRow(loop)`
+    // binds exactly what this renderLoop's header + preamble locals
+    // introduce (#2482 Stage 2 — replaces the ref-counted `Map` this
+    // adapter used to carry). Restored by reference (immutable — no
+    // ref-count bookkeeping) at the matching pop below, once the WHOLE
+    // body (including the filter predicate) has been rendered — except for
+    // one temporary drop-to-outer window around the hoisted sort-comparator
+    // emission below, since that runs OUTSIDE this loop.
     const preambleDecls = loop.preamble?.declarations ?? []
-    for (const d of preambleDecls) loopBound.push(d.name)
-    for (const n of loopBound) {
-      this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
-    }
+    const prevScope = this.scope
+    this.scope = prevScope.enterLoopRow(loop)
     const prevLoopKeyDepth = this.currentLoopKeyDepth
     this.currentLoopKeyDepth = loop.depth
     const renderedChildren = this.renderChildren(loop.children)
@@ -995,18 +997,15 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       // `bf->sort_eval`; fall back to the structured `bf->sort` for a
       // comparator the evaluator can't model (e.g. `localeCompare`).
       //
-      // The hoisted sort runs OUTSIDE this loop, so this loop's bound names
+      // The hoisted sort runs OUTSIDE this loop, so this loop's row scope
       // must not shadow the comparator's captured free vars while emitting the
       // env — otherwise a captured var that happens to share a loop-param name
       // is blocked from inlining its module const and renders as an undefined
-      // `$name` (strict-mode fault, Copilot review #2035). Drop this loop's
-      // bound names for the sort emit, then restore (a nested loop's outer
-      // bindings, ref-counted, stay in effect).
-      for (const n of loopBound) {
-        const c = (this.loopBoundNames.get(n) ?? 1) - 1
-        if (c <= 0) this.loopBoundNames.delete(n)
-        else this.loopBoundNames.set(n, c)
-      }
+      // `$name` (strict-mode fault, Copilot review #2035). Drop back to the
+      // outer (pre-row) scope for the sort emit, then restore the row scope
+      // below (a nested loop's own outer bindings stay in effect throughout,
+      // since `prevScope` already carries them).
+      this.scope = prevScope
       const sortEmit = (e: ParsedExpr) => this.convertExpressionToPerl('', e)
       // `loop.sortComparator` is the generic `IRLoopSort` (#2018 P5): serialize
       // the arrow body for the evaluator (eval-first), recover the structured
@@ -1030,9 +1029,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
         )
         sorted = rawArray
       }
-      for (const n of loopBound) {
-        this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
-      }
+      this.scope = prevScope.enterLoopRow(loop)
       lines.push(`% my $${sortedHoist} = ${sorted};`)
     }
     if (loop.objectIteration) {
@@ -1121,12 +1118,8 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       lines.push(children)
     }
 
-    // Body fully rendered — release the loop-bound names.
-    for (const n of loopBound) {
-      const c = (this.loopBoundNames.get(n) ?? 1) - 1
-      if (c <= 0) this.loopBoundNames.delete(n)
-      else this.loopBoundNames.set(n, c)
-    }
+    // Body fully rendered — restore the outer (pre-row) scope.
+    this.scope = prevScope
 
     lines.push(`% }`)
     lines.push(`<%== bf->comment("/loop:${loop.markerId}") %>`)
@@ -1395,7 +1388,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
         // Inside a `.map()` callback, a param that shadows a nullable
         // optional prop's name is the row binding, not the prop — skip the
         // spurious `defined` guard (#2488).
-        !this.loopBoundNames.has(normalizedBareId)
+        !this.scope.isBound(normalizedBareId)
       ) {
         const perl = this.convertExpressionToPerl(value.expr)
         const body =
@@ -1527,14 +1520,14 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       // lowering. Only function-scope (`!isModule`) consts whose value is
       // NOT itself a bare identifier (loop guard) are considered.
       //
-      // `loopBoundNames` guard (#2221): an enclosing `.map()` callback's
+      // `this.scope` shadow guard (#2221): an enclosing `.map()` callback's
       // own param can shadow this outer const's name (`.map((sizeAttrs)
       // => <li {...sizeAttrs} />)`) — without the guard this forwarded
       // the OUTER const's hashref at every iteration instead of the
-      // per-item `$sizeAttrs` value. Same live ref-counted map
-      // `resolveLiteralConst` / `resolveStaticRecordLiteral` already
+      // per-item `$sizeAttrs` value. Same threaded, position-accurate
+      // scope `resolveLiteralConst` / `resolveStaticRecordLiteral` already
       // consult for this hazard class (#1749).
-      if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed) && !this.loopBoundNames.has(trimmed)) {
+      if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed) && !this.scope.isBound(trimmed)) {
         const localConst = this.localConstants.find(
           c => c.name === trimmed && !c.isModule,
         )

--- a/packages/adapter-rust/src/__tests__/minijinja-adapter-unit.test.ts
+++ b/packages/adapter-rust/src/__tests__/minijinja-adapter-unit.test.ts
@@ -416,10 +416,11 @@ export function Parent() {
 // `ir.metadata.localConstants` with no notion of AST scope — it used to
 // substitute an outer const's literal value even at an occurrence that is
 // actually an enclosing loop callback's own (shadowing) parameter, so every
-// iteration rendered the same hard-coded literal. Guarded with the same
-// coarse `collectLoopBoundNames` exclusion as #2212: any name a loop binds
-// anywhere in the component never inlines, falling back to the bare
-// identifier.
+// iteration rendered the same hard-coded literal. Guarded via the threaded,
+// position-accurate `BindingScope` (#2482 Stage 2 — previously a coarse
+// whole-component exclusion, same as #2212's, that also suppressed a
+// genuinely non-shadowed occurrence outside the loop; the threaded scope
+// only shadows AT the enclosing loop's own body).
 describe('MinijinjaAdapter - const inlining vs loop-param shadowing (#2221)', () => {
   test('a loop param shadowing an outer literal const emits the identifier, not the const value', () => {
     const { template } = compileAndGenerate(`
@@ -458,11 +459,11 @@ function Widget({ values }: { values: number[] }) {
     expect(template).toContain('1 + 5')
   })
 
-  // The accepted coarse-exclusion trade-off (same as #2212): a name that is
-  // loop-bound ANYWHERE in the component never inlines, even at a genuinely
-  // non-shadowed occurrence outside the loop — the bare identifier is
-  // emitted instead of the value.
-  test('a const referenced outside the loop whose name is loop-bound elsewhere falls back to the identifier (accepted trade-off)', () => {
+  // Position-accurate scope (#2482 Stage 2): a name that is loop-bound
+  // elsewhere in the component but NOT at THIS occurrence still inlines
+  // here — the coarse whole-component exclusion this used to hit (and
+  // accept as a trade-off) is gone; only the loop's own body shadows.
+  test('a const referenced outside the loop whose name is loop-bound elsewhere still inlines outside, stays the identifier inside', () => {
     const { template } = compileAndGenerate(`
 function Widget({ values }: { values: number[] }) {
   const label: string = 'x'
@@ -472,7 +473,7 @@ function Widget({ values }: { values: number[] }) {
   </div>
 }
 `)
-    expect(template).not.toContain("1 + 'x'")
+    expect(template).toContain("1 + 'x'")
     expect(template).toContain('2 + label')
   })
 })
@@ -484,9 +485,8 @@ function Widget({ values }: { values: number[] }) {
 // substitute the outer const's member value even at an occurrence that is
 // actually an enclosing loop callback's own (shadowing) parameter, so every
 // iteration rendered the same hard-coded literal instead of the per-item
-// value. Guarded with the same coarse `staticLoopSourceBoundNames`
-// exclusion as #2221: any name a loop binds anywhere in the component
-// never inlines, falling back to the bare `cfg.x` member expression.
+// value. Guarded via the threaded, position-accurate `BindingScope` (#2482
+// Stage 2), same as #2221's fix above.
 describe('MinijinjaAdapter - record-literal member lookup vs loop-param shadowing (#2237)', () => {
   test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
     const { template } = compileAndGenerate(`
@@ -511,12 +511,12 @@ function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
     expect(template).toContain("bf.string('bg-ghost')")
   })
 
-  // The accepted coarse-exclusion trade-off (same as #2221/#2212): an
-  // object name that is loop-bound ANYWHERE in the component never
-  // inlines its member lookups, even at a genuinely non-shadowed
-  // occurrence outside the loop — the bare member expression is emitted
-  // instead of the value.
-  test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
+  // Position-accurate scope (#2482 Stage 2): an object name that is
+  // loop-bound elsewhere in the component but NOT at THIS occurrence still
+  // inlines its member lookup here — the coarse whole-component exclusion
+  // this used to hit (and accept as a trade-off) is gone; only the loop's
+  // own body shadows.
+  test('a record member referenced outside the loop whose object name is loop-bound elsewhere still inlines outside, stays the member expression inside', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
 function Widget({ rows }: { rows: { x: string }[] }) {
@@ -526,7 +526,7 @@ function Widget({ rows }: { rows: { x: string }[] }) {
   </div>
 }
 `)
-    expect(template).not.toContain("bf.string('outer-lit')")
+    expect(template).toContain("bf.string('outer-lit')")
     expect(template).toContain('bf.string(cfg.x)')
   })
 })

--- a/packages/adapter-rust/src/__tests__/minijinja-adapter-unit.test.ts
+++ b/packages/adapter-rust/src/__tests__/minijinja-adapter-unit.test.ts
@@ -531,6 +531,44 @@ function Widget({ rows }: { rows: { x: string }[] }) {
   })
 })
 
+// Copilot review on #2600 (#2482 Stage 2 follow-up): the position-accurate
+// `this.scope` (replacing the old coarse `staticLoopSourceBoundNames` set)
+// was only threaded around `renderChildren(loop.children)` in `renderLoop`
+// — narrower than the coarse set's always-on coverage. Two row-context
+// conversions sit OUTSIDE that window: a `.map()` preamble local's own
+// initializer, and the whole-item-conditional `loop-i:` key anchor
+// (`loop.key`). Both genuinely evaluate PER ROW and must see the row's own
+// bindings — a loop param shadowing a same-named outer const must resolve
+// to the row value there too, exactly as it already does inside the loop
+// body proper. `renderLoop` now enters the row scope before converting
+// either and pops it after, closing the gap.
+describe('MinijinjaAdapter - row scope covers preamble/key conversions outside renderChildren (#2482 Stage 2 Copilot follow-up)', () => {
+  test('a loop param shadowing an outer const resolves to the row value inside a whole-item-conditional loop-i: key anchor', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <ul>{values.map((label) => (label > 0 ? <li key={label}>{label}</li> : null))}</ul>
+}
+`)
+    expect(template).toContain('bf.comment("loop-i:" ~ bf.string(label))')
+    expect(template).not.toContain("bf.comment(\"loop-i:\" ~ bf.string('x'))")
+  })
+
+  test('a loop param shadowing an outer const resolves to the row value inside a .map() preamble local initializer', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <ul>{values.map((label) => {
+    const cls = label
+    return <li key={label} class={cls}>{label}</li>
+  })}</ul>
+}
+`)
+    expect(template).toContain('{% set cls = label %}')
+    expect(template).not.toContain("{% set cls = 'x' %}")
+  })
+})
+
 describe('MinijinjaAdapter - fragment-root scope comment end marker (#2289)', () => {
   // A fragment-rooted component (multiple top-level nodes) uses a
   // comment-based scope marker instead of a real DOM element, so it needs a

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -170,8 +170,8 @@ import {
   dangerousInnerHtmlMetacharViolation,
   dangerousInnerHtmlDiagnostic,
   resolveStaticLoopSource,
-  collectLoopBoundNames,
   derivesScopeFromSlot,
+  BindingScope,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr, isExplicitStringCall } from './boolean-result.ts'
 import type { ParsedExpr, LoweringMatcher, LoopBindingPathSegment } from '@barefootjs/jsx'
@@ -320,30 +320,24 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
   private localConstants: IRMetadata['localConstants'] = []
 
   /**
-   * Every name a `.map()`/`.filter()` loop callback binds as its item/index
-   * parameter anywhere in the component (#2208 fable review). A static
-   * loop-SOURCE name (e.g. a function-scope `const items = [...]`) must
-   * never resolve through `resolveStaticLoopSource` at a use site where a
-   * DIFFERENT, enclosing loop's own callback param shadows it — same
-   * shadowing hazard, and same coarse-but-safe mitigation, as #2212's
-   * `collectLoopBoundNames` use in `collectStringValueNames`.
+   * The one canonical, position-accurate "names bound by an enclosing loop
+   * callback" service (#2482 Stage 2) — replaces the two ad-hoc devices
+   * this adapter used to carry side by side: a coarse whole-component
+   * shadow-name Set (built once at `generate()` entry, used only to guard
+   * static-const inlining) and a ref-counted, position-accurate live map
+   * (pushed/popped around `renderLoop`'s body, used for the boolean-prop/
+   * nullable-optional classification sites (#2488) and `emitSpread`'s
+   * local-const fallback (#2489)). Both consulted the "is this name
+   * loop-bound" question with DIFFERENT meanings — the coarse/live drift
+   * #2482 Stage 2 ends. Every shadow-guard site now reads this ONE
+   * threaded, immutable scope: `enterLoopRow`/pop-by-reference around
+   * `renderChildren(loop.children)` in `renderLoop`, mirroring the Stage
+   * 1a/1b `ctx.scope` precedent in `jsx-to-ir.ts`. `IRLoop` already
+   * structurally satisfies `LoopBindingSource`
+   * (`param`/`index`/`paramBindings`/`preamble`), so `renderLoop` passes
+   * the loop node straight to `enterLoopRow`.
    */
-  private staticLoopSourceBoundNames: Set<string> = new Set()
-
-  /**
-   * Names currently bound by an enclosing loop body — the block-param
-   * locals `renderLoop` introduces (item, index, per-binding destructure
-   * fields, `.map()` preamble declarations) — ref-counted so nested loops
-   * compose. This is the POSITION-ACCURATE twin of the coarse
-   * `staticLoopSourceBoundNames` above: that set is a whole-component
-   * union used only to guard static-const inlining (safe to over-suppress
-   * there — the fallback is just "don't inline"), whereas the boolean-prop
-   * and nullable-optional classification sites (#2488) and `emitSpread`'s
-   * local-const fallback (#2489) need to know whether a name is loop-bound
-   * AT THIS POSITION, because for those the coarse fallback would silently
-   * mis-render a genuine occurrence of the same name outside the loop too.
-   */
-  private loopBoundNames: Map<string, number> = new Map()
+  private scope: BindingScope = BindingScope.EMPTY
 
   /**
    * Optional, no-default props that are `None` when the caller omits them.
@@ -377,8 +371,7 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     // ("True"/"False") (#1897, pagination's data-active).
     this.booleanTypedProps = collectBooleanTypedProps(ir)
     this.localConstants = ir.metadata.localConstants ?? []
-    this.staticLoopSourceBoundNames = collectLoopBoundNames(ir)
-    this.loopBoundNames.clear()
+    this.scope = BindingScope.EMPTY
     this.nullableOptionalProps = collectNullableOptionalProps(ir)
     this.stringValueNames = collectStringValueNames(ir)
     this.moduleStringConsts = collectModuleStringConsts(ir.metadata.localConstants)
@@ -878,9 +871,11 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     // bare identifier expression below, same as before #2208 — which
     // still trips the pre-existing BF101 gate for an unresolvable local
     // const reference (a loud, conservative refusal, not a silent wrong
-    // value).
+    // value). Canonical, position-accurate predicate (#2482 Stage 2) — the
+    // enclosing loop scope's own membership, not a coarse whole-component
+    // union.
     const staticItems = resolveStaticLoopSource(loop.arrayParsed, this.localConstants, {
-      isNameShadowed: name => this.staticLoopSourceBoundNames.has(name),
+      isNameShadowed: this.scope.asShadowPredicate(),
     })
     const staticArray = staticItems !== null ? staticValueToMinijinja(staticItems) : null
 
@@ -993,42 +988,19 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     const preambleLines = (loop.preamble?.declarations ?? []).map(
       d => `{% set ${minijinjaIdent(d.name)} = ${this.convertExpressionToJinja(d.raw, d.valueParsed)} %}`,
     )
-    // Names this loop binds in body scope, for the position-accurate
-    // `loopBoundNames` guard (#2488) — mirrors the ERB adapter's `loopBound`
-    // derivation, adapted to what THIS renderLoop actually binds: the
-    // for-header target(s) (`loopVar` / `objectIteration` key+value /
-    // `iterationShape === 'keys'`'s `param`), each `indexLocalLines` name
-    // (explicit index, or a destructure binding), and the `.map()`
-    // preamble's declared locals. Ref-counted so nested loops compose.
-    const loopBound: string[] = []
-    if (loop.objectIteration === 'entries') {
-      loopBound.push(loop.index ?? param, param)
-    } else if (loop.objectIteration === 'keys') {
-      // `|items` binds both slots; the unused one is a throwaway (#2488).
-      loopBound.push(param, '__bf_v')
-    } else if (loop.objectIteration === 'values') {
-      loopBound.push('__bf_k', param)
-    } else if (loop.iterationShape === 'keys') {
-      // The header still binds the throwaway loop var; `param` is only the
-      // index alias set beneath it (#2488).
-      loopBound.push('__bf_item', param)
-    } else if (supportableDestructure) {
-      loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
-      if (loop.index) loopBound.push(loop.index)
-    } else {
-      loopBound.push(param)
-      if (loop.index) loopBound.push(loop.index)
-    }
-    for (const d of loop.preamble?.declarations ?? []) loopBound.push(d.name)
-    for (const n of loopBound) {
-      this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
-    }
+    // This loop's row scope, for the position-accurate shadow guard
+    // (#2488/#2489, canonicalized on `BindingScope` in #2482 Stage 2).
+    // `IRLoop` already structurally satisfies `LoopBindingSource`
+    // (`param`/`index`/`paramBindings`/`preamble`) — `enterLoopRow(loop)`
+    // binds exactly the for-header target(s), each destructure binding,
+    // the index (when present), and the `.map()` preamble's declared
+    // locals, mirroring what THIS renderLoop's for-header + `indexLocalLines`
+    // actually introduce. Restored by reference (immutable — no ref-count
+    // bookkeeping) so nested loops compose for free.
+    const prevScope = this.scope
+    this.scope = prevScope.enterLoopRow(loop)
     const childrenUnderLoop = this.renderChildren(loop.children)
-    for (const n of loopBound) {
-      const c = (this.loopBoundNames.get(n) ?? 1) - 1
-      if (c <= 0) this.loopBoundNames.delete(n)
-      else this.loopBoundNames.set(n, c)
-    }
+    this.scope = prevScope
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -1527,13 +1499,13 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
       // function-scope (`!isModule`) consts whose value is NOT itself a bare
       // identifier (loop guard) are considered.
       //
-      // `loopBoundNames` guard (#2489): an enclosing `.map()` callback's own
-      // param can shadow this outer const's name (`.map((attrs) => <p
+      // `this.scope` shadow guard (#2489): an enclosing `.map()` callback's
+      // own param can shadow this outer const's name (`.map((attrs) => <p
       // {...attrs} />)`) — without the guard this forwarded the OUTER
       // const's value at every iteration instead of the per-item value.
-      // Must be the LIVE map, not `staticLoopSourceBoundNames` — the same
-      // name spread at ROOT must still resolve the const.
-      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.loopBoundNames.has(trimmed)) {
+      // Must be the threaded, position-accurate scope — the same name
+      // spread at ROOT (no enclosing loop) must still resolve the const.
+      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.scope.isBound(trimmed)) {
         const localConst = (this.localConstants ?? []).find(
           c => c.name === trimmed && !c.isModule,
         )
@@ -1955,9 +1927,9 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     return this.booleanTypedProps.has(bare)
   }
 
-  /** Position-accurate loop-bound-name check — see `loopBoundNames`'s docstring. */
+  /** Position-accurate loop-bound-name check — see `this.scope`'s docstring. */
   private isLoopBoundName(name: string): boolean {
-    return this.loopBoundNames.has(name)
+    return this.scope.isBound(name)
   }
 
   /**
@@ -1984,17 +1956,16 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
    * context, so a bare reference would resolve to Undefined.
    *
    * The lookup is a flat name match with no notion of AST scope, so a
-   * name that any loop callback binds as its item/index param never
-   * inlines (#2221) — the occurrence may be the loop's own (shadowing)
-   * binding, and substituting the outer const's value there renders every
-   * iteration with the same hard-coded literal. Coarse (a genuinely
-   * non-shadowed same-named const elsewhere in the component also stops
-   * inlining, falling back to the bare identifier) but safe — the same
-   * trade-off as #2212's `collectLoopBoundNames` use in
-   * `collectStringValueNames`.
+   * name bound by the CURRENTLY ENCLOSING loop's item/index/destructure/
+   * preamble param never inlines (#2221) — the occurrence may be the
+   * loop's own (shadowing) binding, and substituting the outer const's
+   * value there renders every iteration with the same hard-coded literal.
+   * Position-accurate via the threaded `this.scope` (#2482 Stage 2) — a
+   * same-named const elsewhere in the component, outside any loop that
+   * shadows it, still inlines.
    */
   private _resolveLiteralConst(name: string): string | null {
-    if (this.staticLoopSourceBoundNames.has(name)) return null
+    if (this.scope.isBound(name)) return null
     const c = (this.localConstants ?? []).find(lc => lc.name === name)
     if (c?.value === undefined) return null
     const v = c.value.trim()
@@ -2012,15 +1983,16 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
    * scope, so an enclosing loop callback's own param of the same name
    * (`.map((cfg) => <li>{cfg.x}</li>)` shadowing a module `const cfg = {…}`)
    * still resolved to the OUTER const's member value at every iteration
-   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`. Same
-   * coarse-but-safe `staticLoopSourceBoundNames` guard: any name a loop
-   * binds anywhere in the component never inlines, falling back to the bare
-   * `cfg.x` member expression (which a minijinja `for` loop binds correctly
-   * at the shadowed occurrences).
+   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`.
+   * Position-accurate via the threaded `this.scope` (#2482 Stage 2), passed
+   * as `lookupStaticRecordLiteral`'s required guard: a name the CURRENTLY
+   * ENCLOSING loop binds never inlines, falling back to the bare `cfg.x`
+   * member expression (which a minijinja `for` loop binds correctly at the
+   * shadowed occurrence); a same-named const elsewhere, outside any loop
+   * that shadows it, still inlines.
    */
   private _resolveStaticRecordLiteral(objectName: string, key: string): string | null {
-    if (this.staticLoopSourceBoundNames.has(objectName)) return null
-    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants)
+    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants, name => this.scope.isBound(name))
     if (!hit) return null
     return hit.kind === 'number'
       ? hit.text

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -980,14 +980,6 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
 
-    // Per-row locals for a `.map()` callback preamble (#2447), in source
-    // order so a later initializer sees an earlier local — same as the
-    // source block. Phase 1 refuses the loop outright when the preamble
-    // isn't fully declarable, so there is no partial-lowering case: either
-    // every statement is lowered here, or the build already failed.
-    const preambleLines = (loop.preamble?.declarations ?? []).map(
-      d => `{% set ${minijinjaIdent(d.name)} = ${this.convertExpressionToJinja(d.raw, d.valueParsed)} %}`,
-    )
     // This loop's row scope, for the position-accurate shadow guard
     // (#2488/#2489, canonicalized on `BindingScope` in #2482 Stage 2).
     // `IRLoop` already structurally satisfies `LoopBindingSource`
@@ -996,11 +988,35 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     // the index (when present), and the `.map()` preamble's declared
     // locals, mirroring what THIS renderLoop's for-header + `indexLocalLines`
     // actually introduce. Restored by reference (immutable — no ref-count
-    // bookkeeping) so nested loops compose for free.
+    // bookkeeping) so nested loops compose for free. Entered BEFORE
+    // `preambleLines`/`bodyChildren` are converted and popped AFTER, not
+    // just around `renderChildren` — Copilot review on #2600 caught that
+    // the narrower window silently regressed the module-const shadow guard
+    // (`_resolveLiteralConst`/`_resolveStaticRecordLiteral`, now
+    // scope-driven instead of the old coarse whole-component set) for two
+    // row-context conversions that sit OUTSIDE `renderChildren`: a
+    // `.map()` preamble local's own initializer (`d.raw`, below) and the
+    // whole-item-conditional `loop-i:` key anchor (`loop.key`, in
+    // `bodyChildren` below) — both genuinely evaluate PER ROW and must see
+    // the row's own bindings. `loop.filterPredicate` deliberately stays
+    // OUTSIDE this window (further down, after the pop): per the Stage 0
+    // design a filter/sort callback's own param is a separate `callback`
+    // frame, never folded into the `.map()` row — and empirically
+    // `JinjaFilterEmitter` (the filter predicate's dedicated,
+    // self-contained emitter) never consults `this.scope` at all, so its
+    // position relative to the pop is inert either way.
     const prevScope = this.scope
     this.scope = prevScope.enterLoopRow(loop)
+
+    // Per-row locals for a `.map()` callback preamble (#2447), in source
+    // order so a later initializer sees an earlier local — same as the
+    // source block. Phase 1 refuses the loop outright when the preamble
+    // isn't fully declarable, so there is no partial-lowering case: either
+    // every statement is lowered here, or the build already failed.
+    const preambleLines = (loop.preamble?.declarations ?? []).map(
+      d => `{% set ${minijinjaIdent(d.name)} = ${this.convertExpressionToJinja(d.raw, d.valueParsed)} %}`,
+    )
     const childrenUnderLoop = this.renderChildren(loop.children)
-    this.scope = prevScope
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -1008,11 +1024,13 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     // Whole-item conditional: prepend an always-present `<!--bf-loop-i:KEY-->`
     // anchor before each item's (possibly empty) conditional content so the
     // client's `mapArrayAnchored` can hydrate every SSR-rendered item by its
-    // anchor.
+    // anchor. Still under the row scope (see above) — `loop.key` is a
+    // per-row expression.
     const bodyChildren =
       loop.bodyIsItemConditional && loop.key
         ? `{{ bf.comment("loop-i:" ~ bf.string(${this.convertExpressionToJinja(loop.key)})) | safe }}\n${childrenUnderLoop}`
         : childrenUnderLoop
+    this.scope = prevScope
 
     const lines: string[] = []
     // Scoped per-call-site marker so sibling `.map()`s under the same parent

--- a/packages/adapter-twig/src/__tests__/twig-adapter-unit.test.ts
+++ b/packages/adapter-twig/src/__tests__/twig-adapter-unit.test.ts
@@ -412,11 +412,12 @@ export function Parent() {
 // `ir.metadata.localConstants` with no notion of AST scope — it used to
 // substitute an outer const's literal value even at an occurrence that is
 // actually an enclosing loop callback's own (shadowing) parameter, so every
-// iteration rendered the same hard-coded literal. Guarded with the same
-// coarse `collectLoopBoundNames` exclusion as #2212: any name a loop binds
-// anywhere in the component never inlines, falling back to the bare
-// identifier. SSR-only tests for the same #2222 reason as the #2212
-// describe below.
+// iteration rendered the same hard-coded literal. Guarded via the threaded,
+// position-accurate `BindingScope` (#2482 Stage 2 — previously a coarse
+// whole-component exclusion, same as #2212's, that also suppressed a
+// genuinely non-shadowed occurrence outside the loop; the threaded scope
+// only shadows AT the enclosing loop's own body). SSR-only tests for the
+// same #2222 reason as the #2212 describe below.
 describe('TwigAdapter - const inlining vs loop-param shadowing (#2221)', () => {
   test('a loop param shadowing an outer literal const emits the identifier, not the const value', () => {
     const { template } = compileAndGenerate(`
@@ -455,11 +456,11 @@ function Widget({ values }: { values: number[] }) {
     expect(template).toContain('1 + 5')
   })
 
-  // The accepted coarse-exclusion trade-off (same as #2212): a name that is
-  // loop-bound ANYWHERE in the component never inlines, even at a genuinely
-  // non-shadowed occurrence outside the loop — the bare identifier is
-  // emitted instead of the value.
-  test('a const referenced outside the loop whose name is loop-bound elsewhere falls back to the identifier (accepted trade-off)', () => {
+  // Position-accurate scope (#2482 Stage 2): a name that is loop-bound
+  // elsewhere in the component but NOT at THIS occurrence still inlines
+  // here — the coarse whole-component exclusion this used to hit (and
+  // accept as a trade-off) is gone; only the loop's own body shadows.
+  test('a const referenced outside the loop whose name is loop-bound elsewhere still inlines outside, stays the identifier inside', () => {
     const { template } = compileAndGenerate(`
 function Widget({ values }: { values: number[] }) {
   const label: string = 'x'
@@ -469,7 +470,7 @@ function Widget({ values }: { values: number[] }) {
   </div>
 }
 `)
-    expect(template).not.toContain("1 + 'x'")
+    expect(template).toContain("1 + 'x'")
     expect(template).toContain('2 + label')
   })
 })
@@ -481,9 +482,8 @@ function Widget({ values }: { values: number[] }) {
 // substitute the outer const's member value even at an occurrence that is
 // actually an enclosing loop callback's own (shadowing) parameter, so every
 // iteration rendered the same hard-coded literal instead of the per-item
-// value. Guarded with the same coarse `staticLoopSourceBoundNames`
-// exclusion as #2221: any name a loop binds anywhere in the component
-// never inlines, falling back to the bare `cfg.x` member expression.
+// value. Guarded via the threaded, position-accurate `BindingScope` (#2482
+// Stage 2), same as #2221's fix above.
 describe('TwigAdapter - record-literal member lookup vs loop-param shadowing (#2237)', () => {
   test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
     const { template } = compileAndGenerate(`
@@ -508,12 +508,12 @@ function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
     expect(template).toContain("bf.string('bg-ghost')")
   })
 
-  // The accepted coarse-exclusion trade-off (same as #2221/#2212): an
-  // object name that is loop-bound ANYWHERE in the component never
-  // inlines its member lookups, even at a genuinely non-shadowed
-  // occurrence outside the loop — the bare member expression is emitted
-  // instead of the value.
-  test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
+  // Position-accurate scope (#2482 Stage 2): an object name that is
+  // loop-bound elsewhere in the component but NOT at THIS occurrence still
+  // inlines its member lookup here — the coarse whole-component exclusion
+  // this used to hit (and accept as a trade-off) is gone; only the loop's
+  // own body shadows.
+  test('a record member referenced outside the loop whose object name is loop-bound elsewhere still inlines outside, stays the member expression inside', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
 function Widget({ rows }: { rows: { x: string }[] }) {
@@ -523,7 +523,7 @@ function Widget({ rows }: { rows: { x: string }[] }) {
   </div>
 }
 `)
-    expect(template).not.toContain("bf.string('outer-lit')")
+    expect(template).toContain("bf.string('outer-lit')")
     expect(template).toContain('bf.string(cfg.x)')
   })
 })

--- a/packages/adapter-twig/src/__tests__/twig-adapter-unit.test.ts
+++ b/packages/adapter-twig/src/__tests__/twig-adapter-unit.test.ts
@@ -528,6 +528,44 @@ function Widget({ rows }: { rows: { x: string }[] }) {
   })
 })
 
+// Copilot review on #2600 (#2482 Stage 2 follow-up): the position-accurate
+// `this.scope` (replacing the old coarse `staticLoopSourceBoundNames` set)
+// was only threaded around `renderChildren(loop.children)` in `renderLoop`
+// — narrower than the coarse set's always-on coverage. Two row-context
+// conversions sit OUTSIDE that window: a `.map()` preamble local's own
+// initializer, and the whole-item-conditional `loop-i:` key anchor
+// (`loop.key`). Both genuinely evaluate PER ROW and must see the row's own
+// bindings — a loop param shadowing a same-named outer const must resolve
+// to the row value there too, exactly as it already does inside the loop
+// body proper. `renderLoop` now enters the row scope before converting
+// either and pops it after, closing the gap.
+describe('TwigAdapter - row scope covers preamble/key conversions outside renderChildren (#2482 Stage 2 Copilot follow-up)', () => {
+  test('a loop param shadowing an outer const resolves to the row value inside a whole-item-conditional loop-i: key anchor', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <ul>{values.map((label) => (label > 0 ? <li key={label}>{label}</li> : null))}</ul>
+}
+`)
+    expect(template).toContain('bf.comment("loop-i:" ~ bf.string(label))')
+    expect(template).not.toContain("bf.comment(\"loop-i:\" ~ bf.string('x'))")
+  })
+
+  test('a loop param shadowing an outer const resolves to the row value inside a .map() preamble local initializer', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <ul>{values.map((label) => {
+    const cls = label
+    return <li key={label} class={cls}>{label}</li>
+  })}</ul>
+}
+`)
+    expect(template).toContain('{% set cls = label %}')
+    expect(template).not.toContain("{% set cls = 'x' %}")
+  })
+})
+
 // Fable review (#2212): a loop callback's own param can shadow an outer
 // string-typed prop/const of the same name — `collectLoopBoundNames`
 // excludes every such name from `collectStringValueNames` so the shadowed

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -200,8 +200,8 @@ import {
   dangerousInnerHtmlMetacharViolation,
   dangerousInnerHtmlDiagnostic,
   resolveStaticLoopSource,
-  collectLoopBoundNames,
   derivesScopeFromSlot,
+  BindingScope,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr, isExplicitStringCall } from './boolean-result.ts'
 import type { ParsedExpr, LoweringMatcher } from '@barefootjs/jsx'
@@ -323,30 +323,24 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
   private localConstants: IRMetadata['localConstants'] = []
 
   /**
-   * Every name a `.map()`/`.filter()` loop callback binds as its item/index
-   * parameter anywhere in the component (#2208 fable review). A static
-   * loop-SOURCE name (e.g. a function-scope `const items = [...]`) must
-   * never resolve through `resolveStaticLoopSource` at a use site where a
-   * DIFFERENT, enclosing loop's own callback param shadows it — same
-   * shadowing hazard, and same coarse-but-safe mitigation, as #2212's
-   * `collectLoopBoundNames` use in `collectStringValueNames`.
+   * The one canonical, position-accurate "names bound by an enclosing loop
+   * callback" service (#2482 Stage 2) — replaces the two ad-hoc devices
+   * this adapter used to carry side by side: a coarse whole-component
+   * shadow-name Set (built once at `generate()` entry, used only to guard
+   * static-const inlining) and a ref-counted, position-accurate live map
+   * (pushed/popped around `renderLoop`'s body, used for the boolean-prop/
+   * nullable-optional classification sites (#2488) and `emitSpread`'s
+   * local-const fallback (#2489)). Both consulted the "is this name
+   * loop-bound" question with DIFFERENT meanings — the coarse/live drift
+   * #2482 Stage 2 ends. Every shadow-guard site now reads this ONE
+   * threaded, immutable scope: `enterLoopRow`/pop-by-reference around
+   * `renderChildren(loop.children)` in `renderLoop`, mirroring the Stage
+   * 1a/1b `ctx.scope` precedent in `jsx-to-ir.ts`. `IRLoop` already
+   * structurally satisfies `LoopBindingSource`
+   * (`param`/`index`/`paramBindings`/`preamble`), so
+   * `renderLoop` passes the loop node straight to `enterLoopRow`.
    */
-  private staticLoopSourceBoundNames: Set<string> = new Set()
-
-  /**
-   * Names currently bound by an enclosing loop body — the block-param
-   * locals `renderLoop` introduces (item, index, per-binding destructure
-   * fields, `.map()` preamble declarations) — ref-counted so nested loops
-   * compose. This is the POSITION-ACCURATE twin of the coarse
-   * `staticLoopSourceBoundNames` above: that set is a whole-component
-   * union used only to guard static-const inlining (safe to over-suppress
-   * there — the fallback is just "don't inline"), whereas the boolean-prop
-   * and nullable-optional classification sites (#2488) and `emitSpread`'s
-   * local-const fallback (#2489) need to know whether a name is loop-bound
-   * AT THIS POSITION, because for those the coarse fallback would silently
-   * mis-render a genuine occurrence of the same name outside the loop too.
-   */
-  private loopBoundNames: Map<string, number> = new Map()
+  private scope: BindingScope = BindingScope.EMPTY
 
   /**
    * Optional, no-default props that are `None` when the caller omits them.
@@ -380,8 +374,7 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     // ("1"/"") (#1897, pagination's data-active).
     this.booleanTypedProps = collectBooleanTypedProps(ir)
     this.localConstants = ir.metadata.localConstants ?? []
-    this.staticLoopSourceBoundNames = collectLoopBoundNames(ir)
-    this.loopBoundNames.clear()
+    this.scope = BindingScope.EMPTY
     this.nullableOptionalProps = collectNullableOptionalProps(ir)
     this.stringValueNames = collectStringValueNames(ir)
     this.moduleStringConsts = collectModuleStringConsts(ir.metadata.localConstants)
@@ -878,9 +871,11 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     // bare identifier expression below, same as before #2208 — which
     // still trips the pre-existing BF101 gate for an unresolvable local
     // const reference (a loud, conservative refusal, not a silent wrong
-    // value).
+    // value). Canonical, position-accurate predicate (#2482 Stage 2) — the
+    // enclosing loop scope's own membership, not a coarse whole-component
+    // union.
     const staticItems = resolveStaticLoopSource(loop.arrayParsed, this.localConstants, {
-      isNameShadowed: name => this.staticLoopSourceBoundNames.has(name),
+      isNameShadowed: this.scope.asShadowPredicate(),
     })
     const staticArray = staticItems !== null ? staticValueToTwig(staticItems) : null
 
@@ -997,39 +992,23 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     const preambleLines = (loop.preamble?.declarations ?? []).map(
       d => `{% set ${twigIdent(d.name)} = ${this.convertExpressionToTwig(d.raw, d.valueParsed)} %}`,
     )
-    // Names this loop binds in body scope, for the position-accurate
-    // `loopBoundNames` guard (#2488) — mirrors the ERB adapter's `loopBound`
-    // derivation, adapted to what THIS renderLoop actually binds: the
-    // for-header target(s) (`loopVar` / `objectIteration` key+value /
-    // `iterationShape === 'keys'`'s `param`), each `indexLocalLines` name
-    // (explicit index, or a destructure binding), and the `.map()`
-    // preamble's declared locals. Ref-counted so nested loops compose.
-    const loopBound: string[] = []
-    if (loop.objectIteration === 'entries') {
-      loopBound.push(loop.index ?? param, param)
-    } else if (loop.objectIteration === 'keys' || loop.objectIteration === 'values') {
-      loopBound.push(param)
-    } else if (loop.iterationShape === 'keys') {
-      // The header still binds the throwaway loop var; `param` is only the
-      // index alias set beneath it (#2488).
-      loopBound.push('__bf_item', param)
-    } else if (supportableDestructure) {
-      loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
-      if (loop.index) loopBound.push(loop.index)
-    } else {
-      loopBound.push(param)
-      if (loop.index) loopBound.push(loop.index)
-    }
-    for (const d of loop.preamble?.declarations ?? []) loopBound.push(d.name)
-    for (const n of loopBound) {
-      this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
-    }
+    // This loop's row scope, for the position-accurate shadow guard
+    // (#2488/#2489, canonicalized on `BindingScope` in #2482 Stage 2).
+    // `IRLoop` already structurally satisfies `LoopBindingSource`
+    // (`param`/`index`/`paramBindings`/`preamble`) — `enterLoopRow(loop)`
+    // binds exactly the for-header target(s), each destructure binding,
+    // the index (when present), and the `.map()` preamble's declared
+    // locals, mirroring what THIS renderLoop's for-header + `indexLocalLines`
+    // actually introduce (the `objectIteration`/`iterationShape: 'keys'`
+    // shapes reuse `param`/`index` for their key/value bindings the same
+    // way `jsx-to-ir.ts`'s own `ctx.scope.enterLoopRow` does — see
+    // `jsx-to-ir.ts`'s entries-shape `index`/`param` extraction). Restored
+    // by reference (immutable — no ref-count bookkeeping) so nested loops
+    // compose for free.
+    const prevScope = this.scope
+    this.scope = prevScope.enterLoopRow(loop)
     const childrenUnderLoop = this.renderChildren(loop.children)
-    for (const n of loopBound) {
-      const c = (this.loopBoundNames.get(n) ?? 1) - 1
-      if (c <= 0) this.loopBoundNames.delete(n)
-      else this.loopBoundNames.set(n, c)
-    }
+    this.scope = prevScope
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -1521,13 +1500,13 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
       // function-scope (`!isModule`) consts whose value is NOT itself a bare
       // identifier (loop guard) are considered.
       //
-      // `loopBoundNames` guard (#2489): an enclosing `.map()` callback's own
-      // param can shadow this outer const's name (`.map((attrs) => <p
+      // `this.scope` shadow guard (#2489): an enclosing `.map()` callback's
+      // own param can shadow this outer const's name (`.map((attrs) => <p
       // {...attrs} />)`) — without the guard this forwarded the OUTER
       // const's value at every iteration instead of the per-item value.
-      // Must be the LIVE map, not `staticLoopSourceBoundNames` — the same
-      // name spread at ROOT must still resolve the const.
-      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.loopBoundNames.has(trimmed)) {
+      // Must be the threaded, position-accurate scope — the same name
+      // spread at ROOT (no enclosing loop) must still resolve the const.
+      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.scope.isBound(trimmed)) {
         const localConst = (this.localConstants ?? []).find(
           c => c.name === trimmed && !c.isModule,
         )
@@ -1948,9 +1927,9 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     return this.booleanTypedProps.has(bare)
   }
 
-  /** Position-accurate loop-bound-name check — see `loopBoundNames`'s docstring. */
+  /** Position-accurate loop-bound-name check — see `this.scope`'s docstring. */
   private isLoopBoundName(name: string): boolean {
-    return this.loopBoundNames.has(name)
+    return this.scope.isBound(name)
   }
 
   /**
@@ -1977,17 +1956,16 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
    * context, so a bare reference would resolve to Undefined.
    *
    * The lookup is a flat name match with no notion of AST scope, so a
-   * name that any loop callback binds as its item/index param never
-   * inlines (#2221) — the occurrence may be the loop's own (shadowing)
-   * binding, and substituting the outer const's value there renders every
-   * iteration with the same hard-coded literal. Coarse (a genuinely
-   * non-shadowed same-named const elsewhere in the component also stops
-   * inlining, falling back to the bare identifier) but safe — the same
-   * trade-off as #2212's `collectLoopBoundNames` use in
-   * `collectStringValueNames`.
+   * name bound by the CURRENTLY ENCLOSING loop's item/index/destructure/
+   * preamble param never inlines (#2221) — the occurrence may be the
+   * loop's own (shadowing) binding, and substituting the outer const's
+   * value there renders every iteration with the same hard-coded literal.
+   * Position-accurate via the threaded `this.scope` (#2482 Stage 2) — a
+   * same-named const elsewhere in the component, outside any loop that
+   * shadows it, still inlines.
    */
   private _resolveLiteralConst(name: string): string | null {
-    if (this.staticLoopSourceBoundNames.has(name)) return null
+    if (this.scope.isBound(name)) return null
     const c = (this.localConstants ?? []).find(lc => lc.name === name)
     if (c?.value === undefined) return null
     const v = c.value.trim()
@@ -2005,15 +1983,16 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
    * scope, so an enclosing loop callback's own param of the same name
    * (`.map((cfg) => <li>{cfg.x}</li>)` shadowing a module `const cfg = {…}`)
    * still resolved to the OUTER const's member value at every iteration
-   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`. Same
-   * coarse-but-safe `staticLoopSourceBoundNames` guard: any name a loop
-   * binds anywhere in the component never inlines, falling back to the bare
-   * `cfg.x` member expression (which a Twig for-loop binds correctly at the
-   * shadowed occurrences).
+   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`.
+   * Position-accurate via the threaded `this.scope` (#2482 Stage 2), passed
+   * as `lookupStaticRecordLiteral`'s required guard: a name the CURRENTLY
+   * ENCLOSING loop binds never inlines, falling back to the bare `cfg.x`
+   * member expression (which a Twig for-loop binds correctly at the
+   * shadowed occurrence); a same-named const elsewhere, outside any loop
+   * that shadows it, still inlines.
    */
   private _resolveStaticRecordLiteral(objectName: string, key: string): string | null {
-    if (this.staticLoopSourceBoundNames.has(objectName)) return null
-    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants)
+    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants, name => this.scope.isBound(name))
     if (!hit) return null
     return hit.kind === 'number'
       ? hit.text

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -984,14 +984,6 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
 
-    // Per-row locals for a `.map()` callback preamble (#2447), in source
-    // order so a later initializer sees an earlier local — same as the
-    // source block. Phase 1 refuses the loop outright when the preamble
-    // isn't fully declarable, so there is no partial-lowering case: either
-    // every statement is lowered here, or the build already failed.
-    const preambleLines = (loop.preamble?.declarations ?? []).map(
-      d => `{% set ${twigIdent(d.name)} = ${this.convertExpressionToTwig(d.raw, d.valueParsed)} %}`,
-    )
     // This loop's row scope, for the position-accurate shadow guard
     // (#2488/#2489, canonicalized on `BindingScope` in #2482 Stage 2).
     // `IRLoop` already structurally satisfies `LoopBindingSource`
@@ -1004,11 +996,34 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     // way `jsx-to-ir.ts`'s own `ctx.scope.enterLoopRow` does — see
     // `jsx-to-ir.ts`'s entries-shape `index`/`param` extraction). Restored
     // by reference (immutable — no ref-count bookkeeping) so nested loops
-    // compose for free.
+    // compose for free. Entered BEFORE `preambleLines`/`bodyChildren` are
+    // converted and popped AFTER, not just around `renderChildren` —
+    // Copilot review on #2600 caught that the narrower window silently
+    // regressed the module-const shadow guard (`_resolveLiteralConst`/
+    // `_resolveStaticRecordLiteral`, now scope-driven instead of the old
+    // coarse whole-component set) for two row-context conversions that sit
+    // OUTSIDE `renderChildren`: a `.map()` preamble local's own initializer
+    // (`d.raw`, below) and the whole-item-conditional `loop-i:` key anchor
+    // (`loop.key`, in `bodyChildren` below) — both genuinely evaluate PER
+    // ROW and must see the row's own bindings. `loop.filterPredicate`
+    // deliberately stays OUTSIDE this window (further down, after the pop):
+    // per the Stage 0 design a filter/sort callback's own param is a
+    // separate `callback` frame, never folded into the `.map()` row — and
+    // empirically `TwigFilterEmitter` (the filter predicate's dedicated,
+    // self-contained emitter) never consults `this.scope` at all, so its
+    // position relative to the pop is inert either way.
     const prevScope = this.scope
     this.scope = prevScope.enterLoopRow(loop)
+
+    // Per-row locals for a `.map()` callback preamble (#2447), in source
+    // order so a later initializer sees an earlier local — same as the
+    // source block. Phase 1 refuses the loop outright when the preamble
+    // isn't fully declarable, so there is no partial-lowering case: either
+    // every statement is lowered here, or the build already failed.
+    const preambleLines = (loop.preamble?.declarations ?? []).map(
+      d => `{% set ${twigIdent(d.name)} = ${this.convertExpressionToTwig(d.raw, d.valueParsed)} %}`,
+    )
     const childrenUnderLoop = this.renderChildren(loop.children)
-    this.scope = prevScope
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -1016,11 +1031,13 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     // Whole-item conditional: prepend an always-present `<!--bf-loop-i:KEY-->`
     // anchor before each item's (possibly empty) conditional content so the
     // client's `mapArrayAnchored` can hydrate every SSR-rendered item by its
-    // anchor.
+    // anchor. Still under the row scope (see above) — `loop.key` is a
+    // per-row expression.
     const bodyChildren =
       loop.bodyIsItemConditional && loop.key
         ? `{{ bf.comment("loop-i:" ~ bf.string(${this.convertExpressionToTwig(loop.key)})) | raw }}\n${childrenUnderLoop}`
         : childrenUnderLoop
+    this.scope = prevScope
 
     const lines: string[] = []
     // Scoped per-call-site marker so sibling `.map()`s under the same parent

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -573,6 +573,44 @@ function Widget({ rows }: { rows: { x: string }[] }) {
   })
 })
 
+// Copilot review on #2600 (#2482 Stage 2 follow-up): the position-accurate
+// `this.scope` (replacing the old coarse `staticLoopSourceBoundNames` set)
+// was only threaded around `renderChildren(loop.children)` in `renderLoop`
+// — narrower than the coarse set's always-on coverage. Two row-context
+// conversions sit OUTSIDE that window: a `.map()` preamble local's own
+// initializer, and the whole-item-conditional `loop-i:` key anchor
+// (`loop.key`). Both genuinely evaluate PER ROW and must see the row's own
+// bindings — a loop param shadowing a same-named outer const must resolve
+// to the row value there too, exactly as it already does inside the loop
+// body proper. `renderLoop` now enters the row scope before converting
+// either and pops it after, closing the gap.
+describe('XslateAdapter - row scope covers preamble/key conversions outside renderChildren (#2482 Stage 2 Copilot follow-up)', () => {
+  test('a loop param shadowing an outer const resolves to the row value inside a whole-item-conditional loop-i: key anchor', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <ul>{values.map((label) => (label > 0 ? <li key={label}>{label}</li> : null))}</ul>
+}
+`)
+    expect(template).toContain('$bf.comment("loop-i:" ~ $label)')
+    expect(template).not.toContain('$bf.comment("loop-i:" ~ \'x\')')
+  })
+
+  test('a loop param shadowing an outer const resolves to the row value inside a .map() preamble local initializer', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <ul>{values.map((label) => {
+    const cls = label
+    return <li key={label} class={cls}>{label}</li>
+  })}</ul>
+}
+`)
+    expect(template).toContain(': my $cls = $label;')
+    expect(template).not.toContain(": my $cls = 'x';")
+  })
+})
+
 describe('XslateAdapter - scriptAssets (Vite late-binding, PR1)', () => {
   const CLIENT_COMPONENT = `
 'use client'

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -458,10 +458,11 @@ export function Parent() {
 // `ir.metadata.localConstants` with no notion of AST scope — it used to
 // substitute an outer const's literal value even at an occurrence that is
 // actually an enclosing loop callback's own (shadowing) parameter, so every
-// iteration rendered the same hard-coded literal. Guarded with the same
-// coarse `collectLoopBoundNames` exclusion as #2212: any name a loop binds
-// anywhere in the component never inlines, falling back to the bare
-// identifier.
+// iteration rendered the same hard-coded literal. Guarded via the threaded,
+// position-accurate `BindingScope` (#2482 Stage 2 — previously a coarse
+// whole-component exclusion, same as #2212's, that also suppressed a
+// genuinely non-shadowed occurrence outside the loop; the threaded scope
+// only shadows AT the enclosing loop's own body).
 describe('XslateAdapter - const inlining vs loop-param shadowing (#2221)', () => {
   test('a loop param shadowing an outer literal const emits the identifier, not the const value', () => {
     const { template } = compileAndGenerate(`
@@ -500,11 +501,11 @@ function Widget({ values }: { values: number[] }) {
     expect(template).toContain('1 + 5')
   })
 
-  // The accepted coarse-exclusion trade-off (same as #2212): a name that is
-  // loop-bound ANYWHERE in the component never inlines, even at a genuinely
-  // non-shadowed occurrence outside the loop — the bare identifier is
-  // emitted instead of the value.
-  test('a const referenced outside the loop whose name is loop-bound elsewhere falls back to the identifier (accepted trade-off)', () => {
+  // Position-accurate scope (#2482 Stage 2): a name that is loop-bound
+  // elsewhere in the component but NOT at THIS occurrence still inlines
+  // here — the coarse whole-component exclusion this used to hit (and
+  // accept as a trade-off) is gone; only the loop's own body shadows.
+  test('a const referenced outside the loop whose name is loop-bound elsewhere still inlines outside, stays the identifier inside', () => {
     const { template } = compileAndGenerate(`
 function Widget({ values }: { values: number[] }) {
   const label: string = 'x'
@@ -514,7 +515,7 @@ function Widget({ values }: { values: number[] }) {
   </div>
 }
 `)
-    expect(template).not.toContain("1 + 'x'")
+    expect(template).toContain("1 + 'x'")
     expect(template).toContain('2 + $label')
   })
 })
@@ -526,9 +527,8 @@ function Widget({ values }: { values: number[] }) {
 // substitute the outer const's member value even at an occurrence that is
 // actually an enclosing loop callback's own (shadowing) parameter, so every
 // iteration rendered the same hard-coded literal instead of the per-item
-// value. Guarded with the same coarse `staticLoopSourceBoundNames`
-// exclusion as #2221: any name a loop binds anywhere in the component
-// never inlines, falling back to the bare `$cfg.x` member expression.
+// value. Guarded via the threaded, position-accurate `BindingScope` (#2482
+// Stage 2), same as #2221's fix above.
 describe('XslateAdapter - record-literal member lookup vs loop-param shadowing (#2237)', () => {
   test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
     const { template } = compileAndGenerate(`
@@ -553,12 +553,12 @@ function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
     expect(template).toContain("<: 'bg-ghost' :>")
   })
 
-  // The accepted coarse-exclusion trade-off (same as #2221/#2212): an
-  // object name that is loop-bound ANYWHERE in the component never
-  // inlines its member lookups, even at a genuinely non-shadowed
-  // occurrence outside the loop — the bare member expression is emitted
-  // instead of the value.
-  test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
+  // Position-accurate scope (#2482 Stage 2): an object name that is
+  // loop-bound elsewhere in the component but NOT at THIS occurrence still
+  // inlines its member lookup here — the coarse whole-component exclusion
+  // this used to hit (and accept as a trade-off) is gone; only the loop's
+  // own body shadows.
+  test('a record member referenced outside the loop whose object name is loop-bound elsewhere still inlines outside, stays the member expression inside', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
 function Widget({ rows }: { rows: { x: string }[] }) {
@@ -568,7 +568,7 @@ function Widget({ rows }: { rows: { x: string }[] }) {
   </div>
 }
 `)
-    expect(template).not.toContain("<: 'outer-lit' :>")
+    expect(template).toContain("<: 'outer-lit' :>")
     expect(template).toContain('<: $cfg.x :>')
   })
 })

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -920,14 +920,6 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
 
-    // Per-row locals for a `.map()` callback preamble (#2447), in source
-    // order so a later initializer sees an earlier local — same as the
-    // source block. Phase 1 refuses the loop outright when the preamble
-    // isn't fully declarable, so there is no partial-lowering case: either
-    // every statement is lowered here, or the build already failed.
-    const preambleLines = (loop.preamble?.declarations ?? []).map(
-      d => `: my $${d.name} = ${this.convertExpressionToKolon(d.raw, d.valueParsed)};`,
-    )
     // This loop's row scope, for the position-accurate shadow guard
     // (#2488/#2489, canonicalized on `BindingScope` in #2482 Stage 2).
     // `IRLoop` already structurally satisfies `LoopBindingSource`
@@ -936,11 +928,35 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // the index (when present), and the `.map()` preamble's declared
     // locals, mirroring what THIS renderLoop's for-header + `indexLocalLines`
     // actually introduce. Restored by reference (immutable — no ref-count
-    // bookkeeping) so nested loops compose for free.
+    // bookkeeping) so nested loops compose for free. Entered BEFORE
+    // `preambleLines`/`bodyChildren` are converted and popped AFTER, not
+    // just around `renderChildren` — Copilot review on #2600 caught that
+    // the narrower window silently regressed the module-const shadow guard
+    // (`_resolveLiteralConst`/`_resolveStaticRecordLiteral`, now
+    // scope-driven instead of the old coarse whole-component set) for two
+    // row-context conversions that sit OUTSIDE `renderChildren`: a
+    // `.map()` preamble local's own initializer (`d.raw`, below) and the
+    // whole-item-conditional `loop-i:` key anchor (`loop.key`, in
+    // `bodyChildren` below) — both genuinely evaluate PER ROW and must see
+    // the row's own bindings. `loop.filterPredicate` deliberately stays
+    // OUTSIDE this window (further down, after the pop): per the Stage 0
+    // design a filter/sort callback's own param is a separate `callback`
+    // frame, never folded into the `.map()` row — and empirically
+    // `XslateFilterEmitter` (the filter predicate's dedicated,
+    // self-contained emitter) never consults `this.scope` at all, so its
+    // position relative to the pop is inert either way.
     const prevScope = this.scope
     this.scope = prevScope.enterLoopRow(loop)
+
+    // Per-row locals for a `.map()` callback preamble (#2447), in source
+    // order so a later initializer sees an earlier local — same as the
+    // source block. Phase 1 refuses the loop outright when the preamble
+    // isn't fully declarable, so there is no partial-lowering case: either
+    // every statement is lowered here, or the build already failed.
+    const preambleLines = (loop.preamble?.declarations ?? []).map(
+      d => `: my $${d.name} = ${this.convertExpressionToKolon(d.raw, d.valueParsed)};`,
+    )
     const childrenUnderLoop = this.renderChildren(loop.children)
-    this.scope = prevScope
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -948,11 +964,13 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // Whole-item conditional: prepend an always-present `<!--bf-loop-i:KEY-->`
     // anchor before each item's (possibly empty) conditional content so the
     // client's `mapArrayAnchored` can hydrate every SSR-rendered item by its
-    // anchor.
+    // anchor. Still under the row scope (see above) — `loop.key` is a
+    // per-row expression.
     const bodyChildren =
       loop.bodyIsItemConditional && loop.key
         ? `<: $bf.comment("loop-i:" ~ ${this.convertExpressionToKolon(loop.key)}) | mark_raw :>\n${childrenUnderLoop}`
         : childrenUnderLoop
+    this.scope = prevScope
 
     const lines: string[] = []
     // Scoped per-call-site marker so sibling `.map()`s under the same parent

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -78,8 +78,8 @@ import {
   dangerousInnerHtmlMetacharViolation,
   dangerousInnerHtmlDiagnostic,
   resolveStaticLoopSource,
-  collectLoopBoundNames,
   derivesScopeFromSlot,
+  BindingScope,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result.ts'
 import ts from 'typescript'
@@ -246,30 +246,24 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   private localConstants: IRMetadata['localConstants'] = []
 
   /**
-   * Every name a `.map()`/`.filter()` loop callback binds as its item/index
-   * parameter anywhere in the component (#2208 fable review). A static
-   * loop-SOURCE name (e.g. a function-scope `const items = [...]`) must
-   * never resolve through `resolveStaticLoopSource` at a use site where a
-   * DIFFERENT, enclosing loop's own callback param shadows it — same
-   * shadowing hazard, and same coarse-but-safe mitigation, as #2212's
-   * `collectLoopBoundNames` use in `collectStringValueNames`.
+   * The one canonical, position-accurate "names bound by an enclosing loop
+   * callback" service (#2482 Stage 2) — replaces the two ad-hoc devices
+   * this adapter used to carry side by side: a coarse whole-component
+   * shadow-name Set (built once at `generate()` entry, used only to guard
+   * static-const inlining) and a ref-counted, position-accurate live map
+   * (pushed/popped around `renderLoop`'s body, used for the boolean-prop/
+   * nullable-optional classification sites (#2488) and `emitSpread`'s
+   * local-const fallback (#2489)). Both consulted the "is this name
+   * loop-bound" question with DIFFERENT meanings — the coarse/live drift
+   * #2482 Stage 2 ends. Every shadow-guard site now reads this ONE
+   * threaded, immutable scope: `enterLoopRow`/pop-by-reference around
+   * `renderChildren(loop.children)` in `renderLoop`, mirroring the Stage
+   * 1a/1b `ctx.scope` precedent in `jsx-to-ir.ts`. `IRLoop` already
+   * structurally satisfies `LoopBindingSource`
+   * (`param`/`index`/`paramBindings`/`preamble`), so `renderLoop` passes
+   * the loop node straight to `enterLoopRow`.
    */
-  private staticLoopSourceBoundNames: Set<string> = new Set()
-
-  /**
-   * Names currently bound by an enclosing loop body — the block-param
-   * locals `renderLoop` introduces (item, index, per-binding destructure
-   * fields, `.map()` preamble declarations) — ref-counted so nested loops
-   * compose. This is the POSITION-ACCURATE twin of the coarse
-   * `staticLoopSourceBoundNames` above: that set is a whole-component
-   * union used only to guard static-const inlining (safe to over-suppress
-   * there — the fallback is just "don't inline"), whereas the boolean-prop
-   * and nullable-optional classification sites (#2488) and `emitSpread`'s
-   * local-const fallback (#2489) need to know whether a name is loop-bound
-   * AT THIS POSITION, because for those the coarse fallback would silently
-   * mis-render a genuine occurrence of the same name outside the loop too.
-   */
-  private loopBoundNames: Map<string, number> = new Map()
+  private scope: BindingScope = BindingScope.EMPTY
 
   /**
    * Optional, no-default props that are `undef` when the caller omits them.
@@ -303,8 +297,7 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // Per-compile prop classifications (see `props/prop-classes.ts`).
     this.booleanTypedProps = collectBooleanTypedProps(ir)
     this.localConstants = ir.metadata.localConstants ?? []
-    this.staticLoopSourceBoundNames = collectLoopBoundNames(ir)
-    this.loopBoundNames.clear()
+    this.scope = BindingScope.EMPTY
     this.nullableOptionalProps = collectNullableOptionalProps(ir)
     this.stringValueNames = collectStringValueNames(ir)
     this.moduleStringConsts = collectModuleStringConsts(ir.metadata.localConstants)
@@ -808,9 +801,11 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // bare identifier expression below, same as before #2208 — which
     // still trips the pre-existing BF101 gate for an unresolvable local
     // const reference (a loud, conservative refusal, not a silent wrong
-    // value).
+    // value). Canonical, position-accurate predicate (#2482 Stage 2) — the
+    // enclosing loop scope's own membership, not a coarse whole-component
+    // union.
     const staticItems = resolveStaticLoopSource(loop.arrayParsed, this.localConstants, {
-      isNameShadowed: name => this.staticLoopSourceBoundNames.has(name),
+      isNameShadowed: this.scope.asShadowPredicate(),
     })
     const staticArray = staticItems !== null ? staticValueToKolon(staticItems) : null
 
@@ -933,40 +928,19 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     const preambleLines = (loop.preamble?.declarations ?? []).map(
       d => `: my $${d.name} = ${this.convertExpressionToKolon(d.raw, d.valueParsed)};`,
     )
-    // Names this loop binds in body scope, for the position-accurate
-    // `loopBoundNames` guard (#2488) — mirrors the ERB adapter's `loopBound`
-    // derivation, adapted to what THIS renderLoop actually binds: the
-    // for-header target(s) (`loopVar` / `objectIteration` key+value /
-    // `iterationShape === 'keys'`'s `param`), each `indexLocalLines` name
-    // (explicit index, or a destructure binding), and the `.map()`
-    // preamble's declared locals. Ref-counted so nested loops compose.
-    const loopBound: string[] = []
-    if (loop.objectIteration === 'entries') {
-      // `.kv()` binds the pair var the key/value locals are derived from (#2488).
-      loopBound.push('__bf_pair', loop.index ?? param, param)
-    } else if (loop.objectIteration === 'keys' || loop.objectIteration === 'values') {
-      loopBound.push(param)
-    } else if (loop.iterationShape === 'keys') {
-      // The header still binds the throwaway loop var; `param` is only the
-      // index alias derived from it beneath (#2488).
-      loopBound.push('__bf_item', param)
-    } else if (supportableDestructure) {
-      loopBound.push('__bf_item', ...(loop.paramBindings ?? []).map(b => b.name))
-      if (loop.index) loopBound.push(loop.index)
-    } else {
-      loopBound.push(param)
-      if (loop.index) loopBound.push(loop.index)
-    }
-    for (const d of loop.preamble?.declarations ?? []) loopBound.push(d.name)
-    for (const n of loopBound) {
-      this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
-    }
+    // This loop's row scope, for the position-accurate shadow guard
+    // (#2488/#2489, canonicalized on `BindingScope` in #2482 Stage 2).
+    // `IRLoop` already structurally satisfies `LoopBindingSource`
+    // (`param`/`index`/`paramBindings`/`preamble`) — `enterLoopRow(loop)`
+    // binds exactly the for-header target(s), each destructure binding,
+    // the index (when present), and the `.map()` preamble's declared
+    // locals, mirroring what THIS renderLoop's for-header + `indexLocalLines`
+    // actually introduce. Restored by reference (immutable — no ref-count
+    // bookkeeping) so nested loops compose for free.
+    const prevScope = this.scope
+    this.scope = prevScope.enterLoopRow(loop)
     const childrenUnderLoop = this.renderChildren(loop.children)
-    for (const n of loopBound) {
-      const c = (this.loopBoundNames.get(n) ?? 1) - 1
-      if (c <= 0) this.loopBoundNames.delete(n)
-      else this.loopBoundNames.set(n, c)
-    }
+    this.scope = prevScope
     this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
@@ -1441,13 +1415,13 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       // function-scope (`!isModule`) consts whose value is NOT itself a bare
       // identifier (loop guard) are considered.
       //
-      // `loopBoundNames` guard (#2489): an enclosing `.map()` callback's own
-      // param can shadow this outer const's name (`.map((attrs) => <p
+      // `this.scope` shadow guard (#2489): an enclosing `.map()` callback's
+      // own param can shadow this outer const's name (`.map((attrs) => <p
       // {...attrs} />)`) — without the guard this forwarded the OUTER
       // const's value at every iteration instead of the per-item value.
-      // Must be the LIVE map, not `staticLoopSourceBoundNames` — the same
-      // name spread at ROOT must still resolve the const.
-      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.loopBoundNames.has(trimmed)) {
+      // Must be the threaded, position-accurate scope — the same name
+      // spread at ROOT (no enclosing loop) must still resolve the const.
+      if (/^[A-Za-z_$][\w$]*$/.test(trimmed) && !this.scope.isBound(trimmed)) {
         const localConst = (this.localConstants ?? []).find(
           c => c.name === trimmed && !c.isModule,
         )
@@ -1845,9 +1819,9 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     return this.booleanTypedProps.has(bare)
   }
 
-  /** Position-accurate loop-bound-name check — see `loopBoundNames`'s docstring. */
+  /** Position-accurate loop-bound-name check — see `this.scope`'s docstring. */
   private isLoopBoundName(name: string): boolean {
-    return this.loopBoundNames.has(name)
+    return this.scope.isBound(name)
   }
 
   /**
@@ -1857,17 +1831,16 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
    * stash, so a bare `$totalPages` renders empty.
    *
    * The lookup is a flat name match with no notion of AST scope, so a
-   * name that any loop callback binds as its item/index param never
-   * inlines (#2221) — the occurrence may be the loop's own (shadowing)
-   * binding, and substituting the outer const's value there renders every
-   * iteration with the same hard-coded literal. Coarse (a genuinely
-   * non-shadowed same-named const elsewhere in the component also stops
-   * inlining, falling back to the bare identifier) but safe — the same
-   * trade-off as #2212's `collectLoopBoundNames` use in
-   * `collectStringValueNames`.
+   * name bound by the CURRENTLY ENCLOSING loop's item/index/destructure/
+   * preamble param never inlines (#2221) — the occurrence may be the
+   * loop's own (shadowing) binding, and substituting the outer const's
+   * value there renders every iteration with the same hard-coded literal.
+   * Position-accurate via the threaded `this.scope` (#2482 Stage 2) — a
+   * same-named const elsewhere in the component, outside any loop that
+   * shadows it, still inlines.
    */
   private _resolveLiteralConst(name: string): string | null {
-    if (this.staticLoopSourceBoundNames.has(name)) return null
+    if (this.scope.isBound(name)) return null
     const c = (this.localConstants ?? []).find(lc => lc.name === name)
     if (c?.value === undefined) return null
     const v = c.value.trim()
@@ -1885,15 +1858,16 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
    * scope, so an enclosing loop callback's own param of the same name
    * (`.map((cfg) => <li>{cfg.x}</li>)` shadowing a module `const cfg = {…}`)
    * still resolved to the OUTER const's member value at every iteration
-   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`. Same
-   * coarse-but-safe `staticLoopSourceBoundNames` guard: any name a loop
-   * binds anywhere in the component never inlines, falling back to the bare
-   * `$cfg.x` member expression (which an Xslate `: for` loop binds
-   * correctly at the shadowed occurrences).
+   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`.
+   * Position-accurate via the threaded `this.scope` (#2482 Stage 2), passed
+   * as `lookupStaticRecordLiteral`'s required guard: a name the CURRENTLY
+   * ENCLOSING loop binds never inlines, falling back to the bare `$cfg.x`
+   * member expression (which an Xslate `: for` loop binds correctly at the
+   * shadowed occurrence); a same-named const elsewhere, outside any loop
+   * that shadows it, still inlines.
    */
   private _resolveStaticRecordLiteral(objectName: string, key: string): string | null {
-    if (this.staticLoopSourceBoundNames.has(objectName)) return null
-    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants)
+    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants, name => this.scope.isBound(name))
     if (!hit) return null
     return hit.kind === 'number'
       ? hit.text

--- a/packages/jsx/src/__tests__/binding-scope-ratchet.test.ts
+++ b/packages/jsx/src/__tests__/binding-scope-ratchet.test.ts
@@ -63,9 +63,7 @@ type Pattern = (typeof PATTERNS)[number]
  * means an expected count of 0.
  */
 const ALLOWLIST: Record<string, Partial<Record<Pattern, number>>> = {
-  'packages/adapter-blade/src/adapter/blade-adapter.ts': { staticLoopSourceBoundNames: 8, loopBoundNames: 12 },
-  'packages/adapter-erb/src/adapter/erb-adapter.ts': { 'localConstants.find(': 1, loopBoundNames: 20 },
-  'packages/adapter-erb/src/adapter/expr/emitters.ts': { loopBoundNames: 1 },
+  'packages/adapter-erb/src/adapter/erb-adapter.ts': { 'localConstants.find(': 1 },
   'packages/adapter-go-template/src/adapter/expr/helper-inline.ts': { 'localConstants.find(': 1 },
   'packages/adapter-go-template/src/adapter/go-template-adapter.ts': {
     'localConstants.find(': 5,
@@ -75,15 +73,9 @@ const ALLOWLIST: Record<string, Partial<Record<Pattern, number>>> = {
   'packages/adapter-go-template/src/adapter/lib/compile-state.ts': { staticLoopSourceBoundNames: 1, loopParamStack: 1 },
   'packages/adapter-go-template/src/adapter/memo/ctor-lowering.ts': { 'localConstants.find(': 3 },
   'packages/adapter-go-template/src/adapter/memo/memo-value.ts': { 'localConstants.find(': 1 },
-  'packages/adapter-jinja/src/adapter/jinja-adapter.ts': { staticLoopSourceBoundNames: 8, loopBoundNames: 12 },
   'packages/adapter-mojolicious/src/adapter/mojo-adapter.ts': {
     'localConstants.find(': 1,
-    staticLoopSourceBoundNames: 1,
-    loopBoundNames: 23,
   },
-  'packages/adapter-rust/src/adapter/minijinja-adapter.ts': { staticLoopSourceBoundNames: 8, loopBoundNames: 12 },
-  'packages/adapter-twig/src/adapter/twig-adapter.ts': { staticLoopSourceBoundNames: 8, loopBoundNames: 12 },
-  'packages/adapter-xslate/src/adapter/xslate-adapter.ts': { staticLoopSourceBoundNames: 8, loopBoundNames: 12 },
   'packages/jsx/src/adapters/jsx-adapter.ts': { 'localConstants.find(': 1 },
   'packages/jsx/src/augment-inherited-props.ts': { 'localConstants.find(': 1 },
   'packages/jsx/src/css-layer-prefixer.ts': { 'localConstants.find(': 1 },

--- a/packages/jsx/src/augment-inherited-props.ts
+++ b/packages/jsx/src/augment-inherited-props.ts
@@ -464,14 +464,26 @@ export function collectModuleStringConsts(
  * compile-time lookup (the icon registry's `strokePaths['chevron-down']`,
  * pagination's `variantClasses.ghost`; #1896 / #1897). Returns the
  * looked-up scalar, or `null` for any other shape so callers fall back
- * to their generic lowering. Shared by all three SSR template adapters;
+ * to their generic lowering. Shared by all seven template-string adapters;
  * the prop-KEYED variant of the pattern lives in `parseRecordIndexAccess`.
+ *
+ * `isShadowed` is REQUIRED (#2482 Stage 2) rather than left to caller
+ * discipline: an enclosing loop callback's own param/index/destructure/
+ * preamble binding of the same name as `objectName` (`.map((cfg) =>
+ * <li>{cfg.x}</li>)` shadowing a module `const cfg = {…}`) must resolve to
+ * the ROW value, not the outer const's member — every call site used to
+ * check this itself, against its own ad-hoc per-adapter shadow-name
+ * bookkeeping, with no static guarantee a new caller wouldn't forget it.
+ * Pass `scope.isBound` (or `scope.asShadowPredicate()`) from the caller's
+ * threaded `BindingScope`.
  */
 export function lookupStaticRecordLiteral(
   objectName: string,
   key: string,
   constants: IRMetadata['localConstants'] | undefined,
+  isShadowed: (name: string) => boolean,
 ): { kind: 'string' | 'number'; text: string } | null {
+  if (isShadowed(objectName)) return null
   const constInfo = (constants ?? []).find(c => c.name === objectName && c.isModule)
   if (constInfo?.value === undefined) return null
   const sf = ts.createSourceFile(


### PR DESCRIPTION
**Stage 2 of #2482 Option A** (design: https://github.com/piconic-ai/barefootjs/issues/2482#issuecomment-5224483715; Stages 0/1a/1b = #2585/#2590/#2595, merged).

## Scope note vs the staging table

The staging table's acceptance criterion was "graduate #2488 + #2489 pins" — but both issues were **already fixed and graduated on main** before this stage started (`0e225029f` position-accurate prop-classification guard, `0d3ffaf5a` `emitSpread` local-const guard), using the ad-hoc ref-counted map. Stage 2's job therefore became: collapse the ad-hoc devices into `BindingScope` **without regressing the already-graduated fixtures** — which the conformance suite now enforces continuously (1891 pass / 0 fail, zero fixture diff).

## What changed

- **Each of the 7 template-string adapters** (twig, jinja, blade, xslate, rust/minijinja, erb, mojolicious): the coarse whole-component `staticLoopSourceBoundNames` Set + the ref-counted live `loopBoundNames` Map (erb/mojo: the single live map) collapse into one `private scope: BindingScope`, entered via `enterLoopRow(loop)` (`IRLoop` structurally satisfies `LoopBindingSource`) and restored by reference around `renderChildren(loop.children)` — no ref-count/clear bookkeeping left to forget. **145 legacy occurrences eliminated**; net −120 lines.
- **`resolveStaticLoopSource`'s `isNameShadowed` is now fed `scope.asShadowPredicate()` by all 7 adapters** — ending the coarse/live drift the design comment table-proved (5 adapters passed the coarse set, erb/mojo the live map, same shared function with different meanings per caller).
- **`lookupStaticRecordLiteral` (`augment-inherited-props.ts`) gains a required `isShadowed` guard parameter** — the shadow check moves inside the function instead of depending on caller discipline.
- **Behavior improvement bundled in**: the 5 Twig-family adapters' static-const-inlining guards move from the coarse whole-component exclusion to the position-accurate scope, matching erb/mojo's already-correct behavior — a same-named const outside any shadowing loop now inlines even when the name is loop-bound elsewhere in the component (previously a documented "accepted trade-off" of the coarse set). The 10 unit tests pinning the old coarse behavior (2 × 5 adapters) now assert the corrected one; no conformance fixture relied on the old behavior.
- Ratchet allowlist: `staticLoopSourceBoundNames` and ref-counted `loopBoundNames` drop to 0 across all 7 adapters. `adapter-go-template` (Stage 3) untouched, counts unchanged.
- Changeset: patch on `@barefootjs/jsx` + all 7 adapter packages.

## Deferred

- Go adapter (Stage 3: two parallel structures → threaded scope, guard the `:3790/:3852` siblings).
- `collectLoopBoundNames` inside `collectStringValueNames`: a legitimate one-shot whole-component prepass at `generate()` entry, before any loop scope exists — not replaceable by the runtime-threaded scope; left as-is.

## Verification

- `packages/jsx` **3015 / 0 fail**, `packages/adapter-tests` **1891 / 0 fail**, and all 7 adapter suites 0 fail (twig 1321, jinja 1313, blade 1313, xslate 1313, rust 1311, erb 1284, mojolicious 1479).
- `generate-expected-html.ts` (274 fixtures) and `snapshot.ts` (37 shared components) both regenerate **byte-identical** — zero emitted-output change outside the unit-pinned inlining improvement.
- Environment-only issues hit during verification (not code): rust needed a one-time `cargo build` pre-warm; erb needed `tzinfo` gems; transient 5000ms per-test timeouts under parallel load resolved by sequential re-runs with `--timeout=30000` (0 fail every time; never an assertion failure, never on a modified test).

Refs #2482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_