### PR TITLE
fix(compiler): carry generic type parameters into templates; type the SSR setter stub (#2573)

### DIFF
--- a/.changeset/signal-setter-updater-type-2573.md
+++ b/.changeset/signal-setter-updater-type-2573.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix a type-level emission defect surfaced by the `ui/` corpus type-check gate (#2573): the SSR no-op signal setter stub was declared as `(..._args: any[]) => {}`. Calling it with an updater function (`setBars((prev) => [...prev, bar])`) put that arrow in a rest-`any[]` argument position rather than a function-typed one, so `tsc` had no contextual signature to infer the arrow's own parameter from and flagged it implicit-any (`TS7006`).
+
+The stub now mirrors the real `createSignal<T>` setter's signature (`T | ((prev: T) => T)`, from `packages/client/src/reactive.ts`'s `Signal<T>`) whenever the signal's type is known — the same `SignalInfo.type` field the getter's own type assertion already reads — so updater-function call sites infer correctly. Falls back to the untyped rest-args stub when the type can't be resolved. Type-only — no change to rendered output or runtime behavior. Shared by every `JsxAdapter` subclass (Hono, the internal `TestAdapter`), so both benefit uniformly.
+
+Ratchets the `corpus-typecheck.test.ts` allowlist: `chart TS7006` drops from 34 to 16 (the remaining 16 stem from a distinct, deeper mechanism — SSR context values typed `unknown` — tracked separately in #2573).

--- a/.changeset/xyflow-generic-type-parameters-2573.md
+++ b/.changeset/xyflow-generic-type-parameters-2573.md
@@ -1,0 +1,10 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/hono": patch
+---
+
+Fix a type-level emission defect surfaced by the `ui/` corpus type-check gate (#2573): a generic component function's own type parameters (`function Flow<NodeType, EdgeType>(...)`) were dropped from the emitted `.tsx` SSR template. The function came out as `function Flow(...)` even though its props type annotation — and often its body — kept referencing the type parameter names verbatim (`props: FlowComponentProps<NodeType, EdgeType>`, `createFlowStore<NodeType, EdgeType>(props)`), so `tsc` reported `TS2304` ("Cannot find name 'NodeType'") at every such reference.
+
+`IRMetadata.typeParameters` now carries the source's type parameter list verbatim (per-parameter `node.getText()`, mirroring `ConstantInfo.typeAnnotation`'s #2589 precedent), and `HonoAdapter`/`TestAdapter` splice it between the function name and the parameter list. Type-only — no change to rendered output or runtime behavior. Non-generic components (the overwhelming majority) are unaffected.
+
+Ratchets the `corpus-typecheck.test.ts` allowlist: `xyflow TS2304` (7) drops to zero.

--- a/packages/adapter-hono/src/__tests__/corpus-typecheck.test.ts
+++ b/packages/adapter-hono/src/__tests__/corpus-typecheck.test.ts
@@ -42,7 +42,6 @@ const KNOWN_DIAGNOSTICS: Record<string, number> = {
   'chart TS2307': 2,
   'chart TS2322': 2,
   'chart TS7006': 34,
-  'xyflow TS2304': 7,
   'xyflow TS2307': 2,
 }
 

--- a/packages/adapter-hono/src/__tests__/corpus-typecheck.test.ts
+++ b/packages/adapter-hono/src/__tests__/corpus-typecheck.test.ts
@@ -41,7 +41,7 @@ const KNOWN_DIAGNOSTICS: Record<string, number> = {
   'chart TS18046': 69,
   'chart TS2307': 2,
   'chart TS2322': 2,
-  'chart TS7006': 34,
+  'chart TS7006': 16,
   'xyflow TS2307': 2,
 }
 

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -556,7 +556,12 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
     // Module-export keyword belongs to the adapter: it knows the target language
     // and whether the source declared the component as exported.
     const exportPrefix = ir.metadata.isExported === false ? '' : 'export '
-    lines.push(`${exportPrefix}function ${name}(${fullPropsDestructure}${typeAnnotation}${noArgDefault}) {`)
+    // A generic component's props type (and often its body) keeps
+    // referencing the source's type parameter names verbatim — the
+    // function's own declaration must carry them too, or those references
+    // are unresolved names in the emitted `.tsx` (TS2304, xyflow's `Flow`).
+    const typeParameters = ir.metadata.typeParameters ?? ''
+    lines.push(`${exportPrefix}function ${name}${typeParameters}(${fullPropsDestructure}${typeAnnotation}${noArgDefault}) {`)
 
     // Vite-pipeline script registration (see `scriptAssets`'s field
     // docstring): register this call's resolved URLs against the request

--- a/packages/adapter-tests/fixtures/__snapshots__/carousel.carousel.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/carousel.carousel.ssr.tsx
@@ -92,9 +92,9 @@ export function Carousel(__allProps: CarouselProps & { __instanceId?: string; __
   const { __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props } = __allProps
   const __scopeId = __instanceId || `Carousel_${Math.random().toString(36).slice(2, 8)}`
   const canScrollPrev = () => false
-  const setCanScrollPrev = (..._args: any[]) => {}
+  const setCanScrollPrev: (valueOrFn: boolean | ((prev: boolean) => boolean)) => void = () => {}
   const canScrollNext = () => false
-  const setCanScrollNext = (..._args: any[]) => {}
+  const setCanScrollNext: (valueOrFn: boolean | ((prev: boolean) => boolean)) => void = () => {}
   const orientation = () => props.orientation ?? 'horizontal'
   let emblaApi: EmblaCarouselType | undefined
   const scrollPrev = () => emblaApi?.scrollPrev()

--- a/packages/adapter-tests/fixtures/__snapshots__/combobox.combobox.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/combobox.combobox.ssr.tsx
@@ -124,11 +124,11 @@ export function Combobox(__allProps: ComboboxProps & { __instanceId?: string; __
   const { __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props } = __allProps
   const __scopeId = __instanceId || `Combobox_${Math.random().toString(36).slice(2, 8)}`
   const open = () => false
-  const setOpen = (..._args: any[]) => {}
+  const setOpen: (valueOrFn: boolean | ((prev: boolean) => boolean)) => void = () => {}
   const search = () => ''
-  const setSearch = (..._args: any[]) => {}
+  const setSearch: (valueOrFn: string | ((prev: string) => string)) => void = () => {}
   const internalValue = () => props.value ?? ''
-  const setInternalValue = (..._args: any[]) => {}
+  const setInternalValue: (valueOrFn: string | ((prev: string) => string)) => void = () => {}
   const isControlled = () => props.value !== undefined
   const filterFn = () => props.filter ?? ((value: string, search: string) => {
     if (!search) return true

--- a/packages/adapter-tests/fixtures/__snapshots__/command.command.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.command.ssr.tsx
@@ -141,9 +141,9 @@ export function Command(__allProps: CommandProps & { __instanceId?: string; __bf
   const { __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props } = __allProps
   const __scopeId = __instanceId || `Command_${Math.random().toString(36).slice(2, 8)}`
   const search = () => ''
-  const setSearch = (..._args: any[]) => {}
+  const setSearch: (valueOrFn: string | ((prev: string) => string)) => void = () => {}
   const selectedValue = () => ''
-  const setSelectedValue = (..._args: any[]) => {}
+  const setSelectedValue: (valueOrFn: string | ((prev: string) => string)) => void = () => {}
   const filterFn = () => props.filter ?? ((value: string, search: string) => {
     if (!search) return true
     return value.toLowerCase().includes(search.toLowerCase())

--- a/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.dropdown-menu.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.dropdown-menu.ssr.tsx
@@ -357,7 +357,7 @@ export function DropdownMenuSub(__allProps: DropdownMenuSubProps & { __instanceI
   const { __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props } = __allProps
   const __scopeId = __instanceId || `DropdownMenuSub_${Math.random().toString(36).slice(2, 8)}`
   const subOpen = () => false
-  const setSubOpen = (..._args: any[]) => {}
+  const setSubOpen: (valueOrFn: boolean | ((prev: boolean) => boolean)) => void = () => {}
 
   // Serialize props for client hydration
   const __hydrateProps: Record<string, unknown> = {}

--- a/packages/adapter-tests/fixtures/__snapshots__/radio-group.radio-group.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/radio-group.radio-group.ssr.tsx
@@ -49,9 +49,9 @@ export function RadioGroup(__allProps: RadioGroupProps & { __instanceId?: string
   const { __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props } = __allProps
   const __scopeId = __instanceId || `RadioGroup_${Math.random().toString(36).slice(2, 8)}`
   const internalValue = () => props.defaultValue ?? ''
-  const setInternalValue = (..._args: any[]) => {}
+  const setInternalValue: (valueOrFn: string | ((prev: string) => string)) => void = () => {}
   const controlledValue = () => props.value as string | undefined
-  const setControlledValue = (..._args: any[]) => {}
+  const setControlledValue: (valueOrFn: string | undefined | ((prev: string | undefined) => string | undefined)) => void = () => {}
   const isControlled = () => props.value !== undefined
   const currentValue = () => isControlled() ? (controlledValue() ?? '') : internalValue()
 

--- a/packages/adapter-tests/fixtures/__snapshots__/select.select.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/select.select.ssr.tsx
@@ -131,9 +131,9 @@ export function Select(__allProps: SelectProps & { __instanceId?: string; __bfSc
   const { __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props } = __allProps
   const __scopeId = __instanceId || `Select_${Math.random().toString(36).slice(2, 8)}`
   const open = () => false
-  const setOpen = (..._args: any[]) => {}
+  const setOpen: (valueOrFn: boolean | ((prev: boolean) => boolean)) => void = () => {}
   const internalValue = () => props.value ?? ''
-  const setInternalValue = (..._args: any[]) => {}
+  const setInternalValue: (valueOrFn: string | ((prev: string) => string)) => void = () => {}
   const isControlled = () => props.value !== undefined
 
   // Serialize props for client hydration

--- a/packages/jsx/src/__tests__/component-type-parameters.test.ts
+++ b/packages/jsx/src/__tests__/component-type-parameters.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression test for #2573 (xyflow TS2304 family): a component function's
+ * own generic type parameters (`function Flow<NodeType, EdgeType>(...)`)
+ * were dropped from the emitted `.tsx` SSR template — the function
+ * signature came out as `function Flow(...)` even though its props type
+ * annotation (and often its body) kept referencing `NodeType`/`EdgeType`
+ * verbatim (`props: FlowComponentProps<NodeType, EdgeType>`,
+ * `createFlowStore<NodeType, EdgeType>(props)`). TypeScript then reported
+ * "Cannot find name 'NodeType'" (TS2304) at every such reference — the
+ * declaration that would have brought the name into scope was never
+ * emitted. Runtime output (client JS) was always correct; this is a
+ * type-level emission defect in the SSR template only.
+ *
+ * `IRMetadata.typeParameters` now carries the source's type parameter list
+ * verbatim (`node.getText()` per parameter, mirroring `ConstantInfo.
+ * typeAnnotation`'s #2589 precedent), and `HonoAdapter`/`TestAdapter` splice
+ * it between the function name and the parameter list.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
+
+describe('component type parameter preservation in emitted templates (#2573)', () => {
+  test('a generic function component keeps its type parameters on the emitted signature', () => {
+    const honoAdapter = new HonoAdapter()
+    const source = `
+      interface NodeBase { id: string }
+      interface EdgeBase { id: string }
+      interface FlowProps<NodeType extends NodeBase, EdgeType extends EdgeBase> {
+        nodes: NodeType[]
+        edges: EdgeType[]
+      }
+
+      export function Flow<NodeType extends NodeBase = NodeBase, EdgeType extends EdgeBase = EdgeBase>(
+        props: FlowProps<NodeType, EdgeType>,
+      ) {
+        const count = props.nodes.length + props.edges.length
+        return <div>{count}</div>
+      }
+    `
+
+    const result = compileJSX(source, 'Flow.tsx', { adapter: honoAdapter })
+    expect(result.errors).toHaveLength(0)
+
+    const template = result.files.find((f) => f.type === 'markedTemplate')!
+    expect(template).toBeDefined()
+    expect(template.content).toContain(
+      'function Flow<NodeType extends NodeBase = NodeBase, EdgeType extends EdgeBase = EdgeBase>(',
+    )
+  })
+
+  test('a non-generic function component gains no type parameter clause', () => {
+    const honoAdapter = new HonoAdapter()
+    const source = `
+      interface CardProps { title: string }
+      export function Card(props: CardProps) {
+        return <div>{props.title}</div>
+      }
+    `
+
+    const result = compileJSX(source, 'Card.tsx', { adapter: honoAdapter })
+    expect(result.errors).toHaveLength(0)
+
+    const template = result.files.find((f) => f.type === 'markedTemplate')!
+    expect(template).toBeDefined()
+    expect(template.content).toContain('function Card(')
+    expect(template.content).not.toMatch(/function Card</)
+  })
+})

--- a/packages/jsx/src/__tests__/signal-setter-updater-type.test.ts
+++ b/packages/jsx/src/__tests__/signal-setter-updater-type.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression test for #2573 (chart TS7006 family): the SSR no-op signal
+ * setter stub was declared as `(..._args: any[]) => {}`. Calling it with
+ * an updater function — `setBars((prev) => [...prev, bar])` — puts that
+ * arrow in a rest-`any[]` argument position, not a function-typed one, so
+ * TypeScript has no contextual signature to infer the arrow's own
+ * parameter from and flags it implicit-any (TS7006). Runtime output
+ * (client JS) was always correct; this is a type-level emission defect in
+ * the SSR template only.
+ *
+ * The real `createSignal<T>` setter accepts `T | ((prev: T) => T)`
+ * (`packages/client/src/reactive.ts`'s `Signal<T>`). The stub now mirrors
+ * that signature whenever the signal's type is known (`SignalInfo.type`,
+ * the same field `needsTypeAssertion` already reads for the getter), so
+ * the updater arrow's parameter infers from the real element type.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
+
+describe('signal setter updater-function typing in emitted templates (#2573)', () => {
+  test('a typed signal gets an updater-aware setter stub', () => {
+    const honoAdapter = new HonoAdapter()
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      interface Bar { id: string; height: number }
+
+      export function Chart() {
+        const [bars, setBars] = createSignal<Bar[]>([])
+
+        // Called directly from the returned JSX (not from an onXxx handler
+        // prop, which SSR stubs to a no-op) so it — and the setter call
+        // inside it — stays reachable into the emitted template.
+        const addBar = (bar: Bar) => {
+          setBars((prev) => [...prev, bar])
+          return bars().length
+        }
+
+        return <div>{addBar({ id: 'a', height: 1 })}</div>
+      }
+    `
+
+    const result = compileJSX(source, 'Chart.tsx', { adapter: honoAdapter })
+    expect(result.errors).toHaveLength(0)
+
+    const template = result.files.find((f) => f.type === 'markedTemplate')!
+    expect(template).toBeDefined()
+    expect(template.content).toContain(
+      'const setBars: (valueOrFn: Bar[] | ((prev: Bar[]) => Bar[])) => void = () => {}',
+    )
+  })
+
+  test('a signal with no resolvable type keeps the untyped rest-args stub', () => {
+    const honoAdapter = new HonoAdapter()
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Widget(props: { initial: unknown }) {
+        const [value, setValue] = createSignal(props.initial)
+
+        const reset = () => {
+          setValue(props.initial)
+          return value()
+        }
+
+        return <div>{String(reset())}</div>
+      }
+    `
+
+    const result = compileJSX(source, 'Widget.tsx', { adapter: honoAdapter })
+    expect(result.errors).toHaveLength(0)
+
+    const template = result.files.find((f) => f.type === 'markedTemplate')!
+    expect(template).toBeDefined()
+    expect(template.content).toContain('const setValue = (..._args: any[]) => {}')
+  })
+})

--- a/packages/jsx/src/adapters/jsx-adapter.ts
+++ b/packages/jsx/src/adapters/jsx-adapter.ts
@@ -176,7 +176,25 @@ export abstract class JsxAdapter extends BaseAdapter {
       if (signal.setter) {
         const setterUsed = identifierPattern(signal.setter).test(setterRefText)
         if (setterUsed) {
-          lines.push(`  const ${signal.setter} = (..._args: any[]) => {}`)
+          // The real `createSignal<T>` setter accepts `T | ((prev: T) =>
+          // T)` (`packages/client/src/reactive.ts`'s `Signal<T>`). The
+          // untyped `(..._args: any[]) => {}` stub gave every `setX((prev)
+          // => ...)` updater-function call site an `any[]`-typed argument
+          // position — not a function-typed one — so the arrow's own
+          // `prev` parameter had no contextual type to infer from and
+          // `tsc` flagged it implicit-any (TS7006, #2573 chart family).
+          // Mirror the real setter's signature whenever the signal's type
+          // is known, so updater-function callers keep their inference;
+          // fall back to the untyped stub only when it isn't (matches
+          // `needsTypeAssertion`'s `'unknown'` guard just above).
+          const setterType = preserveTypes && signal.type.kind !== 'unknown'
+            ? `(valueOrFn: ${signal.type.raw} | ((prev: ${signal.type.raw}) => ${signal.type.raw})) => void`
+            : null
+          lines.push(
+            setterType
+              ? `  const ${signal.setter}: ${setterType} = () => {}`
+              : `  const ${signal.setter} = (..._args: any[]) => {}`,
+          )
         }
       }
     }

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -164,7 +164,10 @@ export class TestAdapter extends JsxAdapter {
     // Module-export keyword belongs to the adapter: it knows the target language
     // and whether the source declared the component as exported.
     const exportPrefix = ir.metadata.isExported === false ? '' : 'export '
-    lines.push(`${exportPrefix}function ${name}(${fullPropsDestructure}${typeAnnotation}${noArgDefault}) {`)
+    // Carry the source component's own generic type parameters, if any
+    // (mirrors `HonoAdapter` — see `IRMetadata.typeParameters`'s docstring).
+    const typeParameters = ir.metadata.typeParameters ?? ''
+    lines.push(`${exportPrefix}function ${name}${typeParameters}(${fullPropsDestructure}${typeAnnotation}${noArgDefault}) {`)
 
     // Generate scope ID
     if (hasClientInteractivity) {

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -624,6 +624,23 @@ function compileMultipleComponents(
 // Helpers
 // =============================================================================
 
+/**
+ * Verbatim text of the component function's own generic type parameter
+ * list (`<NodeType extends NodeBase = NodeBase, EdgeType extends EdgeBase
+ * = EdgeBase>`), or `null` when the component isn't generic. Source text
+ * per parameter (`node.getText(sourceFile)`), not a re-printed AST, so
+ * constraints/defaults/comments round-trip exactly like `ConstantInfo.
+ * typeAnnotation` does for `let` (#2589) — see `IRMetadata.typeParameters`.
+ */
+function componentTypeParametersText(
+  componentNode: ts.FunctionDeclaration | ts.ArrowFunction | null,
+  sourceFile: ts.SourceFile,
+): string | null {
+  const typeParameters = componentNode?.typeParameters
+  if (!typeParameters || typeParameters.length === 0) return null
+  return `<${typeParameters.map(p => p.getText(sourceFile)).join(', ')}>`
+}
+
 export function buildMetadata(
   ctx: ReturnType<typeof analyzeComponent>,
 ): IRMetadata {
@@ -634,6 +651,7 @@ export function buildMetadata(
     isClientComponent: ctx.hasUseClientDirective,
     typeDefinitions: ctx.typeDefinitions,
     propsType: ctx.propsType,
+    typeParameters: componentTypeParametersText(ctx.componentNode, ctx.sourceFile),
     propsParams: ctx.propsParams,
     propsObjectName: ctx.propsObjectName,
     restPropsName: ctx.restPropsName,

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1940,6 +1940,25 @@ export interface IRMetadata {
   isClientComponent: boolean
   typeDefinitions: TypeDefinition[]
   propsType: TypeInfo | null
+  /**
+   * The component function's own generic type parameter list, verbatim
+   * from source (each `node.getText()`, joined and wrapped in `<...>`),
+   * e.g. `<NodeType extends NodeBase = NodeBase, EdgeType extends
+   * EdgeBase = EdgeBase>`. `null` when the component isn't generic.
+   *
+   * A generic function component's props type (and often its body) keeps
+   * referencing these names verbatim in emitted output (e.g. `props:
+   * FlowComponentProps<NodeType, EdgeType>`, `createFlowStore<NodeType,
+   * EdgeType>(props)`) — without the function's own declaration also
+   * carrying the type parameters, those references are unresolved names
+   * in the emitted `.tsx` (TS2304). Emitters that print a `function
+   * <name>(...)` signature for the component must splice this verbatim
+   * between the name and the parameter list. Optional (rather than
+   * required) so the many hand-built `IRMetadata` test fixtures across
+   * the suite don't need updating for a field that is `null` for the
+   * overwhelming majority of (non-generic) components.
+   */
+  typeParameters?: string | null
   propsParams: ParamInfo[]
   /** Name of the props object parameter (e.g., 'props' in `function Component(props: Props)`) */
   propsObjectName: string | null


### PR DESCRIPTION
Works down the corpus type-check debt tracked in #2573 (gate: `corpus-typecheck.test.ts`, allowlist shrink-only per the issue's acceptance rule).

## Re-baseline first — most of the issue's table was already cleared

The issue's family table (2026-08-07) predates several merges. Fresh profile on current main: **122 diagnostics, chart + xyflow only** — icon TS2322×34, spinner, carousel, slider were already fixed by #2581, and the chart TS2345 gate violation PR #2599 mentioned turned out to have been incidentally cleared by #2600's `lookupStaticRecordLiteral` shadow-guard (a `.map()` row binding colliding with a same-named module record const no longer misresolves). Gate confirmed green on main before starting.

## Fixed here

1. **xyflow TS2304 ×7 → 0**: a generic component's type-parameter list was dropped from the emitted signature — `function Flow<NodeType extends BuiltInNode, ...>(...)` became `function Flow(...)` while the body still referenced `NodeType`/`EdgeType`. New `IRMetadata.typeParameters` carries the list verbatim from source (`compiler.ts`), spliced into the emitted signature by `HonoAdapter`/`TestAdapter`. Only `ui/xyflow`'s `Flow` is generic in the corpus (verified) — zero blast radius. Same family as #2589's "carry source types verbatim" arc.
2. **chart TS7006 34 → 16**: the SSR no-op signal-setter stub was `(..._args: any[]) => {}`, so an updater-function call (`setBars((prev) => …)`) gave `prev` no contextual type. The stub now mirrors the real setter shape (`(value: T | ((prev: T) => T)) => void`) when `SignalInfo.type` is known (shared `JsxAdapter` base).

Allowlist: `xyflow TS2304` entry deleted; `chart TS7006` 34 → 16.

## Assessed, not fixed (documented for the issue)

- **Cascade hypothesis flagged for a maintainer**: chart TS2307 ×2 / xyflow TS2307 ×2 are a corpus-gate infrastructure gap (`@barefootjs/chart`/`@barefootjs/xyflow` aren't built+linked into the gate's `ts.createProgram`). `ChartConfigContext` therefore collapses to `any`, `useContext<T>` infers `unknown` — which is the direct cause of **TS18046 ×69** and plausibly the remaining TS7006 ×16. Linking the real packages could collapse several families at once, but risks surfacing a wave of new real diagnostics; recommended as a dedicated follow-up.
- **chart TS17001 ×6**: a genuine naming collision — author-written `data-key={props.dataKey}` on the same element where the framework injects its loop-row `data-key` hydration attribute. Precedence is a design decision, not a mechanical fix.
- **chart TS2322 ×2**: `string | null` computed field vs non-nullable SVG attr type; likely a chart-source typing tightening.

## Verification

- Corpus gate green at the shrunken allowlist. New unit tests: `component-type-parameters.test.ts`, `signal-setter-updater-type.test.ts`.
- `packages/adapter-tests` 1891 / 0 fail; `ui/components/ui` 1235 / 0 fail (58 files — confirms the shared-adapter changes perturb no other component); xyflow IR tests 27 / 0 fail. jsx/hono suites match baseline modulo CPU-load timeout flakes (each confirmed passing in isolation).
- Changesets: patch `@barefootjs/jsx` + `@barefootjs/hono` (type-parameters), patch `@barefootjs/jsx` (setter stub).

Refs #2573

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_