### PR TITLE
fix(compiler): wire loop-row conditionals on reactive preamble locals (#2596)

### DIFF
--- a/.changeset/preamble-conditional-reactivity-2596.md
+++ b/.changeset/preamble-conditional-reactivity-2596.md
@@ -1,0 +1,7 @@
+---
+'@barefootjs/jsx': patch
+---
+
+Fix a `.map()` loop-body conditional whose condition bare-references a preamble-declared local (a pre-return `const` in the callback body) never re-evaluating when that local reads a signal/memo/reactive prop. Phase 1 now derives the condition's reactivity from the preamble local's own dependency set (`computePreambleReactiveNames`, transitive through earlier preamble declarations) and grants it the same `reactive` flag + slot id ordinary conditions get; Phase 2's `collectLoopChildConditionals`/`emitOuterConditional` got the `readsPreamble` bypass + preamble-re-run-in-getter treatment reactive attributes already had (#2447), the condition-position twin. A conditional whose preamble local is purely item-derived (no signal/memo/prop read) stays non-reactive, as before.
+
+Closes #2596

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2810,6 +2810,23 @@
         "text"
       ]
     },
+    "loop-preamble-conditional-reactive": {
+      "kinds": [
+        "call",
+        "identifier",
+        "logical",
+        "member"
+      ],
+      "axes": [
+        "logical:||"
+      ],
+      "contexts": [
+        "attribute",
+        "condition",
+        "loop",
+        "text"
+      ]
+    },
     "loop-row-static-conditional": {
       "kinds": [
         "call",
@@ -4996,13 +5013,13 @@
     "array-method": 67,
     "arrow": 64,
     "binary": 84,
-    "call": 202,
+    "call": 203,
     "conditional": 24,
-    "identifier": 291,
+    "identifier": 292,
     "index-access": 14,
     "literal": 241,
-    "logical": 43,
-    "member": 155,
+    "logical": 44,
+    "member": 156,
     "object-literal": 56,
     "template-literal": 30,
     "unary": 23,
@@ -5049,7 +5066,7 @@
     "literal:string": 171,
     "logical:&&": 7,
     "logical:??": 38,
-    "logical:||": 13,
+    "logical:||": 14,
     "member:computed": 8,
     "member:optional": 1,
     "unary:!": 15,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -397,6 +397,7 @@ import { fixture as compositeRowChildDerivedProp } from './composite-row-child-d
 import { fixture as compositeRowChildAliasedProp } from './composite-row-child-aliased-prop'
 import { fixture as loopPreambleAttrValue } from './loop-preamble-attr-value'
 import { fixture as loopPreambleChainedFilter } from './loop-preamble-chained-filter'
+import { fixture as loopPreambleConditionalReactive } from './loop-preamble-conditional-reactive'
 import { fixture as loopRowStaticConditional } from './loop-row-static-conditional'
 import { fixture as childPrimitiveProps } from './child-primitive-props'
 import { fixture as preWhitespace } from './pre-whitespace'
@@ -825,4 +826,5 @@ export const jsxFixtures: JSXFixture[] = [
   detailsOpen,
   dialogOpen,
   progressMeterValue,
+  loopPreambleConditionalReactive,
 ]

--- a/packages/adapter-tests/fixtures/loop-preamble-conditional-reactive.ts
+++ b/packages/adapter-tests/fixtures/loop-preamble-conditional-reactive.ts
@@ -1,0 +1,84 @@
+import { createFixture } from '../src/types'
+
+/**
+ * #2596 — a `.map()` row whose reactive CONDITION is a bare reference to a
+ * preamble-declared local (`isHot`), whose own initializer reads a prop
+ * (`props.highlight`) in addition to the item. Before the fix, the
+ * conditional's IR `reactive` flag was never set for this shape (Phase 1's
+ * classifiers only see the token `isHot`, never its declaration), so the
+ * branch silently froze at its row-construction value instead of re-running
+ * when `highlight` changed.
+ *
+ * This fixture pins the OUTPUT of the fix at both layers, same as
+ * `loop-preamble-attr-value` (#2447, the ATTRIBUTE twin) and
+ * `loop-row-static-conditional` (#2596's non-preamble sibling): the SSR
+ * template must render the preamble-derived branch per row (adapter
+ * conformance), and the CSR template lambda must produce the same markup
+ * (`csr-conformance.test.ts`). A regression that dropped the `reactive` flag
+ * (or its Phase-2 `readsPreamble` wiring) again would show up here only
+ * indirectly — the INITIAL render is correct either way, since both the
+ * broken and fixed compiler render the row's construction-time value
+ * correctly. The generated-code SHAPE of the fix itself (the actual re-run
+ * wiring) is pinned by the compiler-unit tests in
+ * `packages/jsx/src/__tests__/preamble-conditional-reactivity.test.ts` — this
+ * fixture's job is cross-adapter byte parity of what that wiring renders.
+ *
+ * Uses a PROP (not a signal) as the preamble's non-item reactive input
+ * deliberately: `csr-conformance.test.ts` evaluates the CSR "materialize"
+ * template function in isolation, and a signal read directly inside a loop
+ * preamble is spliced into that template verbatim (unresolved at template-
+ * eval scope) — a separate, pre-existing gap unrelated to #2596. A prop read
+ * (`_p.highlight`) is always in scope there, so the fixture exercises the
+ * SAME preamble-reactivity classification (`isReactiveExpression` also
+ * proves prop reads reactive, not just signal/memo reads) without tripping
+ * that unrelated limitation.
+ */
+export const fixture = createFixture({
+  id: 'loop-preamble-conditional-reactive',
+  description: 'Loop row preamble computes a conditional-condition value from item + prop',
+  componentName: 'LoopPreambleConditionalReactive',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; label: string; done: boolean }
+export function LoopPreambleConditionalReactive(props: { rows: Row[]; highlight: boolean }) {
+  const [rows, setRows] = createSignal<Row[]>(props.rows)
+  return (
+    <ul>
+      {rows().map(row => {
+        const isHot = row.done || props.highlight
+        return (
+          <li key={row.id}>{isHot ? <b>{row.label}</b> : <span>{row.label}</span>}</li>
+        )
+      })}
+    </ul>
+  )
+}
+`,
+  props: {
+    rows: [
+      { id: 1, label: 'write it', done: false },
+      { id: 2, label: 'ship it', done: true },
+    ],
+    highlight: false,
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s3">
+      <li data-key="1"><span bf-c="s2"><!--bf:s1-->write it<!--/--></span></li>
+      <li data-key="2"><b bf-c="s2"><!--bf:s0-->ship it<!--/--></b></li>
+    </ul>
+  `,
+  dataPoints: [
+    { name: 'empty', props: { rows: [], highlight: false } },
+    {
+      name: 'highlight-all',
+      props: {
+        rows: [
+          { id: 1, label: 'write it', done: false },
+          { id: 2, label: 'ship it', done: true },
+        ],
+        highlight: true,
+      },
+    },
+  ],
+})

--- a/packages/jsx/src/__tests__/csr-materialize-loop-preamble-shadow.test.ts
+++ b/packages/jsx/src/__tests__/csr-materialize-loop-preamble-shadow.test.ts
@@ -69,7 +69,16 @@ describe('CSR materialize template vs .map() preamble-local shadowing a module c
 
     // The row-local `label` (the preamble's OWN computed value) must
     // drive the branch — never the outer module const's literal.
-    expect(tpl).toContain('label ? `<span>yes</span>`')
+    //
+    // The branch also carries a `bf-c="s0"` slot marker on both arms
+    // (#2596 follow-up): `label`'s initializer reads the real signal `on()`,
+    // so `markPreambleConditionalReactivity` now grants this conditional a
+    // slot id and the `reactive` flag it lacked before — the SAME
+    // observable-failure-mode class this file's docstring describes
+    // ("every row's branch condition evaluated the constant's fixed
+    // truthiness"), just for the signal dimension instead of the shadowing
+    // one. Nothing else about this fixture's shape changed.
+    expect(tpl).toContain('label ? `<span bf-c="s0">yes</span>` : `<span bf-c="s0">no</span>`')
     expect(tpl).not.toContain("('MODULE_CONST')")
     expect(tpl).not.toContain('MODULE_CONST')
   })

--- a/packages/jsx/src/__tests__/preamble-conditional-reactivity.test.ts
+++ b/packages/jsx/src/__tests__/preamble-conditional-reactivity.test.ts
@@ -1,0 +1,191 @@
+/**
+ * #2596 — inside a `.map()` callback, a conditional whose condition is a
+ * bare reference to a preamble-declared local (a pre-return `const` in the
+ * callback body) never got its IR `reactive` flag set, even when the
+ * preamble local reads a signal:
+ *
+ *   {items().map((item) => {
+ *     const label = item.title || fallback()   // preamble local reading a signal
+ *     return <li>{label ? <Badge/> : <Placeholder/>}</li>   // never re-evaluated
+ *   })}
+ *
+ * Root cause: Phase 1's conditional-reactivity classifiers
+ * (`isReactiveExpression` for the condition's own text, `referencesLoopParam`
+ * for item/index/destructure names via `BindingScope.valueBoundNames()`) only
+ * ever see the token `label` — never its declaration — so a bare preamble-
+ * local reference tripped neither.
+ *
+ * Fix (`jsx-to-ir.ts`):
+ *  - `computePreambleReactiveNames` determines which preamble-declared names
+ *    are THEMSELVES reactive — read a signal/memo/reactive prop, directly or
+ *    transitively through an earlier preamble declaration — by re-running
+ *    the SAME `isReactiveExpression` classifier already used for ordinary
+ *    conditions, against each declaration's initializer.
+ *  - `markPreambleConditionalReactivity` is a new post-hoc pass (same shape
+ *    as `collectPreambleRegions`/`markPreambleAttrSlots`, #2447) that grants
+ *    `reactive: true` + a slot id to a loop-body conditional whose condition
+ *    bare-references one of those names.
+ *
+ * This alone isn't sufficient — Phase 2's `collectLoopChildConditionals`
+ * independently re-derives reactivity from the condition's EXPANDED text via
+ * `classifyReactivity`, and `expandConstantForReactivity`'s shadow guard
+ * (#2482 Stage 1b) deliberately leaves a preamble-bound identifier like
+ * `label` unexpanded, so `classifyReactivity('label', …)` always reads
+ * 'none'. `collectLoopChildConditionals` and `emitOuterConditional` (in
+ * `ir-to-client-js/`) got the same `readsPreamble` bypass +
+ * preamble-re-run-in-getter treatment `collectLoopChildReactiveAttrs`
+ * already had (#2447) — the condition-position twin.
+ *
+ * These tests assert the COMPILED OUTPUT shape (mirrors
+ * `csr-materialize-loop-preamble-shadow.test.ts` and
+ * `preamble-region-patch.test.ts`'s convention: compiler-internals
+ * correctness is a generated-code-shape pin, not a live-DOM test — DOM
+ * execution of `insert()`/`mapArrayLazy`'s own reactive-tracking contract is
+ * covered by their own runtime unit tests).
+ *
+ * Depending on loop-row shape, the fix surfaces through one of two Phase 2
+ * plans — both draw from the SAME `collectLoopChildConditionals` fix:
+ *  - Both branches "wiring-free static elements" (`analyzeLazyConditional`,
+ *    §9.4 L3): the lazy-row plan (`mapArrayLazy`), which recomputes the
+ *    preamble in `applyItem` (per-row) AND `applyOuter` (outer-signal
+ *    effect, primed by reading the signal unconditionally).
+ *  - Otherwise: the eager `mapArray` + `insert()` plan, which recomputes the
+ *    preamble inside the getter passed to `insert()`.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsFor(source: string): string {
+  const result = compileJSX(source, 'Repro.tsx', { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('preamble-conditional-reactivity (#2596)', () => {
+  test('(a) a conditional condition reading a signal-derived preamble local is reactive (lazy-row plan)', () => {
+    const js = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Widget({ items }: { items: { id: number; title: string }[] }) {
+        const [fallback, setFallback] = createSignal('x')
+        return (
+          <ul>
+            {items.map((item) => {
+              const label = item.title || fallback()
+              return <li key={item.id}>{label ? <span>yes</span> : <span>no</span>}</li>
+            })}
+          </ul>
+        )
+      }
+    `)
+    // Both arms are wiring-free static elements — eligible for the lazy-row
+    // plan (§9.4 L3), which carries no per-row insert()/createEffect.
+    expect(js).toContain('mapArrayLazy(')
+    // The preamble re-runs (loop-param accessor form, `item()`) inside BOTH
+    // apply bodies — `applyItem` (per-row, same-key update) and `applyOuter`
+    // (the outer-signal effect) — never the plain (`item.title`) form.
+    const preambleRerun = /const label = item\(\)\.title \|\| fallback\(\);/g
+    expect(js.match(preambleRerun)?.length).toBeGreaterThanOrEqual(2)
+    // `applyOuter` primes the signal read unconditionally (§9.3(3)) so the
+    // effect subscribes even when the row list is momentarily empty — this
+    // IS the fix: before it, nothing in the emitted plan read `fallback()`
+    // outside the one-time row-construction line, so the effect never
+    // subscribed and the branch froze at its SSR-time value.
+    expect(js).toMatch(/applyOuter:\s*\(__es, __seed\) => \{\s*fallback\(\)/)
+    // The conditional actually got wired — not the empty no-op body a
+    // non-reactive conditional gets (see negative-case test below).
+    expect(js).not.toContain('applyItem: () => {}')
+  })
+
+  test('(b) the same shape through the eager insert() plan when a branch carries its own reactive text', () => {
+    const js = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Widget({ items }: { items: { id: number; title: string }[] }) {
+        const [fallback, setFallback] = createSignal('x')
+        return (
+          <ul>
+            {items.map((item) => {
+              const label = item.title || fallback()
+              return <li key={item.id}>{label ? <span>{item.title} yes</span> : <span>no</span>}</li>
+            })}
+          </ul>
+        )
+      }
+    `)
+    // A branch with its own reactive text disqualifies the lazy-row plan
+    // (`analyzeLazyConditional` requires wiring-free arms) — this exercises
+    // the OTHER Phase 2 path the fix threads through.
+    expect(js).toContain('mapArray(')
+    expect(js).not.toContain('mapArrayLazy(')
+    // `insert()`'s condition getter re-runs the preamble before reading
+    // `label` — the local isn't otherwise in scope inside that closure.
+    expect(js).toMatch(
+      /insert\(__el, 's1', \(\) => \{ const label = item\(\)\.title \|\| fallback\(\);; return \(label\) \}/,
+    )
+  })
+
+  test('(c) a conditional reading a NON-reactive preamble local stays non-reactive', () => {
+    const js = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Widget({ items }: { items: { id: number; title: string }[] }) {
+        const [count, setCount] = createSignal(0)
+        return (
+          <ul>
+            {items.map((item) => {
+              const label = item.title
+              return <li key={item.id}>{label ? <span>yes</span> : <span>no</span>}</li>
+            })}
+          </ul>
+        )
+      }
+    `)
+    // Still lazy-eligible (both arms are wiring-free statics), but the
+    // conditional itself never got a slot id / reactive flag — no per-row
+    // OR per-outer wiring for it at all.
+    expect(js).toContain('mapArrayLazy(')
+    expect(js).toContain('applyItem: () => {}')
+    expect(js).not.toContain('applyOuter')
+    expect(js).not.toContain('insert(')
+    // The condition's static, row-construction-time value is still baked
+    // into the row template (correct — it's genuinely never going to
+    // change without a fresh row).
+    expect(js).toMatch(/label \? `<span>yes<\/span>` : `<span>no<\/span>`/)
+  })
+
+  test('(d) transitive: a preamble local reading another preamble local that reads a signal', () => {
+    const js = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Widget({ items }: { items: { id: number; title: string }[] }) {
+        const [fallback, setFallback] = createSignal('x')
+        return (
+          <ul>
+            {items.map((item) => {
+              const base = fallback()
+              const label = item.title || base
+              return <li key={item.id}>{label ? <span>yes</span> : <span>no</span>}</li>
+            })}
+          </ul>
+        )
+      }
+    `)
+    // `computePreambleReactiveNames` walks preamble declarations in source
+    // order, folding each name into the reactive set when its initializer
+    // reads a signal/memo/prop directly OR references an earlier name
+    // already in that set — `label` qualifies via `base`, not via any
+    // signal call of its own.
+    expect(js).toContain('mapArrayLazy(')
+    expect(js).not.toContain('applyItem: () => {}')
+    expect(js).toMatch(/applyOuter:\s*\(__es, __seed\) => \{\s*fallback\(\)/)
+    const preambleRerun = /const base = fallback\(\); const label = item\(\)\.title \|\| base;/g
+    expect(js.match(preambleRerun)?.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -5,10 +5,11 @@
 import { type IRNode, type IRElement, type IRComponent, type IRLoop, type IRProp, pickAttrMetaFromIR } from '../types.ts'
 import type { ClientJsContext, ConditionalBranchChildComponent, ConditionalBranchReactiveAttr, BranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildBindings, LoopChildBranchSummary, LoopChildConditional, LoopOffset, NestedLoop } from './types.ts'
 import { attrValueToString, freeIdsFromRefs, quotePropName, PROPS_PARAM } from './utils.ts'
-import { classifyReactivity, decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts, collectLoopChildRefs, emptyLoopChildBindings, buildLoopRowScope } from './reactivity.ts'
+import { classifyReactivity, decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts, collectLoopChildRefs, emptyLoopChildBindings, buildLoopRowScope, anyNameIn } from './reactivity.ts'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr, buildLoopSkeletonTemplate, computeSkeletonSlotPaths, renderFlatMapClientBody, renderFlatMapProjectionClientBody, flatMapCallbackHasKeyedLeaf, type SkeletonSlotPaths } from './html-template.ts'
 import { templateRootIsSvg } from './control-flow/stringify/template-parse.ts'
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling.ts'
+import { extractFreeIdentifiersFromText } from './csr-substitute.ts'
 import { walkIR, stopAt } from './walker.ts'
 import { buildLoopChainExpr } from '../loop-chain.ts'
 import { identifierPattern } from '../identifier-pattern.ts'
@@ -1428,9 +1429,22 @@ export function collectLoopChildConditionals(
       // paying for constant expansion — matches the legacy short-circuit.
       if (!n.reactive && !refsLoopParamInSource) return
       const expanded = expandConstantForReactivity(n.condition, ctx, sourceFreeIds, scope)
+      // A `.map()` callback preamble local (#2596, twin of
+      // `collectLoopChildReactiveAttrs`'s `readsPreamble` #2447). Phase 1
+      // already proved this condition reactive when it's set (`n.reactive`
+      // came from `markPreambleConditionalReactivity`, gated on the local's
+      // OWN initializer reading a signal) — `classifyReactivity` below
+      // cannot independently confirm that: `expandConstantForReactivity`
+      // leaves a preamble-bound identifier like `label` unexpanded on
+      // purpose (the #2482 Stage 1b shadow guard, `scope.isBound`), so the
+      // raw token never string-matches a signal/memo/prop pattern.
+      const readsPreamble =
+        preambleNames !== undefined &&
+        preambleNames.size > 0 &&
+        anyNameIn(expanded.freeIds ?? extractFreeIdentifiersFromText(expanded.expr), preambleNames)
       // Loop-param conditionals are reactive via per-item signal accessors;
       // classifyReactivity sees both paths (signal/memo/prop + loop-param).
-      if (classifyReactivity(expanded.expr, ctx, loopParam, loopParamBindings, expanded.freeIds).kind === 'none') return
+      if (!readsPreamble && classifyReactivity(expanded.expr, ctx, loopParam, loopParamBindings, expanded.freeIds).kind === 'none') return
 
       const loopParamsForCond = loopParam
         ? [{ param: loopParam, bindings: loopParamBindings }]
@@ -1449,6 +1463,7 @@ export function collectLoopChildConditionals(
         whenTrue: summarizeLoopChildBranch(n.whenTrue, ctx, siblingOffsets, loopParam, loopParamBindings, preambleNames, loopIndex),
         whenFalse: summarizeLoopChildBranch(n.whenFalse, ctx, siblingOffsets, loopParam, loopParamBindings, preambleNames, loopIndex),
         ...(expanded.freeIds !== undefined && { conditionFreeIdentifiers: expanded.freeIds }),
+        ...(readsPreamble && { readsPreamble: true }),
       })
     },
   })

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-reactive-effects.ts
@@ -112,6 +112,7 @@ export function buildReactiveEffectsPlan(
         whenFalseTemplateHtml: addCondAttrToTemplate(wrap(cond.whenFalseHtml), cond.slotId),
         whenTrueArm: buildOuterArm(cond.whenTrue, wrap, loopParam, loopParamBindings, profileComponentName),
         whenFalseArm: buildOuterArm(cond.whenFalse, wrap, loopParam, loopParamBindings, profileComponentName),
+        ...(cond.readsPreamble && { readsPreamble: true }),
       })
     }
   }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/reactive-effects.ts
@@ -62,6 +62,13 @@ export interface NestedConditionalPlan {
   whenFalseTemplateHtml: string
   whenTrueArm: LoopChildArmPlan
   whenFalseArm: LoopChildArmPlan
+  /**
+   * `wrappedCondition` reads a `.map()` callback preamble local (#2596,
+   * twin of `ReactiveAttrEffect.readsPreamble`) — the stringifier must run
+   * the row's preamble ahead of evaluating the condition getter passed to
+   * `insert()`; the local isn't otherwise in scope there.
+   */
+  readsPreamble?: boolean
 }
 
 export interface ReactiveEffectsPlan {

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
@@ -140,7 +140,7 @@ export function stringifyReactiveEffects(
   // from the attrs/texts/regions merge above (its own per-branch disposable
   // effects), so it's untouched by row-granularity consolidation.
   for (const cond of conditionals) {
-    emitOuterConditional(lines, indent, elVar, cond, pc)
+    emitOuterConditional(lines, indent, elVar, cond, pc, mapPreambleWrapped)
   }
 }
 
@@ -342,12 +342,22 @@ function emitOuterConditional(
   elVar: string,
   cond: NestedConditionalPlan,
   pc: string | undefined,
+  mapPreambleWrapped: string | undefined,
 ): void {
   const armIndent = `${indent}    `
 
   // Body-form arrows so live `Node` returns from Child-position
   // interpolations route through `__bfSlot` and survive the splice (#1213).
-  lines.push(`${indent}insert(${elVar}, '${cond.slotId}', () => ${cond.wrappedCondition}, {`)
+  // A condition reading a preamble local (#2596) needs the preamble re-run
+  // INSIDE the getter — `insert()` re-invokes this closure on every
+  // dependency change to decide the branch, and the local isn't otherwise in
+  // scope here (it's a plain per-row `const`, not a signal `insert()` can see
+  // through on its own). Same treatment as `readsPreamble` attrs
+  // (`emitAttrUpdate`'s callers) get ahead of their own write.
+  const conditionGetter = cond.readsPreamble && mapPreambleWrapped
+    ? `() => { ${mapPreambleWrapped}; return (${cond.wrappedCondition}) }`
+    : `() => ${cond.wrappedCondition}`
+  lines.push(`${indent}insert(${elVar}, '${cond.slotId}', ${conditionGetter}, {`)
   lines.push(`${indent}  template: () => { const __slots = []; return { html: \`${cond.whenTrueTemplateHtml}\`, slots: __slots } },`)
   lines.push(`${indent}  bindEvents: (__branchScope, { isFirstRun: __bfFirstRun = false } = {}) => {`)
   stringifyLoopChildArm(lines, cond.whenTrueArm, armIndent, pc)

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -671,8 +671,10 @@ export function collectLoopChildReactiveTexts(
  * `loopIndex` (Copilot review on #2595): see `collectLoopChildReactiveTexts`.
  */
 /** Does any name in `names` appear in `set`? Iterates rather than
- *  spreading — this runs per attribute (Copilot review). */
-function anyNameIn(names: Iterable<string>, set: ReadonlySet<string>): boolean {
+ *  spreading — this runs per attribute (Copilot review). Exported for
+ *  `collectLoopChildConditionals`'s `readsPreamble` check (#2596), the
+ *  condition-position twin of the attr check just below this uses it for. */
+export function anyNameIn(names: Iterable<string>, set: ReadonlySet<string>): boolean {
   for (const n of names) if (set.has(n)) return true
   return false
 }

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -578,6 +578,19 @@ export interface LoopChildConditional {
    * constants' own `freeIdentifiers`.
    */
   conditionFreeIdentifiers?: ReadonlySet<string>
+  /**
+   * `condition` reads a `.map()` callback preamble local (#2596, twin of
+   * `LoopChildReactiveAttr.readsPreamble` #2447) — the emitter must run the
+   * preamble ahead of evaluating the condition getter passed to `insert()`,
+   * since the local is not otherwise in scope there and its value is what
+   * makes the condition reactive at all. Set only when Phase 1 already
+   * proved the local reactive (`IRLoop.preamble.reactiveNames` via
+   * `markPreambleConditionalReactivity`) — `classifyReactivity` can't
+   * itself see this: `expandConstantForReactivity`'s shadow guard leaves a
+   * preamble-bound identifier unexpanded on purpose (#2482 Stage 1b), so
+   * the raw token never string-matches a signal/memo/prop pattern.
+   */
+  readsPreamble?: boolean
 }
 
 export interface TopLevelLoop extends LoopCore {

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -579,16 +579,19 @@ export interface LoopChildConditional {
    */
   conditionFreeIdentifiers?: ReadonlySet<string>
   /**
-   * `condition` reads a `.map()` callback preamble local (#2596, twin of
-   * `LoopChildReactiveAttr.readsPreamble` #2447) — the emitter must run the
-   * preamble ahead of evaluating the condition getter passed to `insert()`,
-   * since the local is not otherwise in scope there and its value is what
-   * makes the condition reactive at all. Set only when Phase 1 already
-   * proved the local reactive (`IRLoop.preamble.reactiveNames` via
-   * `markPreambleConditionalReactivity`) — `classifyReactivity` can't
-   * itself see this: `expandConstantForReactivity`'s shadow guard leaves a
-   * preamble-bound identifier unexpanded on purpose (#2482 Stage 1b), so
-   * the raw token never string-matches a signal/memo/prop pattern.
+   * `condition` references a `.map()` callback preamble-declared name
+   * (#2596, twin of `LoopChildReactiveAttr.readsPreamble` #2447) — the
+   * emitter must run the preamble ahead of evaluating the condition getter
+   * passed to `insert()`, since the local is not otherwise in scope there.
+   * Set whenever the condition mentions ANY preamble-declared name
+   * (`preambleNamesOf`), regardless of why the conditional was classified
+   * reactive — the scope obligation is the same either way. Whether the
+   * conditional is wired reactive AT ALL is the separate, stricter Phase-1
+   * question (`IRLoop.preamble.reactiveNames` via
+   * `markPreambleConditionalReactivity`, plus the ordinary signal/prop
+   * classifiers); `classifyReactivity` can't answer it from the token
+   * alone because `expandConstantForReactivity`'s shadow guard leaves a
+   * preamble-bound identifier unexpanded on purpose (#2482 Stage 1b).
    */
   readsPreamble?: boolean
 }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -5021,6 +5021,13 @@ function transformMapCall(
   // the row effect re-runs the preamble ahead of the write.
   if (preamble && !isStaticArray) {
     markPreambleAttrSlots(children, new Set(preamble.declaredNames), ctx)
+    // #2596 follow-up to the two passes above — the CONDITION-position twin.
+    // See `markPreambleConditionalReactivity`'s docstring for why this one is
+    // gated on `reactiveNames` (genuinely signal-derived) rather than the
+    // blanket `declaredNames` the region/attr passes use.
+    if (preamble.reactiveNames && preamble.reactiveNames.length > 0) {
+      markPreambleConditionalReactivity(children, new Set(preamble.reactiveNames), ctx)
+    }
   }
 
   // Collect nested components for both static and dynamic arrays.
@@ -5458,6 +5465,67 @@ function markPreambleAttrSlots(
 }
 
 /**
+ * Grant the IR `reactive` flag (and a slot id) to a loop-body CONDITIONAL
+ * whose condition bare-references a preamble local that is itself reactive
+ * (#2596) — `reactiveNames`, computed by `computePreambleReactiveNames`.
+ *
+ * Root cause this closes: a plain (non-preamble) condition's `reactive` flag
+ * comes from `isReactiveExpression`/`isReactiveOrigin` run against the
+ * condition's OWN text at `transformConditional`/`transformLogicalAnd`/the
+ * if-else-chain builder — none of which know about an enclosing loop's
+ * `.map()` callback preamble (that's assembled and only becomes available
+ * on `IRLoop` after `children` is already built, same ordering constraint
+ * `collectPreambleRegions`/`markPreambleAttrSlots` work around). A condition
+ * that's just a bare reference to a preamble local (`label ? <A/> : <B/>`)
+ * therefore falls through every one of those classifiers with `reactive:
+ * false` even when `label`'s initializer reads a signal — the classifiers
+ * only ever see the token `label`, never its declaration.
+ *
+ * Deliberately narrower than `collectPreambleRegions`/`markPreambleAttrSlots`:
+ * those two mark ANY reference to `declaredNames` because their region-patch
+ * effect re-runs the WHOLE preamble unconditionally on row update, so a
+ * merely item-derived local (`const label = item.title`) still ends up
+ * correctly tracked by ordinary signal auto-tracking inside that effect —
+ * marking it reactive there costs nothing extra. A conditional is different:
+ * `reactive: true` here means Phase 2 wraps it in an `insert()` that swaps
+ * whole DOM subtrees, which is real cost and, for an item-only local, pure
+ * waste — the row already renders fresh whenever it's (re)constructed. So
+ * this only fires for `reactiveNames`, the subset PROVEN to depend on an
+ * actual external signal/memo/prop.
+ *
+ * Mirrors the sibling passes' traversal shape (conditional arms included).
+ */
+function markPreambleConditionalReactivity(
+  nodes: IRNode[],
+  reactiveNames: ReadonlySet<string>,
+  ctx: TransformContext,
+): void {
+  if (reactiveNames.size === 0) return
+  const visit = (list: IRNode[]): void => {
+    for (const node of list) {
+      switch (node.type) {
+        case 'element':
+        case 'fragment':
+          visit(node.children)
+          break
+        case 'conditional': {
+          if (!node.reactive) {
+            const refs = extractFreeIdentifiersFromText(node.condition)
+            if ([...refs].some((r) => reactiveNames.has(r))) {
+              node.reactive = true
+              if (!node.slotId) node.slotId = generateSlotId(ctx)
+            }
+          }
+          visit([node.whenTrue, ...(node.whenFalse ? [node.whenFalse] : [])])
+          break
+        }
+      }
+    }
+  }
+  visit(nodes)
+}
+
+/**
  * Expression-bearing source text of an attribute value, for the
  * free-identifier scan. Only used as a FALLBACK — an attribute normally
  * carries `freeIdentifiers` from its own AST walk, and this reconstruction
@@ -5504,6 +5572,52 @@ function collectPreambleDeclaredNames(stmt: ts.Statement, out: Set<string>): voi
 }
 
 /**
+ * Which {@link MapCallbackPreamble.declaredNames} are themselves reactive —
+ * their OWN initializer reads a signal / memo / reactive prop, directly or
+ * transitively through an earlier declaration in the same preamble (#2596).
+ *
+ * Reuses the same Phase-1 classifier (`isReactiveExpression`) already applied
+ * to every non-preamble condition/attribute — this doesn't invent a second
+ * reactivity heuristic, it runs the existing one over one more declaration
+ * list. `ctx.patterns.constants` (the component-level constant chain
+ * `isSignalOrMemoReference`/`isPropsReference` already walk) doesn't reach
+ * these names — they're scoped to the `.map()` callback body, never added to
+ * `ctx.patterns` — so without this pass a preamble local reading a signal is
+ * invisible to the classifier.
+ *
+ * Value-declaration statements only (`const`/`let x = expr`, including
+ * destructuring targets, which mark every bound name reactive together since
+ * they share one initializer). A non-declaration preamble statement
+ * (assignment, loop, side-effecting call) contributes no reactive names —
+ * consistent with `neutralPreambleDeclarations`'s all-or-nothing DSL gate
+ * treating anything past that as un-lowerable, though this walk (client/JS-
+ * runtime SSR only) doesn't require the same all-or-nothing: it simply skips
+ * what it can't classify.
+ */
+function computePreambleReactiveNames(
+  statements: readonly ts.Statement[],
+  ctx: TransformContext,
+): Set<string> {
+  const reactiveNames = new Set<string>()
+  for (const stmt of statements) {
+    if (!ts.isVariableStatement(stmt)) continue
+    for (const decl of stmt.declarationList.declarations) {
+      if (!decl.initializer) continue
+      const boundNames = new Set<string>()
+      collectBindingNames(decl.name, boundNames)
+      const initText = ctx.getJS(decl.initializer)
+      const initFreeRefs = extractFreeIdentifiersFromNode(decl.initializer)
+      const readsEarlierReactive = [...initFreeRefs].some((r) => reactiveNames.has(r))
+      const isReactive = readsEarlierReactive || isReactiveExpression(initText, ctx, decl.initializer)
+      if (isReactive) {
+        for (const n of boundNames) reactiveNames.add(n)
+      }
+    }
+  }
+  return reactiveNames
+}
+
+/**
  * Build a {@link MapCallbackPreamble} from value-only (JSX-free) pre-return
  * statements — the Stage-2 fold preamble and the plain block-body preamble.
  * One `js` segment per statement, semicolon-normalized and space-joined
@@ -5526,6 +5640,7 @@ function preambleFromValueStatements(
     typedParts.push(raw0.endsWith(';') ? raw0 : raw0 + ';')
     segments.push(tjs !== js ? { kind: 'js', text: js, templateText: tjs } : { kind: 'js', text: js })
   }
+  const reactiveNames = computePreambleReactiveNames(statements, ctx)
   return {
     segments: trimPreambleSegments(segments),
     ssrText: tsxSourceText(typedParts.join(' ')),
@@ -5533,6 +5648,7 @@ function preambleFromValueStatements(
     // Value-only preambles accumulate no JSX, so no child needs the array join.
     builderNames: [],
     declarations: neutralPreambleDeclarations(statements, ctx) ?? undefined,
+    reactiveNames: reactiveNames.size > 0 ? [...reactiveNames] : undefined,
   }
 }
 

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -901,6 +901,28 @@ export interface MapCallbackPreamble {
    * keeps the plain interpolation it always had.
    */
   builderNames: string[]
+  /**
+   * The subset of {@link declaredNames} whose OWN initializer is itself
+   * reactive — reads a signal / memo / reactive prop, directly or
+   * transitively through an earlier preamble declaration (#2596). `undefined`
+   * (never an empty array) when the preamble contributes no such name, or
+   * when it isn't a value-only declaration sequence this analysis covers
+   * (see `preambleFromValueStatements`'s caller — a JSX-building preamble
+   * doesn't compute this and leaves it unset).
+   *
+   * Used to decide whether a loop-body CONDITIONAL whose condition
+   * bare-references a preamble local should carry the IR `reactive` flag
+   * (`markPreambleConditionalReactivity`, jsx-to-ir.ts). Deliberately NOT the
+   * same test `collectPreambleRegions`/`markPreambleAttrSlots` use for
+   * text/attr positions — those mark ANY reference to `declaredNames`
+   * reactive because their region-patch effect re-runs the whole preamble
+   * unconditionally on row update, and ordinary signal auto-tracking inside
+   * that effect picks up genuine dependencies regardless of the IR flag. A
+   * conditional instead swaps whole DOM subtrees via `insert()`, so it stays
+   * unwrapped unless the local it reads is proven to depend on an actual
+   * external signal — a bare `item.title`-derived local needs no such wrap.
+   */
+  reactiveNames?: string[]
 }
 
 /**

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 310,
+    "totalFixtures": 311,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 202,
+      "total": 203,
       "cells": {
         "hono": {
-          "pass": 201,
-          "total": 202,
+          "pass": 202,
+          "total": 203,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1433,8 +1433,8 @@
           ]
         },
         "blade": {
-          "pass": 187,
-          "total": 202,
+          "pass": 188,
+          "total": 203,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1509,8 +1509,8 @@
           ]
         },
         "erb": {
-          "pass": 188,
-          "total": 202,
+          "pass": 189,
+          "total": 203,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1579,8 +1579,8 @@
           ]
         },
         "go-template": {
-          "pass": 187,
-          "total": 202,
+          "pass": 188,
+          "total": 203,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1655,8 +1655,8 @@
           ]
         },
         "jinja": {
-          "pass": 187,
-          "total": 202,
+          "pass": 188,
+          "total": 203,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1731,8 +1731,8 @@
           ]
         },
         "minijinja": {
-          "pass": 187,
-          "total": 202,
+          "pass": 188,
+          "total": 203,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1807,8 +1807,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 188,
-          "total": 202,
+          "pass": 189,
+          "total": 203,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1877,8 +1877,8 @@
           ]
         },
         "twig": {
-          "pass": 187,
-          "total": 202,
+          "pass": 188,
+          "total": 203,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1953,8 +1953,8 @@
           ]
         },
         "xslate": {
-          "pass": 187,
-          "total": 202,
+          "pass": 188,
+          "total": 203,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2174,11 +2174,11 @@
       }
     },
     "identifier": {
-      "total": 291,
+      "total": 292,
       "cells": {
         "hono": {
-          "pass": 290,
-          "total": 291,
+          "pass": 291,
+          "total": 292,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2189,8 +2189,8 @@
           ]
         },
         "blade": {
-          "pass": 274,
-          "total": 291,
+          "pass": 275,
+          "total": 292,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2273,8 +2273,8 @@
           ]
         },
         "erb": {
-          "pass": 275,
-          "total": 291,
+          "pass": 276,
+          "total": 292,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2351,8 +2351,8 @@
           ]
         },
         "go-template": {
-          "pass": 274,
-          "total": 291,
+          "pass": 275,
+          "total": 292,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2435,8 +2435,8 @@
           ]
         },
         "jinja": {
-          "pass": 274,
-          "total": 291,
+          "pass": 275,
+          "total": 292,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2519,8 +2519,8 @@
           ]
         },
         "minijinja": {
-          "pass": 274,
-          "total": 291,
+          "pass": 275,
+          "total": 292,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2603,8 +2603,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 275,
-          "total": 291,
+          "pass": 276,
+          "total": 292,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2681,8 +2681,8 @@
           ]
         },
         "twig": {
-          "pass": 274,
-          "total": 291,
+          "pass": 275,
+          "total": 292,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2765,8 +2765,8 @@
           ]
         },
         "xslate": {
-          "pass": 274,
-          "total": 291,
+          "pass": 275,
+          "total": 292,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3350,15 +3350,15 @@
       }
     },
     "logical": {
-      "total": 43,
+      "total": 44,
       "cells": {
         "hono": {
-          "pass": 43,
-          "total": 43
+          "pass": 44,
+          "total": 44
         },
         "blade": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3373,8 +3373,8 @@
           ]
         },
         "erb": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3389,8 +3389,8 @@
           ]
         },
         "go-template": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3405,8 +3405,8 @@
           ]
         },
         "jinja": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3421,8 +3421,8 @@
           ]
         },
         "minijinja": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3437,8 +3437,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3453,8 +3453,8 @@
           ]
         },
         "twig": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3469,8 +3469,8 @@
           ]
         },
         "xslate": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3491,18 +3491,18 @@
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L172"
       },
       "example": {
-        "fixture": "logical-and-chain",
-        "description": "Chained a() && b() && <element/> conditional",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/logical-and-chain.ts",
-        "code": "ready() && visible()"
+        "fixture": "loop-preamble-conditional-reactive",
+        "description": "Loop row preamble computes a conditional-condition value from item + prop",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/loop-preamble-conditional-reactive.ts",
+        "code": "row.done || props.highlight"
       }
     },
     "member": {
-      "total": 155,
+      "total": 156,
       "cells": {
         "hono": {
-          "pass": 154,
-          "total": 155,
+          "pass": 155,
+          "total": 156,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3513,8 +3513,8 @@
           ]
         },
         "blade": {
-          "pass": 138,
-          "total": 155,
+          "pass": 139,
+          "total": 156,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3597,8 +3597,8 @@
           ]
         },
         "erb": {
-          "pass": 139,
-          "total": 155,
+          "pass": 140,
+          "total": 156,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3675,8 +3675,8 @@
           ]
         },
         "go-template": {
-          "pass": 138,
-          "total": 155,
+          "pass": 139,
+          "total": 156,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3759,8 +3759,8 @@
           ]
         },
         "jinja": {
-          "pass": 138,
-          "total": 155,
+          "pass": 139,
+          "total": 156,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3843,8 +3843,8 @@
           ]
         },
         "minijinja": {
-          "pass": 138,
-          "total": 155,
+          "pass": 139,
+          "total": 156,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3927,8 +3927,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 139,
-          "total": 155,
+          "pass": 140,
+          "total": 156,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4005,8 +4005,8 @@
           ]
         },
         "twig": {
-          "pass": 138,
-          "total": 155,
+          "pass": 139,
+          "total": 156,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4089,8 +4089,8 @@
           ]
         },
         "xslate": {
-          "pass": 138,
-          "total": 155,
+          "pass": 139,
+          "total": 156,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -8203,43 +8203,43 @@
       }
     },
     "logical:||": {
-      "total": 13,
+      "total": 14,
       "cells": {
         "hono": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         },
         "blade": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         },
         "erb": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         },
         "go-template": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         },
         "jinja": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         },
         "minijinja": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         },
         "mojolicious": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         },
         "twig": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         },
         "xslate": {
-          "pass": 13,
-          "total": 13
+          "pass": 14,
+          "total": 14
         }
       },
       "source": {
@@ -8248,10 +8248,10 @@
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L86"
       },
       "example": {
-        "fixture": "array-sort-multikey",
-        "description": ".sort((a,b) => a.price - b.price || a.name.localeCompare(b.name)) sorts by price, then name",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/methods/array-sort-multikey.ts",
-        "code": "a.price - b.price || a.name.localeCompare(b.name)"
+        "fixture": "loop-preamble-conditional-reactive",
+        "description": "Loop row preamble computes a conditional-condition value from item + prop",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/loop-preamble-conditional-reactive.ts",
+        "code": "row.done || props.highlight"
       }
     },
     "member:computed": {


### PR DESCRIPTION
## Summary

Inside a `.map()` callback, a conditional whose condition references a **preamble-declared local** (`const label = item.title || fallback()`) never got its IR `reactive` flag set — the branch never re-evaluated when the signal feeding the local changed. Found during #2482 Stage 1b (PR #2595); specified in #2596.

## The fix — two chokepoints, one per phase

**Phase 1 (`jsx-to-ir.ts`)**: conditionals are classified at construction time, but the `MapCallbackPreamble` isn't assembled until after `children` is built — the same ordering constraint #2447's region/attr passes work around post-hoc. Two new passes in that mold:
- `computePreambleReactiveNames` — re-runs the existing `isReactiveExpression` classifier over each preamble declaration's initializer, **transitively** (a local reading an earlier reactive local is reactive), stored as `MapCallbackPreamble.reactiveNames`.
- `markPreambleConditionalReactivity` — grants `reactive` + a slot id to a loop-body conditional whose condition reads a name in `reactiveNames`. Deliberately gated on *proven-signal-derived* names (unlike the region/attr passes' blanket check): a conditional wrap via `insert()` is real cost, so it's reserved for locals actually depending on an external signal/memo/prop — the reasoning is in the code comments.

**Phase 2 (`ir-to-client-js/collect-elements.ts`)**: not sufficient alone — `collectLoopChildConditionals` independently re-derives reactivity from the condition's expanded text, and Stage 1b's shadow guard (correctly) leaves a preamble-bound identifier unexpanded, so `classifyReactivity('label')` read `'none'` and dropped the conditional regardless of the Phase-1 flag. The condition path now gets the same `readsPreamble` bypass + re-run-in-getter treatment `collectLoopChildReactiveAttrs` already had for attributes (#2447) — the condition-position twin. One chokepoint, benefiting both downstream plans (eager `mapArray`+`insert()` and lazy `mapArrayLazy`).

Nothing here touches the deferred `isSignalOrMemoReference`/`isPropsReference` guard work from PR #2590 — different classifier concern.

## Tests (fix + fixture together)

- `preamble-conditional-reactivity.test.ts`: red-without/green-with verified by stash-revert (3/4 fail without the fix; the negative case passes either way). Covers: the issue's shape, the **negative** (`const label = item.title`, no signal — stays non-reactive, pinned as no-`insert(`), the **transitive** chain, and both Phase-2 plan shapes (lazy wiring-free arms; eager reactive-branch).
- New conformance fixture `loop-preamble-conditional-reactive` (SSR + CSR). It uses a prop as the external reactive input to sidestep a separate pre-existing gap (the CSR materialize template splices preamble-embedded signal calls verbatim — probed, exists on main for plain preamble reads too, not introduced here). `expectedHtml` auto-generated from the Hono reference and matches the hand-derived expectation.
- `csr-materialize-loop-preamble-shadow.test.ts`: one assertion updated — its repro (`item.active && on()`) genuinely reads a signal, so it now correctly gets `bf-c` slot markers on both arms; that's the fix working, explained in the test comment.

## Verification

- `packages/jsx` **3036 / 0 fail**, `packages/adapter-tests` **1897 / 0 fail**, `packages/adapter-hono` **1376 / 0 fail**.
- `coverage-map.json` regenerated (new fixture entry + aggregates only). No other fixture/snapshot movement.
- Changeset: `@barefootjs/jsx` patch.

Closes #2596

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_