### PR TITLE
investigate(benchmarks): hono/jsx render-cost profile + cross-adapter SSR comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,17 @@ Gemfile.lock
 benchmarks/results/
 benchmarks/**/.babel-out*/
 benchmarks/ssr/apps/*/.build-temp/
+
+# SSR render-gap investigation cross-adapter benches: per-run output
+# (timings.json / one.html / cpu.prof), the Go bench binary, and the
+# CPU-profile dumps profile-hono-render.ts produces — all regenerable,
+# some multi-MB.
+benchmarks/ssr/apps/barefoot/*.cpuprofile*
+benchmarks/ssr/apps/barefoot/hono-timings.json
+benchmarks/ssr/apps/barefoot/one.html
+benchmarks/ssr/apps/barefoot/go-render-bench/ssr-bench-go
+benchmarks/ssr/apps/barefoot/go-render-bench/timings.json
+benchmarks/ssr/apps/barefoot/go-render-bench/one.html
+benchmarks/ssr/apps/barefoot/go-render-bench/cpu.prof
+benchmarks/ssr/apps/barefoot/twig-render-bench/timings.json
+benchmarks/ssr/apps/barefoot/twig-render-bench/one.html

--- a/benchmarks/ssr/apps/barefoot/analyze-profile.py
+++ b/benchmarks/ssr/apps/barefoot/analyze-profile.py
@@ -1,0 +1,88 @@
+"""
+SSR render-gap investigation, item 1 (where does hono/jsx's per-request
+render time go?) -- NOT part of the product.
+
+Parses the `--cpu-prof-md` markdown dump `profile-hono-render.ts` produces
+(Bun's real JavaScriptCore sampling CPU profiler, not hand-rolled
+instrumentation) and buckets its "Hot Functions (Self Time)" table into
+named categories (hono's JSXNode tree-walk, native Object.entries(), the
+escape pass, the compiled component body, etc.), separating one-time
+compile/import cost (paid once before the measured loop, in the same
+process) from the per-render-loop steady-state total.
+
+Usage:
+    bun --cpu-prof --cpu-prof-md --cpu-prof-name=hono-render.cpuprofile.md \\
+      benchmarks/ssr/apps/barefoot/profile-hono-render.ts
+    python3 benchmarks/ssr/apps/barefoot/analyze-profile.py \\
+      benchmarks/ssr/apps/barefoot/hono-render.cpuprofile.md.md
+
+The .md profile itself is a multi-MB generated artifact -- regenerate it
+locally rather than expecting it committed.
+"""
+import re
+import sys
+from collections import defaultdict
+
+path = sys.argv[1] if len(sys.argv) > 1 else "hono-render.cpuprofile.md.md"
+totals = defaultdict(float)
+with open(path, encoding="utf-8") as f:
+    lines = f.readlines()
+
+start = next(i for i, l in enumerate(lines) if l.startswith("## Hot Functions (Self Time)"))
+end = next(i for i, l in enumerate(lines) if l.startswith("## Call Tree"))
+section = lines[start:end]
+
+for line in section:
+    m = re.match(
+        r"\|\s*([\d.]+)% \| ([\d.]+)(m?s) \| ([\d.]+)% \| ([\d.]+)(m?s) \| `([^`]*)` \| `([^`]*)`",
+        line,
+    )
+    if m:
+        self_pct, self_val, self_unit, tot_pct, tot_val, tot_unit, fn, loc = m.groups()
+        self_ms = float(self_val) * (1000 if self_unit == "s" else 1)
+        totals[(fn, loc.split(":")[0])] += self_ms
+
+ONE_TIME_NATIVE = {"resolve", "statSync", "readFileSync", "parseModule", "moduleDeclarationInstantiation", "join"}
+
+per_render = defaultdict(float)
+one_time = 0.0
+for (fn, loc), ms in totals.items():
+    if "typescript.js" in loc:
+        one_time += ms
+    elif loc == "[native code]" and fn in ONE_TIME_NATIVE:
+        one_time += ms
+    else:
+        per_render[(fn, loc)] += ms
+
+pr_total = sum(per_render.values())
+print(f"per-render-loop total self time: {pr_total:.1f}ms   (one-time compile/import: {one_time:.1f}ms)")
+print()
+buckets = defaultdict(float)
+for (fn, loc), ms in per_render.items():
+    if "hono/dist/jsx/base.js" in loc and fn in ("toStringToBuffer", "childrenToStringToBuffer", "JSXNode", "JSXFunctionNode"):
+        buckets["hono toStringToBuffer + childrenToStringToBuffer + JSXNode ctor"] += ms
+    elif fn == "jsxFn":
+        buckets["hono jsxFn (element factory / jsx() call)"] += ms
+    elif "hono/dist/jsx/utils.js" in loc:
+        buckets["hono normalizeIntrinsicElementKey / isValidAttributeName"] += ms
+    elif "hono/dist/utils/html.js" in loc:
+        buckets["hono escapeToBuffer + raw()"] += ms
+    elif fn == "entries" and loc == "[native code]":
+        buckets["native Object.entries() (called from toStringToBuffer attr loop)"] += ms
+    elif fn == "search" and loc == "[native code]":
+        buckets["native String.search (escapeToBuffer's regex probe)"] += ms
+    elif loc == "[native code]" and fn == "/[&<>'\"]/":
+        buckets["native regex literal (escapeToBuffer's escapeRe)"] += ms
+    elif "jsx-dev-runtime" in loc:
+        buckets["hono jsxDEV shim"] += ms
+    elif "profile-compiled" in loc:
+        buckets["compiled BenchSsr body (row .map, JSON.stringify, className calc)"] += ms
+    elif fn == "stringify":
+        buckets["native JSON.stringify (bf-p props payload)"] += ms
+    elif fn == "map" and loc == "[native code]":
+        buckets["native Array.prototype.map (row iteration)"] += ms
+    else:
+        buckets[f"other: {fn} ({loc})"] += ms
+
+for k, v in sorted(buckets.items(), key=lambda x: -x[1]):
+    print(f"{k:70s} {v:9.1f}ms  {100*v/pr_total:5.1f}%")

--- a/benchmarks/ssr/apps/barefoot/go-render-bench/dump-template.ts
+++ b/benchmarks/ssr/apps/barefoot/go-render-bench/dump-template.ts
@@ -1,0 +1,43 @@
+/**
+ * SSR render-gap investigation, item 4 (provenance for the Go bench):
+ * regenerates dumped-template.tmpl / dumped-types.go — the VERBATIM output
+ * of GoTemplateAdapter compiling ../components/BenchSsr.tsx, dumped for
+ * reference. Standalone script, not part of the product.
+ *
+ * Usage (run once `bun benchmarks/ssr/apps/barefoot/build.ts` has created
+ * this app's node_modules/@barefootjs/* symlinks — see that file's
+ * ensureWorkspaceLinks docstring):
+ *
+ *   bun benchmarks/ssr/apps/barefoot/go-render-bench/dump-template.ts
+ *
+ * `main.go` / `types.go` in this directory are hand-adjusted copies of
+ * this dump (package renamed `main`, the redundant `math/rand` import
+ * stripped since main.go defines its own `randomID`) wired to Go's real
+ * production entry point (`bf.Renderer.RenderFragment`, not the bare
+ * `tmpl.ExecuteTemplate` the adapter-conformance harness uses) — re-diff
+ * against a fresh dump here after any GoTemplateAdapter change that
+ * touches this component shape.
+ */
+import { compileJSX } from '@barefootjs/jsx'
+import { GoTemplateAdapter } from '../../../../../packages/adapter-go-template/src/adapter/index.ts'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const OUT_DIR = import.meta.dirname
+const source = readFileSync(join(OUT_DIR, '..', 'components', 'BenchSsr.tsx'), 'utf8')
+
+const adapter = new GoTemplateAdapter()
+const result = compileJSX(source, 'BenchSsr.tsx', { adapter, outputIR: true })
+const errors = result.errors.filter((e) => e.severity === 'error')
+if (errors.length) {
+  console.error(errors)
+  process.exit(1)
+}
+const template = result.files.find((f) => f.type === 'markedTemplate')!
+const irFile = result.files.find((f) => f.type === 'ir')!
+const ir = JSON.parse(irFile.content)
+const types = adapter.generateTypes!(ir)!
+
+await Bun.write(join(OUT_DIR, 'dumped-template.tmpl'), template.content)
+await Bun.write(join(OUT_DIR, 'dumped-types.go'), types)
+console.log('wrote', template.content.length, 'bytes template,', types.length, 'bytes types')

--- a/benchmarks/ssr/apps/barefoot/go-render-bench/go.mod
+++ b/benchmarks/ssr/apps/barefoot/go-render-bench/go.mod
@@ -1,0 +1,7 @@
+module ssr-bench-go
+
+go 1.25.6
+
+require github.com/barefootjs/runtime/bf v0.0.0
+
+replace github.com/barefootjs/runtime/bf => ../../../../../packages/adapter-go-template/runtime

--- a/benchmarks/ssr/apps/barefoot/go-render-bench/main.go
+++ b/benchmarks/ssr/apps/barefoot/go-render-bench/main.go
@@ -1,0 +1,121 @@
+// SSR render-gap investigation, item 4: is Hono the slow adapter among
+// barefoot's own backends, or does the JS-tree-walking cost that
+// hono/jsx pays disappear once the compiled *text/template* is executed
+// by Go's html/template package instead? Standalone script, not part of
+// the product.
+//
+// Loads the SAME fixed 1,000-row dataset (../../../data.json) the Hono /
+// React / Solid benches use, parses the marked template ONCE (mirrors a
+// real Go server: `html/template.Parse` runs at startup, not per
+// request), then times `bf.Renderer.RenderFragment` — the real production
+// entry point (BfIsRoot wiring, bf-p JSON marshal, script/portal
+// collectors) — in a tight WARMUP+MEASURE loop, the Go analogue of
+// bench-ssr.ts's measureServerRender. Writes one JSON array of per-call
+// elapsed milliseconds to timings.json so the caller can compute stats
+// the same way the JS harnesses do (median of N, see runner/stats.ts).
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"math/rand"
+	"os"
+	"runtime/pprof"
+	"strings"
+	"time"
+
+	bf "github.com/barefootjs/runtime/bf"
+)
+
+var _ = bf.FuncMap
+
+// randomID generates a random alphanumeric string of given length.
+// Required by generated NewXxxProps constructors.
+func randomID(n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+const tmplContent = `{{define "BenchSsr"}}
+{{if .Scripts}}{{.Scripts.Register "/static/client/barefoot.js"}}{{.Scripts.Register "/static/client/BenchSsr.client.js"}}{{end}}
+<table class="table" bf-s="{{bfScopeAttr .}}" {{bfHydrationAttrs .}} {{bfPropsAttr .}}{{if .BfDataKey}} data-key="{{.BfDataKey}}"{{end}}><tbody id="tbody" bf="s4">{{bfComment "loop:l0"}}{{range $_, $row := .InitialRows}}<tr data-key="{{.ID}}" class="{{if eq $.Selected .ID}}danger{{else}}{{end}}" bf="s3"><td class="col-md-1">{{bfTextStart "s0"}}{{.ID}}{{bfTextEnd}}</td><td class="col-md-4"><a class="lbl" bf="s2">{{bfTextStart "s1"}}{{.Label}}{{bfTextEnd}}</a></td><td class="col-md-1"><a class="remove">x</a></td><td class="col-md-6"></td></tr>{{end}}{{bfComment "/loop:l0"}}</tbody></table>
+{{end}}
+`
+
+func main() {
+	data, err := os.ReadFile("../../../data.json")
+	if err != nil {
+		panic(err)
+	}
+	var rows []RowData
+	if err := json.Unmarshal(data, &rows); err != nil {
+		panic(err)
+	}
+
+	root := template.New("").Funcs(bf.FuncMap())
+	root = root.Funcs(bf.TemplateFuncMap(root))
+	tmpl := template.Must(root.Parse(tmplContent))
+	renderer := bf.NewRenderer(tmpl, nil)
+
+	// render runs the SAME production entry point a real Go app uses for a
+	// standalone island (bf.Renderer.RenderFragment): reflection-based
+	// BfIsRoot/Scripts wiring + BfPropsAttr's json.Marshal(props) for bf-p,
+	// exactly like Render — not the bare tmpl.ExecuteTemplate the adapter
+	// conformance harness (test-render.ts) uses, which SKIPS that wiring and
+	// so under-counts real per-request cost. Fresh props + collectors each
+	// call, mirroring one HTTP request.
+	render := func() template.HTML {
+		props := NewBenchSsrProps(BenchSsrInput{
+			ScopeID:     "BenchSsr_bench",
+			InitialRows: rows,
+		})
+		sc := bf.NewScriptCollector()
+		pc := bf.NewPortalCollector()
+		return renderer.RenderFragment(bf.RenderOptions{
+			ComponentName: "BenchSsr",
+			Props:         &props,
+		}, sc, pc)
+	}
+
+	one := render()
+	if err := os.WriteFile("one.html", []byte(one), 0o644); err != nil {
+		panic(err)
+	}
+	fmt.Printf("rows(<tr): %d, bytes: %d, has bf-p: %v\n",
+		strings.Count(string(one), "<tr"), len(one), strings.Contains(string(one), "bf-p"))
+
+	const warmup = 50
+	const measure = 2000
+
+	for i := 0; i < warmup; i++ {
+		_ = render()
+	}
+
+	profFile, err := os.Create("cpu.prof")
+	if err != nil {
+		panic(err)
+	}
+	defer profFile.Close()
+	if err := pprof.StartCPUProfile(profFile); err != nil {
+		panic(err)
+	}
+
+	iterations := make([]float64, measure)
+	for i := 0; i < measure; i++ {
+		t0 := time.Now()
+		_ = render()
+		iterations[i] = time.Since(t0).Seconds() * 1000 // ms
+	}
+	pprof.StopCPUProfile()
+
+	out, _ := json.Marshal(iterations)
+	if err := os.WriteFile("timings.json", out, 0o644); err != nil {
+		panic(err)
+	}
+	fmt.Println("wrote timings.json")
+}

--- a/benchmarks/ssr/apps/barefoot/go-render-bench/types.go
+++ b/benchmarks/ssr/apps/barefoot/go-render-bench/types.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	bf "github.com/barefootjs/runtime/bf"
+)
+
+// RowData represents a rowdata.
+type RowData struct {
+	ID int `json:"id"`
+	Label string `json:"label"`
+}
+
+// BenchSsrInput is the user-facing input type.
+type BenchSsrInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+	InitialRows []RowData
+}
+
+// BenchSsrProps is the props type for the BenchSsr component.
+type BenchSsrProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	InitialRows []RowData `json:"initialRows"`
+	Selected int `json:"selected"`
+}
+
+// NewBenchSsrProps creates BenchSsrProps from BenchSsrInput.
+func NewBenchSsrProps(in BenchSsrInput) BenchSsrProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "BenchSsr_" + randomID(6)
+	}
+
+	return BenchSsrProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		InitialRows: in.InitialRows,
+		Selected: 0,
+	}
+}

--- a/benchmarks/ssr/apps/barefoot/measure-hono-timings.ts
+++ b/benchmarks/ssr/apps/barefoot/measure-hono-timings.ts
@@ -1,0 +1,74 @@
+/**
+ * SSR render-gap investigation, item 4 (cross-adapter comparison):
+ * Hono's half of the WARMUP=50 / MEASURE=2000 methodology also used by
+ * go-render-bench/main.go and twig-render-bench/bench.php, so the three
+ * adapters' numbers are comparable apples-to-apples (same dataset, same
+ * warmup depth, same iteration count, same "one long-lived process,
+ * discard-and-retime" shape). Standalone script, not part of the product.
+ *
+ * Writes hono-timings.json (a JSON array of per-call elapsed ms, same
+ * shape as the Go/PHP benches' timings.json) plus a one.html sample for
+ * the row-count/byte-size parity check documented in the investigation
+ * writeup.
+ */
+import { compileJSX } from '@barefootjs/jsx'
+import { HonoAdapter } from '@barefootjs/hono/adapter'
+import { renderToHtml } from '@barefootjs/hono/render'
+import { readFileSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+
+const APP_DIR = import.meta.dirname
+const COMPONENT_SRC = join(APP_DIR, 'components', 'BenchSsr.tsx')
+const rows = (await import(join(APP_DIR, '..', '..', 'data.json'))).default as Array<{
+  id: number
+  label: string
+}>
+
+async function main() {
+  const source = readFileSync(COMPONENT_SRC, 'utf8')
+  const result = compileJSX(source, 'BenchSsr.tsx', { adapter: new HonoAdapter() })
+  const errors = result.errors.filter((e) => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`BenchSsr compile errors:\n${errors.map((e) => e.message).join('\n')}`)
+  }
+  const markedTemplate = result.files.find((f) => f.type === 'markedTemplate')
+  if (!markedTemplate) throw new Error('No marked template in BenchSsr compile output')
+
+  const tempFile = join(APP_DIR, `.measure-compiled-${Date.now()}.tsx`)
+  const code = `/** @jsxImportSource hono/jsx */\n${markedTemplate.content}`
+  await Bun.write(tempFile, code)
+  let component: (props: { initialRows: unknown; __instanceId: string; __bfChild: boolean }) => unknown
+  try {
+    const mod = await import(tempFile)
+    component = mod.BenchSsr
+  } finally {
+    unlinkSync(tempFile)
+  }
+
+  const render = async () => {
+    const node = component({ initialRows: rows, __instanceId: 'BenchSsr_bench', __bfChild: false })
+    return renderToHtml(node)
+  }
+
+  const one = await render()
+  await Bun.write(join(APP_DIR, 'one.html'), one)
+  const rowCount = (one.match(/<tr/g) ?? []).length
+  console.log(`rows(<tr): ${rowCount}, bytes: ${one.length}, has bf-p: ${one.includes('bf-p')}`)
+
+  const WARMUP = 50
+  const MEASURE = 2000
+
+  for (let i = 0; i < WARMUP; i++) await render()
+
+  const iterations: number[] = []
+  for (let i = 0; i < MEASURE; i++) {
+    const t0 = performance.now()
+    await render()
+    iterations.push(performance.now() - t0)
+  }
+
+  await Bun.write(join(APP_DIR, 'hono-timings.json'), JSON.stringify(iterations))
+  console.log('wrote hono-timings.json')
+}
+
+await main()

--- a/benchmarks/ssr/apps/barefoot/profile-hono-render.ts
+++ b/benchmarks/ssr/apps/barefoot/profile-hono-render.ts
@@ -1,0 +1,76 @@
+/**
+ * SSR render-gap investigation, Part C (this file's question: PRECISELY
+ * where inside hono/jsx does the ~5ms/1000-row cost go?). Standalone
+ * script, not part of the product — run under Bun's built-in sampling CPU
+ * profiler (`--cpu-prof --cpu-prof-md`, JavaScriptCore's real sampler, not
+ * hand-rolled instrumentation) so the breakdown reflects actual wall time,
+ * not a guess from reading the source.
+ *
+ * Renders the same fixed 1,000-row dataset (../../data.json) through the
+ * real `compileJSX` + `HonoAdapter` + `renderToHtml` path (same compiled
+ * component as lib/render-server.ts) MEASURE times in a tight loop so the
+ * profiler's 1ms sampling interval collects enough samples in hono/jsx's
+ * hot functions to resolve a percentage breakdown.
+ *
+ * Usage:
+ *   bun --cpu-prof --cpu-prof-md --cpu-prof-name=hono-render.cpuprofile.md \
+ *     benchmarks/ssr/apps/barefoot/profile-hono-render.ts
+ *
+ * The .md profile groups self-time by function; see the investigation
+ * writeup for the extracted top-function table and file:line mapping into
+ * hono's dist source (node_modules/.bun/hono@<version>/node_modules/hono).
+ */
+import { compileJSX } from '@barefootjs/jsx'
+import { HonoAdapter } from '@barefootjs/hono/adapter'
+import { renderToHtml } from '@barefootjs/hono/render'
+import { readFileSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+
+const APP_DIR = import.meta.dirname
+const COMPONENT_SRC = join(APP_DIR, 'components', 'BenchSsr.tsx')
+const rows = (await import(join(APP_DIR, '..', '..', 'data.json'))).default as Array<{
+  id: number
+  label: string
+}>
+
+async function main() {
+  const source = readFileSync(COMPONENT_SRC, 'utf8')
+  const result = compileJSX(source, 'BenchSsr.tsx', { adapter: new HonoAdapter() })
+  const errors = result.errors.filter((e) => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`BenchSsr compile errors:\n${errors.map((e) => e.message).join('\n')}`)
+  }
+  const markedTemplate = result.files.find((f) => f.type === 'markedTemplate')
+  if (!markedTemplate) throw new Error('No marked template in BenchSsr compile output')
+
+  const tempFile = join(APP_DIR, `.profile-compiled-${Date.now()}.tsx`)
+  const code = `/** @jsxImportSource hono/jsx */\n${markedTemplate.content}`
+  await Bun.write(tempFile, code)
+  let component: (props: { initialRows: unknown; __instanceId: string; __bfChild: boolean }) => unknown
+  try {
+    const mod = await import(tempFile)
+    component = mod.BenchSsr
+  } finally {
+    unlinkSync(tempFile)
+  }
+
+  const WARMUP = 50
+  const MEASURE = 2000
+
+  for (let i = 0; i < WARMUP; i++) {
+    const node = component({ initialRows: rows, __instanceId: 'BenchSsr_bench', __bfChild: false })
+    await renderToHtml(node)
+  }
+
+  const t0 = performance.now()
+  for (let i = 0; i < MEASURE; i++) {
+    const node = component({ initialRows: rows, __instanceId: 'BenchSsr_bench', __bfChild: false })
+    await renderToHtml(node)
+  }
+  const elapsed = performance.now() - t0
+  console.log(
+    `profiled ${MEASURE} renders in ${elapsed.toFixed(1)}ms (${(elapsed / MEASURE).toFixed(3)}ms/render)`,
+  )
+}
+
+await main()

--- a/benchmarks/ssr/apps/barefoot/twig-render-bench/bench.php
+++ b/benchmarks/ssr/apps/barefoot/twig-render-bench/bench.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * SSR render-gap investigation, item 4: does a compile-to-real-PHP-code
+ * template engine (Twig, via twig/twig's PHP-class compiler) pay the same
+ * per-request "walk an interpreted tree" tax hono/jsx and Go's
+ * html/template do, or does it look more like solid's precompiled-chunk
+ * approach? Standalone script, not part of the product.
+ *
+ * Loads the SAME fixed 1,000-row dataset (../../data.json) the other SSR
+ * benches use, builds ONE Twig\Environment (bench_ssr.twig, sitting next
+ * to this script, dumped from the real TwigAdapter's compile of
+ * ../components/BenchSsr.tsx via packages/adapter-twig/dump-bench.ts) —
+ * `$env->load()` compiles the template to a PHP class on first use and
+ * Twig's Environment caches that compiled class in memory for the rest
+ * of the process, mirroring a warm long-running PHP-FPM worker or the
+ * disk-cached production setting Twig's own docs recommend (TwigBackend's
+ * `cache => false` here only disables the PERSISTENT disk cache across
+ * process restarts, not Twig's in-process compiled-class cache).
+ *
+ * `$bf->_props(['initialRows' => $rows])` is set explicitly before each
+ * render so `bf-p` is emitted — the real Twig test-render.ts conformance
+ * harness never calls `_props()` at all (grep confirms; `bf-p` is
+ * apparently untested for this adapter), which would silently skip the
+ * props-serialization cost this bench exists to measure. Setting it here
+ * keeps the comparison apples-to-apples with the Hono and Go benches,
+ * which both emit their real hydration-props payload.
+ *
+ * WARMUP+MEASURE loop, timed with `hrtime(true)` — the PHP analogue of
+ * bench-ssr.ts's measureServerRender. Writes one JSON array of per-call
+ * elapsed milliseconds to timings.json.
+ */
+require __DIR__ . '/../../../../../packages/adapter-twig/php/vendor/autoload.php';
+
+$rows = json_decode(file_get_contents(__DIR__ . '/../../../data.json'), true);
+
+$backend = new \Barefoot\TwigBackend(['paths' => [__DIR__]]);
+
+function render(\Barefoot\TwigBackend $backend, array $rows): string
+{
+    $bf = new \Barefoot\BarefootJS(null, ['backend' => $backend]);
+    $bf->_scope_id('BenchSsr_bench');
+    $bf->_is_child(false);
+    $bf->_props(['initialRows' => $rows]);
+    $vars = ['initialRows' => $rows, 'selected' => 0];
+    return $backend->render_named('bench_ssr', $bf, $vars);
+}
+
+$one = render($backend, $rows);
+file_put_contents(__DIR__ . '/one.html', $one);
+printf(
+    "rows(<tr): %d, bytes: %d, has bf-p: %s\n",
+    substr_count($one, '<tr'),
+    strlen($one),
+    strpos($one, 'bf-p') !== false ? 'true' : 'false',
+);
+
+const WARMUP = 50;
+const MEASURE = 2000;
+
+for ($i = 0; $i < WARMUP; $i++) {
+    render($backend, $rows);
+}
+
+$iterations = [];
+for ($i = 0; $i < MEASURE; $i++) {
+    $t0 = hrtime(true);
+    render($backend, $rows);
+    $iterations[] = (hrtime(true) - $t0) / 1e6; // ms
+}
+
+file_put_contents(__DIR__ . '/timings.json', json_encode($iterations));
+echo "wrote timings.json\n";

--- a/benchmarks/ssr/apps/barefoot/twig-render-bench/bench_ssr.twig
+++ b/benchmarks/ssr/apps/barefoot/twig-render-bench/bench_ssr.twig
@@ -1,0 +1,7 @@
+{% set _bf_reg0 = bf.register_script('/static/components/barefoot.js') %}
+{% set _bf_reg1 = bf.register_script('/static/components/BenchSsr.client.js') %}
+<table class="table" bf-s="{{ bf.scope_attr() }}" {{ bf.hydration_attrs() | raw }} {{ bf.props_attr() | raw }} {{ bf.data_key_attr() | raw }}><tbody id="tbody" bf="s4">{{ bf.comment("loop:l0") | raw }}
+{% for row in initialRows %}
+<tr data-key="{{ bf.string(row.id) }}" class="{{ (bf.eq(selected, row.id) ? 'danger' : '') }}" bf="s3"><td class="col-md-1">{{ bf.text_start("s0") | raw }}{{ bf.string(row.id) }}{{ bf.text_end() | raw }}</td><td class="col-md-4"><a class="lbl" bf="s2">{{ bf.text_start("s1") | raw }}{{ bf.string(row.label) }}{{ bf.text_end() | raw }}</a></td><td class="col-md-1"><a class="remove">x</a></td><td class="col-md-6"></td></tr>
+{% endfor %}
+{{ bf.comment("/loop:l0") | raw }}</tbody></table>

--- a/benchmarks/ssr/apps/barefoot/twig-render-bench/dump-template.ts
+++ b/benchmarks/ssr/apps/barefoot/twig-render-bench/dump-template.ts
@@ -1,0 +1,31 @@
+/**
+ * SSR render-gap investigation, item 4 (provenance for the Twig bench):
+ * regenerates bench_ssr.twig — the VERBATIM output of TwigAdapter compiling
+ * ../components/BenchSsr.tsx, no hand-editing needed (unlike the Go bench's
+ * types.go). Standalone script, not part of the product.
+ *
+ * Usage (run once `bun benchmarks/ssr/apps/barefoot/build.ts` has created
+ * this app's node_modules/@barefootjs/* symlinks — see that file's
+ * ensureWorkspaceLinks docstring):
+ *
+ *   bun benchmarks/ssr/apps/barefoot/twig-render-bench/dump-template.ts
+ */
+import { compileJSX } from '@barefootjs/jsx'
+import { TwigAdapter } from '../../../../../packages/adapter-twig/src/adapter/index.ts'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const OUT_DIR = import.meta.dirname
+const source = readFileSync(join(OUT_DIR, '..', 'components', 'BenchSsr.tsx'), 'utf8')
+
+const adapter = new TwigAdapter()
+const result = compileJSX(source, 'BenchSsr.tsx', { adapter, outputIR: true })
+const errors = result.errors.filter((e) => e.severity === 'error')
+if (errors.length) {
+  console.error(errors)
+  process.exit(1)
+}
+const template = result.files.find((f) => f.type === 'markedTemplate')!
+
+await Bun.write(join(OUT_DIR, 'bench_ssr.twig'), template.content)
+console.log('wrote', template.content.length, 'bytes twig template')


### PR DESCRIPTION
Stacked on #2607. Answers the follow-up question that PR raised: the ~75–85% "base structural render" cost was attributed to hono/jsx's request-time tree-walk — **is any of it fixable, and could it be contributed upstream?**

Investigation only; nothing here changes the compiler or any adapter.

## 1. The profile names a single surgical cost

Bun's JSC sampling profiler (`--cpu-prof`), 2000 renders after 50 warmup, real `compileJSX` → `HonoAdapter` → `renderToHtml` path. Per-render self-time:

| Share | Cost | file:line | Kind |
|---:|---|---|---|
| **28.3%** | native `Object.entries(props)` | `hono/dist/jsx/base.js:147` | **Incidental** — allocates a `[k,v]` array per element for typically 1–3 props; `for...in` does the same job with zero allocation |
| 23.0% | `toStringToBuffer`/`childrenToStringToBuffer`/`JSXNode` ctor | `base.js:111-199` | Inherent — the actual tree-walk |
| 19.9% | `escapeToBuffer` + `raw()` + regex probe | `utils/html.js:8-72` | Split — escaping unknown-safety values is inherent; re-escaping content the compiler already proved static is not (issue #2608) |
| 14.8% | `jsxFn` element factory | `base.js:249-279` | Mostly inherent; does `intrinsicElementTags[tag]` lookups the compiler already knows |
| 4.4% | `normalizeIntrinsicElementKey` / `isValidAttributeName` | `jsx/utils.js:12,41` | Incidental — re-validates attribute names validated at compile time |
| 3.8% | barefoot's own emitted component body | — | |
| 1.9% | `JSON.stringify` (bf-p) | — | confirms #2607's "props are a minority" finding |
| 1.5% | `jsxDEV` shim | — | **measurement artifact** — `NODE_ENV` unset, so Bun resolves the dev runtime; a production build drops this |

~93% of self-time is inside hono/jsx's runtime machinery; only ~4–6% is barefoot's emitted code. **`Object.entries` alone is bigger than the entire tree-walk** — that's the clean upstream-PR candidate.

## 2. hono/jsx already ships precompiler-shaped primitives, unused

**Observed**: `hono/jsx/jsx-runtime` exports `jsxTemplate` (tagged-template string builder), `jsxAttr`, and `jsxEscape` (`hono@4.13.1/dist/types/jsx/jsx-runtime.d.ts:10-12`) — exactly the shape a Solid-style precompiler targets. Grepping hono's `dist/` shows **nothing in the package calls them**; no precompiler, babel plugin, or CLI hook ships in this version.

More surprising: **barefoot's own `@barefootjs/hono/jsx` shim already re-exports all three** (`packages/adapter-hono/src/jsx/jsx-runtime/index.ts:14-24`) for API parity, yet the adapter's codegen never emits a call to any of them — `jsx`/`jsxs` route through `JSXNode` unconditionally.

**Inference, flagged as such**: this looks like substrate for an external precompiler that either wasn't finished upstream or was plumbed through here for type-completeness without a compiler pass targeting it. The code doesn't say why, and upstream's issue tracker isn't visible from this environment — no claim about their intent.

## 3. Barefoot can fix most of it without upstream

Side-by-side of the current emitted `.tsx` and a Solid-shaped string-building equivalent is in the writeup. Full replacement is a **large** project, and the blast radius is the iceberg, not the string-building: `TsxSourceText` is a deliberately user-visible artifact (`types.ts:824-840`, and the README leads with "TSX in. Your stack out."), `renderToHtml`'s contract, child-component calls, `<Suspense>`/streaming, hono's document-metadata hoisting and SVG namespacing all need equivalents.

**The cheap partial win**: hono's own `raw()` (already used by barefoot for `bfComment`/`bfText`) treats a prebuilt string as an escaped leaf — O(1) append, no recursive descent (`base.js:96-99`). A loop row that is **provably static-shaped** (pure HTML/text, no nested components or component-bearing conditionals) could compile to `.map(row => raw(chunk1 + esc(row.id) + chunk2 + …))`. That touches only `renderLoop` (`hono-adapter.ts:972`) — no adapter contract change, no `renderToHtml` change, no child-render change — while attacking the ~70% of per-row cost sitting in tree-walk + factory + attribute validation.

## 4. The reframe: Hono is NOT the slow backend

Measured on each backend's **real production entry point** (not the conformance harness, which under-counts — Go's `test-render.ts` never sets `BfIsRoot` so `bf-p` is never emitted; Twig's never calls `_props()`), same dataset, same box, all verified to emit 1000 rows and ~320KB:

| Backend | Entry point | Median |
|---|---|---:|
| Twig / PHP | `TwigBackend::render_named` (compiled to a real PHP class) | **7.5 ms** |
| Hono / JS | `renderToHtml` (JSXNode tree-walk) | 8.1 ms |
| Go `html/template` | `bf.Renderer.RenderFragment` | **13.0 ms** |
| Solid (reference) | `renderToString` (precompiled chunks) | **0.35 ms** |

**Go is the slowest, not the fastest**, despite parsing its template once at startup: a pprof profile shows `reflect.Value.call` at **47.9% cumulative** — `html/template.Parse` produces an AST, not bytecode, so every `{{...}}` still dispatches through reflection at execution time. Same category of request-time interpretation as hono/jsx's tree-walk, different implementation. Twig is fastest because its compile target differs in *kind* — a real PHP class with real method calls and a real `foreach`.

So: Twig/Hono/Go are within **1.7x of each other**, and Solid is **20–37x faster than all three**. This is not a Hono problem; it's "every current adapter interprets something per request."

## Artifacts (benchmark-only, no changeset)

`profile-hono-render.ts` + `analyze-profile.py`, `measure-hono-timings.ts`, `go-render-bench/` (Go harness + pprof), `twig-render-bench/` (PHP harness), `.gitignore` entries for per-run outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_