### PR TITLE
docs: document BF101's escapes (#2320 / #2321 kept as by-design limitations)

### DIFF
--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -219,6 +219,47 @@ backend cannot compute, and dies at render time the same way.
 
 ---
 
+## Template Adapter Errors (BF101)
+
+### BF101 — No Template-Language Lowering
+
+**Trigger:** An expression that a JS-runtime adapter (Hono, CSR) executes verbatim has no lowering on a non-JS template adapter (Go, Mojo, Xslate, Twig, ERB, Blade, Jinja, MiniJinja). Two shapes are permanent known limitations rather than subset widenings:
+
+**A nested `.some()` / `.find()` inside a filter predicate** ([#2320](https://github.com/piconic-ai/barefootjs/issues/2320)) — `find`-family methods return an element, not a boolean, so degrading them to their receiver would silently change predicate semantics:
+
+```tsx
+// ❌ BF101 on Go/Mojo/Xslate/Twig/ERB/Blade/Jinja/MiniJinja
+{items().filter(t => picked().some(p => p.id === t.id)).map(t => <li key={t.id}>{t.name}</li>)}
+```
+
+**A `.map()` loop array bound to a component-scope `const` with a computed initializer** ([#2321](https://github.com/piconic-ai/barefootjs/issues/2321)) — no template adapter binds an arbitrary computed local, only a prop/param it passes straight through:
+
+```tsx
+// ❌ BF101 on Go/Mojo/Xslate/Twig/ERB/Blade/Jinja/MiniJinja
+function ReactionBar(props: { reactions: Record<string, string[]> }) {
+  const entries = Object.entries(props.reactions).filter(([, users]) => users.length > 0)
+  return <div>{entries.map(([emoji, users]) => <span key={emoji}>{emoji}</span>)}</div>
+}
+```
+
+**Fix:** For the loop-source shape, prefer precomputing the array where it's already computable and passing the **result** as a prop — this keeps full SSR output. Both shapes fall back to `/* @client */`, which compiles clean everywhere but renders nothing for that region at SSR (client-only, materialised at hydration/mount).
+
+```tsx
+// ✅ Best for the loop-source shape: pass the computed array as a prop
+function ReactionBar({ entries }: { entries: [string, string[]][] }) {
+  return <div>{entries.map(([emoji, users]) => <span key={emoji}>{emoji}</span>)}</div>
+}
+
+// ✅ Either shape: defer to the client
+{/* @client */ items().filter(t => picked().some(p => p.id === t.id)).map(t => (
+  <li key={t.id}>{t.name}</li>
+))}
+```
+
+See [JSX Compatibility](../rendering/jsx-compatibility.md) for the full worked examples.
+
+---
+
 ## Component Errors (BF043–BF044)
 
 ### BF043 — Props Destructuring (Warning)

--- a/docs/core/rendering/jsx-compatibility.md
+++ b/docs/core/rendering/jsx-compatibility.md
@@ -125,6 +125,7 @@ Some JavaScript expressions cannot be translated into marked template syntax. Wh
 | JSX-returning `.flatMap()` with a statement body (early `return`, `const` before the projection) | works (runs as JS) | **BF021** |
 | Nested `.filter()` / `.map()` in a filter predicate (`x => x.tags.filter(...).length > 0`) | works | works |
 | Nested `.some()` / `.find()` / `.reduce()` in a filter predicate | works | **BF101** |
+| `.map()` loop array bound to a component-scope `const` with a computed initializer (e.g. `Object.entries(props.x).filter(...)`) | works | **BF101** |
 | Sort comparator that's a multi-statement block body or `localeCompare(b, locale, opts)` | works (runs as JS) | **BF021** |
 | Sort comparator that's a function reference to an imported/prop identifier, or an alias chain (`const c2 = c1`) | works (runs as JS) | **BF021** |
 | `typeof` in a filter predicate | works (runs as JS) | **BF021** |
@@ -181,6 +182,39 @@ A nested `.some()` / `.find()` / `.reduce()` still has no faithful Go/Mojo lower
 // ✅ Use arrow functions for adapter portability
 {items().filter(x => x.done)}
 ```
+
+**Computed loop array (`const` with a runtime initializer):**
+
+A `.map()` loop whose array is a bare identifier works when that identifier is a prop or a signal read, but not when it's a component-scope `const` computed from one at render time (`Object.entries(...)`, `.filter(...)`, …) — no template adapter has a binding for an arbitrary computed local, only for a prop/param it can pass straight through:
+
+```tsx
+// ❌ BF101 on Go/Mojo/Xslate/Twig/ERB/Blade/Jinja/MiniJinja; works on Hono
+type Props = { reactions: Record<string, string[]> }
+function ReactionBar(props: Props) {
+  const entries = Object.entries(props.reactions).filter(([, users]) => users.length > 0)
+  return <div>{entries.map(([emoji, users]) => (
+    <span key={emoji}>{emoji}: {String(users.length)}</span>
+  ))}</div>
+}
+
+// ✅ Best: precompute the array in the parent/route handler and pass it as a prop
+type Entry = [string, string[]]
+function ReactionBarByProp({ entries }: { entries: Entry[] }) {
+  return <div>{entries.map(([emoji, users]) => (
+    <span key={emoji}>{emoji}: {String(users.length)}</span>
+  ))}</div>
+}
+
+// ✅ Or defer to the client with /* @client */
+function ReactionBarClientOnly(props: Props) {
+  const entries = Object.entries(props.reactions).filter(([, users]) => users.length > 0)
+  return <div>{/* @client */ entries.map(([emoji, users]) => (
+    <span key={emoji}>{emoji}: {String(users.length)}</span>
+  ))}</div>
+}
+```
+
+The prop-passing form is the better fix — it keeps full SSR output, since the template adapters bind a plain prop array directly. `/* @client */` compiles clean too, but renders **nothing** for that region at SSR — no content until hydration/mount runs the loop client-side.
 
 ### Sort comparators that error on Go / Mojo
 

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -757,676 +757,6 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div><button bf="s0"
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L142 — ✅ Nested \`.filter()\` / \`.map()\` now compiles everywhere 1`] = `
-"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = items().filter(x => x.tags.filter(t => t.active).length > 0).map(t => t.name)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(x => x.tags.filter(t => t.active).length > 0).map(t => t.name))}<!--/--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L149 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
-"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = items().filter(x => x.tags.some(t => t.active)).map(t => t.name)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(x => x.tags.some(t => t.active)).map(t => t.name))}<!--/--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L152 — ✅ Add /* @client */ to evaluate on the client 1`] = `
-"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  // @client: s0
-  { const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'text', path: [0], markerless: true }])
-  createEffect(() => {
-    __bfw_s0('s0', items().filter(x => x.tags.some(t => t.active)).map(t => t.name))
-  }) }
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0--><!--/--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L159 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
-"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = items().reduce((sum, x) => sum + x.price, 0)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).reduce((sum, x) => sum + x.price, 0))}<!--/--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L162 — ✅ Use /* @client */ 1`] = `
-"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  // @client: s0
-  { const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'text', path: [0], markerless: true }])
-  createEffect(() => {
-    __bfw_s0('s0', items().reduce((sum, x) => sum + x.price, 0))
-  }) }
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0--><!--/--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L179 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
-"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = items().filter(function(x) { return x.done })
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(function(x) { return x.done }))}<!--/--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L182 — ✅ Use arrow functions for adapter portability 1`] = `
-"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = items().filter(x => x.done)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(x => x.done))}<!--/--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L195 — ✅ Value-producing block bodies normalize (let-inline) and lower everywhere 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const [_s1] = $(__scope, 's1')
-
-  mapArray(() => items().toSorted((a, b) => a.name > b.name ? 1 : -1), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
-    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
-  }, 'l0')
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).toSorted((a, b) => a.name > b.name ? 1 : -1).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L205 — ❌ BF021 on Go/Mojo — a JS-runtime target (Hono, CSR) runs the comparator 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const [_s1] = $(__scope, 's1')
-
-  mapArray(() => items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
-    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
-  }, 'l0')
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L210 — ✅ Use /* @client */ 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const [_s1] = $(__scope, 's1')
-
-  mapArray(() => items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
-    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
-  }, 'l0')
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L222 — ❌ BF021 on Go/Mojo — \`byPrice\` is imported, not declared in this file 1`] = `
-"import { $, createComponent, createEffect, escapeAttr, escapeText, hydrate, lazySlots, mapArray } from '@barefootjs/client/runtime'
-import { byPrice } from './comparators'
-
-
-export function initSortedList(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const items = _p.items
-
-  const [_s1] = $(__scope, 's1')
-
-  const __tpl_l0 = document.createElement('template')
-  __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
-  mapArray(() => items.sort(byPrice), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
-    const __bfw_s0 = lazySlots(__el, [{ id: 's0', kind: 'text', path: __existing ? [] : [0] }])
-    createEffect(() => { __bfw_s0('s0', String(item().name)) })
-    return __el
-  }, 'l0')
-
-}
-
-hydrate('SortedList__b3c36eee', { init: initSortedList, template: (_p) => \`<ul bf="s1"><!--bf-loop:l0-->\${_p.items.sort(byPrice).map((item) => \`<li data-key="\${escapeAttr(item.id)}"><!--bf:s0-->\${escapeText(item.name)}<!--/--></li>\`).join('')}<!--bf-/loop:l0--></ul>\`, name: 'SortedList' })
-export function SortedList(_p, __bfKey) { return createComponent('SortedList__b3c36eee', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L228 — ✅ Use /* @client */, or inline / re-declare the comparator locally 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const [_s1] = $(__scope, 's1')
-
-  mapArray(() => items().sort(byPrice), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
-    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
-  }, 'l0')
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort(byPrice).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
 exports[`docs/core/rendering/client-directive.md doc-examples L76 — Nested higher-order methods 1`] = `
 "import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
 
@@ -5497,4 +4827,774 @@ export function initCounter(__scope, _p = {}) {
 
 hydrate('Counter', { init: initCounter, template: (_p) => \`<button bf="s1"> Count: <!--bf:s0-->\${escapeText((0))}<!--/--></button>\` })
 export function Counter(_p, __bfKey) { return createComponent('Counter', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L143 — ✅ Nested \`.filter()\` / \`.map()\` now compiles everywhere 1`] = `
+"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = items().filter(x => x.tags.filter(t => t.active).length > 0).map(t => t.name)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(x => x.tags.filter(t => t.active).length > 0).map(t => t.name))}<!--/--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L150 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
+"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = items().filter(x => x.tags.some(t => t.active)).map(t => t.name)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(x => x.tags.some(t => t.active)).map(t => t.name))}<!--/--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L153 — ✅ Add /* @client */ to evaluate on the client 1`] = `
+"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  // @client: s0
+  { const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'text', path: [0], markerless: true }])
+  createEffect(() => {
+    __bfw_s0('s0', items().filter(x => x.tags.some(t => t.active)).map(t => t.name))
+  }) }
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0--><!--/--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L160 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
+"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = items().reduce((sum, x) => sum + x.price, 0)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).reduce((sum, x) => sum + x.price, 0))}<!--/--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L163 — ✅ Use /* @client */ 1`] = `
+"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  // @client: s0
+  { const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'text', path: [0], markerless: true }])
+  createEffect(() => {
+    __bfw_s0('s0', items().reduce((sum, x) => sum + x.price, 0))
+  }) }
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0--><!--/--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L180 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
+"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = items().filter(function(x) { return x.done })
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(function(x) { return x.done }))}<!--/--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L183 — ✅ Use arrow functions for adapter portability 1`] = `
+"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = items().filter(x => x.done)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(x => x.done))}<!--/--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L192 — ❌ BF101 on Go/Mojo/Xslate/Twig/ERB/Blade/Jinja/MiniJinja; works on Hono 1`] = `
+"import { $, createComponent, createEffect, escapeAttr, escapeText, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+
+export function initReactionBar(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const entries = Object.entries(_p.reactions).filter(([, users]) => users.length > 0)
+
+  const [_s2] = $(__scope, 's2')
+
+  // Reactive texts / CSR materialize in static array children
+  if (_s2) {
+    entries.forEach(([emoji, users], __idx) => {
+      let __iterEl = _s2.children[__idx]
+      if (!__iterEl) {
+        const __tpl = document.createElement('template')
+        __tpl.innerHTML = \`<span data-key="\${escapeAttr(emoji)}"><!--bf:s0-->\${escapeText(emoji)}<!--/-->: <!--bf:s1-->\${escapeText(String(users.length))}<!--/--></span>\`
+        const __cloned = __tpl.content.firstElementChild
+        if (__cloned) {
+          const __anchor = _s2.children[__idx] ?? null
+          _s2.insertBefore(__cloned, __anchor)
+          __iterEl = __cloned
+        }
+      }
+      if (__iterEl) {
+        const __bfw_s0 = lazySlots(__iterEl, [{ id: 's0', kind: 'text', path: [] }, { id: 's1', kind: 'text', path: [] }])
+        createEffect(() => { __bfw_s0('s0', String(emoji)) })
+        createEffect(() => { __bfw_s0('s1', String(String(users.length))) })
+      }
+    })
+  }
+
+}
+
+hydrate('ReactionBar__b3c36eee', { init: initReactionBar, template: (_p) => \`<div bf="s2"><!--bf-loop:l0-->\${[].map(([emoji, users]) => \`<span data-key="\${escapeAttr(emoji)}"><!--bf:s0-->\${escapeText(emoji)}<!--/-->: <!--bf:s1-->\${escapeText(String(users.length))}<!--/--></span>\`).join('')}<!--bf-/loop:l0--></div>\`, name: 'ReactionBar' })
+export function ReactionBar(_p, __bfKey) { return createComponent('ReactionBar__b3c36eee', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L201 — ✅ Best: precompute the array in the parent/route handler and pass it as a prop 1`] = `
+"import { $, createComponent, escapeAttr, escapeText, hydrate, lazySlots, mapArrayLazy, textOrNode } from '@barefootjs/client/runtime'
+
+
+export function initReactionBarByProp(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const entries = _p.entries ?? []
+
+  const [_s2] = $(__scope, 's2')
+
+  const __tpl_l0 = document.createElement('template')
+  __tpl_l0.innerHTML = \`<span data-key=""><!--bf:s0--><!--/-->: <!--bf:s1--><!--/--></span>\`
+  const __lzp_l0 = [[0], [3]]
+  const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }, { id: 's1', kind: 'text', path: [] }]
+  const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }, { id: 's1', kind: 'text', path: __lzp_l0[1] }]
+  mapArrayLazy(() => entries, _s2, ([emoji, users]) => String(emoji), {
+    createRow: (__e, __idx) => {
+      const __bfItem = () => __e.item
+      const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
+      const __r = __e.refs = [lazySlots(__el, __lzsc_l0)]
+      const __l = __e.last = []
+      { const __x = __bfItem()[0]
+      __r[0]('s0', textOrNode(__x))
+      __l[0] = __x }
+      { const __x = String(__bfItem()[1].length)
+      __r[0]('s1', textOrNode(__x))
+      __l[1] = __x }
+      return __el
+    },
+    applyItem: (__e) => {
+      const __bfItem = () => __e.item
+      const __r = __e.refs ?? (__e.refs = [])
+      const __l = __e.last ?? (__e.last = [])
+      const __d = __r[0] ?? (__r[0] = lazySlots(__e.primaryEl, __lzs_l0))
+      { const __x = __bfItem()[0]
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __d('s0', textOrNode(__x))
+      __l[0] = __x }
+      { const __x = String(__bfItem()[1].length)
+      if (!(1 in __l) || !Object.is(__l[1], __x)) __d('s1', textOrNode(__x))
+      __l[1] = __x }
+    },
+  }, 'l0')
+
+}
+
+hydrate('ReactionBarByProp__b3c36eee', { init: initReactionBarByProp, template: (_p) => \`<div bf="s2"><!--bf-loop:l0-->\${_p.entries.map(([emoji, users]) => \`<span data-key="\${escapeAttr(emoji)}"><!--bf:s0-->\${escapeText(emoji)}<!--/-->: <!--bf:s1-->\${escapeText(String(users.length))}<!--/--></span>\`).join('')}<!--bf-/loop:l0--></div>\`, name: 'ReactionBarByProp' })
+export function ReactionBarByProp(_p, __bfKey) { return createComponent('ReactionBarByProp__b3c36eee', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L209 — ✅ Or defer to the client with /* @client */ 1`] = `
+"import { createComponent, hydrate } from '@barefootjs/client/runtime'
+
+function initStatementExample() {}
+
+hydrate('StatementExample', { init: initStatementExample, template: (_p) => \`<div></div>\` })
+export function StatementExample(_p, __bfKey) { return createComponent('StatementExample', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L229 — ✅ Value-producing block bodies normalize (let-inline) and lower everywhere 1`] = `
+"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().toSorted((a, b) => a.name > b.name ? 1 : -1), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).toSorted((a, b) => a.name > b.name ? 1 : -1).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L239 — ❌ BF021 on Go/Mojo — a JS-runtime target (Hono, CSR) runs the comparator 1`] = `
+"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L244 — ✅ Use /* @client */ 1`] = `
+"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L256 — ❌ BF021 on Go/Mojo — \`byPrice\` is imported, not declared in this file 1`] = `
+"import { $, createComponent, createEffect, escapeAttr, escapeText, hydrate, lazySlots, mapArray } from '@barefootjs/client/runtime'
+import { byPrice } from './comparators'
+
+
+export function initSortedList(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const items = _p.items
+
+  const [_s1] = $(__scope, 's1')
+
+  const __tpl_l0 = document.createElement('template')
+  __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
+  mapArray(() => items.sort(byPrice), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
+    const __bfw_s0 = lazySlots(__el, [{ id: 's0', kind: 'text', path: __existing ? [] : [0] }])
+    createEffect(() => { __bfw_s0('s0', String(item().name)) })
+    return __el
+  }, 'l0')
+
+}
+
+hydrate('SortedList__b3c36eee', { init: initSortedList, template: (_p) => \`<ul bf="s1"><!--bf-loop:l0-->\${_p.items.sort(byPrice).map((item) => \`<li data-key="\${escapeAttr(item.id)}"><!--bf:s0-->\${escapeText(item.name)}<!--/--></li>\`).join('')}<!--bf-/loop:l0--></ul>\`, name: 'SortedList' })
+export function SortedList(_p, __bfKey) { return createComponent('SortedList__b3c36eee', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L262 — ✅ Use /* @client */, or inline / re-declare the comparator locally 1`] = `
+"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().sort(byPrice), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort(byPrice).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -757,6 +757,776 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div><button bf="s0"
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L143 — ✅ Nested \`.filter()\` / \`.map()\` now compiles everywhere 1`] = `
+"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = items().filter(x => x.tags.filter(t => t.active).length > 0).map(t => t.name)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(x => x.tags.filter(t => t.active).length > 0).map(t => t.name))}<!--/--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L150 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
+"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = items().filter(x => x.tags.some(t => t.active)).map(t => t.name)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(x => x.tags.some(t => t.active)).map(t => t.name))}<!--/--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L153 — ✅ Add /* @client */ to evaluate on the client 1`] = `
+"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  // @client: s0
+  { const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'text', path: [0], markerless: true }])
+  createEffect(() => {
+    __bfw_s0('s0', items().filter(x => x.tags.some(t => t.active)).map(t => t.name))
+  }) }
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0--><!--/--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L160 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
+"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = items().reduce((sum, x) => sum + x.price, 0)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).reduce((sum, x) => sum + x.price, 0))}<!--/--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L163 — ✅ Use /* @client */ 1`] = `
+"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  // @client: s0
+  { const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'text', path: [0], markerless: true }])
+  createEffect(() => {
+    __bfw_s0('s0', items().reduce((sum, x) => sum + x.price, 0))
+  }) }
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0--><!--/--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L180 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
+"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = items().filter(function(x) { return x.done })
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(function(x) { return x.done }))}<!--/--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L183 — ✅ Use arrow functions for adapter portability 1`] = `
+"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = items().filter(x => x.done)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(x => x.done))}<!--/--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L192 — ❌ BF101 on Go/Mojo/Xslate/Twig/ERB/Blade/Jinja/MiniJinja; works on Hono 1`] = `
+"import { $, createComponent, createEffect, escapeAttr, escapeText, hydrate, lazySlots } from '@barefootjs/client/runtime'
+
+
+export function initReactionBar(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const entries = Object.entries(_p.reactions).filter(([, users]) => users.length > 0)
+
+  const [_s2] = $(__scope, 's2')
+
+  // Reactive texts / CSR materialize in static array children
+  if (_s2) {
+    entries.forEach(([emoji, users], __idx) => {
+      let __iterEl = _s2.children[__idx]
+      if (!__iterEl) {
+        const __tpl = document.createElement('template')
+        __tpl.innerHTML = \`<span data-key="\${escapeAttr(emoji)}"><!--bf:s0-->\${escapeText(emoji)}<!--/-->: <!--bf:s1-->\${escapeText(String(users.length))}<!--/--></span>\`
+        const __cloned = __tpl.content.firstElementChild
+        if (__cloned) {
+          const __anchor = _s2.children[__idx] ?? null
+          _s2.insertBefore(__cloned, __anchor)
+          __iterEl = __cloned
+        }
+      }
+      if (__iterEl) {
+        const __bfw_s0 = lazySlots(__iterEl, [{ id: 's0', kind: 'text', path: [] }, { id: 's1', kind: 'text', path: [] }])
+        createEffect(() => { __bfw_s0('s0', String(emoji)) })
+        createEffect(() => { __bfw_s0('s1', String(String(users.length))) })
+      }
+    })
+  }
+
+}
+
+hydrate('ReactionBar__b3c36eee', { init: initReactionBar, template: (_p) => \`<div bf="s2"><!--bf-loop:l0-->\${[].map(([emoji, users]) => \`<span data-key="\${escapeAttr(emoji)}"><!--bf:s0-->\${escapeText(emoji)}<!--/-->: <!--bf:s1-->\${escapeText(String(users.length))}<!--/--></span>\`).join('')}<!--bf-/loop:l0--></div>\`, name: 'ReactionBar' })
+export function ReactionBar(_p, __bfKey) { return createComponent('ReactionBar__b3c36eee', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L201 — ✅ Best: precompute the array in the parent/route handler and pass it as a prop 1`] = `
+"import { $, createComponent, escapeAttr, escapeText, hydrate, lazySlots, mapArrayLazy, textOrNode } from '@barefootjs/client/runtime'
+
+
+export function initReactionBarByProp(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const entries = _p.entries ?? []
+
+  const [_s2] = $(__scope, 's2')
+
+  const __tpl_l0 = document.createElement('template')
+  __tpl_l0.innerHTML = \`<span data-key=""><!--bf:s0--><!--/-->: <!--bf:s1--><!--/--></span>\`
+  const __lzp_l0 = [[0], [3]]
+  const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }, { id: 's1', kind: 'text', path: [] }]
+  const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }, { id: 's1', kind: 'text', path: __lzp_l0[1] }]
+  mapArrayLazy(() => entries, _s2, ([emoji, users]) => String(emoji), {
+    createRow: (__e, __idx) => {
+      const __bfItem = () => __e.item
+      const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
+      const __r = __e.refs = [lazySlots(__el, __lzsc_l0)]
+      const __l = __e.last = []
+      { const __x = __bfItem()[0]
+      __r[0]('s0', textOrNode(__x))
+      __l[0] = __x }
+      { const __x = String(__bfItem()[1].length)
+      __r[0]('s1', textOrNode(__x))
+      __l[1] = __x }
+      return __el
+    },
+    applyItem: (__e) => {
+      const __bfItem = () => __e.item
+      const __r = __e.refs ?? (__e.refs = [])
+      const __l = __e.last ?? (__e.last = [])
+      const __d = __r[0] ?? (__r[0] = lazySlots(__e.primaryEl, __lzs_l0))
+      { const __x = __bfItem()[0]
+      if (!(0 in __l) || !Object.is(__l[0], __x)) __d('s0', textOrNode(__x))
+      __l[0] = __x }
+      { const __x = String(__bfItem()[1].length)
+      if (!(1 in __l) || !Object.is(__l[1], __x)) __d('s1', textOrNode(__x))
+      __l[1] = __x }
+    },
+  }, 'l0')
+
+}
+
+hydrate('ReactionBarByProp__b3c36eee', { init: initReactionBarByProp, template: (_p) => \`<div bf="s2"><!--bf-loop:l0-->\${_p.entries.map(([emoji, users]) => \`<span data-key="\${escapeAttr(emoji)}"><!--bf:s0-->\${escapeText(emoji)}<!--/-->: <!--bf:s1-->\${escapeText(String(users.length))}<!--/--></span>\`).join('')}<!--bf-/loop:l0--></div>\`, name: 'ReactionBarByProp' })
+export function ReactionBarByProp(_p, __bfKey) { return createComponent('ReactionBarByProp__b3c36eee', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L209 — ✅ Or defer to the client with /* @client */ 1`] = `
+"import { createComponent, hydrate } from '@barefootjs/client/runtime'
+
+function initStatementExample() {}
+
+hydrate('StatementExample', { init: initStatementExample, template: (_p) => \`<div></div>\` })
+export function StatementExample(_p, __bfKey) { return createComponent('StatementExample', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L229 — ✅ Value-producing block bodies normalize (let-inline) and lower everywhere 1`] = `
+"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().toSorted((a, b) => a.name > b.name ? 1 : -1), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).toSorted((a, b) => a.name > b.name ? 1 : -1).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L239 — ❌ BF021 on Go/Mojo — a JS-runtime target (Hono, CSR) runs the comparator 1`] = `
+"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L244 — ✅ Use /* @client */ 1`] = `
+"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L256 — ❌ BF021 on Go/Mojo — \`byPrice\` is imported, not declared in this file 1`] = `
+"import { $, createComponent, createEffect, escapeAttr, escapeText, hydrate, lazySlots, mapArray } from '@barefootjs/client/runtime'
+import { byPrice } from './comparators'
+
+
+export function initSortedList(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const items = _p.items
+
+  const [_s1] = $(__scope, 's1')
+
+  const __tpl_l0 = document.createElement('template')
+  __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
+  mapArray(() => items.sort(byPrice), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
+    const __bfw_s0 = lazySlots(__el, [{ id: 's0', kind: 'text', path: __existing ? [] : [0] }])
+    createEffect(() => { __bfw_s0('s0', String(item().name)) })
+    return __el
+  }, 'l0')
+
+}
+
+hydrate('SortedList__b3c36eee', { init: initSortedList, template: (_p) => \`<ul bf="s1"><!--bf-loop:l0-->\${_p.items.sort(byPrice).map((item) => \`<li data-key="\${escapeAttr(item.id)}"><!--bf:s0-->\${escapeText(item.name)}<!--/--></li>\`).join('')}<!--bf-/loop:l0--></ul>\`, name: 'SortedList' })
+export function SortedList(_p, __bfKey) { return createComponent('SortedList__b3c36eee', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L262 — ✅ Use /* @client */, or inline / re-declare the comparator locally 1`] = `
+"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
+  createEffect(() => {
+    const __val = String(_p.item)
+    __bfw_s0('s0', escapeTextOrNode(__val))
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().sort(byPrice), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort(byPrice).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
 exports[`docs/core/rendering/client-directive.md doc-examples L76 — Nested higher-order methods 1`] = `
 "import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
 
@@ -4827,774 +5597,4 @@ export function initCounter(__scope, _p = {}) {
 
 hydrate('Counter', { init: initCounter, template: (_p) => \`<button bf="s1"> Count: <!--bf:s0-->\${escapeText((0))}<!--/--></button>\` })
 export function Counter(_p, __bfKey) { return createComponent('Counter', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L143 — ✅ Nested \`.filter()\` / \`.map()\` now compiles everywhere 1`] = `
-"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = items().filter(x => x.tags.filter(t => t.active).length > 0).map(t => t.name)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(x => x.tags.filter(t => t.active).length > 0).map(t => t.name))}<!--/--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L150 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
-"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = items().filter(x => x.tags.some(t => t.active)).map(t => t.name)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(x => x.tags.some(t => t.active)).map(t => t.name))}<!--/--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L153 — ✅ Add /* @client */ to evaluate on the client 1`] = `
-"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  // @client: s0
-  { const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'text', path: [0], markerless: true }])
-  createEffect(() => {
-    __bfw_s0('s0', items().filter(x => x.tags.some(t => t.active)).map(t => t.name))
-  }) }
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0--><!--/--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L160 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
-"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = items().reduce((sum, x) => sum + x.price, 0)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).reduce((sum, x) => sum + x.price, 0))}<!--/--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L163 — ✅ Use /* @client */ 1`] = `
-"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  // @client: s0
-  { const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'text', path: [0], markerless: true }])
-  createEffect(() => {
-    __bfw_s0('s0', items().reduce((sum, x) => sum + x.price, 0))
-  }) }
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0--><!--/--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L180 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
-"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = items().filter(function(x) { return x.done })
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(function(x) { return x.done }))}<!--/--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L183 — ✅ Use arrow functions for adapter portability 1`] = `
-"import { createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = items().filter(x => x.done)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:s0-->\${escapeText(([]).filter(x => x.done))}<!--/--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L192 — ❌ BF101 on Go/Mojo/Xslate/Twig/ERB/Blade/Jinja/MiniJinja; works on Hono 1`] = `
-"import { $, createComponent, createEffect, escapeAttr, escapeText, hydrate, lazySlots } from '@barefootjs/client/runtime'
-
-
-export function initReactionBar(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const entries = Object.entries(_p.reactions).filter(([, users]) => users.length > 0)
-
-  const [_s2] = $(__scope, 's2')
-
-  // Reactive texts / CSR materialize in static array children
-  if (_s2) {
-    entries.forEach(([emoji, users], __idx) => {
-      let __iterEl = _s2.children[__idx]
-      if (!__iterEl) {
-        const __tpl = document.createElement('template')
-        __tpl.innerHTML = \`<span data-key="\${escapeAttr(emoji)}"><!--bf:s0-->\${escapeText(emoji)}<!--/-->: <!--bf:s1-->\${escapeText(String(users.length))}<!--/--></span>\`
-        const __cloned = __tpl.content.firstElementChild
-        if (__cloned) {
-          const __anchor = _s2.children[__idx] ?? null
-          _s2.insertBefore(__cloned, __anchor)
-          __iterEl = __cloned
-        }
-      }
-      if (__iterEl) {
-        const __bfw_s0 = lazySlots(__iterEl, [{ id: 's0', kind: 'text', path: [] }, { id: 's1', kind: 'text', path: [] }])
-        createEffect(() => { __bfw_s0('s0', String(emoji)) })
-        createEffect(() => { __bfw_s0('s1', String(String(users.length))) })
-      }
-    })
-  }
-
-}
-
-hydrate('ReactionBar__b3c36eee', { init: initReactionBar, template: (_p) => \`<div bf="s2"><!--bf-loop:l0-->\${[].map(([emoji, users]) => \`<span data-key="\${escapeAttr(emoji)}"><!--bf:s0-->\${escapeText(emoji)}<!--/-->: <!--bf:s1-->\${escapeText(String(users.length))}<!--/--></span>\`).join('')}<!--bf-/loop:l0--></div>\`, name: 'ReactionBar' })
-export function ReactionBar(_p, __bfKey) { return createComponent('ReactionBar__b3c36eee', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L201 — ✅ Best: precompute the array in the parent/route handler and pass it as a prop 1`] = `
-"import { $, createComponent, escapeAttr, escapeText, hydrate, lazySlots, mapArrayLazy, textOrNode } from '@barefootjs/client/runtime'
-
-
-export function initReactionBarByProp(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const entries = _p.entries ?? []
-
-  const [_s2] = $(__scope, 's2')
-
-  const __tpl_l0 = document.createElement('template')
-  __tpl_l0.innerHTML = \`<span data-key=""><!--bf:s0--><!--/-->: <!--bf:s1--><!--/--></span>\`
-  const __lzp_l0 = [[0], [3]]
-  const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }, { id: 's1', kind: 'text', path: [] }]
-  const __lzsc_l0 = [{ id: 's0', kind: 'text', path: __lzp_l0[0] }, { id: 's1', kind: 'text', path: __lzp_l0[1] }]
-  mapArrayLazy(() => entries, _s2, ([emoji, users]) => String(emoji), {
-    createRow: (__e, __idx) => {
-      const __bfItem = () => __e.item
-      const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
-      const __r = __e.refs = [lazySlots(__el, __lzsc_l0)]
-      const __l = __e.last = []
-      { const __x = __bfItem()[0]
-      __r[0]('s0', textOrNode(__x))
-      __l[0] = __x }
-      { const __x = String(__bfItem()[1].length)
-      __r[0]('s1', textOrNode(__x))
-      __l[1] = __x }
-      return __el
-    },
-    applyItem: (__e) => {
-      const __bfItem = () => __e.item
-      const __r = __e.refs ?? (__e.refs = [])
-      const __l = __e.last ?? (__e.last = [])
-      const __d = __r[0] ?? (__r[0] = lazySlots(__e.primaryEl, __lzs_l0))
-      { const __x = __bfItem()[0]
-      if (!(0 in __l) || !Object.is(__l[0], __x)) __d('s0', textOrNode(__x))
-      __l[0] = __x }
-      { const __x = String(__bfItem()[1].length)
-      if (!(1 in __l) || !Object.is(__l[1], __x)) __d('s1', textOrNode(__x))
-      __l[1] = __x }
-    },
-  }, 'l0')
-
-}
-
-hydrate('ReactionBarByProp__b3c36eee', { init: initReactionBarByProp, template: (_p) => \`<div bf="s2"><!--bf-loop:l0-->\${_p.entries.map(([emoji, users]) => \`<span data-key="\${escapeAttr(emoji)}"><!--bf:s0-->\${escapeText(emoji)}<!--/-->: <!--bf:s1-->\${escapeText(String(users.length))}<!--/--></span>\`).join('')}<!--bf-/loop:l0--></div>\`, name: 'ReactionBarByProp' })
-export function ReactionBarByProp(_p, __bfKey) { return createComponent('ReactionBarByProp__b3c36eee', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L209 — ✅ Or defer to the client with /* @client */ 1`] = `
-"import { createComponent, hydrate } from '@barefootjs/client/runtime'
-
-function initStatementExample() {}
-
-hydrate('StatementExample', { init: initStatementExample, template: (_p) => \`<div></div>\` })
-export function StatementExample(_p, __bfKey) { return createComponent('StatementExample', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L229 — ✅ Value-producing block bodies normalize (let-inline) and lower everywhere 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const [_s1] = $(__scope, 's1')
-
-  mapArray(() => items().toSorted((a, b) => a.name > b.name ? 1 : -1), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
-    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
-  }, 'l0')
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).toSorted((a, b) => a.name > b.name ? 1 : -1).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L239 — ❌ BF021 on Go/Mojo — a JS-runtime target (Hono, CSR) runs the comparator 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const [_s1] = $(__scope, 's1')
-
-  mapArray(() => items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
-    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
-  }, 'l0')
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L244 — ✅ Use /* @client */ 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const [_s1] = $(__scope, 's1')
-
-  mapArray(() => items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
-    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
-  }, 'l0')
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L256 — ❌ BF021 on Go/Mojo — \`byPrice\` is imported, not declared in this file 1`] = `
-"import { $, createComponent, createEffect, escapeAttr, escapeText, hydrate, lazySlots, mapArray } from '@barefootjs/client/runtime'
-import { byPrice } from './comparators'
-
-
-export function initSortedList(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const items = _p.items
-
-  const [_s1] = $(__scope, 's1')
-
-  const __tpl_l0 = document.createElement('template')
-  __tpl_l0.innerHTML = \`<li data-key=""><!--bf:s0--><!--/--></li>\`
-  mapArray(() => items.sort(byPrice), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    const __el = __existing ?? __tpl_l0.content.firstElementChild.cloneNode(true)
-    const __bfw_s0 = lazySlots(__el, [{ id: 's0', kind: 'text', path: __existing ? [] : [0] }])
-    createEffect(() => { __bfw_s0('s0', String(item().name)) })
-    return __el
-  }, 'l0')
-
-}
-
-hydrate('SortedList__b3c36eee', { init: initSortedList, template: (_p) => \`<ul bf="s1"><!--bf-loop:l0-->\${_p.items.sort(byPrice).map((item) => \`<li data-key="\${escapeAttr(item.id)}"><!--bf:s0-->\${escapeText(item.name)}<!--/--></li>\`).join('')}<!--bf-/loop:l0--></ul>\`, name: 'SortedList' })
-export function SortedList(_p, __bfKey) { return createComponent('SortedList__b3c36eee', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L262 — ✅ Use /* @client */, or inline / re-declare the comparator locally 1`] = `
-"import { $, createComponent, createEffect, createSignal, escapeText, escapeTextOrNode, hydrate, initChild, lazySlots, mapArray, renderChild } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\`, name: 'TodoItem' })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const __bfw_s0 = lazySlots(__scope, [{ id: 's0', kind: 'markup', path: [] }])
-  createEffect(() => {
-    const __val = String(_p.item)
-    __bfw_s0('s0', escapeTextOrNode(__val))
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\`, name: 'Item' })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\`, name: 'Dashboard' })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const [_s1] = $(__scope, 's1')
-
-  mapArray(() => items().sort(byPrice), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
-    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
-  }, 'l0')
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort(byPrice).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -460,6 +460,7 @@ const ERROR_CODES_DOC_TOO_MINIMAL: Record<string, string> = {
   BF021: 'BF021 has multiple ❌ snippets in placeholder form (`.map(...)`) — covered concretely by `jsx-compatibility.md` tests; the doc-form snippets here remain placeholder',
   BF043: 'BF043 fires only for STATEFUL components (signals/memos/effects). The doc snippet `function Child({ count }: Props)` has no reactivity, so the check is correctly silent — doc snippet needs enrichment to be testable as-is',
   BF044: 'BF044 fires only when a real signal getter is bound. The doc snippet `<Child count={count} />` references an undeclared `count`, so the check is silent — doc snippet needs enrichment',
+  BF101: 'BF101 is raised by the non-JS template adapters\' own per-adapter checks (Go/Mojo/Xslate/… `renderLoop` / callback lowering), not by the shared `isSupported` gate every adapter shares — `TestAdapter` here is JS-runtime-style like Hono and executes both doc snippets verbatim, so the check is correctly silent. Covered concretely (compiled against the real 8 template adapters, with verbatim diagnostic text) by `jsx-compatibility.md`\'s doc-examples coverage and the `filter-nested-callback-predicate` / `filter-nested-find-predicate` / `static-array-from-props` adapter-conformance fixtures.',
 }
 
 // BFxxx codes that `errors.ts` defines but no production code in

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -841,6 +841,7 @@ symbol of each JSX tag through to the resolver; tracked as a follow-up.
 | BF023 | Missing `key` attribute in `.map()` loop — root JSX element has no `key` prop |
 | BF024 | Missing `key` attribute in nested `.map()` loop — inner loop root JSX element has no `key` prop |
 | BF025 | Unsupported destructure shape in `.map()` callback (computed property key — rest elements have been supported since #1244/#1309) |
+| BF101 | An adapter has no template-language lowering for the expression (an off-catalogue array/string method, a nested higher-order callback, or a loop array bound to a computed component-scope local) — raised only by non-JS template adapters (Go, Mojo, Xslate, Twig, ERB, Blade, Jinja, MiniJinja); a JS-runtime adapter (Hono, CSR) executes the expression verbatim instead. See "Unsupported Expressions (BF101)" below. |
 | BF043 | Props destructuring breaks reactivity |
 | BF044 | Signal/memo getter passed without calling it |
 | BF048 | `'use client'` file references a same-file sibling component that produced no template — typically a multi-return JSX `switch`/`if`-`else` dispatch, which only #932's non-client verbatim-preservation path can compile (#2556) |
@@ -980,6 +981,26 @@ The refusal is deliberately conservative — it only fires when the receiver's t
 - **`/* @client */`** — the expression already opts out of SSR lowering, exactly as for the filter/sort BF021 shapes above.
 - **A registered lowering plugin claims the call** — `checkRichTypeMethodCalls` checks the same `matchLoweringCall` seam every adapter's call lowering goes through (`lowering-registry.ts`, #2057). Cataloguing a rich-type API (e.g. a `Date.toISOString()` → ISO-string lowering) is a plugin, not a change to this module — see #2274.
 - **An in-file type declaration shadows the host name** (`interface Date { … }` in the same file) — the local declaration wins; only a same-file shadow is recognized, not an imported type that happens to reuse the name.
+
+### Unsupported Expressions (BF101)
+
+**BF101** is the sibling of BF021 for the non-JS template adapters (Go, Mojo, Xslate, Twig, ERB, Blade, Jinja, MiniJinja): it fires when one of those adapters has no template-language lowering for an expression that a JS-runtime adapter (Hono, CSR) executes verbatim and compiles clean. Two shapes tracked as permanent known limitations (rather than subset widenings) illustrate the two BF101 sources — a per-method reason string vs. an adapter-specific structural check — and both name `/* @client */` in their `suggestion`:
+
+**A nested higher-order callback with no scalar template form** ([#2320](https://github.com/piconic-ai/barefootjs/issues/2320), successor to #2038) — `items().filter(t => picked().some(p => …))` / `.find(...)`. `some`/`every`/`filter` nested one level DO lower on adapters with an inline scalar form (e.g. Mojo's `grep`); `find`/`findIndex`/`findLast`/`findLastIndex` never do (they return an element, not a boolean) — degrading them to their receiver would silently change predicate semantics, so every such adapter refuses loudly instead:
+
+```
+error[BF101]: Filter predicate contains a nested '.some(...)' callback, which has no Kolon scalar form
+  = help: Rewrite the predicate without a nested callback method, or add /* @client */ for client-only evaluation (no SSR).
+```
+
+**A `.map()` loop array bound to a computed component-scope `const`** ([#2321](https://github.com/piconic-ai/barefootjs/issues/2321)) — `const entries = Object.entries(props.x).filter(...); … entries.map(...)`. Every template adapter can bind a loop to a prop/param it passes straight through, but none has a general binding for an arbitrary computed local (only a string-derived local resolves to a generated field). The message leads with the better fix — precompute the value where it's already computable (the parent / route handler) and pass the **result** as a prop, which keeps full SSR output — before the `/* @client */` fallback, which drops SSR output for that region entirely:
+
+```
+error[BF101]: Loop array `entries` is a local computed value (`Object.entries(props.reactions ?? {}).filter(([, users]) => users.length > 0)`) that the Go template adapter cannot bind as a template variable — only a string-derived local resolves to a generated struct field.
+  = help: Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.
+```
+
+See "Computed loop array" and "Nested higher-order methods" in [`jsx-compatibility.md`](../docs/core/rendering/jsx-compatibility.md) for the full worked examples, including what SSR output looks like for each escape (a plain-prop array still server-renders; `/* @client */` does not).
 
 ### Known limitations — methods that don't lower to the template adapters
 


### PR DESCRIPTION
Follows a decision to keep #2320 and #2321 as permanent known-limitations rather than widening the SSR-evaluable subset — **conditional on three properties actually holding**: the refusal is loud and at compile time, the diagnostic guides the user to the escape hatch, and following that guidance works. This PR verifies all three empirically and closes the one gap found.

## The three conditions — verified, not assumed

**1. Loud, at compile time.** Compiled all four fixtures against all 8 non-Hono adapters. Every refusal is `severity: 'error'`, `code: 'BF101'`, emitted by `compileJSX` — never a runtime crash, never a silent divergence. `static-array-from-props` refuses 8/8; `filter-nested-find-predicate` 8/8; `filter-nested-callback-predicate` 6/8 (Mojo lowers it via inline `grep`, ERB has a scalar form).

**2. The message names the escape — it already did, on all 16 adapter/fixture combinations.** Verbatim, from a real compile:

> `BF101: Loop array \`entries\` is a local computed value (…) that the Go template adapter cannot bind as a template variable`
> **suggestion**: *Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.*

> `BF101: Filter predicate contains a nested '.some(...)' callback, which has no Kolon scalar form`
> **suggestion**: *Rewrite the predicate without a nested callback method, or add `/* @client */` for client-only evaluation (no SSR).*

Notably #2321's messages already **lead with the pass-as-prop fix** ahead of `/* @client */` — which is the right ordering, for the reason in condition 3.

**3. The escape works — and here is what it actually costs.** Both `/* @client */` variants and the pass-as-prop variant compile clean (0 diagnostics) on all 8 adapters, and the client JS produces the correct DOM (verified with a real happy-dom mount, not just a template-string check: #2321's escaped version materializes both buttons; #2320's correctly filters the picked item out).

But `/* @client */` is **not** "same output, computed elsewhere" — the region is genuinely **empty in SSR output** until hydration:

```html
<div data-reaction-bar="true" bf-s="test" bf-r="" bf="s2"><!--bf-loop:l0--><!--bf-/loop:l0--></div>
```

The pass-as-prop escape for #2321 has no such cost — it server-renders fully (`<button data-key="👍" …><span>👍</span><span>2</span></button>`). That asymmetry is why the messages' ordering matters, and it is now stated explicitly in the docs.

## The gap this PR closes (docs only — no compiler or message change)

The runtime diagnostics were fine; the written reference was not:
- `spec/compiler.md` — Error Codes table had **no BF101 row at all**; added it plus an "Unsupported Expressions (BF101)" subsection quoting both real diagnostics.
- `docs/core/advanced/error-codes.md` — the canonical user-facing reference **had no BF101 section**; added one.
- `docs/core/rendering/jsx-compatibility.md` — #2320's shape had a worked example, #2321's had nothing; added one, stating the pass-as-prop vs `/* @client */` SSR-output tradeoff explicitly.

## One gap left open, deliberately

The compatibility matrix strips the diagnostic down to `{code, severity, issues}` (`packages/compat/src/engine.ts`'s `buildCompatCell`), so a red cell on barefootjs.dev shows `BF101` and a GitHub link — **no escape-hatch guidance in the matrix UI itself**. That is the same failure mode as a message that doesn't tell you the way out, just relocated. Embedding message text in the matrix is an architectural change to the compat pipeline, not a docs edit, so it is flagged rather than attempted here.

## Verification

`doc-examples.test.ts`: 218 pass / 28 skip (2 new, each documented with why `TestAdapter` can't trip an adapter-specific check) / 0 fail, 156/156 snapshots. The `.snap` diff is large but is **pure rekeying** — its keys embed source line numbers, and the doc edits shifted them; independently confirmed that the multiset of snapshot *values* gained exactly the two new examples and lost nothing.

No changeset — no published package's behavior or diagnostic text changes.

Refs #2320, #2321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_