### PR TITLE
test(adapter-tests): escape twins + escapeNotOwed — 1 of 8 closed, 7 exposed a compiler bug (#2613)

### DIFF
--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -96,25 +96,13 @@ export const conformancePins: ConformancePins = {
   // e.g. the `flatmap-expression-body` fixture) is NOT pinned: it lowers to
   // neutral nested-loop IR this adapter templatizes natively.
   // See spec/callback-fidelity.md.
-  'tag-cloud': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'tag-cloud': [{ code: 'BF021', severity: 'error' }],
   // A keyed `.map()` row body whose preamble builds a JSX leaf from item
   // state (`cells.push(<td>{stateLabel}</td>)`) embedded as `{cells}` — the
   // Stage 3 array-builder carrier, jsRuntime-only: a JS runtime runs it
   // verbatim (and patches the region on same-key updates, #2389), a DSL
   // adapter refuses with BF021 + `/* @client */`. See spec/callback-fidelity.md.
-  'preamble-cells': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'preamble-cells': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -173,14 +173,7 @@ export const conformancePins: ConformancePins = {
   'filter-nested-callback-predicate': [
     { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
-  'filter-nested-find-predicate': [
-    {
-      code: 'BF101',
-      severity: 'error',
-      issue: 'https://github.com/piconic-ai/barefootjs/issues/2320',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
-    },
-  ],
+  'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' }],
   // NB: TOP-LEVEL `.find` / `.findIndex` / `.findLast` / `.findLastIndex`
   // (text position) are NOT pinned here — like Jinja (unlike mojo, which
   // refuses them), Blade lowers them to `$bf->find_eval` / `find_index_eval`

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -172,14 +172,7 @@ export const conformancePins: ConformancePins = {
   // lowers it to a real inline Ruby block predicate and must render to
   // Hono parity instead.
   // Faithful lowering tracked: https://github.com/piconic-ai/barefootjs/issues/2320 (successor to #2038)
-  'filter-nested-find-predicate': [
-    {
-      code: 'BF101',
-      severity: 'error',
-      issue: 'https://github.com/piconic-ai/barefootjs/issues/2320',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
-    },
-  ],
+  'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' }],
   // #1467 demo-corpus context providers (`radio-group`, `accordion`,
   // `dialog`, `popover`, `select`, `dropdown-menu`, `combobox`,
   // `command`) are NOT pinned — an object-literal provider value lowers

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -97,25 +97,13 @@ export const conformancePins: ConformancePins = {
   // e.g. the `flatmap-expression-body` fixture) is NOT pinned: it lowers to
   // neutral nested-loop IR this adapter templatizes natively.
   // See spec/callback-fidelity.md.
-  'tag-cloud': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'tag-cloud': [{ code: 'BF021', severity: 'error' }],
   // A keyed `.map()` row body whose preamble builds a JSX leaf from item
   // state (`cells.push(<td>{stateLabel}</td>)`) embedded as `{cells}` — the
   // Stage 3 array-builder carrier, jsRuntime-only: a JS runtime runs it
   // verbatim (and patches the region on same-key updates, #2389), a DSL
   // adapter refuses with BF021 + `/* @client */`. See spec/callback-fidelity.md.
-  'preamble-cells': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'preamble-cells': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -170,14 +170,7 @@ export const conformancePins: ConformancePins = {
   'filter-nested-callback-predicate': [
     { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
-  'filter-nested-find-predicate': [
-    {
-      code: 'BF101',
-      severity: 'error',
-      issue: 'https://github.com/piconic-ai/barefootjs/issues/2320',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
-    },
-  ],
+  'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' }],
   // #1310 / #2087: rest destructure in .map() callback. `isLowerableLoopDestructure`
   // now admits every shape this fixture family exercises — each fixed/rest
   // binding resolves via `buildSegmentAccessor`/`buildDestructureBindingMap`

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -96,25 +96,13 @@ export const conformancePins: ConformancePins = {
   // e.g. the `flatmap-expression-body` fixture) is NOT pinned: it lowers to
   // neutral nested-loop IR this adapter templatizes natively.
   // See spec/callback-fidelity.md.
-  'tag-cloud': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'tag-cloud': [{ code: 'BF021', severity: 'error' }],
   // A keyed `.map()` row body whose preamble builds a JSX leaf from item
   // state (`cells.push(<td>{stateLabel}</td>)`) embedded as `{cells}` — the
   // Stage 3 array-builder carrier, jsRuntime-only: a JS runtime runs it
   // verbatim (and patches the region on same-key updates, #2389), a DSL
   // adapter refuses with BF021 + `/* @client */`. See spec/callback-fidelity.md.
-  'preamble-cells': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'preamble-cells': [{ code: 'BF021', severity: 'error' }],
   // `style-object-dynamic` / `style-3-signals` no longer pinned — a
   // `style={{ … }}` object literal now lowers to a CSS string with dynamic
   // values interpolated (`background-color:{{.Color}};padding:8px`) via

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -96,25 +96,13 @@ export const conformancePins: ConformancePins = {
   // e.g. the `flatmap-expression-body` fixture) is NOT pinned: it lowers to
   // neutral nested-loop IR this adapter templatizes natively.
   // See spec/callback-fidelity.md.
-  'tag-cloud': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'tag-cloud': [{ code: 'BF021', severity: 'error' }],
   // A keyed `.map()` row body whose preamble builds a JSX leaf from item
   // state (`cells.push(<td>{stateLabel}</td>)`) embedded as `{cells}` — the
   // Stage 3 array-builder carrier, jsRuntime-only: a JS runtime runs it
   // verbatim (and patches the region on same-key updates, #2389), a DSL
   // adapter refuses with BF021 + `/* @client */`. See spec/callback-fidelity.md.
-  'preamble-cells': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'preamble-cells': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -186,14 +186,7 @@ export const conformancePins: ConformancePins = {
   'filter-nested-callback-predicate': [
     { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
-  'filter-nested-find-predicate': [
-    {
-      code: 'BF101',
-      severity: 'error',
-      issue: 'https://github.com/piconic-ai/barefootjs/issues/2320',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
-    },
-  ],
+  'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' }],
   // NB: TOP-LEVEL `.find` / `.findIndex` / `.findLast` / `.findLastIndex`
   // (text position) are NOT pinned here — like xslate (unlike mojo, which
   // refuses them), Jinja lowers them to `bf.find_eval` / `find_index_eval`

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -171,14 +171,7 @@ export const conformancePins: ConformancePins = {
   // NOT pinned: Mojo lowers it to a real inline Perl `grep` and must
   // render to Hono parity instead.
   // Faithful lowering tracked: https://github.com/piconic-ai/barefootjs/issues/2320 (successor to #2038)
-  'filter-nested-find-predicate': [
-    {
-      code: 'BF101',
-      severity: 'error',
-      issue: 'https://github.com/piconic-ai/barefootjs/issues/2320',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
-    },
-  ],
+  'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' }],
   // #1467 demo-corpus context providers (`radio-group`, `accordion`,
   // `dialog`, `popover`, `select`, `dropdown-menu`, `combobox`,
   // `command`) are no longer pinned — an object-literal provider value

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -94,25 +94,13 @@ export const conformancePins: ConformancePins = {
   // e.g. the `flatmap-expression-body` fixture) is NOT pinned: it lowers to
   // neutral nested-loop IR this adapter templatizes natively.
   // See spec/callback-fidelity.md.
-  'tag-cloud': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'tag-cloud': [{ code: 'BF021', severity: 'error' }],
   // A keyed `.map()` row body whose preamble builds a JSX leaf from item
   // state (`cells.push(<td>{stateLabel}</td>)`) embedded as `{cells}` — the
   // Stage 3 array-builder carrier, jsRuntime-only: a JS runtime runs it
   // verbatim (and patches the region on same-key updates, #2389), a DSL
   // adapter refuses with BF021 + `/* @client */`. See spec/callback-fidelity.md.
-  'preamble-cells': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'preamble-cells': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -186,14 +186,7 @@ export const conformancePins: ConformancePins = {
   'filter-nested-callback-predicate': [
     { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
-  'filter-nested-find-predicate': [
-    {
-      code: 'BF101',
-      severity: 'error',
-      issue: 'https://github.com/piconic-ai/barefootjs/issues/2320',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
-    },
-  ],
+  'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' }],
   // NB: TOP-LEVEL `.find` / `.findIndex` / `.findLast` / `.findLastIndex`
   // (text position) are NOT pinned here — like xslate (unlike mojo, which
   // refuses them), Jinja lowers them to `bf.find_eval` / `find_index_eval`

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -97,25 +97,13 @@ export const conformancePins: ConformancePins = {
   // e.g. the `flatmap-expression-body` fixture) is NOT pinned: it lowers to
   // neutral nested-loop IR this adapter templatizes natively.
   // See spec/callback-fidelity.md.
-  'tag-cloud': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'tag-cloud': [{ code: 'BF021', severity: 'error' }],
   // A keyed `.map()` row body whose preamble builds a JSX leaf from item
   // state (`cells.push(<td>{stateLabel}</td>)`) embedded as `{cells}` — the
   // Stage 3 array-builder carrier, jsRuntime-only: a JS runtime runs it
   // verbatim (and patches the region on same-key updates, #2389), a DSL
   // adapter refuses with BF021 + `/* @client */`. See spec/callback-fidelity.md.
-  'preamble-cells': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'preamble-cells': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1937,6 +1937,25 @@
         "text"
       ]
     },
+    "every-typeof-predicate-client": {
+      "kinds": [
+        "array-literal",
+        "arrow",
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "unsupported"
+      ],
+      "axes": [
+        "binary:===",
+        "literal:string"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "falsy-text-values": {
       "kinds": [
         "literal"
@@ -1950,6 +1969,24 @@
       ]
     },
     "fill-unsupported": {
+      "kinds": [
+        "array-literal",
+        "array-method",
+        "call",
+        "identifier",
+        "literal",
+        "member"
+      ],
+      "axes": [
+        "array-method:join",
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
+    "fill-unsupported-client": {
       "kinds": [
         "array-literal",
         "array-method",
@@ -2008,6 +2045,24 @@
       ]
     },
     "filter-nested-find-predicate": {
+      "kinds": [
+        "array-literal",
+        "arrow",
+        "binary",
+        "call",
+        "identifier",
+        "member"
+      ],
+      "axes": [
+        "binary:==="
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "filter-nested-find-predicate-client": {
       "kinds": [
         "array-literal",
         "arrow",
@@ -2164,6 +2219,25 @@
         "text"
       ]
     },
+    "find-typeof-predicate-client": {
+      "kinds": [
+        "array-literal",
+        "arrow",
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "unsupported"
+      ],
+      "axes": [
+        "binary:===",
+        "literal:string"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "flatmap-expression-body": {
       "kinds": [
         "identifier",
@@ -2178,6 +2252,28 @@
       ]
     },
     "flatmap-typeof-projection": {
+      "kinds": [
+        "array-literal",
+        "array-method",
+        "arrow",
+        "binary",
+        "call",
+        "conditional",
+        "identifier",
+        "literal",
+        "member",
+        "unsupported"
+      ],
+      "axes": [
+        "array-method:join",
+        "binary:===",
+        "literal:string"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
+    "flatmap-typeof-projection-client": {
       "kinds": [
         "array-literal",
         "array-method",
@@ -3662,6 +3758,22 @@
         "text"
       ]
     },
+    "reduce-right-typeof-body-client": {
+      "kinds": [
+        "array-literal",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "unsupported"
+      ],
+      "axes": [
+        "literal:number"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "reduce-sum-field": {
       "kinds": [
         "arrow",
@@ -3697,6 +3809,22 @@
       ]
     },
     "reduce-typeof-body": {
+      "kinds": [
+        "array-literal",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "unsupported"
+      ],
+      "axes": [
+        "literal:number"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
+    "reduce-typeof-body-client": {
       "kinds": [
         "array-literal",
         "call",
@@ -4138,6 +4266,25 @@
       ]
     },
     "some-typeof-predicate": {
+      "kinds": [
+        "array-literal",
+        "arrow",
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "unsupported"
+      ],
+      "axes": [
+        "binary:===",
+        "literal:string"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
+    "some-typeof-predicate-client": {
       "kinds": [
         "array-literal",
         "arrow",
@@ -5009,21 +5156,21 @@
     }
   },
   "kindCounts": {
-    "array-literal": 71,
-    "array-method": 67,
-    "arrow": 64,
-    "binary": 84,
-    "call": 203,
-    "conditional": 24,
-    "identifier": 292,
+    "array-literal": 79,
+    "array-method": 69,
+    "arrow": 69,
+    "binary": 89,
+    "call": 211,
+    "conditional": 25,
+    "identifier": 300,
     "index-access": 14,
-    "literal": 241,
+    "literal": 248,
     "logical": 44,
-    "member": 156,
+    "member": 164,
     "object-literal": 56,
     "template-literal": 30,
     "unary": 23,
-    "unsupported": 31
+    "unsupported": 37
   },
   "axisCounts": {
     "array-method:at": 2,
@@ -5032,7 +5179,7 @@
     "array-method:flat": 4,
     "array-method:includes": 12,
     "array-method:indexOf": 1,
-    "array-method:join": 39,
+    "array-method:join": 41,
     "array-method:lastIndexOf": 1,
     "array-method:padEnd": 1,
     "array-method:padStart": 1,
@@ -5057,13 +5204,13 @@
     "binary:-": 11,
     "binary:/": 1,
     "binary:<": 1,
-    "binary:===": 44,
+    "binary:===": 49,
     "binary:>": 11,
     "binary:>=": 1,
     "literal:boolean": 49,
     "literal:null": 23,
-    "literal:number": 101,
-    "literal:string": 171,
+    "literal:number": 104,
+    "literal:string": 176,
     "logical:&&": 7,
     "logical:??": 38,
     "logical:||": 14,

--- a/packages/adapter-tests/fixtures/_helpers.ts
+++ b/packages/adapter-tests/fixtures/_helpers.ts
@@ -27,6 +27,7 @@ import { fileURLToPath } from 'node:url'
 import ts from 'typescript'
 import {
   createFixture,
+  type EscapeNotOwed,
   type InteractionStep,
   type JSXFixture,
 } from '../src/types'
@@ -143,6 +144,12 @@ export interface SharedFixtureSpec {
    * layout to measure. See `JSXFixture.hostStyles`.
    */
   hostStyles?: string
+  /**
+   * Declares this fixture's DSL refusal owes no escape, by design. Passed
+   * straight through to `JSXFixture.escapeNotOwed` — see
+   * {@link EscapeNotOwed} for the bar a reason must clear.
+   */
+  escapeNotOwed?: EscapeNotOwed
 }
 
 export function sourceFileBasename(spec: SharedFixtureSpec): string {
@@ -454,6 +461,7 @@ function defineFixture(spec: SharedFixtureSpec): JSXFixture {
     interactions: spec.interactions,
     externalImports: spec.externalImports,
     hostStyles: spec.hostStyles,
+    escapeNotOwed: spec.escapeNotOwed,
   })
 }
 

--- a/packages/adapter-tests/fixtures/every-typeof-predicate-client.ts
+++ b/packages/adapter-tests/fixtures/every-typeof-predicate-client.ts
@@ -1,0 +1,40 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `/* @client *​/` twin of `every-typeof-predicate` (#2613). Marking the
+ * expression defers `.every()` (and the `String(...)` wrapper around it) to
+ * client-only evaluation. No conformance pin: this compiles clean, unpinned
+ * and non-divergent on every DSL adapter (SSR HTML matches the Hono
+ * reference — an empty `<div>`, no slot markup).
+ *
+ * NOT declared as `every-typeof-predicate`'s `escapes` twin, though —
+ * `csr-conformance.test.ts` (a REAL run, not the floor test's static
+ * proxy) shows this is not yet a working escape. It surfaced a genuine
+ * compiler bug: `generateCsrTemplateWithOpts` (`html-template.ts`), one of
+ * the "CSR emitters" `client-only-elision.ts`'s docstring claims all read
+ * `IRExpression.markerless`, does NOT check it for the `case 'expression'`
+ * branch — it always emits `<!--bf:sN-->...<!--/-->` for a
+ * `clientOnly && slotId` expression regardless of `markerless`. So the
+ * standalone CSR template (used for a fresh, non-hydrating mount) embeds
+ * marker comments that SSR correctly elides, diverging from
+ * `expectedHtml`. This is CSR-skipped (`csr-skip-set.ts`) pending that
+ * fix — every sibling `*-typeof-*` / `fill-unsupported` client twin hits
+ * the identical bug (bare, non-loop TEXT-expression `/* @client *​/`; the
+ * elision machinery IS exercised and works correctly for the pre-existing
+ * LOOP-shaped twins, e.g. `filter-typeof-predicate-client`).
+ */
+export const fixture = createFixture({
+  id: 'every-typeof-predicate-client',
+  description: 'Off-subset `.every()` predicate deferred to the client via /* @client */',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function EveryTypeofPredicateClient() {
+  const [items, setItems] = createSignal<unknown[]>([])
+  return <div>{/* @client */ String(items().every(t => typeof t === 'string'))}</div>
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1"></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/every-typeof-predicate.ts
+++ b/packages/adapter-tests/fixtures/every-typeof-predicate.ts
@@ -29,4 +29,9 @@ export function EveryTypeofPredicate() {
   expectedHtml: `
     <div bf-s="test" bf="s1"><!--bf:s0-->true<!--/--></div>
   `,
+  // NOT declaring `escapes` here (#2613): a `client-directive` twin
+  // (`every-typeof-predicate-client`) was authored and DOES compile clean
+  // on every DSL adapter, but real `csr-conformance.test.ts` execution
+  // shows it is not actually a working escape — see that fixture's own
+  // docstring for the specific SSR/CSR divergence this uncovered.
 })

--- a/packages/adapter-tests/fixtures/fill-unsupported-client.ts
+++ b/packages/adapter-tests/fixtures/fill-unsupported-client.ts
@@ -1,0 +1,33 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `/* @client *​/` twin of `fill-unsupported` (#2613). Marking the expression
+ * defers `.fill()` (and the `.join(',')` after it) to client-only
+ * evaluation. No conformance pin: compiles clean, unpinned, non-divergent
+ * on every DSL adapter — `fill-unsupported`'s own prior docstring claimed
+ * this was "already covered by the filter-*-client twins," but nothing
+ * exercised `.fill()` directly until this fixture. That specific claim IS
+ * false, though not for a `.fill()`-specific reason.
+ *
+ * NOT declared as `fill-unsupported`'s `escapes` twin — same
+ * `generateCsrTemplateWithOpts` markerless bug as `every-typeof-predicate-
+ * client` (see that fixture's docstring for the full explanation; every
+ * sibling `*-typeof-*` fixture hits the identical bug, so this is a
+ * method-agnostic compiler gap, not something specific to `.fill()`).
+ * CSR-skipped (`csr-skip-set.ts`) pending the compiler fix.
+ */
+export const fixture = createFixture({
+  id: 'fill-unsupported-client',
+  description: 'Off-subset array method `.fill()` deferred to the client via /* @client */',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function FillUnsupportedClient() {
+  const [items, setItems] = createSignal<number[]>([])
+  return <div>{/* @client */ items().fill(0).join(',')}</div>
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1"></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/fill-unsupported.ts
+++ b/packages/adapter-tests/fixtures/fill-unsupported.ts
@@ -13,8 +13,22 @@ import { createFixture } from '../src/types'
  *   - DSL adapters (Go, Perl, Ruby, PHP, Rust, Python) can't lower it at SSR
  *     and surface BF101 with a `/* @client *\/` escape (declared via each
  *     adapter's `conformancePins`). Marking the expression `/* @client *\/`
- *     defers it to client-only rendering — the method-agnostic suppression
- *     contract is already covered by the `filter-*-client` twins.
+ *     defers it to client-only rendering.
+ *
+ * The claim that this is "already covered by the filter-*-client twins"
+ * sat unverified until #2613's floor test — and turned out to be FALSE, in
+ * an interesting way: a dedicated twin (`fill-unsupported-client`) DOES
+ * compile clean, unpinned, and non-divergent on every DSL adapter (tier 1
+ * of the floor test), but it does NOT actually render correctly — real
+ * `csr-conformance.test.ts` execution shows the compiled client JS's
+ * standalone template still embeds `<!--bf:sN-->...<!--/-->` markers that
+ * SSR correctly elides, a genuine SSR/CSR divergence in the compiler's
+ * `/* @client *\/` marker-elision machinery for a bare (non-loop)
+ * TEXT-expression position — see `fill-unsupported-client`'s own docstring.
+ * So the suppression contract is method-agnostic (this isn't
+ * `.fill()`-specific — every sibling `*-typeof-*` fixture hits the exact
+ * same bug), but it is NOT yet a verified WORKING escape. Not declaring
+ * `escapes` here until that compiler bug is fixed.
  */
 export const fixture = createFixture({
   id: 'fill-unsupported',

--- a/packages/adapter-tests/fixtures/filter-nested-find-predicate-client.ts
+++ b/packages/adapter-tests/fixtures/filter-nested-find-predicate-client.ts
@@ -1,0 +1,28 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `/* @client *​/` twin of `filter-nested-find-predicate` (#2038, #2613).
+ * The marker defers the whole chain to client evaluation, so the loop is
+ * client-only: SSR renders the empty `<ul>` on EVERY adapter and no BF101
+ * may fire — the SSR render helpers throw on any compile error, so this
+ * fixture pins the suppression contract across the corpus without any
+ * per-adapter `expectedDiagnostics` entry, same pattern as
+ * `filter-nested-callback-predicate-client` (the sibling `.some()` shape).
+ */
+export const fixture = createFixture({
+  id: 'filter-nested-find-predicate-client',
+  description: 'Nested-callback (.find()) filter predicate + /* @client */ suppresses BF101 (#2038)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number }
+export function NestedFindPredicateClient() {
+  const [items, setItems] = createSignal<Item[]>([])
+  const [picked, setPicked] = createSignal<Item[]>([])
+  return <ul>{/* @client */ items().filter(t => picked().find(p => p.id === t.id)).map((t, i) => <li key={i}>{t.id}</li>)}</ul>
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s1"></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/filter-nested-find-predicate.ts
+++ b/packages/adapter-tests/fixtures/filter-nested-find-predicate.ts
@@ -11,7 +11,11 @@ import { createFixture } from '../src/types'
  *   - Hono / CSR evaluate JS natively and render the chain faithfully.
  *   - Go template / Mojo / Xslate surface a loud BF101 (declared via each
  *     adapter's `expectedDiagnostics`) instead of a silent lossy rewrite.
- * Faithful SSR lowering for the nested callback is tracked in #2320.
+ * Faithful SSR lowering for the nested callback is tracked in #2320. The
+ * `/* @client *\/` twin (`filter-nested-find-predicate-client`) has no pin —
+ * it must render clean on every adapter, asserting the suppression contract
+ * (#2613, the `.find()` sibling of `filter-nested-callback-predicate`'s
+ * `.some()` twin).
  */
 export const fixture = createFixture({
   id: 'filter-nested-find-predicate',
@@ -29,4 +33,5 @@ export function NestedFindPredicate() {
   expectedHtml: `
     <ul bf-s="test" bf="s1"></ul>
   `,
+  escapes: [{ kind: 'client-directive', fixture: 'filter-nested-find-predicate-client' }],
 })

--- a/packages/adapter-tests/fixtures/find-typeof-predicate-client.ts
+++ b/packages/adapter-tests/fixtures/find-typeof-predicate-client.ts
@@ -1,0 +1,27 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `/* @client *​/` twin of `find-typeof-predicate` (#2613). Marking the
+ * expression defers `.find()` to client-only evaluation. No conformance
+ * pin: compiles clean, unpinned, non-divergent on every DSL adapter.
+ *
+ * NOT declared as `find-typeof-predicate`'s `escapes` twin — same
+ * `generateCsrTemplateWithOpts` markerless bug as `every-typeof-predicate-
+ * client` (see that fixture's docstring for the full explanation).
+ * CSR-skipped (`csr-skip-set.ts`) pending the compiler fix.
+ */
+export const fixture = createFixture({
+  id: 'find-typeof-predicate-client',
+  description: 'Off-subset `.find()` predicate deferred to the client via /* @client */',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function FindTypeofPredicateClient() {
+  const [items, setItems] = createSignal<unknown[]>([])
+  return <div>{/* @client */ items().find(t => typeof t === 'string')}</div>
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1"></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/find-typeof-predicate.ts
+++ b/packages/adapter-tests/fixtures/find-typeof-predicate.ts
@@ -28,4 +28,7 @@ export function FindTypeofPredicate() {
   expectedHtml: `
     <div bf-s="test" bf="s1"><!--bf:s0--><!--/--></div>
   `,
+  // NOT declaring `escapes` here (#2613) — see `every-typeof-predicate`'s
+  // identical note; `find-typeof-predicate-client` hits the same CSR
+  // divergence.
 })

--- a/packages/adapter-tests/fixtures/flatmap-typeof-projection-client.ts
+++ b/packages/adapter-tests/fixtures/flatmap-typeof-projection-client.ts
@@ -1,0 +1,28 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `/* @client *​/` twin of `flatmap-typeof-projection` (#2613). Marking the
+ * expression defers `.flatMap()` (and the `.join(',')` after it) to
+ * client-only evaluation. No conformance pin: compiles clean, unpinned,
+ * non-divergent on every DSL adapter.
+ *
+ * NOT declared as `flatmap-typeof-projection`'s `escapes` twin — same
+ * `generateCsrTemplateWithOpts` markerless bug as `every-typeof-predicate-
+ * client` (see that fixture's docstring for the full explanation).
+ * CSR-skipped (`csr-skip-set.ts`) pending the compiler fix.
+ */
+export const fixture = createFixture({
+  id: 'flatmap-typeof-projection-client',
+  description: 'Off-subset `.flatMap()` projection deferred to the client via /* @client */',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function FlatMapTypeofProjectionClient() {
+  const [items, setItems] = createSignal<unknown[]>([])
+  return <div>{/* @client */ items().flatMap(t => typeof t === 'string' ? [t] : []).join(',')}</div>
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1"></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/flatmap-typeof-projection.ts
+++ b/packages/adapter-tests/fixtures/flatmap-typeof-projection.ts
@@ -29,4 +29,7 @@ export function FlatMapTypeofProjection() {
   expectedHtml: `
     <div bf-s="test" bf="s1"><!--bf:s0--><!--/--></div>
   `,
+  // NOT declaring `escapes` here (#2613) — see `every-typeof-predicate`'s
+  // identical note; `flatmap-typeof-projection-client` hits the same CSR
+  // divergence.
 })

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -132,13 +132,21 @@ import { fixture as filterNestedCallbackPredicateClient } from './filter-nested-
 import { fixture as filterTypeofPredicate } from './filter-typeof-predicate'
 import { fixture as filterTypeofPredicateClient } from './filter-typeof-predicate-client'
 import { fixture as filterNestedFindPredicate } from './filter-nested-find-predicate'
+import { fixture as filterNestedFindPredicateClient } from './filter-nested-find-predicate-client'
 import { fixture as fillUnsupported } from './fill-unsupported'
+import { fixture as fillUnsupportedClient } from './fill-unsupported-client'
 import { fixture as findTypeofPredicate } from './find-typeof-predicate'
+import { fixture as findTypeofPredicateClient } from './find-typeof-predicate-client'
 import { fixture as someTypeofPredicate } from './some-typeof-predicate'
+import { fixture as someTypeofPredicateClient } from './some-typeof-predicate-client'
 import { fixture as everyTypeofPredicate } from './every-typeof-predicate'
+import { fixture as everyTypeofPredicateClient } from './every-typeof-predicate-client'
 import { fixture as reduceTypeofBody } from './reduce-typeof-body'
+import { fixture as reduceTypeofBodyClient } from './reduce-typeof-body-client'
 import { fixture as reduceRightTypeofBody } from './reduce-right-typeof-body'
+import { fixture as reduceRightTypeofBodyClient } from './reduce-right-typeof-body-client'
 import { fixture as flatMapTypeofProjection } from './flatmap-typeof-projection'
+import { fixture as flatMapTypeofProjectionClient } from './flatmap-typeof-projection-client'
 import { fixture as flatMapExpressionBody } from './flatmap-expression-body'
 import { fixture as mapIfChainBody } from './map-if-chain-body'
 import { fixture as mapSwitchFallthroughBody } from './map-switch-fallthrough-body'
@@ -559,13 +567,21 @@ export const jsxFixtures: JSXFixture[] = [
   filterTypeofPredicate,
   filterTypeofPredicateClient,
   filterNestedFindPredicate,
+  filterNestedFindPredicateClient,
   fillUnsupported,
+  fillUnsupportedClient,
   findTypeofPredicate,
+  findTypeofPredicateClient,
   someTypeofPredicate,
+  someTypeofPredicateClient,
   everyTypeofPredicate,
+  everyTypeofPredicateClient,
   reduceTypeofBody,
+  reduceTypeofBodyClient,
   reduceRightTypeofBody,
+  reduceRightTypeofBodyClient,
   flatMapTypeofProjection,
+  flatMapTypeofProjectionClient,
   flatMapExpressionBody,
   mapIfChainBody,
   mapSwitchFallthroughBody,

--- a/packages/adapter-tests/fixtures/preamble-cells.ts
+++ b/packages/adapter-tests/fixtures/preamble-cells.ts
@@ -30,6 +30,23 @@ export const spec: SharedFixtureSpec = {
   sourceRoot: 'fixture',
   description:
     'keyed .map() row with a preamble-built leaf child — patched in place on same-key update, not frozen',
+  // #2613 escapeNotOwed: this fixture is the real-browser regression pin
+  // for #2389 (patch-on-update) — its interactions assert that a same-key
+  // `toggle()` PATCHES an already-SSR-adopted preamble region in place. A
+  // `/* @client */` twin would SSR nothing for that region, so there would
+  // be no adopted DOM node left to patch: the test would degrade into
+  // "does client-only mounting work", which `client-only-loop` already
+  // covers, contributing zero new coverage. Separately, per this
+  // component's own file-placement docstring, the component lives outside
+  // `integrations/shared/components/` specifically because every
+  // integration app's `bf build` compiles that directory wholesale, and an
+  // un-escaped copy there would break every DSL integration build — so an
+  // escaped copy would also need to live there to be reachable by a DSL
+  // build at all, defeating the reason it's kept fixture-only.
+  escapeNotOwed: {
+    reason:
+      "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either.",
+  },
   interactions: [
     // Initial SSR/hydration state.
     { type: 'expectText', selector: stateCell(1), text: 'open' },

--- a/packages/adapter-tests/fixtures/reduce-right-typeof-body-client.ts
+++ b/packages/adapter-tests/fixtures/reduce-right-typeof-body-client.ts
@@ -1,0 +1,28 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `/* @client *​/` twin of `reduce-right-typeof-body` (#2613). Marking the
+ * expression defers `.reduceRight()` to client-only evaluation. No
+ * conformance pin: compiles clean, unpinned, non-divergent on every DSL
+ * adapter.
+ *
+ * NOT declared as `reduce-right-typeof-body`'s `escapes` twin — same
+ * `generateCsrTemplateWithOpts` markerless bug as `every-typeof-predicate-
+ * client` (see that fixture's docstring for the full explanation).
+ * CSR-skipped (`csr-skip-set.ts`) pending the compiler fix.
+ */
+export const fixture = createFixture({
+  id: 'reduce-right-typeof-body-client',
+  description: 'Off-subset `.reduceRight()` body deferred to the client via /* @client */',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function ReduceRightTypeofBodyClient() {
+  const [items, setItems] = createSignal<unknown[]>([])
+  return <div>{/* @client */ items().reduceRight((acc, t) => { const k = typeof t; return acc + k.length }, 0)}</div>
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1"></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/reduce-right-typeof-body.ts
+++ b/packages/adapter-tests/fixtures/reduce-right-typeof-body.ts
@@ -28,4 +28,7 @@ export function ReduceRightTypeofBody() {
   expectedHtml: `
     <div bf-s="test" bf="s1"><!--bf:s0-->0<!--/--></div>
   `,
+  // NOT declaring `escapes` here (#2613) — see `every-typeof-predicate`'s
+  // identical note; `reduce-right-typeof-body-client` hits the same CSR
+  // divergence.
 })

--- a/packages/adapter-tests/fixtures/reduce-typeof-body-client.ts
+++ b/packages/adapter-tests/fixtures/reduce-typeof-body-client.ts
@@ -1,0 +1,27 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `/* @client *​/` twin of `reduce-typeof-body` (#2613). Marking the
+ * expression defers `.reduce()` to client-only evaluation. No conformance
+ * pin: compiles clean, unpinned, non-divergent on every DSL adapter.
+ *
+ * NOT declared as `reduce-typeof-body`'s `escapes` twin — same
+ * `generateCsrTemplateWithOpts` markerless bug as `every-typeof-predicate-
+ * client` (see that fixture's docstring for the full explanation).
+ * CSR-skipped (`csr-skip-set.ts`) pending the compiler fix.
+ */
+export const fixture = createFixture({
+  id: 'reduce-typeof-body-client',
+  description: 'Off-subset `.reduce()` body deferred to the client via /* @client */',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function ReduceTypeofBodyClient() {
+  const [items, setItems] = createSignal<unknown[]>([])
+  return <div>{/* @client */ items().reduce((acc, t) => { const k = typeof t; return acc + k.length }, 0)}</div>
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1"></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/reduce-typeof-body.ts
+++ b/packages/adapter-tests/fixtures/reduce-typeof-body.ts
@@ -29,4 +29,7 @@ export function ReduceTypeofBody() {
   expectedHtml: `
     <div bf-s="test" bf="s1"><!--bf:s0-->0<!--/--></div>
   `,
+  // NOT declaring `escapes` here (#2613) — see `every-typeof-predicate`'s
+  // identical note; `reduce-typeof-body-client` hits the same CSR
+  // divergence.
 })

--- a/packages/adapter-tests/fixtures/some-typeof-predicate-client.ts
+++ b/packages/adapter-tests/fixtures/some-typeof-predicate-client.ts
@@ -1,0 +1,28 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `/* @client *​/` twin of `some-typeof-predicate` (#2613). Marking the
+ * expression defers `.some()` (and the `String(...)` wrapper around it) to
+ * client-only evaluation. No conformance pin: compiles clean, unpinned,
+ * non-divergent on every DSL adapter.
+ *
+ * NOT declared as `some-typeof-predicate`'s `escapes` twin — same
+ * `generateCsrTemplateWithOpts` markerless bug as `every-typeof-predicate-
+ * client` (see that fixture's docstring for the full explanation).
+ * CSR-skipped (`csr-skip-set.ts`) pending the compiler fix.
+ */
+export const fixture = createFixture({
+  id: 'some-typeof-predicate-client',
+  description: 'Off-subset `.some()` predicate deferred to the client via /* @client */',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function SomeTypeofPredicateClient() {
+  const [items, setItems] = createSignal<unknown[]>([])
+  return <div>{/* @client */ String(items().some(t => typeof t === 'string'))}</div>
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1"></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/some-typeof-predicate.ts
+++ b/packages/adapter-tests/fixtures/some-typeof-predicate.ts
@@ -29,4 +29,7 @@ export function SomeTypeofPredicate() {
   expectedHtml: `
     <div bf-s="test" bf="s1"><!--bf:s0-->false<!--/--></div>
   `,
+  // NOT declaring `escapes` here (#2613) — see `every-typeof-predicate`'s
+  // identical note; `some-typeof-predicate-client` hits the same CSR
+  // divergence.
 })

--- a/packages/adapter-tests/fixtures/tag-cloud.ts
+++ b/packages/adapter-tests/fixtures/tag-cloud.ts
@@ -32,6 +32,20 @@ export const spec: SharedFixtureSpec = {
   sourceRoot: 'fixture',
   description:
     'flatMap block-body tag list — hydration adoption, in-place leaf patch, add, and remove',
+  // #2613 escapeNotOwed: interaction (1) explicitly asserts hydration
+  // ADOPTS pre-existing SSR leaves ("pre-fix: leaves vanished on load —
+  // reconciled against the UN-flattened source with index keys"). A
+  // `/* @client */` twin would SSR no leaves at all, so there would be
+  // nothing to adopt — the fixture's core regression coverage (SSR-adopted
+  // leaves surviving hydration + patching) would be lost, degrading to the
+  // client-only-loop case. Same file-placement reasoning as
+  // `preamble-cells`: kept out of `integrations/shared/components/`
+  // because every DSL integration app's `bf build` compiles that
+  // directory wholesale, per this file's own docstring.
+  escapeNotOwed: {
+    reason:
+      "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either.",
+  },
   props: {
     items: [
       { id: 1, label: 'write <b>docs</b>', tags: ['a & b', 'q "c"'] },

--- a/packages/adapter-tests/src/csr-skip-set.ts
+++ b/packages/adapter-tests/src/csr-skip-set.ts
@@ -249,5 +249,29 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   // above (#968). Graduates to a full pass if that ordering is ever
   // unified.
   'signal-early-return',
+  // #2613: a genuine compiler bug the new `*-typeof-*` / `fill-unsupported`
+  // `/* @client */` escape twins uncovered. `generateCsrTemplateWithOpts`
+  // (`html-template.ts`'s `case 'expression'`) does not consult
+  // `IRExpression.markerless` before emitting `<!--bf:sN-->...<!--/-->` —
+  // unlike `client-only-elision.ts`'s docstring claims ("every CSR
+  // emitter... reads the single markerless flag"), this ONE emitter still
+  // always marks a `clientOnly && slotId` expression. So the standalone
+  // CSR template (fresh mount, no SSR to adopt) embeds marker comments
+  // that SSR correctly elides for a bare (non-loop) `/* @client */` TEXT
+  // expression, diverging from `expectedHtml`. Each entry's own fixture
+  // docstring has the full trace. The pre-existing LOOP-shaped
+  // `/* @client */` twins (`filter-typeof-predicate-client`,
+  // `filter-nested-callback-predicate-client`,
+  // `filter-nested-find-predicate-client`) are UNAFFECTED — elision only
+  // applies to bare expression children, and a loop's own container
+  // element is the mount anchor either way, so there is no separate
+  // markerless slot in play for those shapes.
+  'every-typeof-predicate-client',
+  'find-typeof-predicate-client',
+  'some-typeof-predicate-client',
+  'reduce-typeof-body-client',
+  'reduce-right-typeof-body-client',
+  'flatmap-typeof-projection-client',
+  'fill-unsupported-client',
 ])
 

--- a/packages/adapter-tests/src/types.ts
+++ b/packages/adapter-tests/src/types.ts
@@ -128,6 +128,38 @@ export interface JSXDataPoint {
 export type EscapeKind = 'client-directive' | 'prop-precompute' | 'rewrite'
 
 /**
+ * Declares that a refused fixture owes NO escape, by design — not merely
+ * "not authored yet" (#2613's increment-1 seed-run comment, "Two
+ * refinements this issue should absorb", refinement 1).
+ *
+ * The mechanical boundary in `escape-coverage.test.ts` treats every
+ * `(adapter, fixture)` pair where the reference adapter succeeds as owing
+ * an escape — correct for the overwhelming majority, but wrong for a
+ * fixture that exists specifically to pin JS-runtime-only behavior (e.g.
+ * an SSR-adopting-hydration regression test): for those, a `/* @client *\/`
+ * twin would defeat the fixture's own purpose (SSR renders nothing left to
+ * adopt) and, per the fixture's own docstring, would break every DSL
+ * integration app's `bf build` if the escaped variant were ever placed in
+ * the shared component corpus. Declaring a fixture like that `unescapable`
+ * on every refusing adapter's pin (`ConformancePin`, `@barefootjs/jsx`)
+ * conflates "todo" with "will never happen", which means that per-adapter
+ * debt can never legitimately reach zero.
+ *
+ * Deliberately NOT a bare boolean: exemption mechanisms get reached for
+ * more than they should, so this is costly-by-visibility — a required
+ * non-empty prose `reason`, asserted and surfaced in the floor test's own
+ * output (the test name embeds it), not a silent flag a reviewer can wave
+ * through without reading. `escapeNotOwed` (fixture-level) and
+ * `unescapable` (per-adapter pin-level) are mutually exclusive for the
+ * same (adapter, fixture) pair — declaring both is a floor-test failure,
+ * not a redundancy to shrug off.
+ */
+export interface EscapeNotOwed {
+  /** Non-empty prose explaining why this refusal owes no escape by design. */
+  reason: string
+}
+
+/**
  * A JSX fixture defines a component source and optional props for rendering.
  * Used by the JSX conformance runner to compile and render across adapters.
  *
@@ -253,6 +285,13 @@ export interface JSXFixture {
    * "Where an escape is owed" for why per-code classification rots).
    */
   escapes?: ReadonlyArray<{ kind: EscapeKind; fixture: string }>
+  /**
+   * Declares that this fixture's refusal owes NO escape, by design — the
+   * `escapeNotOwed` exemption (#2613's increment-1 seed comment). See
+   * {@link EscapeNotOwed} for what justifies using this over either
+   * authoring an `escapes` twin or ledgering in `KNOWN_UNESCAPABLE`.
+   */
+  escapeNotOwed?: EscapeNotOwed
 }
 
 /**
@@ -365,6 +404,7 @@ export function createFixture(input: {
   externalImports?: Record<string, string>
   hostStyles?: string
   escapes?: ReadonlyArray<{ kind: EscapeKind; fixture: string }>
+  escapeNotOwed?: EscapeNotOwed
 }): JSXFixture {
   const trimmedComponents = input.components
     ? Object.fromEntries(

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -96,25 +96,13 @@ export const conformancePins: ConformancePins = {
   // e.g. the `flatmap-expression-body` fixture) is NOT pinned: it lowers to
   // neutral nested-loop IR this adapter templatizes natively.
   // See spec/callback-fidelity.md.
-  'tag-cloud': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'tag-cloud': [{ code: 'BF021', severity: 'error' }],
   // A keyed `.map()` row body whose preamble builds a JSX leaf from item
   // state (`cells.push(<td>{stateLabel}</td>)`) embedded as `{cells}` — the
   // Stage 3 array-builder carrier, jsRuntime-only: a JS runtime runs it
   // verbatim (and patches the region on same-key updates, #2389), a DSL
   // adapter refuses with BF021 + `/* @client */`. See spec/callback-fidelity.md.
-  'preamble-cells': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'preamble-cells': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -173,14 +173,7 @@ export const conformancePins: ConformancePins = {
   'filter-nested-callback-predicate': [
     { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
-  'filter-nested-find-predicate': [
-    {
-      code: 'BF101',
-      severity: 'error',
-      issue: 'https://github.com/piconic-ai/barefootjs/issues/2320',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
-    },
-  ],
+  'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' }],
   // NB: TOP-LEVEL `.find` / `.findIndex` / `.findLast` / `.findLastIndex`
   // (text position) are NOT pinned here — like Jinja (unlike mojo, which
   // refuses them), Twig lowers them to `bf.find_eval` / `find_index_eval`

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -200,14 +200,7 @@ export const conformancePins: ConformancePins = {
   'filter-nested-callback-predicate': [
     { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
-  'filter-nested-find-predicate': [
-    {
-      code: 'BF101',
-      severity: 'error',
-      issue: 'https://github.com/piconic-ai/barefootjs/issues/2320',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
-    },
-  ],
+  'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' }],
   // NB: TOP-LEVEL `.find` / `.findIndex` / `.findLast` / `.findLastIndex`
   // (text position) are NOT pinned here — unlike mojo (which refuses them),
   // Xslate lowers them to `$bf.find` / `find_index` / `find_last` /

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -94,25 +94,13 @@ export const conformancePins: ConformancePins = {
   // e.g. the `flatmap-expression-body` fixture) is NOT pinned: it lowers to
   // neutral nested-loop IR this adapter templatizes natively.
   // See spec/callback-fidelity.md.
-  'tag-cloud': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'tag-cloud': [{ code: 'BF021', severity: 'error' }],
   // A keyed `.map()` row body whose preamble builds a JSX leaf from item
   // state (`cells.push(<td>{stateLabel}</td>)`) embedded as `{cells}` — the
   // Stage 3 array-builder carrier, jsRuntime-only: a JS runtime runs it
   // verbatim (and patches the region on same-key updates, #2389), a DSL
   // adapter refuses with BF021 + `/* @client */`. See spec/callback-fidelity.md.
-  'preamble-cells': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  'preamble-cells': [{ code: 'BF021', severity: 'error' }],
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the

--- a/packages/compat/src/__tests__/escape-coverage.test.ts
+++ b/packages/compat/src/__tests__/escape-coverage.test.ts
@@ -17,7 +17,17 @@
 //      `renderDivergences`, not CSR-skipped — the structural proxy for
 //      "renders correctly," not re-checked behaviourally here); or
 //   2. the adapter's OWN error pin for this fixture carries
-//      `unescapable: { issue }` (`ConformancePin`, `@barefootjs/jsx`).
+//      `unescapable: { issue }` (`ConformancePin`, `@barefootjs/jsx`); or
+//   3. the fixture declares `escapeNotOwed: { reason }` — an explicit,
+//      required-non-empty prose declaration that NO escape is owed here,
+//      by design (not merely "not authored yet") — see `EscapeNotOwed` in
+//      `packages/adapter-tests/src/types.ts`. Distinct from (2):
+//      `unescapable` means "an escape is owed but not authored yet";
+//      `escapeNotOwed` means "will never happen", so a by-design refusal
+//      doesn't sit forever as per-adapter debt that can never legitimately
+//      reach zero. Mutually exclusive with (2) for the same pair (enforced
+//      below). The reason is folded into the TEST NAME so it is visible in
+//      ordinary `bun test` output, not hidden behind a boolean.
 //
 // COST ORDERING — read this before reaching for either fast path:
 // shipping a refusal with NO working escape and NO `unescapable`
@@ -126,7 +136,16 @@ describe('escape coverage — every adapter refusal is escapable or self-declare
       }
 
       for (const fixtureId of domainFixtureIds) {
-        test(`[${fixtureId}] escapable or self-declared unescapable`, () => {
+        // `escapeNotOwed` is deliberately costly-by-visibility (#2613):
+        // its reason string is folded into the TEST NAME itself, so it
+        // shows up in every `bun test` run's output — a reviewer scanning
+        // CI output sees the justification, not just a pass/fail dot.
+        const notOwedReason = jsxFixtures.find(f => f.id === fixtureId)?.escapeNotOwed?.reason
+        const testName = notOwedReason
+          ? `[${fixtureId}] escape not owed: ${notOwedReason}`
+          : `[${fixtureId}] escapable or self-declared unescapable`
+
+        test(testName, () => {
           const outcome = evaluateFixtureEscapeCoverage(adapter, fixtureId, jsxFixtures)
           if (!outcome.ok) {
             throw new Error(outcome.message)

--- a/packages/compat/src/escape-coverage.ts
+++ b/packages/compat/src/escape-coverage.ts
@@ -73,9 +73,10 @@ export interface EscapeCoverageOutcome {
 }
 
 /**
- * The single check every domain pair must pass: a verified `escapes`
- * twin, or the adapter's own error pin declaring `unescapable`. Pure
- * function (no `expect`/`throw`) so it can run outside `bun:test`.
+ * The single check every domain pair must pass: `escapeNotOwed` on the
+ * fixture (no escape owed, by design), a verified `escapes` twin, or the
+ * adapter's own error pin declaring `unescapable`. Pure function (no
+ * `expect`/`throw`) so it can run outside `bun:test`.
  */
 export function evaluateFixtureEscapeCoverage(
   adapter: LoadedCompatAdapter,
@@ -92,6 +93,27 @@ export function evaluateFixtureEscapeCoverage(
 
   const errorPins = adapter.pins[fixtureId].filter(p => p.severity === 'error')
   const unescapablePin = errorPins.find(p => p.unescapable)
+
+  if (fixture.escapeNotOwed) {
+    if (!fixture.escapeNotOwed.reason || fixture.escapeNotOwed.reason.trim().length === 0) {
+      return {
+        ok: false,
+        message: `[${fixtureId}] declares 'escapeNotOwed' with an empty reason — a non-empty prose justification is required (EscapeNotOwed, packages/adapter-tests/src/types.ts).`,
+      }
+    }
+    if (unescapablePin) {
+      return {
+        ok: false,
+        message:
+          `[${adapter.id}/${fixtureId}] is declared BOTH 'escapeNotOwed' on the fixture AND 'unescapable' ` +
+          `on the '${unescapablePin.code}' pin in ${adapter.pkg}'s own conformance-pins.ts — pick one. ` +
+          `'escapeNotOwed' means "no escape is owed, by design"; 'unescapable' means "an escape is owed ` +
+          `but not authored yet". They are mutually exclusive.`,
+      }
+    }
+    // Escape genuinely not owed, by design, with a reviewed reason: satisfied.
+    return { ok: true }
+  }
 
   const declaredEscapes = fixture.escapes ?? []
   let workingTwinId: string | undefined

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 311,
+    "totalFixtures": 319,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 71,
+      "total": 79,
       "cells": {
         "hono": {
-          "pass": 71,
-          "total": 71
+          "pass": 79,
+          "total": 79
         },
         "blade": {
-          "pass": 59,
-          "total": 71,
+          "pass": 67,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 60,
-          "total": 71,
+          "pass": 68,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 59,
-          "total": 71,
+          "pass": 67,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -189,8 +189,8 @@
           ]
         },
         "jinja": {
-          "pass": 59,
-          "total": 71,
+          "pass": 67,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -247,8 +247,8 @@
           ]
         },
         "minijinja": {
-          "pass": 59,
-          "total": 71,
+          "pass": 67,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -305,8 +305,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 60,
-          "total": 71,
+          "pass": 68,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -357,8 +357,8 @@
           ]
         },
         "twig": {
-          "pass": 59,
-          "total": 71,
+          "pass": 67,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -415,8 +415,8 @@
           ]
         },
         "xslate": {
-          "pass": 59,
-          "total": 71,
+          "pass": 67,
+          "total": 79,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -486,15 +486,15 @@
       }
     },
     "array-method": {
-      "total": 67,
+      "total": 69,
       "cells": {
         "hono": {
-          "pass": 67,
-          "total": 67
+          "pass": 69,
+          "total": 69
         },
         "blade": {
-          "pass": 64,
-          "total": 67,
+          "pass": 66,
+          "total": 69,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -511,8 +511,8 @@
           ]
         },
         "erb": {
-          "pass": 64,
-          "total": 67,
+          "pass": 66,
+          "total": 69,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -529,8 +529,8 @@
           ]
         },
         "go-template": {
-          "pass": 64,
-          "total": 67,
+          "pass": 66,
+          "total": 69,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -547,8 +547,8 @@
           ]
         },
         "jinja": {
-          "pass": 64,
-          "total": 67,
+          "pass": 66,
+          "total": 69,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -565,8 +565,8 @@
           ]
         },
         "minijinja": {
-          "pass": 64,
-          "total": 67,
+          "pass": 66,
+          "total": 69,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -583,8 +583,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 64,
-          "total": 67,
+          "pass": 66,
+          "total": 69,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -601,8 +601,8 @@
           ]
         },
         "twig": {
-          "pass": 64,
-          "total": 67,
+          "pass": 66,
+          "total": 69,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -619,8 +619,8 @@
           ]
         },
         "xslate": {
-          "pass": 64,
-          "total": 67,
+          "pass": 66,
+          "total": 69,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -650,15 +650,15 @@
       }
     },
     "arrow": {
-      "total": 64,
+      "total": 69,
       "cells": {
         "hono": {
-          "pass": 64,
-          "total": 64
+          "pass": 69,
+          "total": 69
         },
         "blade": {
-          "pass": 55,
-          "total": 64,
+          "pass": 60,
+          "total": 69,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -703,8 +703,8 @@
           ]
         },
         "erb": {
-          "pass": 56,
-          "total": 64,
+          "pass": 61,
+          "total": 69,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -743,8 +743,8 @@
           ]
         },
         "go-template": {
-          "pass": 55,
-          "total": 64,
+          "pass": 60,
+          "total": 69,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -789,8 +789,8 @@
           ]
         },
         "jinja": {
-          "pass": 55,
-          "total": 64,
+          "pass": 60,
+          "total": 69,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -835,8 +835,8 @@
           ]
         },
         "minijinja": {
-          "pass": 55,
-          "total": 64,
+          "pass": 60,
+          "total": 69,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -881,8 +881,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 56,
-          "total": 64,
+          "pass": 61,
+          "total": 69,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -921,8 +921,8 @@
           ]
         },
         "twig": {
-          "pass": 55,
-          "total": 64,
+          "pass": 60,
+          "total": 69,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -967,8 +967,8 @@
           ]
         },
         "xslate": {
-          "pass": 55,
-          "total": 64,
+          "pass": 60,
+          "total": 69,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1026,15 +1026,15 @@
       }
     },
     "binary": {
-      "total": 84,
+      "total": 89,
       "cells": {
         "hono": {
-          "pass": 84,
-          "total": 84
+          "pass": 89,
+          "total": 89
         },
         "blade": {
-          "pass": 75,
-          "total": 84,
+          "pass": 80,
+          "total": 89,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1081,8 +1081,8 @@
           ]
         },
         "erb": {
-          "pass": 76,
-          "total": 84,
+          "pass": 81,
+          "total": 89,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1123,8 +1123,8 @@
           ]
         },
         "go-template": {
-          "pass": 75,
-          "total": 84,
+          "pass": 80,
+          "total": 89,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1171,8 +1171,8 @@
           ]
         },
         "jinja": {
-          "pass": 75,
-          "total": 84,
+          "pass": 80,
+          "total": 89,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1219,8 +1219,8 @@
           ]
         },
         "minijinja": {
-          "pass": 75,
-          "total": 84,
+          "pass": 80,
+          "total": 89,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1267,8 +1267,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 76,
-          "total": 84,
+          "pass": 81,
+          "total": 89,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1309,8 +1309,8 @@
           ]
         },
         "twig": {
-          "pass": 75,
-          "total": 84,
+          "pass": 80,
+          "total": 89,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1357,8 +1357,8 @@
           ]
         },
         "xslate": {
-          "pass": 75,
-          "total": 84,
+          "pass": 80,
+          "total": 89,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 203,
+      "total": 211,
       "cells": {
         "hono": {
-          "pass": 202,
-          "total": 203,
+          "pass": 210,
+          "total": 211,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1433,8 +1433,8 @@
           ]
         },
         "blade": {
-          "pass": 188,
-          "total": 203,
+          "pass": 196,
+          "total": 211,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1509,8 +1509,8 @@
           ]
         },
         "erb": {
-          "pass": 189,
-          "total": 203,
+          "pass": 197,
+          "total": 211,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1579,8 +1579,8 @@
           ]
         },
         "go-template": {
-          "pass": 188,
-          "total": 203,
+          "pass": 196,
+          "total": 211,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1655,8 +1655,8 @@
           ]
         },
         "jinja": {
-          "pass": 188,
-          "total": 203,
+          "pass": 196,
+          "total": 211,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1731,8 +1731,8 @@
           ]
         },
         "minijinja": {
-          "pass": 188,
-          "total": 203,
+          "pass": 196,
+          "total": 211,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1807,8 +1807,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 189,
-          "total": 203,
+          "pass": 197,
+          "total": 211,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1877,8 +1877,8 @@
           ]
         },
         "twig": {
-          "pass": 188,
-          "total": 203,
+          "pass": 196,
+          "total": 211,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1953,8 +1953,8 @@
           ]
         },
         "xslate": {
-          "pass": 188,
-          "total": 203,
+          "pass": 196,
+          "total": 211,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2042,15 +2042,15 @@
       }
     },
     "conditional": {
-      "total": 24,
+      "total": 25,
       "cells": {
         "hono": {
-          "pass": 24,
-          "total": 24
+          "pass": 25,
+          "total": 25
         },
         "blade": {
-          "pass": 22,
-          "total": 24,
+          "pass": 23,
+          "total": 25,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2063,8 +2063,8 @@
           ]
         },
         "erb": {
-          "pass": 22,
-          "total": 24,
+          "pass": 23,
+          "total": 25,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2077,8 +2077,8 @@
           ]
         },
         "go-template": {
-          "pass": 22,
-          "total": 24,
+          "pass": 23,
+          "total": 25,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2091,8 +2091,8 @@
           ]
         },
         "jinja": {
-          "pass": 22,
-          "total": 24,
+          "pass": 23,
+          "total": 25,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2105,8 +2105,8 @@
           ]
         },
         "minijinja": {
-          "pass": 22,
-          "total": 24,
+          "pass": 23,
+          "total": 25,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2119,8 +2119,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 22,
-          "total": 24,
+          "pass": 23,
+          "total": 25,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2133,8 +2133,8 @@
           ]
         },
         "twig": {
-          "pass": 22,
-          "total": 24,
+          "pass": 23,
+          "total": 25,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2147,8 +2147,8 @@
           ]
         },
         "xslate": {
-          "pass": 22,
-          "total": 24,
+          "pass": 23,
+          "total": 25,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2174,11 +2174,11 @@
       }
     },
     "identifier": {
-      "total": 292,
+      "total": 300,
       "cells": {
         "hono": {
-          "pass": 291,
-          "total": 292,
+          "pass": 299,
+          "total": 300,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2189,8 +2189,8 @@
           ]
         },
         "blade": {
-          "pass": 275,
-          "total": 292,
+          "pass": 283,
+          "total": 300,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2273,8 +2273,8 @@
           ]
         },
         "erb": {
-          "pass": 276,
-          "total": 292,
+          "pass": 284,
+          "total": 300,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2351,8 +2351,8 @@
           ]
         },
         "go-template": {
-          "pass": 275,
-          "total": 292,
+          "pass": 283,
+          "total": 300,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2435,8 +2435,8 @@
           ]
         },
         "jinja": {
-          "pass": 275,
-          "total": 292,
+          "pass": 283,
+          "total": 300,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2519,8 +2519,8 @@
           ]
         },
         "minijinja": {
-          "pass": 275,
-          "total": 292,
+          "pass": 283,
+          "total": 300,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2603,8 +2603,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 276,
-          "total": 292,
+          "pass": 284,
+          "total": 300,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2681,8 +2681,8 @@
           ]
         },
         "twig": {
-          "pass": 275,
-          "total": 292,
+          "pass": 283,
+          "total": 300,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2765,8 +2765,8 @@
           ]
         },
         "xslate": {
-          "pass": 275,
-          "total": 292,
+          "pass": 283,
+          "total": 300,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2914,15 +2914,15 @@
       }
     },
     "literal": {
-      "total": 241,
+      "total": 248,
       "cells": {
         "hono": {
-          "pass": 241,
-          "total": 241
+          "pass": 248,
+          "total": 248
         },
         "blade": {
-          "pass": 230,
-          "total": 241,
+          "pass": 237,
+          "total": 248,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2973,8 +2973,8 @@
           ]
         },
         "erb": {
-          "pass": 230,
-          "total": 241,
+          "pass": 237,
+          "total": 248,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3025,8 +3025,8 @@
           ]
         },
         "go-template": {
-          "pass": 230,
-          "total": 241,
+          "pass": 237,
+          "total": 248,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3077,8 +3077,8 @@
           ]
         },
         "jinja": {
-          "pass": 230,
-          "total": 241,
+          "pass": 237,
+          "total": 248,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3129,8 +3129,8 @@
           ]
         },
         "minijinja": {
-          "pass": 230,
-          "total": 241,
+          "pass": 237,
+          "total": 248,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3181,8 +3181,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 230,
-          "total": 241,
+          "pass": 237,
+          "total": 248,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3233,8 +3233,8 @@
           ]
         },
         "twig": {
-          "pass": 230,
-          "total": 241,
+          "pass": 237,
+          "total": 248,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3285,8 +3285,8 @@
           ]
         },
         "xslate": {
-          "pass": 230,
-          "total": 241,
+          "pass": 237,
+          "total": 248,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3498,11 +3498,11 @@
       }
     },
     "member": {
-      "total": 156,
+      "total": 164,
       "cells": {
         "hono": {
-          "pass": 155,
-          "total": 156,
+          "pass": 163,
+          "total": 164,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3513,8 +3513,8 @@
           ]
         },
         "blade": {
-          "pass": 139,
-          "total": 156,
+          "pass": 147,
+          "total": 164,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3597,8 +3597,8 @@
           ]
         },
         "erb": {
-          "pass": 140,
-          "total": 156,
+          "pass": 148,
+          "total": 164,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3675,8 +3675,8 @@
           ]
         },
         "go-template": {
-          "pass": 139,
-          "total": 156,
+          "pass": 147,
+          "total": 164,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3759,8 +3759,8 @@
           ]
         },
         "jinja": {
-          "pass": 139,
-          "total": 156,
+          "pass": 147,
+          "total": 164,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3843,8 +3843,8 @@
           ]
         },
         "minijinja": {
-          "pass": 139,
-          "total": 156,
+          "pass": 147,
+          "total": 164,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3927,8 +3927,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 140,
-          "total": 156,
+          "pass": 148,
+          "total": 164,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4005,8 +4005,8 @@
           ]
         },
         "twig": {
-          "pass": 139,
-          "total": 156,
+          "pass": 147,
+          "total": 164,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4089,8 +4089,8 @@
           ]
         },
         "xslate": {
-          "pass": 139,
-          "total": 156,
+          "pass": 147,
+          "total": 164,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4580,15 +4580,15 @@
       }
     },
     "unsupported": {
-      "total": 31,
+      "total": 37,
       "cells": {
         "hono": {
-          "pass": 31,
-          "total": 31
+          "pass": 37,
+          "total": 37
         },
         "blade": {
-          "pass": 20,
-          "total": 31,
+          "pass": 26,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -4641,8 +4641,8 @@
           ]
         },
         "erb": {
-          "pass": 20,
-          "total": 31,
+          "pass": 26,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -4695,8 +4695,8 @@
           ]
         },
         "go-template": {
-          "pass": 20,
-          "total": 31,
+          "pass": 26,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -4749,8 +4749,8 @@
           ]
         },
         "jinja": {
-          "pass": 20,
-          "total": 31,
+          "pass": 26,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -4803,8 +4803,8 @@
           ]
         },
         "minijinja": {
-          "pass": 20,
-          "total": 31,
+          "pass": 26,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -4857,8 +4857,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 20,
-          "total": 31,
+          "pass": 26,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -4911,8 +4911,8 @@
           ]
         },
         "twig": {
-          "pass": 20,
-          "total": 31,
+          "pass": 26,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -4965,8 +4965,8 @@
           ]
         },
         "xslate": {
-          "pass": 20,
-          "total": 31,
+          "pass": 26,
+          "total": 37,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -5345,15 +5345,15 @@
       }
     },
     "array-method:join": {
-      "total": 39,
+      "total": 41,
       "cells": {
         "hono": {
-          "pass": 39,
-          "total": 39
+          "pass": 41,
+          "total": 41
         },
         "blade": {
-          "pass": 37,
-          "total": 39,
+          "pass": 39,
+          "total": 41,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5366,8 +5366,8 @@
           ]
         },
         "erb": {
-          "pass": 37,
-          "total": 39,
+          "pass": 39,
+          "total": 41,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5380,8 +5380,8 @@
           ]
         },
         "go-template": {
-          "pass": 37,
-          "total": 39,
+          "pass": 39,
+          "total": 41,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5394,8 +5394,8 @@
           ]
         },
         "jinja": {
-          "pass": 37,
-          "total": 39,
+          "pass": 39,
+          "total": 41,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5408,8 +5408,8 @@
           ]
         },
         "minijinja": {
-          "pass": 37,
-          "total": 39,
+          "pass": 39,
+          "total": 41,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5422,8 +5422,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 37,
-          "total": 39,
+          "pass": 39,
+          "total": 41,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5436,8 +5436,8 @@
           ]
         },
         "twig": {
-          "pass": 37,
-          "total": 39,
+          "pass": 39,
+          "total": 41,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5450,8 +5450,8 @@
           ]
         },
         "xslate": {
-          "pass": 37,
-          "total": 39,
+          "pass": 39,
+          "total": 41,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -6836,15 +6836,15 @@
       }
     },
     "binary:===": {
-      "total": 44,
+      "total": 49,
       "cells": {
         "hono": {
-          "pass": 44,
-          "total": 44
+          "pass": 49,
+          "total": 49
         },
         "blade": {
-          "pass": 36,
-          "total": 44,
+          "pass": 41,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6885,8 +6885,8 @@
           ]
         },
         "erb": {
-          "pass": 37,
-          "total": 44,
+          "pass": 42,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6921,8 +6921,8 @@
           ]
         },
         "go-template": {
-          "pass": 36,
-          "total": 44,
+          "pass": 41,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -6963,8 +6963,8 @@
           ]
         },
         "jinja": {
-          "pass": 36,
-          "total": 44,
+          "pass": 41,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7005,8 +7005,8 @@
           ]
         },
         "minijinja": {
-          "pass": 36,
-          "total": 44,
+          "pass": 41,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7047,8 +7047,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 37,
-          "total": 44,
+          "pass": 42,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7083,8 +7083,8 @@
           ]
         },
         "twig": {
-          "pass": 36,
-          "total": 44,
+          "pass": 41,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7125,8 +7125,8 @@
           ]
         },
         "xslate": {
-          "pass": 36,
-          "total": 44,
+          "pass": 41,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7435,15 +7435,15 @@
       }
     },
     "literal:number": {
-      "total": 101,
+      "total": 104,
       "cells": {
         "hono": {
-          "pass": 101,
-          "total": 101
+          "pass": 104,
+          "total": 104
         },
         "blade": {
-          "pass": 96,
-          "total": 101,
+          "pass": 99,
+          "total": 104,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7468,8 +7468,8 @@
           ]
         },
         "erb": {
-          "pass": 96,
-          "total": 101,
+          "pass": 99,
+          "total": 104,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7494,8 +7494,8 @@
           ]
         },
         "go-template": {
-          "pass": 96,
-          "total": 101,
+          "pass": 99,
+          "total": 104,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7520,8 +7520,8 @@
           ]
         },
         "jinja": {
-          "pass": 96,
-          "total": 101,
+          "pass": 99,
+          "total": 104,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7546,8 +7546,8 @@
           ]
         },
         "minijinja": {
-          "pass": 96,
-          "total": 101,
+          "pass": 99,
+          "total": 104,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7572,8 +7572,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 96,
-          "total": 101,
+          "pass": 99,
+          "total": 104,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7598,8 +7598,8 @@
           ]
         },
         "twig": {
-          "pass": 96,
-          "total": 101,
+          "pass": 99,
+          "total": 104,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7624,8 +7624,8 @@
           ]
         },
         "xslate": {
-          "pass": 96,
-          "total": 101,
+          "pass": 99,
+          "total": 104,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7663,15 +7663,15 @@
       }
     },
     "literal:string": {
-      "total": 171,
+      "total": 176,
       "cells": {
         "hono": {
-          "pass": 171,
-          "total": 171
+          "pass": 176,
+          "total": 176
         },
         "blade": {
-          "pass": 163,
-          "total": 171,
+          "pass": 168,
+          "total": 176,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7710,8 +7710,8 @@
           ]
         },
         "erb": {
-          "pass": 163,
-          "total": 171,
+          "pass": 168,
+          "total": 176,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7750,8 +7750,8 @@
           ]
         },
         "go-template": {
-          "pass": 163,
-          "total": 171,
+          "pass": 168,
+          "total": 176,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7790,8 +7790,8 @@
           ]
         },
         "jinja": {
-          "pass": 163,
-          "total": 171,
+          "pass": 168,
+          "total": 176,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7830,8 +7830,8 @@
           ]
         },
         "minijinja": {
-          "pass": 163,
-          "total": 171,
+          "pass": 168,
+          "total": 176,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7870,8 +7870,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 163,
-          "total": 171,
+          "pass": 168,
+          "total": 176,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7910,8 +7910,8 @@
           ]
         },
         "twig": {
-          "pass": 163,
-          "total": 171,
+          "pass": 168,
+          "total": 176,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7950,8 +7950,8 @@
           ]
         },
         "xslate": {
-          "pass": 163,
-          "total": 171,
+          "pass": 168,
+          "total": 176,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",


### PR DESCRIPTION
Stacked on #2615. This was framed as a **hypothesis test**, not a chore: increment 1's seed put 89% of pairs in the ledger, and the offered interpretation was that ~8 fixtures were merely *"twin not authored yet"* — the same class as the already-working `filter-typeof-predicate` twin.

## The hypothesis was wrong — 1 of 8 closed

Twins were authored for all 8. All 8 compile clean, unpinned and non-divergent on every DSL adapter. But running the **real** `csr-conformance.test.ts` (not the floor test's static proxy) failed 7 of them, and the cause is a genuine compiler bug, not a missing fixture.

**`generateCsrTemplateWithOpts` (`html-template.ts:2229`) never consults `IRExpression.markerless`** before emitting `<!--bf:sN-->…<!--/-->` for a `clientOnly && slotId` expression. So SSR correctly elides the markers and the standalone CSR template still embeds them — a real SSR/CSR divergence. Filed as #2617.

Note this directly contradicts `client-only-elision.ts`'s own docstring ("every CSR emitter … reads the single markerless flag") and the claim landed in `spec/slot-unification.md` §5a by #2606, which checked `irToHtmlTemplate` (line 737 — that one *does* check, at 813) and missed the second emitter. Spec correction is part of #2617.

**Why these 7 and not the two pre-existing twins**: the failures are all **bare, non-loop text-expression** `/* @client */` positions. Both existing twins are loop-shaped, where the container element is the mount anchor and no separate markerless slot is in play. No corpus fixture had exercised the bare-text-expression shape before.

So #2613's boundary is sharper than the seed comment guessed: **a ratchet for the loop-shaped class, aspirational for the bare-text-expression class** — pending #2617.

Per the task framing, I did **not** add `skipJsx` / `renderDivergences` / CSR-skips to force those 7 to count as escapes. They are CSR-skipped only to pin the defect as a reproducible fixture (CLAUDE.md's "a reproducible defect lands as a fixture"), with **no `escapes` declared** and their `KNOWN_UNESCAPABLE` entries kept — reworded to say *why*, rather than the previous "no twin yet".

## Ledger movement

| | Seed (#2615) | Now |
|---|---:|---:|
| Domain pairs | 126 | 126 |
| Covered by a verified twin | 14 (11.1%) | **22 (17.5%)** |
| `escapeNotOwed` | — | **16 (12.7%)** |
| `KNOWN_UNESCAPABLE` | 112 (88.9%) | **88 (69.8%)** |

`filter-nested-find-predicate` closed (the `.find()` sibling of the working `.some()` twin — genuinely the same class). Its SSR output is `<ul bf-s="test" bf="s1"></ul>`, matching the existing loop-shaped twins exactly.

The 7 blocked twins' SSR output is `<div bf-s="test" bf="s1"></div>` — fully empty, no slot markers, i.e. **the SSR side's markerless elision is working correctly**; only the CSR template disagrees. That asymmetry is the bug in one line.

`fill-unsupported`'s docstring claim ("already covered by the filter-*-client twins") is confirmed **false** — but for a method-agnostic reason: every `*-typeof-*` sibling hits the identical bug, nothing `.fill()`-specific.

## `escapeNotOwed` (commit 2, isolated)

Verified independently that `preamble-cells` / `tag-cloud` are refused **by design**, and found a second technical reason beyond their docstrings: both are the real-browser regression pins for SSR-**adopting** hydration (#2389 patch-on-update, flatMap client-loop rewiring) — their interactions assert that hydration adopts pre-existing SSR markup and patches it in place. A `/* @client */` twin would SSR nothing, leaving no adopted node to patch, collapsing the fixture into the already-covered `client-only-loop` case with zero new coverage.

`EscapeNotOwed = { reason: string }`, threaded through `createFixture`/`SharedFixtureSpec`. Made costly-by-visibility as the design asks: empty reason throws, declaring both `escapeNotOwed` and a ledger entry throws, and the reason is folded into the generated test name (verified visible via `-t "escape not owed"`, 16 matching tests). This keeps `KNOWN_UNESCAPABLE` a pure to-do list — without it the ledger can never legitimately reach zero and its size stops carrying information.

## A weakness in the invariant this exposed

The floor test's tier-2 "not CSR-skipped" condition is a **static membership check, not an execution**. All 7 broken twins sailed through `escape-coverage.test.ts` as apparently-covered while genuinely failing `csr-conformance.test.ts`. That is precisely #2613's own "in-process compile vs real backend" risk, now observed rather than hypothesised — recorded on #2613.

## Verification

`packages/compat` **311 pass / 0 fail** (verified at both commit states independently) · `escape-coverage.test.ts` **128 / 0** · `packages/adapter-tests` **1936–1938 pass / 0 real fail** — every run showed 2–5 transient 5000ms timeouts under sandbox CPU contention on unrelated pre-existing fixtures (including the *pre-existing* `filter-typeof-predicate*` twins), none reproducing when rerun isolated. `coverage-map.json` and `ui/support-matrix.lock.json` regenerated mechanically (pass/total counts only).

No changeset: `@barefootjs/adapter-tests`, `@barefootjs/compat` and `@barefootjs/ui` are all in `.changeset/config.json`'s ignore list.

Refs #2613, #2617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_