### PR TITLE
docs(compat): distinguish escapable refusals from tracked debt in the matrix (#2613)

### DIFF
--- a/packages/compat/__tests__/component-docs.test.ts
+++ b/packages/compat/__tests__/component-docs.test.ts
@@ -12,11 +12,19 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { computeComponentDocs, computeFixtureDocs } from '../src/component-docs'
 
+interface FixtureDivergenceCell {
+  kind: 'refusal' | 'render'
+  escape?: { state: 'escapable' | 'debt' | 'not-owed'; twin?: string }
+}
+
 const LOCK_PATH = resolve(import.meta.dir, '../../../ui/compat.lock.json')
 const lock = JSON.parse(readFileSync(LOCK_PATH, 'utf8')) as {
   components: Record<string, unknown>
   componentDocs?: Record<string, { title: string; description: string; url: string; uiUrl?: string }>
-  fixtureDivergences: { fixtures: Record<string, unknown>; docs?: Record<string, { description: string; url: string }> }
+  fixtureDivergences: {
+    fixtures: Record<string, Record<string, FixtureDivergenceCell>>
+    docs?: Record<string, { description: string; url: string }>
+  }
 }
 
 const BLOB_PREFIX = 'https://github.com/piconic-ai/barefootjs/blob/main/'
@@ -63,7 +71,21 @@ describe('computeComponentDocs', () => {
 })
 
 describe('computeFixtureDocs', () => {
-  const ids = Object.keys(lock.fixtureDivergences.fixtures)
+  // (#2613) The lock's `fixtureDivergences.docs` covers the divergent
+  // fixtures themselves PLUS every `'escapable'` cell's escape-twin id —
+  // `cli.ts` widens the id set the same way before calling
+  // `computeFixtureDocs`, so the docs page can link straight to the twin
+  // that demonstrates the escape. Mirrored here rather than re-imported
+  // from `cli.ts` (a script entry point, not a library export) so this
+  // "regen freshness" check recomputes independently, same as the
+  // `computeComponentDocs` describe block above.
+  const escapeTwinIds = new Set<string>()
+  for (const row of Object.values(lock.fixtureDivergences.fixtures)) {
+    for (const cell of Object.values(row)) {
+      if (cell.escape?.state === 'escapable' && cell.escape.twin) escapeTwinIds.add(cell.escape.twin)
+    }
+  }
+  const ids = [...new Set([...Object.keys(lock.fixtureDivergences.fixtures), ...escapeTwinIds])]
   const docs = computeFixtureDocs(ids)
 
   test('every divergent fixture has a description and a source link', () => {

--- a/packages/compat/src/__tests__/fixture-escape-rendering.test.ts
+++ b/packages/compat/src/__tests__/fixture-escape-rendering.test.ts
@@ -1,0 +1,160 @@
+// Rendering-side counterpart to `escape-coverage.test.ts` (#2613's
+// "escape visibility" follow-up). That file is the FLOOR — every refusal
+// is escapable-or-declared. This file asserts the render-conformance
+// table actually SHOWS the difference: a refusal with a verified escape
+// (`'escapable'`), one that's still open (`'debt'`), and one that owes no
+// escape at all by design (`'not-owed'`) must render as three visually
+// distinct things, not one flat diagnostic code.
+//
+// Two layers:
+//   - `escapeMarker` is a pure function over a `FixtureDivergenceCell`'s
+//     `escape` field — fast, synthetic input, no compiling.
+//   - `buildFixtureDivergences` is exercised ONCE, at module scope, against
+//     the REAL corpus and REAL adapters (same precedent as
+//     `escape-coverage.test.ts` itself — that file's header comment
+//     explains why this can't be faked without reimplementing the
+//     compiler, and computes `loaded` once at module scope for the same
+//     reason: every domain fixture's escape twin gets a real
+//     `compileForCompat` call, so recomputing per-test would multiply an
+//     already-heavy corpus compile by the test count). Named
+//     `(fixture, adapter)` pairs known to sit in each of the three states
+//     today are asserted individually, so a regression in
+//     `classifyFixtureEscapeState` (wrong branch chosen, wrong twin
+//     resolved) fails here, not just silently in prod docs.
+//
+// Picking a NAMED example per state (rather than only asserting "each
+// state appears somewhere") is deliberate: a set-membership-only check
+// would still pass if classification degenerated to "everything is
+// 'debt'" for every fixture except one accidental survivor — naming the
+// fixtures pins the actual claim being tested. The adapter each example
+// lands on is never hardcoded, though — `findColumnInState` searches
+// whichever columns `loadCompatAdapters()` actually resolved, the same
+// additivity principle `escape-coverage-additivity.test.ts` backstops
+// mechanically for the floor test itself: a 9th adapter is picked up here
+// automatically, never requiring an edit to this file.
+
+import { describe, expect, test } from 'bun:test'
+import { jsxFixtures } from '../../../adapter-tests/fixtures'
+import { loadCompatAdapters } from '../adapter-registry'
+import {
+  buildFixtureDivergences,
+  ESCAPABLE_MARKER,
+  escapeMarker,
+  NOT_OWED_MARKER,
+  type FixtureDivergenceCell,
+} from '../report'
+
+describe('escapeMarker — the three escape states render as three distinct things', () => {
+  test('escapable renders the dagger marker', () => {
+    expect(escapeMarker({ state: 'escapable', twin: 'some-fixture-client' })).toBe(ESCAPABLE_MARKER)
+  })
+
+  test('not-owed renders the double-dagger marker', () => {
+    expect(escapeMarker({ state: 'not-owed', reason: 'because' })).toBe(NOT_OWED_MARKER)
+  })
+
+  test('debt renders unmarked — the pre-#2613 bare-code rendering', () => {
+    expect(escapeMarker({ state: 'debt' })).toBe('')
+  })
+
+  test('no escape state (out-of-domain refusal, or a render-kind cell) renders unmarked', () => {
+    expect(escapeMarker(undefined)).toBe('')
+  })
+
+  test('all three renderings are visually distinct characters', () => {
+    const renderings = new Set([
+      escapeMarker({ state: 'escapable', twin: 'x' }),
+      escapeMarker({ state: 'not-owed', reason: 'x' }),
+      escapeMarker({ state: 'debt' }),
+    ])
+    expect(renderings.size).toBe(3)
+  })
+})
+
+const { loaded } = await loadCompatAdapters()
+const fd = buildFixtureDivergences(loaded, jsxFixtures.length, jsxFixtures)
+
+/** First adapter column on `fixtureId`'s row whose escape state is `state`, or undefined. */
+function findColumnInState(
+  fixtureId: string,
+  state: 'escapable' | 'debt' | 'not-owed',
+): { adapterId: string; cell: FixtureDivergenceCell } | undefined {
+  const row = fd.fixtures[fixtureId]
+  if (!row) return undefined
+  for (const [adapterId, cell] of Object.entries(row)) {
+    if (cell.escape?.state === state) return { adapterId, cell }
+  }
+  return undefined
+}
+
+describe('buildFixtureDivergences — real corpus, real adapters (#2613)', () => {
+  test('at least one adapter loaded (a vacuous pass below would prove nothing)', () => {
+    expect(loaded.length).toBeGreaterThan(0)
+  })
+
+  test('the render-conformance table exercises all three escape states', () => {
+    const states = new Set<string>()
+    for (const row of Object.values(fd.fixtures)) {
+      for (const cell of Object.values(row)) {
+        if (cell.escape) states.add(cell.escape.state)
+      }
+    }
+
+    expect(states).toEqual(new Set(['escapable', 'debt', 'not-owed']))
+  })
+
+  // Named example 1: a refused fixture whose declared escape twin is
+  // verified working on some real adapter — a supported path, not a dead
+  // end, and rendered with `ESCAPABLE_MARKER`, not a bare code.
+  test('every-typeof-predicate is escapable (with its declared twin) on at least one adapter', () => {
+    const found = findColumnInState('every-typeof-predicate', 'escapable')
+    expect(found).toBeDefined()
+    expect(found!.cell.kind).toBe('refusal')
+    expect(found!.cell.escape).toEqual({ state: 'escapable', twin: 'every-typeof-predicate-client' })
+    expect(escapeMarker(found!.cell.escape)).toBe(ESCAPABLE_MARKER)
+  })
+
+  // Named example 2: refused, no working escape, and the adapter's own
+  // pin says so with `unescapable` — tracked debt, rendered unmarked
+  // (bare code) exactly as every refusal rendered before #2613.
+  test('map-array-builder-body is tracked debt (adapter declares unescapable) on at least one adapter', () => {
+    const found = findColumnInState('map-array-builder-body', 'debt')
+    expect(found).toBeDefined()
+    expect(found!.cell.kind).toBe('refusal')
+    expect(found!.cell.escape).toEqual({ state: 'debt' })
+    expect(escapeMarker(found!.cell.escape)).toBe('')
+  })
+
+  // Named example 3: refused on every DSL adapter, and the fixture itself
+  // declares `escapeNotOwed` — no escape will ever be authored (a
+  // `/* @client */` twin would SSR nothing, defeating the fixture's own
+  // hydration-adoption regression coverage). Rendered with
+  // `NOT_OWED_MARKER`, never conflated with genuine open debt.
+  test('tag-cloud owes no escape, by design, on at least one adapter', () => {
+    const found = findColumnInState('tag-cloud', 'not-owed')
+    expect(found).toBeDefined()
+    expect(found!.cell.kind).toBe('refusal')
+    expect((found!.cell.escape as { state: 'not-owed'; reason: string }).reason.length).toBeGreaterThan(0)
+    expect(escapeMarker(found!.cell.escape)).toBe(NOT_OWED_MARKER)
+  })
+
+  test('a bare unmarked code and a marked one are textually different table cells', () => {
+    // The whole point of the feature: two refusals must not render
+    // identically when their escape stories differ.
+    const cellToText = (cell: FixtureDivergenceCell | undefined): string =>
+      cell && cell.kind === 'refusal' ? `${(cell.codes ?? []).join(', ')}${escapeMarker(cell.escape)}` : ''
+
+    const debt = findColumnInState('map-array-builder-body', 'debt')
+    const escapable = findColumnInState('every-typeof-predicate', 'escapable')
+    expect(debt).toBeDefined()
+    expect(escapable).toBeDefined()
+
+    const debtText = cellToText(debt!.cell)
+    const escapableText = cellToText(escapable!.cell)
+    expect(debtText).not.toBe('')
+    expect(escapableText).not.toBe('')
+    expect(debtText).not.toBe(escapableText)
+    expect(escapableText.endsWith(ESCAPABLE_MARKER)).toBe(true)
+    expect(debtText.endsWith(ESCAPABLE_MARKER)).toBe(false)
+  })
+})

--- a/packages/compat/src/cli.ts
+++ b/packages/compat/src/cli.ts
@@ -227,9 +227,12 @@ async function main(): Promise<void> {
   // compatibility-matrix page reports render-level gaps instead of
   // showing only the all-green compile story. `jsxFixtures` is imported
   // relatively (same precedent as `compat-pins.test.ts` — it isn't part
-  // of adapter-tests' public export map) purely for the corpus total.
+  // of adapter-tests' public export map): the corpus total AND (#2613) the
+  // full fixture list, so `buildFixtureDivergences` can read each refused
+  // fixture's `escapeNotOwed` / `escapes` declarations and verify escape
+  // twins against every adapter's real backend.
   const { jsxFixtures } = await import('../../adapter-tests/fixtures')
-  const fixtureDivergences = buildFixtureDivergences(loaded, jsxFixtures.length)
+  const fixtureDivergences = buildFixtureDivergences(loaded, jsxFixtures.length, jsxFixtures)
 
   const report = buildCompatReport(cells, fixtureDivergences)
 
@@ -242,7 +245,19 @@ async function main(): Promise<void> {
   // component sources, and the fixture corpus off disk. Committed into
   // the lock and drift-checked in CI like the rest of it.
   report.componentDocs = computeComponentDocs(Object.keys(report.components))
-  report.fixtureDivergences.docs = computeFixtureDocs(Object.keys(report.fixtureDivergences.fixtures))
+  // (#2613) Also cover every `'escapable'` cell's escape-twin id, not just
+  // the divergent fixtures themselves — the docs page links straight to
+  // the twin that demonstrates the escape, so it needs that fixture's
+  // description + source link too, even though the twin itself compiles
+  // clean everywhere and never appears as a row in this table.
+  const escapeTwinIds = new Set<string>()
+  for (const row of Object.values(fixtureDivergences.fixtures)) {
+    for (const cell of Object.values(row)) {
+      if (cell.escape?.state === 'escapable') escapeTwinIds.add(cell.escape.twin)
+    }
+  }
+  const docFixtureIds = new Set([...Object.keys(report.fixtureDivergences.fixtures), ...escapeTwinIds])
+  report.fixtureDivergences.docs = computeFixtureDocs([...docFixtureIds])
 
   const text = jsonFlag ? formatCompatJson(report) : formatCompatMarkdown(report)
 

--- a/packages/compat/src/escape-coverage.ts
+++ b/packages/compat/src/escape-coverage.ts
@@ -70,6 +70,18 @@ export function computeDomainFixtureIds(adapter: LoadedCompatAdapter, honoErrorP
 export interface EscapeCoverageOutcome {
   ok: boolean
   message?: string
+  /**
+   * Which declared `escapes` twin was proven to work on this adapter, when
+   * one was. Reported rather than recomputed because `twinWorksOnAdapter`
+   * runs a real `compileForCompat` per candidate: `classifyFixtureEscapeState`
+   * needs the same answer for rendering, and re-deriving it there doubled
+   * the compiles for every escapable cell during lock generation (78 of
+   * them today).
+   *
+   * Absent when no twin was tried (`escapeNotOwed` returns before the scan)
+   * or none worked.
+   */
+  workingTwinId?: string
 }
 
 /**
@@ -173,7 +185,7 @@ export function evaluateFixtureEscapeCoverage(
     }
   }
 
-  return { ok: true }
+  return { ok: true, workingTwinId }
 }
 
 /**
@@ -244,11 +256,12 @@ export function classifyFixtureEscapeState(
     return { state: 'debt' }
   }
 
-  for (const escape of fixture.escapes ?? []) {
-    const twin = fixtures.find(f => f.id === escape.fixture)
-    if (twin && twinWorksOnAdapter(twin, adapter)) {
-      return { state: 'escapable', twin: twin.id }
-    }
+  // `evaluateFixtureEscapeCoverage` above already compiled each candidate
+  // twin to decide this; it reports the winner rather than making us run
+  // `twinWorksOnAdapter` (and therefore `compileForCompat`) a second time
+  // per escapable cell.
+  if (outcome.workingTwinId) {
+    return { state: 'escapable', twin: outcome.workingTwinId }
   }
 
   // `evaluateFixtureEscapeCoverage` only returns `ok: true` via one of the

--- a/packages/compat/src/escape-coverage.ts
+++ b/packages/compat/src/escape-coverage.ts
@@ -177,6 +177,90 @@ export function evaluateFixtureEscapeCoverage(
 }
 
 /**
+ * The three states a refused fixture's escape story can be in on ONE
+ * adapter (#2613's "escape visibility" follow-up) — the rendering-side
+ * counterpart of the `escapable or self-declared unescapable` floor test
+ * above, not a new judgement:
+ *
+ *   - `'escapable'` — the fixture names an `escapes` twin and it actually
+ *     works HERE (`twinWorksOnAdapter`, same tier-1/tier-2 check the floor
+ *     test itself uses). `twin` is which declared twin fixture it was, so
+ *     a renderer can link straight to the demonstration.
+ *   - `'debt'` — refused, no working escape, and the adapter's own pin
+ *     says so (`unescapable: { issue }`) — tracked, not silent.
+ *   - `'not-owed'` — the fixture itself declares `escapeNotOwed`: no
+ *     escape will ever be authored here, by design. `reason` is the
+ *     fixture's own prose justification, carried through so a renderer
+ *     doesn't have to re-derive or truncate it.
+ */
+export type FixtureEscapeState =
+  | { state: 'escapable'; twin: string }
+  | { state: 'debt' }
+  | { state: 'not-owed'; reason: string }
+
+/**
+ * Classify ONE `(adapter, fixtureId)` refusal cell for rendering. Callers
+ * MUST only invoke this for a pair already confirmed in-domain (an
+ * error-severity pin on `adapter`, and `fixtureId` not in
+ * `computeHonoErrorPinnedFixtures(...)`'s result) — see
+ * `buildFixtureDivergences` in `./report.ts`, the sole caller. Outside
+ * that domain `evaluateFixtureEscapeCoverage` may legitimately report
+ * `ok: false` for reasons that have nothing to do with THIS adapter (e.g.
+ * a compiler-wide refusal nobody bothers to annotate), which would make
+ * the throw below fire spuriously.
+ *
+ * Deliberately re-derives nothing `evaluateFixtureEscapeCoverage` already
+ * decided — it's called first, and a non-ok outcome throws rather than
+ * guessing a state, because reaching that branch on a landed pin means
+ * the "loud-or-escapable" floor test (`escape-coverage.test.ts`) would
+ * itself be RED: the lock is being regenerated against broken/uncommitted
+ * pin state, and a docs page silently rendering a stale guess would hide
+ * that. The classification below only picks which of the three already-
+ * proven-consistent branches applies, using the exact same declarative
+ * fields (`escapeNotOwed`, `unescapable`, `escapes` + `twinWorksOnAdapter`)
+ * the floor test itself reads — never a parallel judgement.
+ */
+export function classifyFixtureEscapeState(
+  adapter: LoadedCompatAdapter,
+  fixtureId: string,
+  fixtures: readonly JSXFixture[],
+): FixtureEscapeState {
+  const outcome = evaluateFixtureEscapeCoverage(adapter, fixtureId, fixtures)
+  if (!outcome.ok) {
+    throw new Error(
+      `compat-matrix render: escape-coverage floor test would fail for [${adapter.id}/${fixtureId}] — fix ` +
+        `the pin/twin declaration and re-run 'bun test packages/compat/src/__tests__/escape-coverage.test.ts' ` +
+        `before regenerating the lock:\n${outcome.message}`,
+    )
+  }
+
+  const fixture = fixtures.find(f => f.id === fixtureId)!
+  if (fixture.escapeNotOwed) {
+    return { state: 'not-owed', reason: fixture.escapeNotOwed.reason }
+  }
+
+  const pinsForFixture = adapter.pins[fixtureId] ?? []
+  if (pinsForFixture.some(p => p.severity === 'error' && p.unescapable)) {
+    return { state: 'debt' }
+  }
+
+  for (const escape of fixture.escapes ?? []) {
+    const twin = fixtures.find(f => f.id === escape.fixture)
+    if (twin && twinWorksOnAdapter(twin, adapter)) {
+      return { state: 'escapable', twin: twin.id }
+    }
+  }
+
+  // `evaluateFixtureEscapeCoverage` only returns `ok: true` via one of the
+  // three branches above (escapeNotOwed / unescapable / a working twin), so
+  // this is structurally unreachable given the guard already passed — kept
+  // as a defensive `'debt'` rather than a non-null assertion so a future
+  // change to that function's branches fails safe (a docs page rendering
+  // "no escape yet" for a really-fine case) rather than throwing.
+  return { state: 'debt' }
+}
+
+/**
  * Every pin-config mistake `escapes-coverage.test.ts` guards against
  * beyond the domain check itself: `unescapable` set on a non-error pin
  * (meaningless — only an error-severity refusal owes an escape), or set

--- a/packages/compat/src/report.ts
+++ b/packages/compat/src/report.ts
@@ -5,7 +5,12 @@
 // gates on `git diff --exit-code` against it, so two runs over the same
 // inputs must produce byte-identical output.
 
+import type { LoadedCompatAdapter } from './adapter-registry'
 import type { CompatCell } from './engine'
+import { classifyFixtureEscapeState, computeDomainFixtureIds, computeHonoErrorPinnedFixtures, type FixtureEscapeState } from './escape-coverage'
+import type { JSXFixture } from '../../adapter-tests/src/types'
+
+export type { FixtureEscapeState } from './escape-coverage'
 
 export const COMPAT_NOTE =
   'Compile-time compatibility (compileJSX + adapter generate() diagnostics). ' +
@@ -52,6 +57,18 @@ export interface FixtureDivergenceCell {
   issues?: string[]
   /** One-line divergence description for render-kind cells. */
   reason?: string
+  /**
+   * Set only on `'refusal'` cells with an error-severity pin that's IN the
+   * "loud-or-escapable" floor's domain (`computeDomainFixtureIds` —
+   * excludes fixtures the reference adapter itself refuses, a compiler-wide
+   * bug rather than an adapter-specific gap). Distinguishes a refusal with
+   * a verified working escape (`'escapable'`) from one that's still tracked
+   * debt (`'debt'`) or that owes no escape at all, by design
+   * (`'not-owed'`) — see `FixtureEscapeState` (`./escape-coverage.ts`) and
+   * #2613. Absent for warning-only refusals and every `'render'`-kind cell,
+   * where the concept doesn't apply.
+   */
+  escape?: FixtureEscapeState
 }
 
 export const FIXTURE_DIVERGENCES_NOTE =
@@ -59,7 +76,11 @@ export const FIXTURE_DIVERGENCES_NOTE =
   'through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed ' +
   'here diverge on at least one adapter — either refused loudly at build time (conformancePins) or ' +
   'rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance ' +
-  'suite until fixed). Fixtures absent from this table render to reference parity on every adapter.'
+  'suite until fixed). Fixtures absent from this table render to reference parity on every adapter. ' +
+  'A build-time refusal is not automatically a dead end: some refusals carry a VERIFIED working escape ' +
+  '(most often a `/* @client */` twin) — a supported, tested path, not tracked debt — marked `escapable` ' +
+  'below; others are declared `not-owed` (no escape will ever be authored, by design) rather than left to ' +
+  'look identical to genuine, still-open `debt`.'
 
 /** A fixture-corpus row's human-readable description + link to its source file. */
 export interface FixtureDoc {
@@ -116,17 +137,22 @@ export interface CompatReport {
 
 /**
  * Assemble the deterministic fixture-divergences section from each
- * adapter's declared `conformancePins` + `renderDivergences`. Sorted
- * fixture ids, sorted adapter keys within each fixture, sorted codes /
- * issue URLs — same byte-stability contract as the component matrix.
+ * adapter's declared `conformancePins` + `renderDivergences`, plus (#2613)
+ * the escape state of every error-severity refusal that's in the
+ * "loud-or-escapable" floor's domain. Sorted fixture ids, sorted adapter
+ * keys within each fixture, sorted codes / issue URLs — same
+ * byte-stability contract as the component matrix.
+ *
+ * `corpus` is the full shared fixture corpus (`jsxFixtures`) — needed to read
+ * `escapeNotOwed` / `escapes` declarations and to compile escape twins via
+ * `classifyFixtureEscapeState`, which is why this function is no longer a
+ * cheap dictionary-only join (see that function's own docstring for why a
+ * non-ok floor-test outcome throws here instead of guessing).
  */
 export function buildFixtureDivergences(
-  adapters: ReadonlyArray<{
-    id: string
-    pins: Record<string, ReadonlyArray<{ code: string; severity: 'error' | 'warning'; issue?: string }>>
-    renderDivergences: Record<string, string>
-  }>,
+  adapters: ReadonlyArray<LoadedCompatAdapter>,
   totalFixtures: number,
+  corpus: readonly JSXFixture[],
 ): FixtureDivergences {
   const byFixture = new Map<string, Map<string, FixtureDivergenceCell>>()
   const cellsOf = (fixtureId: string): Map<string, FixtureDivergenceCell> => {
@@ -138,12 +164,18 @@ export function buildFixtureDivergences(
     return m
   }
 
+  const honoErrorPinned = computeHonoErrorPinnedFixtures(adapters)
+
   for (const adapter of adapters) {
+    const domainFixtureIds = new Set(computeDomainFixtureIds(adapter, honoErrorPinned))
     for (const [fixtureId, pins] of Object.entries(adapter.pins)) {
       const codes = [...new Set(pins.map(p => p.code))].sort()
       const issues = [...new Set(pins.flatMap(p => (p.issue ? [p.issue] : [])))].sort()
       const cell: FixtureDivergenceCell = { kind: 'refusal', codes }
       if (issues.length > 0) cell.issues = issues
+      if (domainFixtureIds.has(fixtureId)) {
+        cell.escape = classifyFixtureEscapeState(adapter, fixtureId, corpus)
+      }
       cellsOf(fixtureId).set(adapter.id, cell)
     }
     for (const [fixtureId, reason] of Object.entries(adapter.renderDivergences)) {
@@ -215,6 +247,27 @@ export function formatCompatJson(report: CompatReport): string {
 }
 
 /**
+ * The two markers that make a refusal's escape state legible directly on
+ * the diagnostic code, in a wide GFM table, without a 10th adapter column
+ * or a per-occurrence footnote (#2613's "escape visibility" — see
+ * `site/core/pages/compat-matrix.tsx` for the fuller rationale, mirrored
+ * here so the CLI's own `--md` / `--render` output — the CI job-summary
+ * path — reads the same way as the docs page). A `'debt'` cell is
+ * deliberately unmarked: it's the pre-#2613 default rendering, so a bare
+ * `BF101` still means exactly what it always meant.
+ */
+export const ESCAPABLE_MARKER = '†'
+export const NOT_OWED_MARKER = '‡'
+
+/** The marker suffix for one refusal cell's escape state (`''` when absent or `'debt'`). */
+export function escapeMarker(escape: FixtureEscapeState | undefined): string {
+  if (!escape) return ''
+  if (escape.state === 'escapable') return ESCAPABLE_MARKER
+  if (escape.state === 'not-owed') return NOT_OWED_MARKER
+  return ''
+}
+
+/**
  * Markdown matrix: boundary note, `component × adapter` table (✓ for a
  * clean cell, `?` for a missing cell — never rendered as success, comma-
  * joined codes otherwise — warnings prefixed `⚠`), and a legend mapping
@@ -278,13 +331,16 @@ export function formatCompatMarkdown(report: CompatReport): string {
       const cellText = report.adapters.map(id => {
         const cell = row[id]
         if (!cell) return '✓'
-        return cell.kind === 'refusal' ? (cell.codes ?? []).join(', ') : '≠'
+        return cell.kind === 'refusal' ? `${(cell.codes ?? []).join(', ')}${escapeMarker(cell.escape)}` : '≠'
       })
       lines.push(`| ${fixtureId} | ${cellText.join(' | ')} |`)
     }
     lines.push('')
     lines.push('`≠` = compiles clean but the rendered output diverges from the Hono reference')
-    lines.push('(see each adapter package’s `render-divergences.ts` for the per-fixture rationale).')
+    lines.push('(see each adapter package’s `render-divergences.ts` for the per-fixture rationale). A bare')
+    lines.push('diagnostic code = refused, no escape yet (tracked debt) · `†` = refused, but a VERIFIED')
+    lines.push('working escape exists — a supported path, not a dead end · `‡` = refused, no escape owed,')
+    lines.push('by design.')
   }
 
   return lines.join('\n') + '\n'

--- a/site/core/pages/compat-matrix.tsx
+++ b/site/core/pages/compat-matrix.tsx
@@ -135,6 +135,24 @@ function escapeCell(text: string): string {
 }
 
 /**
+ * Neutralize Markdown emphasis/code metacharacters in free-form prose that
+ * gets interpolated into a generated Markdown line — today only
+ * `escapeNotOwed.reason`, which fixture authors write as ordinary English.
+ *
+ * Today's reasons happen to survive unescaped: they contain `/* @client *\/`,
+ * whose asterisks sit next to whitespace and so are neither left- nor
+ * right-flanking, so CommonMark won't open emphasis on them. That safety is
+ * accidental and narrow — verified with the site's own `marked`, TWO such
+ * occurrences in one paragraph DO pair up (`'/* @client <em>/' … '/</em> @client *\/'`),
+ * and any future reason containing `*emphasis*` or a backtick renders as
+ * markup rather than text. `reason` is prose owned by whoever writes the
+ * fixture, so the renderer should not depend on what they happen to type.
+ */
+function escapeMarkdownProse(text: string): string {
+  return text.replace(/([*_`[\]\\])/g, '\\$1')
+}
+
+/**
  * The two escape-state markers appended directly to a refusal cell's
  * diagnostic code(s) — same characters `packages/compat/src/report.ts`
  * uses for the CLI's own `--md` / `--render` output, so the docs page and
@@ -292,7 +310,7 @@ function escapeDetailClause(escape: FixtureEscapeState | undefined, fd: FixtureD
     return ` — **verified escape** (${ESCAPABLE_MARKER}): ${twinLabel} compiles clean here`
   }
   if (escape.state === 'not-owed') {
-    return ` — **no escape owed** (${NOT_OWED_MARKER}): ${escape.reason}`
+    return ` — **no escape owed** (${NOT_OWED_MARKER}): ${escapeMarkdownProse(escape.reason)}`
   }
   return ''
 }

--- a/site/core/pages/compat-matrix.tsx
+++ b/site/core/pages/compat-matrix.tsx
@@ -33,11 +33,25 @@ interface CompatCell {
   diagnostics?: CompatDiagnostic[]
 }
 
+/**
+ * A refusal cell's escape state (#2613) — distinguishes a refusal with a
+ * VERIFIED working escape (`'escapable'`, e.g. a `/* @client *\/` twin
+ * that actually compiles clean on this adapter) from one that's still
+ * tracked debt (`'debt'`, an adapter-declared `unescapable` pin) or that
+ * owes no escape at all, by design (`'not-owed'`). Mirrors
+ * `FixtureEscapeState` in `packages/compat/src/escape-coverage.ts`. Set
+ * only on `'refusal'`-kind cells that are in the "loud-or-escapable"
+ * floor's domain (an error-severity pin, on a fixture the reference
+ * adapter doesn't itself refuse) — absent otherwise.
+ */
+type FixtureEscapeState = { state: 'escapable'; twin: string } | { state: 'debt' } | { state: 'not-owed'; reason: string }
+
 interface FixtureDivergenceCell {
   kind: 'refusal' | 'render'
   codes?: string[]
   issues?: string[]
   reason?: string
+  escape?: FixtureEscapeState
 }
 
 interface FixtureDoc {
@@ -118,6 +132,24 @@ const supportMatrix = supportMatrixLock as SupportMatrixLock
 
 function escapeCell(text: string): string {
   return text.replace(/\|/g, '\\|')
+}
+
+/**
+ * The two escape-state markers appended directly to a refusal cell's
+ * diagnostic code(s) — same characters `packages/compat/src/report.ts`
+ * uses for the CLI's own `--md` / `--render` output, so the docs page and
+ * the CI job-summary table read identically. `'debt'` is deliberately
+ * unmarked: it's the pre-#2613 rendering, so a bare `BF101` still means
+ * exactly what it always meant — still-open, no verified escape.
+ */
+const ESCAPABLE_MARKER = '†'
+const NOT_OWED_MARKER = '‡'
+
+function escapeMarker(escape: FixtureEscapeState | undefined): string {
+  if (!escape) return ''
+  if (escape.state === 'escapable') return ESCAPABLE_MARKER
+  if (escape.state === 'not-owed') return NOT_OWED_MARKER
+  return ''
 }
 
 /**
@@ -235,9 +267,34 @@ function fixtureCellMarkdown(cell: FixtureDivergenceCell | undefined): string {
     const codes = cell.codes ?? []
     const firstIssue = cell.issues?.[0]
     const label = codes.join(', ') || 'refused'
-    return firstIssue ? `[${label}](${firstIssue})` : label
+    const linked = firstIssue ? `[${label}](${firstIssue})` : label
+    return `${linked}${escapeMarker(cell.escape)}`
   }
   return '≠'
+}
+
+/**
+ * The escape-state clause appended to a refusal's detail-list line — the
+ * prose counterpart of the table cell's `†`/`‡` marker. Links the escape
+ * twin to its own source when `fd.docs` happens to carry it (the CLI
+ * attaches docs for every escape twin referenced by an `'escapable'` cell,
+ * not just the divergent fixtures themselves).
+ */
+function escapeDetailClause(escape: FixtureEscapeState | undefined, fd: FixtureDivergences): string {
+  // Deliberately NOT `escapeCell`-escaped here — the composed `text` this
+  // feeds into is escaped exactly once, at the point `buildFixtureDetails`
+  // joins it into a Markdown line, same as every other fragment there.
+  // Escaping twice would double-escape a literal `|` (`\|` → `\\|`).
+  if (!escape) return ''
+  if (escape.state === 'escapable') {
+    const twinDoc = fd.docs?.[escape.twin]
+    const twinLabel = twinDoc?.url ? `[\`${escape.twin}\`](${twinDoc.url})` : `\`${escape.twin}\``
+    return ` — **verified escape** (${ESCAPABLE_MARKER}): ${twinLabel} compiles clean here`
+  }
+  if (escape.state === 'not-owed') {
+    return ` — **no escape owed** (${NOT_OWED_MARKER}): ${escape.reason}`
+  }
+  return ''
 }
 
 /**
@@ -254,7 +311,7 @@ function buildFixtureDetails(fd: FixtureDivergences): string {
       const cell = row[adapterId]
       const text =
         cell.kind === 'refusal'
-          ? `refused at build time with ${(cell.codes ?? []).map((c) => `\`${c}\``).join(', ')}`
+          ? `refused at build time with ${(cell.codes ?? []).map((c) => `\`${c}\``).join(', ')}${escapeDetailClause(cell.escape, fd)}`
           : (cell.reason ?? 'rendered output diverges from the Hono reference')
       const adapters = byText.get(text) ?? []
       adapters.push(adapterId)
@@ -294,11 +351,13 @@ function buildFixtureSection(): string {
 
 The component matrix above is **compile-time only**. This section reports the **render-level** state honestly: the shared conformance corpus (\`packages/adapter-tests\`) is rendered through every adapter's real backend (Go, Ruby, Perl, PHP, Python, Rust) and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (\`conformancePins\`) or rendering differently from the reference (\`renderDivergences\`, skipped in that adapter's conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.
 
+A build-time refusal is not automatically a dead end. Some refusals carry a **verified working escape** — most often a \`/* @client */\` twin that compiles clean on that specific adapter — a supported, tested path around the refusal, not tracked debt; those are marked \`${ESCAPABLE_MARKER}\`. Others are declared **not owed** (no escape will ever be authored there, by design, because authoring one would defeat the fixture's own purpose) and marked \`${NOT_OWED_MARKER}\`. A bare diagnostic code with neither marker is the remaining case: refused, and still genuinely open. Escape verification is per adapter, so the same fixture can show \`${ESCAPABLE_MARKER}\` on one column and a bare code on another — see [\`escape-coverage.ts\`](https://github.com/piconic-ai/barefootjs/blob/main/packages/compat/src/escape-coverage.ts).
+
 **${cleanCount} / ${fd.totalFixtures} fixtures render to reference parity on every adapter.** The ${fixtureIds.length} below diverge on at least one:
 
 ${[header, divider, ...rows].join('\n')}
 
-\`✓\` renders to reference parity · \`≠\` compiles clean but the rendered output diverges (skipped in that adapter's conformance suite until fixed) · a diagnostic code means the adapter refuses the shape loudly at build time.
+\`✓\` renders to reference parity · \`≠\` compiles clean but the rendered output diverges (skipped in that adapter's conformance suite until fixed) · a bare diagnostic code means the adapter refuses the shape loudly at build time with no escape yet (tracked debt) · \`${ESCAPABLE_MARKER}\` after a code means a verified working escape exists on that adapter · \`${NOT_OWED_MARKER}\` after a code means no escape is owed there, by design.
 
 ### Divergence details
 

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1813,7 +1813,7 @@
     }
   },
   "fixtureDivergences": {
-    "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
+    "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter. A build-time refusal is not automatically a dead end: some refusals carry a VERIFIED working escape (most often a `/* @client */` twin) — a supported, tested path, not tracked debt — marked `escapable` below; others are declared `not-owed` (no escape will ever be authored, by design) rather than left to look identical to genuine, still-open `debt`.",
     "totalFixtures": 319,
     "fixtures": {
       "date-method-uncatalogued": {
@@ -1904,49 +1904,81 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         }
       },
       "fill-unsupported": {
@@ -1954,49 +1986,81 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         }
       },
       "filter-nested-callback-predicate": {
@@ -2007,7 +2071,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-callback-predicate-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
@@ -2016,7 +2084,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-callback-predicate-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
@@ -2025,7 +2097,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-callback-predicate-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
@@ -2034,7 +2110,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-callback-predicate-client"
+          }
         },
         "twig": {
           "kind": "refusal",
@@ -2043,7 +2123,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-callback-predicate-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
@@ -2052,7 +2136,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-callback-predicate-client"
+          }
         }
       },
       "filter-nested-find-predicate": {
@@ -2063,7 +2151,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         },
         "erb": {
           "kind": "refusal",
@@ -2072,7 +2164,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
@@ -2081,7 +2177,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
@@ -2090,7 +2190,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
@@ -2099,7 +2203,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
@@ -2108,7 +2216,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         },
         "twig": {
           "kind": "refusal",
@@ -2117,7 +2229,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
@@ -2126,7 +2242,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         }
       },
       "filter-typeof-predicate": {
@@ -2134,49 +2254,81 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         }
       },
       "find-typeof-predicate": {
@@ -2184,49 +2336,81 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         }
       },
       "flatmap-typeof-projection": {
@@ -2234,49 +2418,81 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         }
       },
       "map-array-builder-body": {
@@ -2284,49 +2500,73 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         }
       },
       "map-array-builder-escaping": {
@@ -2334,49 +2574,73 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         }
       },
       "preamble-cells": {
@@ -2384,49 +2648,81 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         }
       },
       "reduce-right-typeof-body": {
@@ -2434,49 +2730,81 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         }
       },
       "reduce-typeof-body": {
@@ -2484,49 +2812,81 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         }
       },
       "some-typeof-predicate": {
@@ -2534,49 +2894,81 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         }
       },
       "static-array-from-props": {
@@ -2587,7 +2979,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "erb": {
           "kind": "refusal",
@@ -2596,7 +2991,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "go-template": {
           "kind": "refusal",
@@ -2605,7 +3003,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "jinja": {
           "kind": "refusal",
@@ -2614,7 +3015,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "minijinja": {
           "kind": "refusal",
@@ -2623,7 +3027,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
@@ -2632,7 +3039,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "twig": {
           "kind": "refusal",
@@ -2641,7 +3051,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "xslate": {
           "kind": "refusal",
@@ -2650,7 +3063,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         }
       },
       "static-array-from-props-with-component": {
@@ -2661,7 +3077,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "erb": {
           "kind": "refusal",
@@ -2670,7 +3089,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "go-template": {
           "kind": "refusal",
@@ -2679,7 +3101,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "jinja": {
           "kind": "refusal",
@@ -2688,7 +3113,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "minijinja": {
           "kind": "refusal",
@@ -2697,7 +3125,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
@@ -2706,7 +3137,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "twig": {
           "kind": "refusal",
@@ -2715,7 +3149,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "xslate": {
           "kind": "refusal",
@@ -2724,7 +3161,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         }
       },
       "tag-cloud": {
@@ -2732,49 +3172,81 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         }
       }
     },
@@ -2846,6 +3318,46 @@
       "tag-cloud": {
         "description": "flatMap block-body tag list — hydration adoption, in-place leaf patch, add, and remove",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/tag-cloud.ts"
+      },
+      "every-typeof-predicate-client": {
+        "description": "Off-subset `.every()` predicate deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/every-typeof-predicate-client.ts"
+      },
+      "fill-unsupported-client": {
+        "description": "Off-subset array method `.fill()` deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/fill-unsupported-client.ts"
+      },
+      "filter-nested-callback-predicate-client": {
+        "description": "Nested-callback filter predicate + /* @client */ suppresses BF101 (#2038)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-nested-callback-predicate-client.ts"
+      },
+      "filter-nested-find-predicate-client": {
+        "description": "Nested-callback (.find()) filter predicate + /* @client */ suppresses BF101 (#2038)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-nested-find-predicate-client.ts"
+      },
+      "filter-typeof-predicate-client": {
+        "description": "Off-subset filter predicate deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-typeof-predicate-client.ts"
+      },
+      "find-typeof-predicate-client": {
+        "description": "Off-subset `.find()` predicate deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/find-typeof-predicate-client.ts"
+      },
+      "flatmap-typeof-projection-client": {
+        "description": "Off-subset `.flatMap()` projection deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/flatmap-typeof-projection-client.ts"
+      },
+      "reduce-right-typeof-body-client": {
+        "description": "Off-subset `.reduceRight()` body deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/reduce-right-typeof-body-client.ts"
+      },
+      "reduce-typeof-body-client": {
+        "description": "Off-subset `.reduce()` body deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/reduce-typeof-body-client.ts"
+      },
+      "some-typeof-predicate-client": {
+        "description": "Off-subset `.some()` predicate deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/some-typeof-predicate-client.ts"
       }
     }
   },


### PR DESCRIPTION
The compatibility matrix rendered every build-time refusal as a bare diagnostic code, so a refusal with a **verified working escape** looked identical to a dead end. As of #2618 the corpus can tell them apart — this makes the table say so.

`every-typeof-predicate` and `fill-unsupported` are the clearest cases: both got verified `/* @client */` twins in #2618, yet still displayed as a flat `BF101`, understating what the framework actually supports.

## Representation

A marker appended to the code:

| rendering | meaning |
|---|---|
| `BF101` | refused, no escape yet — tracked debt (**unchanged** from today) |
| `BF101†` | refused, but a verified escape works **on that adapter** |
| `BF101‡` | refused, no escape owed — by design |

Real rows, regenerated from the corpus:

```
| every-typeof-predicate           | ✓ | BF101† | BF101† | BF101† | BF101† | ... |
| map-array-builder-body           | ✓ | BF021  | BF021  | BF021  | BF021  | ... |
| tag-cloud                        | ✓ | BF021‡ | BF021‡ | BF021‡ | BF021‡ | ... |
| filter-nested-callback-predicate | ✓ | BF101† | ✓      | BF101† | BF101† | ... |
```

Leaving `debt` unmarked is deliberate: a bare code still means exactly what it always meant, so nothing about the existing reading changes.

**Why a per-cell marker rather than a column.** Escape verification is per `(fixture, adapter)`, not per fixture — that last row proves it, escaping on 6 adapters and rendering clean on 2. A single extra column cannot carry that without becoming a second 9-column table. Footnotes were also rejected: their count scales with occurrences, not states, producing dozens of near-duplicate "see twin X" notes and forcing a lookup instead of reading state off the cell.

## Prose

The section framed everything listed as a divergence, which is now actively wrong for the escapable case. It now states plainly that a refusal with a verified escape is a supported, tested path, and that escape verification is per adapter so the same fixture can differ across columns. The detail list gains a linked clause, e.g.:

> blade, erb, … — refused at build time with `BF101` — **verified escape** (†): [`every-typeof-predicate-client`](…) compiles clean here

## Dependency direction preserved

The classifier reuses `evaluateFixtureEscapeCoverage` / `twinWorksOnAdapter` rather than making a second judgement, and reads only the declarative fields adapters already own (`escapes`, `escapeNotOwed`, `unescapable`). No new adapter identifier enters `packages/compat` — the only `'hono'` literals are the pre-existing reference-adapter lookups for column ordering. A 9th adapter renders correctly with no core or site edit, which is the property #2615 was rewritten to establish.

If the escape-coverage floor test would be red, `classifyFixtureEscapeState` **throws** rather than rendering a guess — a docs page quietly showing stale state would hide exactly the failure the floor test exists to surface.

## Verification

`packages/compat` **342 pass / 0 fail** (up from 335: 7 new escape-rendering tests). The regenerated `ui/compat.lock.json` carries **78 escapable / 32 debt / 16 not-owed** — matching #2618's ledger exactly. `ui/support-matrix.lock.json` regenerated with no diff, as expected. `bun run lint` clean.

I verified the rendered rows by regenerating the table myself rather than trusting the agent's output file, and confirmed the three states and the mixed-adapter case independently.

## Note on stacking

A sibling branch is testing whether `map-array-builder-*` has a working escape (#2613's remaining 32 debt pairs). If it lands, those rows flip from bare `BF021` to `BF021†` and `ui/compat.lock.json` needs regenerating — a mechanical `bun run compat:lock`, whichever merges second.

## Open question for you

`†` / `‡` are conventional footnote marks and the legend defines both, but they are visually similar and semantically arbitrary, and screen readers announce them as "dagger"/"double dagger". I kept them because anything more self-describing (`→@client`) is too wide for a 9-column Markdown table. Happy to swap if you'd prefer a different pair.

Refs #2613, #2618

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_