### PR TITLE
test(adapter-tests): verify the /* @client */ escape for array-builder loops — ledger 32 → 16 (#2613)

### DIFF
--- a/.changeset/map-array-builder-escape-verified.md
+++ b/.changeset/map-array-builder-escape-verified.md
@@ -1,0 +1,14 @@
+---
+'@barefootjs/blade': patch
+'@barefootjs/erb': patch
+'@barefootjs/go-template': patch
+'@barefootjs/jinja': patch
+'@barefootjs/mojolicious': patch
+'@barefootjs/rust': patch
+'@barefootjs/twig': patch
+'@barefootjs/xslate': patch
+---
+
+Removes the `unescapable` declaration from each adapter's `map-array-builder-body` / `map-array-builder-escaping` conformance pins (#2613). These two fixtures still refuse the imperative array-builder `.map()` body with BF021 on every DSL adapter, but the `/* @client */` escape is now verified with an executable twin (`map-array-builder-body-client`) rather than merely asserted in a docstring: it compiles clean and produces zero diagnostics on all 8 DSL adapters, and its CSR template renders the empty host correctly.
+
+No runtime or emission behavior changes — the BF021 refusal is unchanged; only the escape-coverage declaration is corrected from "owed but unverified" to "verified."

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -15,20 +15,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  'map-array-builder-body': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
-  'map-array-builder-escaping': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  // Array-builder `.map()` body (imperative `push`-into-array preamble):
+  // BF021, with a verified `/* @client */` escape — `map-array-builder-
+  // body-client` (#2613). See that fixture's docstring.
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -16,20 +16,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  'map-array-builder-body': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
-  'map-array-builder-escaping': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  // Array-builder `.map()` body (imperative `push`-into-array preamble):
+  // BF021, with a verified `/* @client */` escape — `map-array-builder-
+  // body-client` (#2613). See that fixture's docstring.
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -15,20 +15,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  'map-array-builder-body': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
-  'map-array-builder-escaping': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  // Array-builder `.map()` body (imperative `push`-into-array preamble):
+  // BF021, with a verified `/* @client */` escape — `map-array-builder-
+  // body-client` (#2613). See that fixture's docstring.
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -15,20 +15,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  'map-array-builder-body': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
-  'map-array-builder-escaping': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  // Array-builder `.map()` body (imperative `push`-into-array preamble):
+  // BF021, with a verified `/* @client */` escape — `map-array-builder-
+  // body-client` (#2613). See that fixture's docstring.
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -13,20 +13,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  'map-array-builder-body': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
-  'map-array-builder-escaping': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  // Array-builder `.map()` body (imperative `push`-into-array preamble):
+  // BF021, with a verified `/* @client */` escape — `map-array-builder-
+  // body-client` (#2613). See that fixture's docstring.
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -16,20 +16,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  'map-array-builder-body': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
-  'map-array-builder-escaping': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  // Array-builder `.map()` body (imperative `push`-into-array preamble):
+  // BF021, with a verified `/* @client */` escape — `map-array-builder-
+  // body-client` (#2613). See that fixture's docstring.
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2948,6 +2948,20 @@
         "text"
       ]
     },
+    "map-array-builder-body-client": {
+      "kinds": [
+        "array-literal",
+        "call",
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "map-array-builder-escaping": {
       "kinds": [
         "identifier",
@@ -5156,17 +5170,17 @@
     }
   },
   "kindCounts": {
-    "array-literal": 79,
+    "array-literal": 80,
     "array-method": 69,
     "arrow": 69,
     "binary": 89,
-    "call": 211,
+    "call": 212,
     "conditional": 25,
-    "identifier": 300,
+    "identifier": 301,
     "index-access": 14,
     "literal": 248,
     "logical": 44,
-    "member": 164,
+    "member": 165,
     "object-literal": 56,
     "template-literal": 30,
     "unary": 23,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -152,6 +152,7 @@ import { fixture as mapIfChainBody } from './map-if-chain-body'
 import { fixture as mapSwitchFallthroughBody } from './map-switch-fallthrough-body'
 import { fixture as mapPreambleBranchBody } from './map-preamble-branch-body'
 import { fixture as mapArrayBuilderBody } from './map-array-builder-body'
+import { fixture as mapArrayBuilderBodyClient } from './map-array-builder-body-client'
 import { fixture as mapArrayBuilderEscaping } from './map-array-builder-escaping'
 import { fixture as sortSimple } from './sort-simple'
 import { fixture as filterSortChain } from './filter-sort-chain'
@@ -587,6 +588,7 @@ export const jsxFixtures: JSXFixture[] = [
   mapSwitchFallthroughBody,
   mapPreambleBranchBody,
   mapArrayBuilderBody,
+  mapArrayBuilderBodyClient,
   mapArrayBuilderEscaping,
   sortSimple,
   filterSortChain,

--- a/packages/adapter-tests/fixtures/map-array-builder-body-client.ts
+++ b/packages/adapter-tests/fixtures/map-array-builder-body-client.ts
@@ -59,7 +59,7 @@ export const fixture = createFixture({
   source: `
 'use client'
 import { createSignal } from '@barefootjs/client'
-export function TableBuilderClient() {
+function TableBuilderClient() {
   const [rows, setRows] = createSignal<{ id: string; cells: string[] }[]>([])
   return (
     <table>

--- a/packages/adapter-tests/fixtures/map-array-builder-body-client.ts
+++ b/packages/adapter-tests/fixtures/map-array-builder-body-client.ts
@@ -1,6 +1,34 @@
 import { createFixture } from '../src/types'
 
 /**
+ * WHY THIS TWIN IS NOT A BYTE-FOR-BYTE COPY OF ITS BASE, unlike
+ * `filter-typeof-predicate-client` / `find-typeof-predicate-client`
+ * (which are exact copies of theirs plus the comment) — read this before
+ * "simplifying" it back:
+ *
+ * The base (`map-array-builder-body`) sources its array from a PROP. The
+ * CSR conformance harness evaluates a fixture's `template:` lambda with
+ * NO props, so a prop-sourced array throws there
+ * (`undefined is not an object (evaluating '_p.rows.map')`) — and a twin
+ * that has to be CSR-skipped fails tier 2 and cannot count as a verified
+ * escape at all. Hence the `'use client'` + signal-backed array here: it
+ * is a harness requirement, not a claim that escaping needs a rewrite.
+ * The bases whose twins ARE exact copies were already `'use client'` +
+ * signal themselves, so the question never arose for them.
+ *
+ * That drift matters because `twinWorksOnAdapter` only checks that the
+ * twin compiles clean — it cannot detect a twin that wandered away from
+ * its base, so a sufficiently different twin would "verify" an escape
+ * nobody can actually use. The claim `escapes` makes here is the narrow
+ * one — add one comment to the code you already have — and it was checked
+ * directly rather than inferred: the base source VERBATIM with only
+ * `/* @client *​/` inserted before `.map()` compiles with zero
+ * error-severity diagnostics on all nine adapters (blade, erb,
+ * go-template, hono, jinja, mojolicious, minijinja, twig, xslate). Only
+ * the CSR-render step, which needs props the harness doesn't supply,
+ * forced the signal form below. If that harness ever passes props, this
+ * fixture should collapse back to an exact copy of its base.
+ *
  * `/* @client *​/` twin of `map-array-builder-body` (#2613). Marking the
  * `.map()` call client-only defers the WHOLE loop — the imperative
  * `const out = []; for (...) out.push(<td>{c}</td>); return <tr>{out}</tr>`

--- a/packages/adapter-tests/fixtures/map-array-builder-body-client.ts
+++ b/packages/adapter-tests/fixtures/map-array-builder-body-client.ts
@@ -1,0 +1,53 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `/* @client *​/` twin of `map-array-builder-body` (#2613). Marking the
+ * `.map()` call client-only defers the WHOLE loop — the imperative
+ * `const out = []; for (...) out.push(<td>{c}</td>); return <tr>{out}</tr>`
+ * preamble included — to the browser, where a JS runtime (always present
+ * client-side) runs the exact same verbatim body. SSR renders the loop
+ * host empty on every backend (Hono included — `isClientOnly` short-
+ * circuits the same way a signal-gated `/* @client *\/` would), so this
+ * pins the suppression contract across the DSL corpus without a
+ * per-adapter `expectedDiagnostics` entry, the same pattern as
+ * `filter-nested-find-predicate-client`.
+ *
+ * `map-array-builder-escaping` declares this same fixture as ITS
+ * `escapes` twin rather than getting a dedicated one — its own docstring:
+ * "DSL adapters refuse the array-builder shape itself (BF021, pinned via
+ * `map-array-builder-body`); this fixture rides the same gate." Both
+ * fixtures are refused by the identical BF021 site (the array-builder
+ * preamble check in `jsx-to-ir.ts`); the escaping fixture only varies the
+ * PROPS (special characters in cell text) exercised at SSR, which this
+ * client-only twin never reaches (SSR renders nothing — escaping is a
+ * browser-side concern once deferred). A second near-duplicate twin would
+ * assert nothing about escaping that this one doesn't already cover: the
+ * gate being suppressed is the only claim either fixture's `escapes`
+ * needs to verify.
+ */
+export const fixture = createFixture({
+  id: 'map-array-builder-body-client',
+  description: 'Array-builder .map() body deferred to the client via /* @client */ — DSL BF021 suppressed',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function TableBuilderClient() {
+  const [rows, setRows] = createSignal<{ id: string; cells: string[] }[]>([])
+  return (
+    <table>
+      <tbody>
+        {/* @client */ rows().map((r) => {
+          const out = []
+          for (const c of r.cells) out.push(<td>{c}</td>)
+          return <tr key={r.id}>{out}</tr>
+        })}
+      </tbody>
+    </table>
+  )
+}
+export { TableBuilderClient }
+`,
+  expectedHtml: `
+    <table bf-s="test"><tbody bf="s1"></tbody></table>
+  `,
+})

--- a/packages/adapter-tests/fixtures/map-array-builder-body.ts
+++ b/packages/adapter-tests/fixtures/map-array-builder-body.ts
@@ -13,10 +13,14 @@ import { createFixture } from '../src/types'
  * Adapter-gated, like the const-preamble branch body and the off-subset
  * filter/sort predicates:
  *   - Hono / CSR run it; the reference `expectedHtml` renders the cells.
- *   - DSL adapters (Go, Perl, Ruby, PHP, Rust, Python) surface BF021 with the
- *     `/* @client *\/` escape (declared via each adapter's `conformancePins`);
- *     marking the map client-only defers the whole loop to the browser, which
- *     runs the same verbatim body.
+ *   - DSL adapters (Go, Perl, Ruby, PHP, Rust, Python) surface BF021; marking
+ *     the map client-only (`/* @client *\/`) defers the whole loop to the
+ *     browser, which runs the same verbatim body. Verified, not merely
+ *     asserted (#2613): `map-array-builder-body-client` is declared below as
+ *     the `escapes` twin and passes real execution — `csr-conformance.test.ts`
+ *     (CSR template renders the empty host) and every DSL adapter's own
+ *     conformance suite (compiles clean, zero diagnostics) — so all 8 DSL
+ *     adapters' `unescapable` pins for this fixture have been removed.
  */
 export const fixture = createFixture({
   id: 'map-array-builder-body',
@@ -41,4 +45,5 @@ export { TableBuilder }
   expectedHtml: `
     <table bf-s="test"><tbody bf="s1"><tr data-key="1"><!--bf:s0--><td>a</td><td>b</td><!--/--></tr><tr data-key="2"><!--bf:s0--><td>c</td><td>d</td><!--/--></tr></tbody></table>
   `,
+  escapes: [{ kind: 'client-directive', fixture: 'map-array-builder-body-client' }],
 })

--- a/packages/adapter-tests/fixtures/map-array-builder-escaping.ts
+++ b/packages/adapter-tests/fixtures/map-array-builder-escaping.ts
@@ -10,7 +10,14 @@ import { createFixture } from '../src/types'
  * divergence. Cells here carry `<`, `&`, and quotes to pin byte parity.
  *
  * DSL adapters refuse the array-builder shape itself (BF021, pinned via
- * `map-array-builder-body`); this fixture rides the same gate.
+ * `map-array-builder-body`); this fixture rides the same gate, so it
+ * declares `map-array-builder-body`'s own `escapes` twin
+ * (`map-array-builder-body-client`) rather than a dedicated one — the
+ * gate being suppressed is the only claim either fixture's `escapes`
+ * needs to verify; the escaping props (special characters in cell text)
+ * are an SSR-only concern this client-only twin never reaches (SSR
+ * renders nothing once deferred). Verified against real suites, not
+ * merely asserted (#2613): see `map-array-builder-body`'s docstring.
  */
 export const fixture = createFixture({
   id: 'map-array-builder-escaping',
@@ -40,4 +47,5 @@ export { EscapeTable }
   expectedHtml: `
     <table bf-s="test"><tbody bf="s1"><tr data-key="1"><!--bf:s0--><td>&lt;b&gt;bold&lt;/b&gt;</td><td>a &amp; b</td><!--/--></tr><tr data-key="2"><!--bf:s0--><td>&quot;quoted&quot;</td><td>it&#39;s</td><!--/--></tr></tbody></table>
   `,
+  escapes: [{ kind: 'client-directive', fixture: 'map-array-builder-body-client' }],
 })

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -15,20 +15,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  'map-array-builder-body': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
-  'map-array-builder-escaping': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  // Array-builder `.map()` body (imperative `push`-into-array preamble):
+  // BF021, with a verified `/* @client */` escape — `map-array-builder-
+  // body-client` (#2613). See that fixture's docstring.
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -13,20 +13,11 @@ export const conformancePins: ConformancePins = {
   // JS-runtime target runs it, a DSL adapter surfaces BF021 + `/* @client */`.
   // See spec/callback-fidelity.md.
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
-  'map-array-builder-body': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
-  'map-array-builder-escaping': [
-    {
-      code: 'BF021',
-      severity: 'error',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2613' },
-    },
-  ],
+  // Array-builder `.map()` body (imperative `push`-into-array preamble):
+  // BF021, with a verified `/* @client */` escape — `map-array-builder-
+  // body-client` (#2613). See that fixture's docstring.
+  'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
+  'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],
   // `.fill(value)` mutates the receiver in place — no template lowering
   // on any DSL adapter; a JS-runtime target runs it, a DSL adapter
   // surfaces BF101 + `/* @client */`. See spec/callback-fidelity.md.

--- a/packages/compat/src/__tests__/fixture-escape-rendering.test.ts
+++ b/packages/compat/src/__tests__/fixture-escape-rendering.test.ts
@@ -117,8 +117,13 @@ describe('buildFixtureDivergences — real corpus, real adapters (#2613)', () =>
   // Named example 2: refused, no working escape, and the adapter's own
   // pin says so with `unescapable` — tracked debt, rendered unmarked
   // (bare code) exactly as every refusal rendered before #2613.
-  test('map-array-builder-body is tracked debt (adapter declares unescapable) on at least one adapter', () => {
-    const found = findColumnInState('map-array-builder-body', 'debt')
+  //
+  // `static-array-from-props` (#2321), not `map-array-builder-body`: the
+  // latter graduated to 'escapable' once `map-array-builder-body-client`
+  // was verified against the real suites (#2613's array-builder twin
+  // task) and every DSL adapter's `unescapable` pin for it was removed.
+  test('static-array-from-props is tracked debt (adapter declares unescapable) on at least one adapter', () => {
+    const found = findColumnInState('static-array-from-props', 'debt')
     expect(found).toBeDefined()
     expect(found!.cell.kind).toBe('refusal')
     expect(found!.cell.escape).toEqual({ state: 'debt' })
@@ -144,7 +149,7 @@ describe('buildFixtureDivergences — real corpus, real adapters (#2613)', () =>
     const cellToText = (cell: FixtureDivergenceCell | undefined): string =>
       cell && cell.kind === 'refusal' ? `${(cell.codes ?? []).join(', ')}${escapeMarker(cell.escape)}` : ''
 
-    const debt = findColumnInState('map-array-builder-body', 'debt')
+    const debt = findColumnInState('static-array-from-props', 'debt')
     const escapable = findColumnInState('every-typeof-predicate', 'escapable')
     expect(debt).toBeDefined()
     expect(escapable).toBeDefined()

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1813,8 +1813,8 @@
     }
   },
   "fixtureDivergences": {
-    "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter. A build-time refusal is not automatically a dead end: some refusals carry a VERIFIED working escape (most often a `/* @client */` twin) — a supported, tested path, not tracked debt — marked `escapable` below; others are declared `not-owed` (no escape will ever be authored, by design) rather than left to look identical to genuine, still-open `debt`.",
-    "totalFixtures": 319,
+    "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
+    "totalFixtures": 320,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -1904,81 +1904,49 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "every-typeof-predicate-client"
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "every-typeof-predicate-client"
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "every-typeof-predicate-client"
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "every-typeof-predicate-client"
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "every-typeof-predicate-client"
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "every-typeof-predicate-client"
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "every-typeof-predicate-client"
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "every-typeof-predicate-client"
-          }
+          ]
         }
       },
       "fill-unsupported": {
@@ -1986,81 +1954,49 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "fill-unsupported-client"
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "fill-unsupported-client"
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "fill-unsupported-client"
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "fill-unsupported-client"
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "fill-unsupported-client"
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "fill-unsupported-client"
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "fill-unsupported-client"
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "fill-unsupported-client"
-          }
+          ]
         }
       },
       "filter-nested-callback-predicate": {
@@ -2071,11 +2007,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-nested-callback-predicate-client"
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
@@ -2084,11 +2016,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-nested-callback-predicate-client"
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
@@ -2097,11 +2025,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-nested-callback-predicate-client"
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
@@ -2110,11 +2034,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-nested-callback-predicate-client"
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
@@ -2123,11 +2043,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-nested-callback-predicate-client"
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
@@ -2136,11 +2052,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-nested-callback-predicate-client"
-          }
+          ]
         }
       },
       "filter-nested-find-predicate": {
@@ -2151,11 +2063,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-nested-find-predicate-client"
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
@@ -2164,11 +2072,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-nested-find-predicate-client"
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
@@ -2177,11 +2081,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-nested-find-predicate-client"
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
@@ -2190,11 +2090,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-nested-find-predicate-client"
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
@@ -2203,11 +2099,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-nested-find-predicate-client"
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
@@ -2216,11 +2108,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-nested-find-predicate-client"
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
@@ -2229,11 +2117,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-nested-find-predicate-client"
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
@@ -2242,11 +2126,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-nested-find-predicate-client"
-          }
+          ]
         }
       },
       "filter-typeof-predicate": {
@@ -2254,81 +2134,49 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-typeof-predicate-client"
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-typeof-predicate-client"
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-typeof-predicate-client"
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-typeof-predicate-client"
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-typeof-predicate-client"
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-typeof-predicate-client"
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-typeof-predicate-client"
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "filter-typeof-predicate-client"
-          }
+          ]
         }
       },
       "find-typeof-predicate": {
@@ -2336,81 +2184,49 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "find-typeof-predicate-client"
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "find-typeof-predicate-client"
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "find-typeof-predicate-client"
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "find-typeof-predicate-client"
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "find-typeof-predicate-client"
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "find-typeof-predicate-client"
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "find-typeof-predicate-client"
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "find-typeof-predicate-client"
-          }
+          ]
         }
       },
       "flatmap-typeof-projection": {
@@ -2418,81 +2234,49 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "flatmap-typeof-projection-client"
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "flatmap-typeof-projection-client"
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "flatmap-typeof-projection-client"
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "flatmap-typeof-projection-client"
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "flatmap-typeof-projection-client"
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "flatmap-typeof-projection-client"
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "flatmap-typeof-projection-client"
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "flatmap-typeof-projection-client"
-          }
+          ]
         }
       },
       "map-array-builder-body": {
@@ -2500,73 +2284,49 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         }
       },
       "map-array-builder-escaping": {
@@ -2574,73 +2334,49 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         }
       },
       "preamble-cells": {
@@ -2648,81 +2384,49 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         }
       },
       "reduce-right-typeof-body": {
@@ -2730,81 +2434,49 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-right-typeof-body-client"
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-right-typeof-body-client"
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-right-typeof-body-client"
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-right-typeof-body-client"
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-right-typeof-body-client"
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-right-typeof-body-client"
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-right-typeof-body-client"
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-right-typeof-body-client"
-          }
+          ]
         }
       },
       "reduce-typeof-body": {
@@ -2812,81 +2484,49 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-typeof-body-client"
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-typeof-body-client"
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-typeof-body-client"
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-typeof-body-client"
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-typeof-body-client"
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-typeof-body-client"
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-typeof-body-client"
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "reduce-typeof-body-client"
-          }
+          ]
         }
       },
       "some-typeof-predicate": {
@@ -2894,81 +2534,49 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "some-typeof-predicate-client"
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "some-typeof-predicate-client"
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "some-typeof-predicate-client"
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "some-typeof-predicate-client"
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "some-typeof-predicate-client"
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "some-typeof-predicate-client"
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "some-typeof-predicate-client"
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "some-typeof-predicate-client"
-          }
+          ]
         }
       },
       "static-array-from-props": {
@@ -2979,10 +2587,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
@@ -2991,10 +2596,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
@@ -3003,10 +2605,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
@@ -3015,10 +2614,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
@@ -3027,10 +2623,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
@@ -3039,10 +2632,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
@@ -3051,10 +2641,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
@@ -3063,10 +2650,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         }
       },
       "static-array-from-props-with-component": {
@@ -3077,10 +2661,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
@@ -3089,10 +2670,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
@@ -3101,10 +2679,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
@@ -3113,10 +2688,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
@@ -3125,10 +2697,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
@@ -3137,10 +2706,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
@@ -3149,10 +2715,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
@@ -3161,10 +2724,7 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ],
-          "escape": {
-            "state": "debt"
-          }
+          ]
         }
       },
       "tag-cloud": {
@@ -3172,81 +2732,49 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "escape": {
-            "state": "not-owed",
-            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
-          }
+          ]
         }
       }
     },
@@ -3318,46 +2846,6 @@
       "tag-cloud": {
         "description": "flatMap block-body tag list — hydration adoption, in-place leaf patch, add, and remove",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/tag-cloud.ts"
-      },
-      "every-typeof-predicate-client": {
-        "description": "Off-subset `.every()` predicate deferred to the client via /* @client */",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/every-typeof-predicate-client.ts"
-      },
-      "fill-unsupported-client": {
-        "description": "Off-subset array method `.fill()` deferred to the client via /* @client */",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/fill-unsupported-client.ts"
-      },
-      "filter-nested-callback-predicate-client": {
-        "description": "Nested-callback filter predicate + /* @client */ suppresses BF101 (#2038)",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-nested-callback-predicate-client.ts"
-      },
-      "filter-nested-find-predicate-client": {
-        "description": "Nested-callback (.find()) filter predicate + /* @client */ suppresses BF101 (#2038)",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-nested-find-predicate-client.ts"
-      },
-      "filter-typeof-predicate-client": {
-        "description": "Off-subset filter predicate deferred to the client via /* @client */",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-typeof-predicate-client.ts"
-      },
-      "find-typeof-predicate-client": {
-        "description": "Off-subset `.find()` predicate deferred to the client via /* @client */",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/find-typeof-predicate-client.ts"
-      },
-      "flatmap-typeof-projection-client": {
-        "description": "Off-subset `.flatMap()` projection deferred to the client via /* @client */",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/flatmap-typeof-projection-client.ts"
-      },
-      "reduce-right-typeof-body-client": {
-        "description": "Off-subset `.reduceRight()` body deferred to the client via /* @client */",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/reduce-right-typeof-body-client.ts"
-      },
-      "reduce-typeof-body-client": {
-        "description": "Off-subset `.reduce()` body deferred to the client via /* @client */",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/reduce-typeof-body-client.ts"
-      },
-      "some-typeof-predicate-client": {
-        "description": "Off-subset `.some()` predicate deferred to the client via /* @client */",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/some-typeof-predicate-client.ts"
       }
     }
   },

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1813,7 +1813,7 @@
     }
   },
   "fixtureDivergences": {
-    "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
+    "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter. A build-time refusal is not automatically a dead end: some refusals carry a VERIFIED working escape (most often a `/* @client */` twin) — a supported, tested path, not tracked debt — marked `escapable` below; others are declared `not-owed` (no escape will ever be authored, by design) rather than left to look identical to genuine, still-open `debt`.",
     "totalFixtures": 320,
     "fixtures": {
       "date-method-uncatalogued": {
@@ -1904,49 +1904,81 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "every-typeof-predicate-client"
+          }
         }
       },
       "fill-unsupported": {
@@ -1954,49 +1986,81 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "fill-unsupported-client"
+          }
         }
       },
       "filter-nested-callback-predicate": {
@@ -2007,7 +2071,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-callback-predicate-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
@@ -2016,7 +2084,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-callback-predicate-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
@@ -2025,7 +2097,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-callback-predicate-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
@@ -2034,7 +2110,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-callback-predicate-client"
+          }
         },
         "twig": {
           "kind": "refusal",
@@ -2043,7 +2123,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-callback-predicate-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
@@ -2052,7 +2136,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-callback-predicate-client"
+          }
         }
       },
       "filter-nested-find-predicate": {
@@ -2063,7 +2151,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         },
         "erb": {
           "kind": "refusal",
@@ -2072,7 +2164,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
@@ -2081,7 +2177,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
@@ -2090,7 +2190,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
@@ -2099,7 +2203,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
@@ -2108,7 +2216,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         },
         "twig": {
           "kind": "refusal",
@@ -2117,7 +2229,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
@@ -2126,7 +2242,11 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2320"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-nested-find-predicate-client"
+          }
         }
       },
       "filter-typeof-predicate": {
@@ -2134,49 +2254,81 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "filter-typeof-predicate-client"
+          }
         }
       },
       "find-typeof-predicate": {
@@ -2184,49 +2336,81 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "find-typeof-predicate-client"
+          }
         }
       },
       "flatmap-typeof-projection": {
@@ -2234,49 +2418,81 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "flatmap-typeof-projection-client"
+          }
         }
       },
       "map-array-builder-body": {
@@ -2284,49 +2500,81 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         }
       },
       "map-array-builder-escaping": {
@@ -2334,49 +2582,81 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "map-array-builder-body-client"
+          }
         }
       },
       "preamble-cells": {
@@ -2384,49 +2664,81 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture is the SSR-adopting-hydration + patch-on-update regression pin for #2389. A '/* @client */' escape twin would SSR an empty region, eliminating the adopted DOM node the fixture exists to test patching — collapsing it to the already-covered client-only-loop case with zero new coverage. It is also deliberately kept out of integrations/shared/components (per this file's own docstring) because every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         }
       },
       "reduce-right-typeof-body": {
@@ -2434,49 +2746,81 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-right-typeof-body-client"
+          }
         }
       },
       "reduce-typeof-body": {
@@ -2484,49 +2828,81 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "reduce-typeof-body-client"
+          }
         }
       },
       "some-typeof-predicate": {
@@ -2534,49 +2910,81 @@
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
-          ]
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "some-typeof-predicate-client"
+          }
         }
       },
       "static-array-from-props": {
@@ -2587,7 +2995,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "erb": {
           "kind": "refusal",
@@ -2596,7 +3007,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "go-template": {
           "kind": "refusal",
@@ -2605,7 +3019,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "jinja": {
           "kind": "refusal",
@@ -2614,7 +3031,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "minijinja": {
           "kind": "refusal",
@@ -2623,7 +3043,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
@@ -2632,7 +3055,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "twig": {
           "kind": "refusal",
@@ -2641,7 +3067,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "xslate": {
           "kind": "refusal",
@@ -2650,7 +3079,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         }
       },
       "static-array-from-props-with-component": {
@@ -2661,7 +3093,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "erb": {
           "kind": "refusal",
@@ -2670,7 +3105,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "go-template": {
           "kind": "refusal",
@@ -2679,7 +3117,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "jinja": {
           "kind": "refusal",
@@ -2688,7 +3129,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "minijinja": {
           "kind": "refusal",
@@ -2697,7 +3141,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "mojolicious": {
           "kind": "refusal",
@@ -2706,7 +3153,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "twig": {
           "kind": "refusal",
@@ -2715,7 +3165,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         },
         "xslate": {
           "kind": "refusal",
@@ -2724,7 +3177,10 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2321"
-          ]
+          ],
+          "escape": {
+            "state": "debt"
+          }
         }
       },
       "tag-cloud": {
@@ -2732,49 +3188,81 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ]
+          ],
+          "escape": {
+            "state": "not-owed",
+            "reason": "By design: this fixture pins hydration ADOPTING pre-existing SSR flatMap leaves (interaction 1) plus in-place patch/add/remove on top of that adopted DOM. A '/* @client */' escape twin would SSR zero leaves, so there would be nothing to adopt — the adoption regression this fixture exists for would be untestable, collapsing it to the already-covered client-only-loop case. Also deliberately kept out of integrations/shared/components (per this file's own docstring) since every DSL integration app's bf build compiles that directory wholesale, so no DSL escape variant is wanted there either."
+          }
         }
       }
     },
@@ -2846,6 +3334,50 @@
       "tag-cloud": {
         "description": "flatMap block-body tag list — hydration adoption, in-place leaf patch, add, and remove",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/tag-cloud.ts"
+      },
+      "every-typeof-predicate-client": {
+        "description": "Off-subset `.every()` predicate deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/every-typeof-predicate-client.ts"
+      },
+      "fill-unsupported-client": {
+        "description": "Off-subset array method `.fill()` deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/fill-unsupported-client.ts"
+      },
+      "filter-nested-callback-predicate-client": {
+        "description": "Nested-callback filter predicate + /* @client */ suppresses BF101 (#2038)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-nested-callback-predicate-client.ts"
+      },
+      "filter-nested-find-predicate-client": {
+        "description": "Nested-callback (.find()) filter predicate + /* @client */ suppresses BF101 (#2038)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-nested-find-predicate-client.ts"
+      },
+      "filter-typeof-predicate-client": {
+        "description": "Off-subset filter predicate deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-typeof-predicate-client.ts"
+      },
+      "find-typeof-predicate-client": {
+        "description": "Off-subset `.find()` predicate deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/find-typeof-predicate-client.ts"
+      },
+      "flatmap-typeof-projection-client": {
+        "description": "Off-subset `.flatMap()` projection deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/flatmap-typeof-projection-client.ts"
+      },
+      "map-array-builder-body-client": {
+        "description": "Array-builder .map() body deferred to the client via /* @client */ — DSL BF021 suppressed",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/map-array-builder-body-client.ts"
+      },
+      "reduce-right-typeof-body-client": {
+        "description": "Off-subset `.reduceRight()` body deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/reduce-right-typeof-body-client.ts"
+      },
+      "reduce-typeof-body-client": {
+        "description": "Off-subset `.reduce()` body deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/reduce-typeof-body-client.ts"
+      },
+      "some-typeof-predicate-client": {
+        "description": "Off-subset `.some()` predicate deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/some-typeof-predicate-client.ts"
       }
     }
   },

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 79,
+      "total": 80,
       "cells": {
         "hono": {
-          "pass": 79,
-          "total": 79
+          "pass": 80,
+          "total": 80
         },
         "blade": {
-          "pass": 67,
-          "total": 79,
+          "pass": 68,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 68,
-          "total": 79,
+          "pass": 69,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 67,
-          "total": 79,
+          "pass": 68,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -189,8 +189,8 @@
           ]
         },
         "jinja": {
-          "pass": 67,
-          "total": 79,
+          "pass": 68,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -247,8 +247,8 @@
           ]
         },
         "minijinja": {
-          "pass": 67,
-          "total": 79,
+          "pass": 68,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -305,8 +305,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 68,
-          "total": 79,
+          "pass": 69,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -357,8 +357,8 @@
           ]
         },
         "twig": {
-          "pass": 67,
-          "total": 79,
+          "pass": 68,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -415,8 +415,8 @@
           ]
         },
         "xslate": {
-          "pass": 67,
-          "total": 79,
+          "pass": 68,
+          "total": 80,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 211,
+      "total": 212,
       "cells": {
         "hono": {
-          "pass": 210,
-          "total": 211,
+          "pass": 211,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1433,8 +1433,8 @@
           ]
         },
         "blade": {
-          "pass": 196,
-          "total": 211,
+          "pass": 197,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1509,8 +1509,8 @@
           ]
         },
         "erb": {
-          "pass": 197,
-          "total": 211,
+          "pass": 198,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1579,8 +1579,8 @@
           ]
         },
         "go-template": {
-          "pass": 196,
-          "total": 211,
+          "pass": 197,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1655,8 +1655,8 @@
           ]
         },
         "jinja": {
-          "pass": 196,
-          "total": 211,
+          "pass": 197,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1731,8 +1731,8 @@
           ]
         },
         "minijinja": {
-          "pass": 196,
-          "total": 211,
+          "pass": 197,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1807,8 +1807,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 197,
-          "total": 211,
+          "pass": 198,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1877,8 +1877,8 @@
           ]
         },
         "twig": {
-          "pass": 196,
-          "total": 211,
+          "pass": 197,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1953,8 +1953,8 @@
           ]
         },
         "xslate": {
-          "pass": 196,
-          "total": 211,
+          "pass": 197,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2174,11 +2174,11 @@
       }
     },
     "identifier": {
-      "total": 300,
+      "total": 301,
       "cells": {
         "hono": {
-          "pass": 299,
-          "total": 300,
+          "pass": 300,
+          "total": 301,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2189,8 +2189,8 @@
           ]
         },
         "blade": {
-          "pass": 283,
-          "total": 300,
+          "pass": 284,
+          "total": 301,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2273,8 +2273,8 @@
           ]
         },
         "erb": {
-          "pass": 284,
-          "total": 300,
+          "pass": 285,
+          "total": 301,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2351,8 +2351,8 @@
           ]
         },
         "go-template": {
-          "pass": 283,
-          "total": 300,
+          "pass": 284,
+          "total": 301,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2435,8 +2435,8 @@
           ]
         },
         "jinja": {
-          "pass": 283,
-          "total": 300,
+          "pass": 284,
+          "total": 301,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2519,8 +2519,8 @@
           ]
         },
         "minijinja": {
-          "pass": 283,
-          "total": 300,
+          "pass": 284,
+          "total": 301,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2603,8 +2603,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 284,
-          "total": 300,
+          "pass": 285,
+          "total": 301,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2681,8 +2681,8 @@
           ]
         },
         "twig": {
-          "pass": 283,
-          "total": 300,
+          "pass": 284,
+          "total": 301,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2765,8 +2765,8 @@
           ]
         },
         "xslate": {
-          "pass": 283,
-          "total": 300,
+          "pass": 284,
+          "total": 301,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3498,11 +3498,11 @@
       }
     },
     "member": {
-      "total": 164,
+      "total": 165,
       "cells": {
         "hono": {
-          "pass": 163,
-          "total": 164,
+          "pass": 164,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3513,8 +3513,8 @@
           ]
         },
         "blade": {
-          "pass": 147,
-          "total": 164,
+          "pass": 148,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3597,8 +3597,8 @@
           ]
         },
         "erb": {
-          "pass": 148,
-          "total": 164,
+          "pass": 149,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3675,8 +3675,8 @@
           ]
         },
         "go-template": {
-          "pass": 147,
-          "total": 164,
+          "pass": 148,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3759,8 +3759,8 @@
           ]
         },
         "jinja": {
-          "pass": 147,
-          "total": 164,
+          "pass": 148,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3843,8 +3843,8 @@
           ]
         },
         "minijinja": {
-          "pass": 147,
-          "total": 164,
+          "pass": 148,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3927,8 +3927,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 148,
-          "total": 164,
+          "pass": 149,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4005,8 +4005,8 @@
           ]
         },
         "twig": {
-          "pass": 147,
-          "total": 164,
+          "pass": 148,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4089,8 +4089,8 @@
           ]
         },
         "xslate": {
-          "pass": 147,
-          "total": 164,
+          "pass": 148,
+          "total": 165,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",


### PR DESCRIPTION
`map-array-builder-body`'s docstring has always **asserted** an escape exists:

> DSL adapters surface BF021 with the `/* @client */` escape … marking the map client-only defers the whole loop to the browser

Nothing had ever executed that claim. #2616 showed why that matters — `fill-unsupported` made an equivalent "already covered" claim that turned out to be **false**, and chasing it produced #2617.

Run as a hypothesis test, with no `skipJsx` / `renderDivergences` / CSR-skip permitted to manufacture a pass.

## The hypothesis held

The escape works. Ledger **32 → 16**; the remaining 16 are all `static-array-from-props{,-with-component}` (#2321), untouched here.

| | before | after |
|---|---:|---:|
| `unescapable` pairs | 32 | **16** |

- New twin `map-array-builder-body-client`, declared as the `escapes` twin of **both** `map-array-builder-body` and `map-array-builder-escaping` — the latter "rides the same gate" per its own docstring, and a client-only twin never reaches SSR-side escaping at all, so a second near-duplicate would assert nothing new.
- `unescapable` removed for both ids across all 8 DSL adapters. The BF021 refusal is unchanged — only the "no verified escape" declaration was stale.
- The docstring claim that was true-by-assertion is now true-by-execution.

## What review changed

The twin drifts from its base in two ways beyond the comment: it adds `'use client'` and swaps the prop-sourced array for a signal. The precedent twins (`filter-typeof-predicate-client`, `find-typeof-predicate-client`) are exact copies of their bases, so this looked like an unjustified rewrite — and it matters, because `twinWorksOnAdapter` only checks that the twin *compiles clean*. It cannot detect a twin that wandered off, so a sufficiently different twin would "verify" an escape nobody can use.

Checked in both directions rather than assumed:

**The narrow claim is real.** The base source **verbatim**, with only `/* @client */` inserted before `.map()`, compiles with zero error-severity diagnostics on all nine adapters:

```
blade CLEAN · erb CLEAN · go-template CLEAN · hono CLEAN · jinja CLEAN
mojolicious CLEAN · minijinja CLEAN · twig CLEAN · xslate CLEAN
```

**The drift is not avoidable.** Substituting that minimal version into the fixture fails CSR conformance:

```
TypeError: undefined is not an object (evaluating '_p.rows.map')
```

The CSR harness evaluates `template:` with **no props**, so a prop-sourced array always throws — and a CSR-skipped twin fails tier 2, disqualifying it as a verified escape entirely. The bases whose twins *are* exact copies were already `'use client'` + signal, so the question never arose for them.

So the source stands as authored; what was missing was the reason. The docstring now records the harness constraint, the nine-adapter check backing the one-comment claim, and a note to collapse this back to an exact copy if the harness ever supplies props. Without that, the next reader either "simplifies" it and breaks CSR, or spots the drift and rightly doubts the verification.

## Every pre-existing artifact that changed

- `coverage-map.json` — additive: one fixture entry, `kindCounts` +1 for `array-literal`/`call`/`identifier`/`member`.
- `ui/compat.lock.json` — the two fixtures' cells move from bare `BF021` to `escape: { state: 'escapable', twin: 'map-array-builder-body-client' }` on all 8 DSL adapters; `totalFixtures` 319→320. This is #2622's new rendering picking up the graduation: those rows now show `BF021†`.
- `ui/support-matrix.lock.json` — `pass`/`total` +1 across the same four kinds per adapter; no new gaps.
- `fixture-escape-rendering.test.ts` (landed by #2622 mid-flight) — its named "tracked debt" example was `map-array-builder-body`, the very fixture this graduates. Swapped to `static-array-from-props`, which is still genuinely unescapable.
- No pre-existing fixture's `expectedHtml` changed (verified by running the generator in full and diffing).

## Verification

`csr-conformance` **267 / 0** · `packages/adapter-tests` **1952 pass / 0 fail / 1 skip** · `packages/compat` **342 / 0** · `bun run lint` clean. Ledger independently counted at 16 from the adapters' own sources.

Changeset: patch bump for the 8 adapter packages — `conformancePins` is exported from each package's `index.ts`, so the declaration change is shipped surface.

Rebased onto `main` after #2622 merged; the `ui/compat.lock.json` conflict was resolved by regenerating rather than hand-merging.

Refs #2613. Remaining ledger is #2321 only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_