### PR TITLE
fix(go-template): stop a child component's plural field name from swallowing a prop (#2627)

### DIFF
--- a/.changeset/go-template-record-prop-shadow-fix.md
+++ b/.changeset/go-template-record-prop-shadow-fix.md
@@ -1,0 +1,11 @@
+---
+'@barefootjs/go-template': patch
+---
+
+Fixes a `Record<string, T>` prop compiling to an invalid Go slice field when its name pluralizes into a same-named `/* @client */` child-component loop (#2627, e.g. a `tags: Record<string, T>` prop alongside a `{/* @client */ entries.map(([id, t]) => <Tag .../>)}` loop, where `entries` is itself derived from `Object.entries(props.tags)`, not a direct prop reference).
+
+Root cause: the Input/Props/NewProps struct generation treated ANY same-named child-component loop as "subsumed" by the prop and dropped the prop's own field in favor of a synthesized `Tags []TagInput` array field — correct when the loop ranges directly over the prop (`props.rows.map(...)`), but wrong here, where the loop's array is a client-only-deferred computed local with no Go-side value to seed that field from at all. The result was either a duplicate Go struct field (compile error) or the prop's own field silently disappearing, so the caller-supplied `map[string]any` value had no matching field to assign into.
+
+Fix: the nested-array "shadow" now only applies when the loop is genuinely prop-derived, and a clientOnly loop whose array is neither a signal/memo nor a direct prop reference is excluded entirely from Input/Props/NewProps codegen — the SSR template never references it (`renderLoop`'s clientOnly branch emits only marker comments), so the client computes everything from the prop's own value, which now keeps its own field and type.
+
+Graduates the `static-array-from-props-with-component-client` render divergence and the matching `unescapable` pin on `static-array-from-props-with-component` — the escape is now verified working on go-template like every other adapter.

--- a/packages/adapter-go-template/src/adapter/analysis/component-tree.ts
+++ b/packages/adapter-go-template/src/adapter/analysis/component-tree.ts
@@ -127,6 +127,7 @@ function collectNestedComponents(node: IRNode, result: NestedComponentInfo[]): v
           ...loop.childComponent,
           isDynamic: !loop.isStaticArray,
           isPropDerived: !!loop.isPropDerivedArray,
+          clientOnly: loop.clientOnly,
           loopKey: loop.key ?? undefined,
           loopParam: loop.param ?? undefined,
           bodyChildren: hasBodyChildren ? loop.childComponent.children : undefined,

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1010,6 +1010,32 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
+   * The auto-pluralized Go field names (`Row` -> `Rows`) that genuinely
+   * SUBSUME a same-named props param, so that param must not also get its
+   * own field. Four sites consume this — `generateInputStruct`,
+   * `generatePropsStruct`, `emitPropsAuxFields` and `recordRepropsSpec` —
+   * and they must agree exactly: a one-sided answer lets Input and
+   * Props/NewProps disagree about whether a field exists, producing a
+   * duplicate json tag or a dead Input field whose caller writes are
+   * silently ignored. Extracted to one function so that agreement is
+   * structural rather than four copies kept in step by hand (#2628 review).
+   *
+   * Only `isPropDerived` loops qualify (#2627). Such a loop ranges directly
+   * over `props.X` (or a destructured binding of it), so the array field and
+   * the prop are the same data, merely re-shaped into typed rows. A mere
+   * NAME coincidence is not subsumption: `Object.entries(props.tags)
+   * .filter(...)` feeding a `<Tag>` loop pluralizes to `Tags` and collides
+   * with a `tags` prop, but the prop is a `Record` while the loop array is a
+   * derived slice of tuples — dropping the prop's field there leaves it with
+   * no Go field at all to receive the caller's value. Note the check is
+   * purely name-based, so this is not specific to `Record`: any prop whose
+   * capitalized name matches a child's plural hits the same path.
+   */
+  private propDerivedNestedArrayFields(nestedComponents: readonly NestedComponentInfo[]): Set<string> {
+    return new Set(nestedComponents.filter(n => n.isPropDerived).map(n => `${n.name}s`))
+  }
+
+  /**
    * Every Go field name these props params could claim — LOCAL and
    * caller-facing. A context-consumer field must exist in ALL of
    * Input/Props/NewProps or none, and the three key prop fields under
@@ -1125,21 +1151,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   ): void {
     if (!this.childDerivedFieldDeps.has(componentName)) return
 
-    // Must mirror `generateInputStruct`'s exclusion/collision checks exactly —
-    // both walk the Input struct's actual (caller-keyed) field names, or the
-    // reprops switch references fields the struct doesn't have.
-    // Only a PROP-DERIVED nested loop (`isPropDerived` — the loop ranges
-    // directly over `props.X` / a destructured binding of it, #2627) actually
-    // subsumes a same-named prop: the array field and the prop are then the
-    // same data, just re-shaped into typed rows. A same-name coincidence with
-    // a NON-prop-derived loop (e.g. `Object.entries(props.tags).filter(...)`
-    // feeding a `<Tag>` loop, whose plural `Tags` happens to match a `tags`
-    // prop) is not a subsumption — the prop is a `Record`, the loop array is
-    // a derived slice of tuples, and dropping the prop's own field there
-    // orphans it with no Go field to receive the caller's actual value.
-    const nestedArrayFields = new Set(
-      nestedComponents.filter(n => n.isPropDerived).map(n => `${n.name}s`),
-    )
+    const nestedArrayFields = this.propDerivedNestedArrayFields(nestedComponents)
     const params = (ir.metadata.propsParams ?? []).filter(
       p => !this.isNestedArrayShadowed(p, nestedArrayFields),
     )
@@ -1462,18 +1474,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       n => (!n.isDynamic || n.isPropDerived) && !this.isOrphanedClientOnlyNested(n),
     )
 
-    // Only a PROP-DERIVED nested loop (`isPropDerived` — the loop ranges
-    // directly over `props.X` / a destructured binding of it, #2627) actually
-    // subsumes a same-named prop: the array field and the prop are then the
-    // same data, just re-shaped into typed rows. A same-name coincidence with
-    // a NON-prop-derived loop (e.g. `Object.entries(props.tags).filter(...)`
-    // feeding a `<Tag>` loop, whose plural `Tags` happens to match a `tags`
-    // prop) is not a subsumption — the prop is a `Record`, the loop array is
-    // a derived slice of tuples, and dropping the prop's own field there
-    // orphans it with no Go field to receive the caller's actual value.
-    const nestedArrayFields = new Set(
-      nestedComponents.filter(n => n.isPropDerived).map(n => `${n.name}s`),
-    )
+    const nestedArrayFields = this.propDerivedNestedArrayFields(nestedComponents)
 
     for (const param of ir.metadata.propsParams) {
       // #2525: caller-facing name, not the local destructure binding — a
@@ -1854,18 +1855,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       lines.push('\t\tSearchParams: in.SearchParams,')
     }
 
-    // Only a PROP-DERIVED nested loop (`isPropDerived` — the loop ranges
-    // directly over `props.X` / a destructured binding of it, #2627) actually
-    // subsumes a same-named prop: the array field and the prop are then the
-    // same data, just re-shaped into typed rows. A same-name coincidence with
-    // a NON-prop-derived loop (e.g. `Object.entries(props.tags).filter(...)`
-    // feeding a `<Tag>` loop, whose plural `Tags` happens to match a `tags`
-    // prop) is not a subsumption — the prop is a `Record`, the loop array is
-    // a derived slice of tuples, and dropping the prop's own field there
-    // orphans it with no Go field to receive the caller's actual value.
-    const nestedArrayFields = new Set(
-      nestedComponents.filter(n => n.isPropDerived).map(n => `${n.name}s`),
-    )
+    const nestedArrayFields = this.propDerivedNestedArrayFields(nestedComponents)
 
     // Props params (field names tracked to skip duplicate signal assignments).
     // A JSX-declared default (`variant = 'default'`) or signal-side fallback
@@ -2590,20 +2580,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     propTypeOverrides: Map<string, string>,
     takenJsonTags: Set<string>,
   ): void {
-    // Nested-component array fields are emitted as typed arrays below, not as
-    // their raw prop; track them (and emitted names) to skip duplicates.
-    // Only a PROP-DERIVED nested loop (`isPropDerived` — the loop ranges
-    // directly over `props.X` / a destructured binding of it, #2627) actually
-    // subsumes a same-named prop: the array field and the prop are then the
-    // same data, just re-shaped into typed rows. A same-name coincidence with
-    // a NON-prop-derived loop (e.g. `Object.entries(props.tags).filter(...)`
-    // feeding a `<Tag>` loop, whose plural `Tags` happens to match a `tags`
-    // prop) is not a subsumption — the prop is a `Record`, the loop array is
-    // a derived slice of tuples, and dropping the prop's own field there
-    // orphans it with no Go field to receive the caller's actual value.
-    const nestedArrayFields = new Set(
-      nestedComponents.filter(n => n.isPropDerived).map(n => `${n.name}s`),
-    )
+    const nestedArrayFields = this.propDerivedNestedArrayFields(nestedComponents)
     const propFieldNames = new Set<string>()
 
     for (const param of ir.metadata.propsParams) {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -961,6 +961,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * caller-facing while Props/NewProps key local, so a one-sided check lets
    * the structs disagree on whether the field exists (a duplicate json tag,
    * or a dead Input field whose caller writes are silently ignored).
+   *
+   * `nestedArrayFields` (built by each call site) is ALREADY restricted to
+   * prop-derived loops (#2627) — a same-name coincidence with a loop that
+   * merely transforms a differently-shaped prop (`Object.entries(props.tags)
+   * .filter(...)` feeding a `<Tag>` loop, whose plural `Tags` happens to
+   * match a `tags: Record<...>` prop) must NOT shadow the prop's own field;
+   * the two are different Go types and the prop has no other field to land
+   * in. See the call sites' `nestedArrayFields` construction.
    */
   private isNestedArrayShadowed(
     param: { name: string; sourceName?: string },
@@ -970,6 +978,35 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       nestedArrayFields.has(capitalizeFieldName(param.name)) ||
       nestedArrayFields.has(capitalizeFieldName(param.sourceName ?? param.name))
     )
+  }
+
+  /**
+   * True when `nested` is a `/* @client *\/` child-component loop (#2627)
+   * whose array is neither a real signal/memo (`isDynamic`) nor a direct
+   * prop reference (`isPropDerived`) — e.g. `Object.entries(props.tags)
+   * .filter(...)` feeding a `<Tag>` loop. `renderLoop`'s clientOnly branch
+   * (its very first check) renders such a loop as bare start/end comment
+   * markers on every backend — the SSR template NEVER references this
+   * nested component's Go field — and for a non-clientOnly loop with this
+   * same array shape, `renderLoop`'s own later BF101 gate (`arrayName` /
+   * `isBound` check) refuses to bind a function-scope computed local as a
+   * template variable at all. So there is no Go value anywhere to seed an
+   * Input field from or range over in `NewXxxProps` — treating `nested` as
+   * a normal static/prop-derived child loop emits a field/range/wrapper var
+   * for data nothing ever populates, and when its plural name happens to
+   * collide with the ACTUAL driving prop (`tags` -> `Tags`, `Tag` ->
+   * `Tags`), that dead field is worse than dead: either a duplicate Go
+   * field name (compile error) or — via `isNestedArrayShadowed` — silent
+   * loss of the prop's own field, the one channel the client actually
+   * reads hydration data from.
+   *
+   * `nested.isDynamic` is excluded from this check on purpose: a genuinely
+   * signal-backed clientOnly loop keeps its existing (tested, harmless)
+   * `json:"-"` Props field — only the "looks static but is actually an
+   * unbindable local" shape needs full exclusion.
+   */
+  private isOrphanedClientOnlyNested(nested: NestedComponentInfo): boolean {
+    return !!nested.clientOnly && !nested.isDynamic && !nested.isPropDerived
   }
 
   /**
@@ -1091,7 +1128,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // Must mirror `generateInputStruct`'s exclusion/collision checks exactly —
     // both walk the Input struct's actual (caller-keyed) field names, or the
     // reprops switch references fields the struct doesn't have.
-    const nestedArrayFields = new Set(nestedComponents.map(n => `${n.name}s`))
+    // Only a PROP-DERIVED nested loop (`isPropDerived` — the loop ranges
+    // directly over `props.X` / a destructured binding of it, #2627) actually
+    // subsumes a same-named prop: the array field and the prop are then the
+    // same data, just re-shaped into typed rows. A same-name coincidence with
+    // a NON-prop-derived loop (e.g. `Object.entries(props.tags).filter(...)`
+    // feeding a `<Tag>` loop, whose plural `Tags` happens to match a `tags`
+    // prop) is not a subsumption — the prop is a `Record`, the loop array is
+    // a derived slice of tuples, and dropping the prop's own field there
+    // orphans it with no Go field to receive the caller's actual value.
+    const nestedArrayFields = new Set(
+      nestedComponents.filter(n => n.isPropDerived).map(n => `${n.name}s`),
+    )
     const params = (ir.metadata.propsParams ?? []).filter(
       p => !this.isNestedArrayShadowed(p, nestedArrayFields),
     )
@@ -1407,10 +1455,25 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
 
     // Static + prop-derived nested components are in Input; signal-backed
-    // dynamic ones are template-only.
-    const inputNested = nestedComponents.filter(n => !n.isDynamic || n.isPropDerived)
+    // dynamic ones are template-only. An orphaned clientOnly nested loop
+    // (#2627 — see `isOrphanedClientOnlyNested`) has no Go value to seed an
+    // Input field from at all, so it's excluded from both buckets.
+    const inputNested = nestedComponents.filter(
+      n => (!n.isDynamic || n.isPropDerived) && !this.isOrphanedClientOnlyNested(n),
+    )
 
-    const nestedArrayFields = new Set(nestedComponents.map(n => `${n.name}s`))
+    // Only a PROP-DERIVED nested loop (`isPropDerived` — the loop ranges
+    // directly over `props.X` / a destructured binding of it, #2627) actually
+    // subsumes a same-named prop: the array field and the prop are then the
+    // same data, just re-shaped into typed rows. A same-name coincidence with
+    // a NON-prop-derived loop (e.g. `Object.entries(props.tags).filter(...)`
+    // feeding a `<Tag>` loop, whose plural `Tags` happens to match a `tags`
+    // prop) is not a subsumption — the prop is a `Record`, the loop array is
+    // a derived slice of tuples, and dropping the prop's own field there
+    // orphans it with no Go field to receive the caller's actual value.
+    const nestedArrayFields = new Set(
+      nestedComponents.filter(n => n.isPropDerived).map(n => `${n.name}s`),
+    )
 
     for (const param of ir.metadata.propsParams) {
       // #2525: caller-facing name, not the local destructure binding — a
@@ -1648,8 +1711,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     lines.push('\t}')
     lines.push('')
 
-    // Static + prop-derived nested components auto-populate from input.
-    const staticNested = nestedComponents.filter(n => !n.isDynamic || n.isPropDerived)
+    // Static + prop-derived nested components auto-populate from input. An
+    // orphaned clientOnly nested loop (#2627 — see `isOrphanedClientOnlyNested`)
+    // has no Input field to range over (excluded above in `generateInputStruct`),
+    // so it's excluded here too.
+    const staticNested = nestedComponents.filter(
+      n => (!n.isDynamic || n.isPropDerived) && !this.isOrphanedClientOnlyNested(n),
+    )
 
     // Wrapper vars emitted (by either the static-with-body or dynamic-with-body
     // path), so the return struct only includes the ones that were built.
@@ -1786,7 +1854,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       lines.push('\t\tSearchParams: in.SearchParams,')
     }
 
-    const nestedArrayFields = new Set(nestedComponents.map(n => `${n.name}s`))
+    // Only a PROP-DERIVED nested loop (`isPropDerived` — the loop ranges
+    // directly over `props.X` / a destructured binding of it, #2627) actually
+    // subsumes a same-named prop: the array field and the prop are then the
+    // same data, just re-shaped into typed rows. A same-name coincidence with
+    // a NON-prop-derived loop (e.g. `Object.entries(props.tags).filter(...)`
+    // feeding a `<Tag>` loop, whose plural `Tags` happens to match a `tags`
+    // prop) is not a subsumption — the prop is a `Record`, the loop array is
+    // a derived slice of tuples, and dropping the prop's own field there
+    // orphans it with no Go field to receive the caller's actual value.
+    const nestedArrayFields = new Set(
+      nestedComponents.filter(n => n.isPropDerived).map(n => `${n.name}s`),
+    )
 
     // Props params (field names tracked to skip duplicate signal assignments).
     // A JSX-declared default (`variant = 'default'`) or signal-side fallback
@@ -2513,7 +2592,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   ): void {
     // Nested-component array fields are emitted as typed arrays below, not as
     // their raw prop; track them (and emitted names) to skip duplicates.
-    const nestedArrayFields = new Set(nestedComponents.map(n => `${n.name}s`))
+    // Only a PROP-DERIVED nested loop (`isPropDerived` — the loop ranges
+    // directly over `props.X` / a destructured binding of it, #2627) actually
+    // subsumes a same-named prop: the array field and the prop are then the
+    // same data, just re-shaped into typed rows. A same-name coincidence with
+    // a NON-prop-derived loop (e.g. `Object.entries(props.tags).filter(...)`
+    // feeding a `<Tag>` loop, whose plural `Tags` happens to match a `tags`
+    // prop) is not a subsumption — the prop is a `Record`, the loop array is
+    // a derived slice of tuples, and dropping the prop's own field there
+    // orphans it with no Go field to receive the caller's actual value.
+    const nestedArrayFields = new Set(
+      nestedComponents.filter(n => n.isPropDerived).map(n => `${n.name}s`),
+    )
     const propFieldNames = new Set<string>()
 
     for (const param of ir.metadata.propsParams) {
@@ -2636,6 +2726,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
 
     for (const nested of nestedComponents) {
+      // An orphaned clientOnly nested loop (#2627 — see
+      // `isOrphanedClientOnlyNested`) gets NO Props field at all, not even
+      // the dead `json:"-"` one the signal-backed dynamic branch below gets:
+      // its Go field name (`${nested.name}s`) can collide with the ACTUAL
+      // driving prop's own field (e.g. `tags` -> `Tags` colliding with
+      // `Tag` -> `Tags`), which `emitPropsDataFields` already emitted for
+      // real — a second same-named field here is a Go compile error
+      // ("redeclared"), not just dead code.
+      if (this.isOrphanedClientOnlyNested(nested)) continue
       // Loop body with JSX children → use the wrapper struct type.
       const elemType = nested.bodyChildren?.length
         ? this.loopBodyWrapperName(componentName, nested)

--- a/packages/adapter-go-template/src/adapter/lib/types.ts
+++ b/packages/adapter-go-template/src/adapter/lib/types.ts
@@ -30,6 +30,21 @@ export type GoRenderCtx = {
 export interface NestedComponentInfo extends IRLoopChildComponent {
   isDynamic: boolean
   isPropDerived: boolean
+  /**
+   * True when the enclosing loop carries a `/* @client *\/` directive
+   * (`loop.clientOnly`, #2627). `renderLoop`'s FIRST branch short-circuits a
+   * clientOnly loop to bare start/end comment markers — the SSR template
+   * never references this nested component's Go field, no matter how
+   * `isDynamic`/`isPropDerived` classify its array. Combined with
+   * `!isDynamic && !isPropDerived` (a clientOnly loop whose array is
+   * neither a real signal/memo NOR a direct prop reference — e.g.
+   * `Object.entries(props.tags).filter(...)`), there is no Go value to
+   * seed an Input/Props field FROM at all: the array is a function-scope
+   * computed local that `renderLoop`'s own BF101 gate refuses to bind as a
+   * template variable for a non-clientOnly loop. See
+   * `GoTemplateAdapter.isOrphanedClientOnlyNested`.
+   */
+  clientOnly?: boolean
   /** The enclosing loop's `key` expression (e.g. `item.label`) and map param
    *  name (`item`), so the loop-child init can stamp `data-key` per item. */
   loopKey?: string

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -93,22 +93,18 @@ export const conformancePins: ConformancePins = {
   // longer contributes a diagnostic, and BF103 (sibling-imported child
   // component in the loop body) no longer fires either now that the
   // conformance harness passes `siblingTemplatesRegistered: true` (#2205).
-  // `unescapable` stays HERE, unlike on the other seven adapters, and
-  // unlike this fixture's sibling `static-array-from-props` (whose twin
-  // does work here). The `/* @client */` twin compiles clean on Go but the
-  // generated program does not BUILD: a `Record<string, T>` prop is
-  // emitted as a slice field, so the map-shaped caller literal will not
-  // assign (#2627). That twin is therefore pinned in this package's
-  // `render-divergences.ts`, which makes `twinWorksOnAdapter` false here —
-  // so this adapter genuinely has no verified escape for this fixture and
-  // must say so. Graduating #2627 deletes the divergence entry and this
-  // `unescapable` line together.
+  // #2627 graduated: the `/* @client */` twin
+  // (`static-array-from-props-with-component-client`) now renders clean on
+  // real Go (its clientOnly nested `<Tag>` loop is excluded from the
+  // Input/Props/NewProps codegen instead of colliding with the `tags` prop's
+  // own field — see `GoTemplateAdapter.isOrphanedClientOnlyNested`), so this
+  // adapter has a verified escape for this fixture like every other one —
+  // no more `unescapable` line.
   'static-array-from-props-with-component': [
     {
       code: 'BF101',
       severity: 'error',
       issue: 'https://github.com/piconic-ai/barefootjs/issues/2321',
-      unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2627' },
     },
   ],
   // (`style-3-signals` graduated alongside `style-object-dynamic` — see note

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -13,9 +13,15 @@
  * the docs compatibility-matrix page. Graduating an entry means fixing
  * the adapter (or the shared compiler layer) and deleting the line.
  *
- * Empty — the file's last live entry (`aliased-destructured-prop`, #2525)
- * graduated: the Input struct field is now keyed by `sourceName ?? name`
- * (caller-facing), so the caller-side composite literal `go run`s clean.
+ * Empty — the file's last live entry (`static-array-from-props-with-
+ * component-client`, #2627) graduated: a clientOnly child-component loop
+ * whose array is neither a signal/memo nor a direct prop reference (e.g.
+ * `Object.entries(props.tags).filter(...)` feeding a `<Tag>` loop) is now
+ * excluded entirely from the Input/Props/NewProps codegen instead of
+ * colliding with the driving prop's own field — see
+ * `GoTemplateAdapter.isOrphanedClientOnlyNested`. The caller-side composite
+ * literal for the `tags` prop now type-checks against its own `interface{}`
+ * field and `go run`s clean.
  * Keep the file (and this header) when the set is empty — the next
  * divergence lands here, not in a re-created file.
  */
@@ -35,28 +41,4 @@ export const renderDivergences: RenderDivergences = {
   // production). `buildDynamicChildLoopSeeding` (this package's
   // `test-render.ts`) now replicates that documented contract for a
   // signal-backed dynamic child-component loop.
-
-  // exit 1 — generated Go does not compile (#2627):
-  //   ./main.go:54:9: cannot use map[string]any{…} (value of type
-  //   map[string]any) as []TagInput value in struct literal
-  // The `tags` prop is a `Record<string, T>`; this adapter emits a SLICE
-  // field (`[]TagInput`) for it, so the caller-side composite literal —
-  // correctly a map, since the component calls `Object.entries(props.tags)`
-  // — cannot be assigned. Squarely the "should eventually become a loud
-  // BF101 refusal instead of broken codegen" class this file's header
-  // describes.
-  //
-  // Pre-existing, not caused by the twin: the BASE fixture
-  // (`static-array-from-props-with-component`) is BF101-refused here
-  // (#2321), so Go codegen was never reached and the bad type sat behind
-  // that refusal. #2626's `/* @client */` twin suppresses BF101, reaches
-  // the Go backend for the first time, and exposes it.
-  //
-  // Consequence for the escape ledger, stated plainly: this entry makes
-  // `twinWorksOnAdapter` false here, so the base fixture KEEPS its
-  // `unescapable` pin on this adapter. The escape is verified on the other
-  // adapters, not on go-template. Graduating #2627 deletes this entry and
-  // that pin together.
-  'static-array-from-props-with-component-client':
-    'generated Go fails `go run` (exit 1): a Record<string, T> prop is emitted as a slice field, so the map-shaped caller literal will not assign — https://github.com/piconic-ai/barefootjs/issues/2627',
 }

--- a/packages/compat/src/__tests__/fixture-escape-rendering.test.ts
+++ b/packages/compat/src/__tests__/fixture-escape-rendering.test.ts
@@ -165,11 +165,15 @@ describe('buildFixtureDivergences — real corpus, real adapters (#2613)', () =>
   // (`static-array-from-props-client` /
   // `static-array-from-props-with-component-client`) removed the last two
   // `unescapable` pins anywhere in the corpus, so the render-conformance
-  // ledger is at zero. Its rendering (bare, unmarked code) stays covered by
-  // the synthetic `escapeMarker` / `fixtureCellText` tests above, which need
-  // no real fixture — deliberately, so that reaching zero debt costs this
-  // file no coverage and creates no pressure to keep a debt entry alive
-  // just to keep a test meaningful.
+  // ledger was at zero — briefly reopened to one when #2626's go-template
+  // twin exposed #2627 (a `Record<string, T>` prop misrendered as a slice
+  // field), pinned `unescapable` on go-template in the interim. #2627's fix
+  // graduated that pin, so the ledger is back at zero. Its rendering (bare,
+  // unmarked code) stays covered by the synthetic `escapeMarker` /
+  // `fixtureCellText` tests above, which need no real fixture —
+  // deliberately, so that reaching zero debt costs this file no coverage
+  // and creates no pressure to keep a debt entry alive just to keep a test
+  // meaningful.
   test('the render-conformance table exercises the escapable and not-owed states on real fixtures', () => {
     const states = new Set<string>()
     for (const row of Object.values(fd.fixtures)) {
@@ -282,21 +286,22 @@ describe('buildFixtureDivergences — real corpus, real adapters (#2613)', () =>
     expect(fd.fixtures['tag-cloud']).toBeDefined()
     expect(rowWorksEverywhere(fd.fixtures['tag-cloud']!)).toBe(false)
 
-    // #2321's escape-twin work graduated ONE of its two fixtures fully.
+    // #2321's escape-twin work graduated BOTH of its fixtures fully.
     expect(fd.fixtures['static-array-from-props']).toBeDefined()
     expect(rowWorksEverywhere(fd.fixtures['static-array-from-props']!)).toBe(true)
 
-    // Its sibling did NOT, and the difference is the point rather than an
-    // oversight: the twin compiles clean on go-template but the generated
-    // Go does not build (a `Record<string, T>` prop is emitted as a slice
-    // field — #2627), so that adapter is pinned in its own
-    // `render-divergences.ts` and keeps its `unescapable` declaration.
-    // Seven adapters escape this fixture; go-template does not, so the row
-    // does not work everywhere. Asserting `true` here would have been the
-    // easy way to keep the suite green while claiming an escape nobody can
-    // use on Go.
+    // Its sibling initially did NOT graduate on go-template: the twin
+    // compiled clean but the generated Go didn't build (a `Record<string,
+    // T>` prop was emitted as a slice field — #2627). #2627 fixed that (a
+    // clientOnly child-component loop whose array isn't a signal/memo or a
+    // direct prop reference is now excluded from the Input/Props/NewProps
+    // codegen entirely, instead of colliding with the driving prop's own
+    // field — see `GoTemplateAdapter.isOrphanedClientOnlyNested`), so
+    // go-template's `render-divergences.ts` entry and this fixture's
+    // `unescapable` pin were deleted together. All eight adapters escape
+    // this fixture now, so the row works everywhere.
     expect(fd.fixtures['static-array-from-props-with-component']).toBeDefined()
-    expect(rowWorksEverywhere(fd.fixtures['static-array-from-props-with-component']!)).toBe(false)
+    expect(rowWorksEverywhere(fd.fixtures['static-array-from-props-with-component']!)).toBe(true)
 
     expect(fd.fixtures['map-array-builder-body']).toBeDefined()
     expect(rowWorksEverywhere(fd.fixtures['map-array-builder-body']!)).toBe(true)

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -3129,7 +3129,8 @@
             "https://github.com/piconic-ai/barefootjs/issues/2321"
           ],
           "escape": {
-            "state": "debt"
+            "state": "escapable",
+            "twin": "static-array-from-props-with-component-client"
           }
         },
         "jinja": {
@@ -3196,12 +3197,6 @@
             "state": "escapable",
             "twin": "static-array-from-props-with-component-client"
           }
-        }
-      },
-      "static-array-from-props-with-component-client": {
-        "go-template": {
-          "kind": "render",
-          "reason": "generated Go fails `go run` (exit 1): a Record<string, T> prop is emitted as a slice field, so the map-shaped caller literal will not assign — https://github.com/piconic-ai/barefootjs/issues/2627"
         }
       },
       "tag-cloud": {
@@ -3352,10 +3347,6 @@
         "description": "Static-array loop with childComponent body materialises rendered children on CSR (#1268)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts"
       },
-      "static-array-from-props-with-component-client": {
-        "description": "/* @client */ twin of static-array-from-props-with-component — DSL BF101 (computed-const loop…",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component-client.ts"
-      },
       "tag-cloud": {
         "description": "flatMap block-body tag list — hydration adoption, in-place leaf patch, add, and remove",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/tag-cloud.ts"
@@ -3407,6 +3398,10 @@
       "static-array-from-props-client": {
         "description": "/* @client */ twin of static-array-from-props — DSL BF101 (computed-const loop array) suppressed…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-client.ts"
+      },
+      "static-array-from-props-with-component-client": {
+        "description": "/* @client */ twin of static-array-from-props-with-component — DSL BF101 (computed-const loop…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component-client.ts"
       }
     }
   },

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1123,7 +1123,7 @@
           ]
         },
         "go-template": {
-          "pass": 80,
+          "pass": 81,
           "total": 90,
           "gaps": [
             {
@@ -1167,10 +1167,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component-client",
-              "issues": []
             }
           ]
         },
@@ -1583,7 +1579,7 @@
           ]
         },
         "go-template": {
-          "pass": 198,
+          "pass": 199,
           "total": 214,
           "gaps": [
             {
@@ -1651,10 +1647,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component-client",
-              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -2359,7 +2351,7 @@
           ]
         },
         "go-template": {
-          "pass": 285,
+          "pass": 286,
           "total": 303,
           "gaps": [
             {
@@ -2435,10 +2427,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component-client",
-              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -3037,7 +3025,7 @@
           ]
         },
         "go-template": {
-          "pass": 237,
+          "pass": 238,
           "total": 249,
           "gaps": [
             {
@@ -3081,10 +3069,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component-client",
-              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -3691,7 +3675,7 @@
           ]
         },
         "go-template": {
-          "pass": 149,
+          "pass": 150,
           "total": 167,
           "gaps": [
             {
@@ -3767,10 +3751,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component-client",
-              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -4715,7 +4695,7 @@
           ]
         },
         "go-template": {
-          "pass": 27,
+          "pass": 28,
           "total": 39,
           "gaps": [
             {
@@ -4761,10 +4741,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component-client",
-              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -6619,7 +6595,7 @@
           ]
         },
         "go-template": {
-          "pass": 18,
+          "pass": 19,
           "total": 20,
           "gaps": [
             {
@@ -6627,10 +6603,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component-client",
-              "issues": []
             }
           ]
         },
@@ -7778,7 +7750,7 @@
           ]
         },
         "go-template": {
-          "pass": 168,
+          "pass": 169,
           "total": 177,
           "gaps": [
             {
@@ -7814,10 +7786,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component-client",
-              "issues": []
             }
           ]
         },


### PR DESCRIPTION
Fixes #2627 and graduates the last entry in #2613's debt ledger. **Ledger: 1 → 0**, verified by enumeration (`adapters=9 DEBT PAIRS=0`), not grep.

## The issue was wrong about the cause — including its title

I filed #2627 from the symptom (`[]TagInput` where a map belonged) and inferred a type-mapping bug. It isn't one. `typeInfoToGo` handles the type correctly: `Record<string, T>` resolves to `TypeInfo{kind:'interface'}` and falls through to `interface{}` cleanly. I've retitled the issue and posted a correction.

**The real mechanism is a name collision, and it is type-independent.**

Every nested child-component loop gets an auto-pluralized Go field `${ChildName}s`. `isNestedArrayShadowed` drops a prop's own field when its capitalized name collides with that plural — correct for genuine subsumption:

```tsx
{items.map(item => <Row … />)}   // items IS the rows prop → Rows []RowInput
```

But the shadow set was built from **every** nested component unconditionally:

```ts
const nestedArrayFields = new Set(nestedComponents.map(n => `${n.name}s`))
```

Nothing there consults the prop's type. `<Tag>` pluralizes to `Tags`, collides with a `tags` prop, and the prop's field is dropped — even though the loop array (`Object.entries(props.tags).filter(…)`) is a *derived local*, not the prop. The prop then has no Go field to receive the caller's value.

So `Record` is incidental. A `tags: string[]` prop with a non-prop-derived `<Tag>` loop hits the identical path — the shadow check is purely name-based.

## The dangerous half

The collision has two outcomes and only one is loud:

- names collide **and** types disagree → Go fails to compile ← this reproducer
- names collide **and** types happen to line up → **compiles, and the client reads hydration data from a field the caller never populated**

The second is worse and nothing in the corpus was exercising it. That's why this was worth fixing rather than converting to a BF101 refusal.

## Fix

1. The shadow set is restricted to genuinely `isPropDerived` loops (4 call sites, which must agree or Input and Props/NewProps disagree about whether a field exists).
2. New `isOrphanedClientOnlyNested` (`clientOnly && !isDynamic && !isPropDerived`) excludes such loops from `inputNested`, `staticNested`, and the Props-aux field loop. A `/* @client */` loop over an unbindable local has no Go value to seed a field from: `renderLoop`'s clientOnly branch emits only comment markers, so the SSR template never references it. `isDynamic` is deliberately excluded — a genuinely signal-backed clientOnly loop keeps its existing `json:"-"` Props field.

Route (a), a real fix, not the BF101 escape hatch `render-divergences.ts` prescribes for the "exit 1" class — justified because `Object.entries` lowering was never the blocker. The loop is fully deferred to client JS, so Go SSR never needs to range over the data at all.

## The legitimate case still works, and was already covered

`a nested-array field name collision skips the prop everywhere ({ rows: items } direction)` asserts `Rows []RowInput` with no `Items` field. That loop is `isPropDerived`, so it stays in the narrowed set. Green.

## Graduation, same PR

Per the change-time coupling rule, both pins removed together:
- the `static-array-from-props-with-component-client` entry in `render-divergences.ts`
- the `unescapable: { issue: …/2627 }` line in `conformance-pins.ts`
- plus `fixture-escape-rendering.test.ts`'s `rowWorksEverywhere(...)` assertion flipped back to `true`

## Verification

The trap that burned me on #2626: `isGoAvailable()` requires Go 1.25+, the box default is 1.24.7, and the whole Go render path silently skips — reporting a clean pass while CI is red. So this was run under `GOTOOLCHAIN=go1.25.6` **and** checked for the absence of the skip marker rather than trusting the pass count.

- `packages/adapter-go-template` **1636 pass / 18 skip**, one 5000ms timeout on `composite-row-child-component` (unrelated fixture, passes standalone — same transient class as #2616/#2626)
- `packages/adapter-tests` **1963 / 0** · `packages/compat` **352 / 0** · `packages/jsx` **3043 / 0** · lint clean
- ledger by enumeration: **0**

Not re-run after the final graduation edits: the full 846s go-template suite. `dist` was rebuilt with all changes before that run, and the target fixture plus the flaky test were re-verified in isolation afterwards — but CI is the authority.

Closes #2627. Refs #2613, #2321

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT)_