### PR TITLE
feat(compat): surface escape guidance on the matrix — a red cell now tells you the way out (#2614)

### DIFF
--- a/.changeset/error-suggestion-escape.md
+++ b/.changeset/error-suggestion-escape.md
@@ -1,0 +1,21 @@
+---
+'@barefootjs/jsx': patch
+'@barefootjs/blade': patch
+'@barefootjs/erb': patch
+'@barefootjs/go-template': patch
+'@barefootjs/jinja': patch
+'@barefootjs/mojolicious': patch
+'@barefootjs/rust': patch
+'@barefootjs/twig': patch
+'@barefootjs/xslate': patch
+---
+
+`ErrorSuggestion` gains an optional `escape?: ReadonlyArray<{ kind: EscapeKind }>` — the structured half of a refusal's suggestion (#2613, #2614). `EscapeKind` and `ESCAPE_SSR_COST` are exported from `@barefootjs/jsx` alongside it.
+
+This is what lets a tool answer "how does the user get out of this refusal?" without parsing prose. `suggestion.message` stays authoritative for humans — several sites have site-specific wording no enum should flatten — while `escape` is authoritative for machines, and `ESCAPE_SSR_COST` is the one place the trade each kind makes is defined (`'client-directive'` renders nothing at SSR until hydration; `'prop-precompute'` and `'rewrite'` keep full server output). Consumers surfacing an escape should surface its cost from that map rather than restating it, so the trade cannot be quietly dropped on the way to a user.
+
+The field is additive and one-way: it is populated at the BF101 refusal sites behind #2320/#2321 in every DSL adapter, and absent elsewhere. **Absent means "not declared yet", never "no escape exists"** — do not infer unescapability from its absence.
+
+Adapter authors: what you claim here is checked. `escape-coverage.test.ts` verifies that every kind a diagnostic claims is demonstrated by a conformance twin that actually compiles clean on the refusing adapter, so a claim can no longer outrun its proof.
+
+No emission or runtime behavior changes.

--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -24,6 +24,8 @@ error[BF001]: 'use client' directive required for components with createSignal
 
 ## Directive Errors (BF001–BF003)
 
+<a id="bf001"></a>
+
 ### BF001 — Missing `"use client"` Directive
 
 **Trigger:** Reactive APIs used without `"use client"`.
@@ -46,6 +48,8 @@ import { createSignal } from '@barefootjs/client'
 export function Counter() { ... }
 ```
 
+<a id="bf003"></a>
+
 ### BF003 — Client Component Importing Server Component
 
 **Trigger:** Client component imports from a file without `"use client"`.
@@ -55,6 +59,8 @@ export function Counter() { ... }
 ---
 
 ## Signal Errors (BF011)
+
+<a id="bf011"></a>
 
 ### BF011 — Module-Level Reactive Declaration
 
@@ -99,6 +105,8 @@ export function Counter() {
 ---
 
 ## JSX Errors (BF021–BF023)
+
+<a id="bf021"></a>
 
 ### BF021 — Unsupported JSX Pattern
 
@@ -201,6 +209,8 @@ that a component-body local (`const iso = createdAt.toISOString()`) is NOT a
 workaround: it lowers to a template variable whose value the template
 backend cannot compute, and dies at render time the same way.
 
+<a id="bf023"></a>
+
 ### BF023 — Missing Key in List
 
 **Trigger:** `.map()` loop without `key` prop.
@@ -220,6 +230,8 @@ backend cannot compute, and dies at render time the same way.
 ---
 
 ## Template Adapter Errors (BF101)
+
+<a id="bf101"></a>
 
 ### BF101 — No Template-Language Lowering
 
@@ -242,7 +254,10 @@ function ReactionBar(props: { reactions: Record<string, string[]> }) {
 }
 ```
 
-**Fix:** For the loop-source shape, prefer precomputing the array where it's already computable and passing the **result** as a prop — this keeps full SSR output. Both shapes fall back to `/* @client */`, which compiles clean everywhere but renders nothing for that region at SSR (client-only, materialised at hydration/mount).
+**Escapes** — each verified by a conformance twin that compiles clean on the refusing adapter, listed best-SSR-first:
+
+- **Pass the computed result as a prop** (`prop-precompute`) — available for the loop-source shape, wherever the array is already computable server-side. **Full server render**: the rendered result is present in the server HTML.
+- **`/* @client */`** (`client-directive`) — available for both shapes, and compiles clean on every adapter. **Client-render**: the region is *empty in server HTML until hydration*. That trade is the cost of the escape, not a bug — the twin fixtures pin the empty region in their own committed `expectedHtml`.
 
 ```tsx
 // ✅ Best for the loop-source shape: pass the computed array as a prop
@@ -261,6 +276,8 @@ See [JSX Compatibility](../rendering/jsx-compatibility.md) for the full worked e
 ---
 
 ## Component Errors (BF043–BF044)
+
+<a id="bf043"></a>
 
 ### BF043 — Props Destructuring (Warning)
 
@@ -298,6 +315,8 @@ function Child({ initialCount }: Props) {
 }
 ```
 
+<a id="bf044"></a>
+
 ### BF044 — Signal/Memo Getter Not Called
 
 **Trigger:** Signal/memo getter passed without calling it.
@@ -313,6 +332,8 @@ function Child({ initialCount }: Props) {
 // ✅ Fixed
 <Child count={count()} />
 ```
+
+<a id="bf054"></a>
 
 ### BF054 — Built-in `<Async>` / `<Region>` Used Without Import
 

--- a/packages/adapter-blade/src/adapter/blade-adapter.ts
+++ b/packages/adapter-blade/src/adapter/blade-adapter.ts
@@ -994,6 +994,7 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
           suggestion: {
             message:
               'Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.',
+            escape: [{ kind: 'prop-precompute' }, { kind: 'client-directive' }],
           },
         })
       }

--- a/packages/adapter-erb/src/adapter/erb-adapter.ts
+++ b/packages/adapter-erb/src/adapter/erb-adapter.ts
@@ -97,7 +97,7 @@ import {
   BindingScope,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr, isExplicitStringCall } from './boolean-result.ts'
-import type { ParsedExpr, LoweringMatcher, LoopBindingPathSegment } from '@barefootjs/jsx'
+import type { ParsedExpr, LoweringMatcher, LoopBindingPathSegment, EscapeKind } from '@barefootjs/jsx'
 import { BF_SLOT, BF_COND, BF_REGION, escapeHtml } from '@barefootjs/shared'
 
 import type { ErbRenderCtx } from './lib/types.ts'
@@ -981,6 +981,7 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
         this._recordExprBF101(
           `Loop array \`${arrayName}\` is a component-scope const computed from a runtime expression the ERB adapter cannot evaluate at SSR render time.`,
           `Options:\n1. Inline the array expression directly in the .map() call instead of a preceding const.\n2. Mark the loop position as @client-only so the array materialises on the client.\n3. Precompute the value server-side and pass it in as a prop.`,
+          [{ kind: 'prop-precompute' }, { kind: 'client-directive' }],
         )
       }
     }
@@ -1961,7 +1962,16 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
     return this.stringValueNames.has(name)
   }
 
-  private _recordExprBF101(message: string, reason?: string): void {
+  /**
+   * `escape` is the structured claim (#2613) — populate it only with kinds
+   * a conformance twin actually demonstrates for this shape, since
+   * `escape-coverage.test.ts` checks claims against the twins. The prose
+   * in `reason` may legitimately offer more than the structured field
+   * (ERB's numbered list opens with an inline-rewrite option that no twin
+   * proves); prose stays authoritative for humans, this field for
+   * machines.
+   */
+  private _recordExprBF101(message: string, reason?: string, escape?: ReadonlyArray<{ kind: EscapeKind }>): void {
     this.errors.push({
       code: 'BF101',
       severity: 'error',
@@ -1971,6 +1981,7 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
         message: reason
           ? `${reason}\n\nOptions:\n1. Use /* @client */ for client-side evaluation\n2. Pre-compute the value in Ruby`
           : 'Options:\n1. Use /* @client */ for client-side evaluation\n2. Pre-compute the value in Ruby',
+        ...(escape ? { escape } : {}),
       },
     })
   }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -6490,6 +6490,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           suggestion: {
             message:
               'Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.',
+            escape: [{ kind: 'prop-precompute' }, { kind: 'client-directive' }],
           },
         })
       }

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -29,6 +29,26 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
+  // #2630: a prop-backed loop whose BODY is a child component renders the
+  // loop host empty — compiles clean, `go run`s clean, emits no children.
+  // Its sibling `static-array-from-props-precomputed` (same fixture,
+  // inline element body instead of a `<Tag>` child) renders correctly on
+  // every adapter, so this is specific to child-component bodies over a
+  // prop-backed array — plausibly the same missing server-side population
+  // path the `todo-app-ssr` note below describes, where
+  // `buildDynamicChildLoopSeeding` covers only the SIGNAL-backed dynamic
+  // case and a prop-backed static child loop has no analogue.
+  //
+  // This one costs a user something concrete: the BF101 diagnostic for
+  // #2321 lists pass-as-prop FIRST because it is the escape that keeps
+  // full server output, so a go-template user following that advice for a
+  // child-component loop gets an empty container at SSR with nothing
+  // reporting it. The fixture asserts the CORRECT (reference) output, so
+  // deleting this entry once the gap is fixed turns it into the
+  // regression test.
+  'static-array-from-props-with-component-precomputed':
+    'prop-backed child-component loop renders the loop host empty at SSR (https://github.com/piconic-ai/barefootjs/issues/2630)',
+
   // `todo-app-ssr` no longer diverges (#2209). Two parts: (1) `.Todos`
   // (the loop's DATUM slice) is already seeded straight from the caller's
   // Input — the constructor derives it from `initialTodos`, and `[]Todo`

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -842,6 +842,7 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
           suggestion: {
             message:
               'Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.',
+            escape: [{ kind: 'prop-precompute' }, { kind: 'client-directive' }],
           },
         })
       }

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -928,6 +928,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
           suggestion: {
             message:
               'Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.',
+            escape: [{ kind: 'prop-precompute' }, { kind: 'client-directive' }],
           },
         })
       }

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -891,6 +891,7 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
           suggestion: {
             message:
               'Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.',
+            escape: [{ kind: 'prop-precompute' }, { kind: 'client-directive' }],
           },
         })
       }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -4388,6 +4388,19 @@
         "text"
       ]
     },
+    "static-array-from-props-precomputed": {
+      "kinds": [
+        "call",
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "static-array-from-props-with-component": {
       "kinds": [
         "binary",
@@ -4415,6 +4428,23 @@
         "literal",
         "member",
         "unsupported"
+      ],
+      "axes": [
+        "binary:+",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "static-array-from-props-with-component-precomputed": {
+      "kinds": [
+        "binary",
+        "identifier",
+        "literal",
+        "member"
       ],
       "axes": [
         "binary:+",
@@ -5210,14 +5240,14 @@
     "array-literal": 80,
     "array-method": 69,
     "arrow": 69,
-    "binary": 90,
-    "call": 214,
+    "binary": 91,
+    "call": 215,
     "conditional": 25,
-    "identifier": 303,
+    "identifier": 305,
     "index-access": 14,
-    "literal": 249,
+    "literal": 250,
     "logical": 45,
-    "member": 167,
+    "member": 169,
     "object-literal": 57,
     "template-literal": 30,
     "unary": 23,
@@ -5251,7 +5281,7 @@
     "binary:!=": 2,
     "binary:!==": 9,
     "binary:*": 10,
-    "binary:+": 20,
+    "binary:+": 21,
     "binary:-": 11,
     "binary:/": 1,
     "binary:<": 1,
@@ -5261,7 +5291,7 @@
     "literal:boolean": 49,
     "literal:null": 23,
     "literal:number": 104,
-    "literal:string": 177,
+    "literal:string": 178,
     "logical:&&": 7,
     "logical:??": 39,
     "logical:||": 14,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -210,8 +210,10 @@ import { fixture as staticArrayChildren } from './static-array-children'
 import { fixture as staticArrayOfObjectsElementBody } from './static-array-of-objects-element-body'
 import { fixture as staticArrayFromProps } from './static-array-from-props'
 import { fixture as staticArrayFromPropsClient } from './static-array-from-props-client'
+import { fixture as staticArrayFromPropsPrecomputed } from './static-array-from-props-precomputed'
 import { fixture as staticArrayFromPropsWithComponent } from './static-array-from-props-with-component'
 import { fixture as staticArrayFromPropsWithComponentClient } from './static-array-from-props-with-component-client'
+import { fixture as staticArrayFromPropsWithComponentPrecomputed } from './static-array-from-props-with-component-precomputed'
 // Priority 8: CSR conformance
 import { fixture as booleanDynamicAttr } from './boolean-dynamic-attr'
 import { fixture as childComponentInit } from './child-component-init'
@@ -642,8 +644,10 @@ export const jsxFixtures: JSXFixture[] = [
   staticArrayOfObjectsElementBody,
   staticArrayFromProps,
   staticArrayFromPropsClient,
+  staticArrayFromPropsPrecomputed,
   staticArrayFromPropsWithComponent,
   staticArrayFromPropsWithComponentClient,
+  staticArrayFromPropsWithComponentPrecomputed,
   // Priority 8: CSR conformance
   booleanDynamicAttr,
   childComponentInit,

--- a/packages/adapter-tests/fixtures/static-array-from-props-precomputed.ts
+++ b/packages/adapter-tests/fixtures/static-array-from-props-precomputed.ts
@@ -1,0 +1,76 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `prop-precompute` twin of `static-array-from-props` (#2321) — the
+ * SECOND escape kind, and the one the diagnostic offers FIRST.
+ *
+ * The base refuses on every DSL adapter because the loop array is a
+ * component-scope `const` with a computed initializer
+ * (`Object.entries(props.reactions ?? {}).filter(...)`). Its sibling
+ * `static-array-from-props-client` escapes by deferring the whole loop to
+ * the browser; this one escapes by moving the COMPUTATION out of the
+ * component entirely — the caller passes the already-reduced array in as
+ * a prop, so no adapter is ever asked to lower the expression.
+ *
+ * The contrast between the two twins is the point, and it is visible in
+ * their committed `expectedHtml` rather than asserted in prose:
+ *
+ *   - `-client`      → `<div data-reaction-bar="true"></div>`  (empty until hydration)
+ *   - `-precomputed` → the button, its emoji and its count, fully rendered
+ *
+ * That is exactly the `ssrCost` distinction `ESCAPE_SSR_COST` types
+ * (`'client-render'` vs `'none'`, `packages/jsx/src/types.ts`), pinned in
+ * a real backend render instead of a docstring. It is also why the
+ * BF101 diagnostic lists pass-as-prop before `/* @client *​/`, and why the
+ * compat matrix legend renders the cost next to each kind: a reader
+ * choosing between the two escapes is choosing whether their content
+ * exists in server HTML.
+ *
+ * Shape note: the precomputed array is an array of OBJECTS, not the
+ * base's `[emoji, users]` pairs. An array-destructured loop param is
+ * itself a shape several DSL adapters refuse (see the base fixture's
+ * docstring, #1266) — a twin that traded one refusal for another would
+ * fail tier 1 and prove nothing about `prop-precompute`. Reducing to
+ * `{ emoji, count }` at the call site is what a user pre-computing
+ * server-side would write anyway.
+ *
+ * This does NOT fix #2321: the compiler still cannot lower a
+ * props-derived computed const at SSR time. What it proves is that the
+ * refusal's first-listed escape genuinely works — full SSR included — on
+ * every adapter.
+ */
+export const fixture = createFixture({
+  id: 'static-array-from-props-precomputed',
+  description: 'prop-precompute twin of static-array-from-props — computation moved to the caller, full SSR (#2321)',
+  source: `
+'use client'
+
+type Reaction = {
+  emoji: string
+  count: number
+}
+
+type Props = {
+  reactions: Reaction[]
+}
+
+export function ReactionBar(props: Props) {
+  return (
+    <div data-reaction-bar="true">
+      {props.reactions.map(reaction => (
+        <button key={reaction.emoji} type="button">
+          <span>{reaction.emoji}</span>
+          <span>{String(reaction.count)}</span>
+        </button>
+      ))}
+    </div>
+  )
+}
+`,
+  props: {
+    reactions: [{ emoji: '👍', count: 2 }],
+  },
+  expectedHtml: `
+    <div bf-s="test" bf="s2" data-reaction-bar="true"><button data-key="👍" type="button"><span><!--bf:s0-->👍<!--/--></span><span><!--bf:s1-->2<!--/--></span></button></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/static-array-from-props-with-component-precomputed.ts
+++ b/packages/adapter-tests/fixtures/static-array-from-props-with-component-precomputed.ts
@@ -1,0 +1,74 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `prop-precompute` twin of `static-array-from-props-with-component`
+ * (#2321) — the child-component counterpart of
+ * `static-array-from-props-precomputed`.
+ *
+ * The base refuses on the DSL adapters because the loop array is a
+ * component-scope `const` with a computed initializer
+ * (`Object.entries(props.tags).filter(...)`). Here the caller passes the
+ * already-filtered array in as a prop, so the loop source is a plain
+ * prop the adapters bind directly, and the `<Tag>` child body — the part
+ * this fixture family exists to cover (#1268) — still renders through the
+ * childComponent path at SSR.
+ *
+ * Contrast with the `-client` twin, visible in the committed
+ * `expectedHtml` of each: that one renders `<ul></ul>` and materializes
+ * the tags at hydration; this one renders the `<span>` children on the
+ * server. Same refusal, two escapes, two different `ssrCost` values
+ * (`ESCAPE_SSR_COST`, `packages/jsx/src/types.ts`).
+ *
+ * Shape note: like its sibling, the precomputed array holds OBJECTS
+ * rather than the base's `[id, t]` pairs — an array-destructured loop
+ * param is itself a refusal shape on several DSL adapters (#1266), so
+ * keeping it would trade one refusal for another and prove nothing about
+ * `prop-precompute`.
+ */
+export const fixture = createFixture({
+  id: 'static-array-from-props-with-component-precomputed',
+  description: 'prop-precompute twin of static-array-from-props-with-component — child components render at SSR (#2321)',
+  source: `
+'use client'
+import { Tag } from './tag'
+
+type Entry = {
+  id: string
+  variant: 'on' | 'off'
+}
+
+type Props = {
+  entries: Entry[]
+}
+
+export function TagList(props: Props) {
+  return (
+    <ul>
+      {props.entries.map(entry => (
+        <Tag key={entry.id} id={entry.id} variant={entry.variant} />
+      ))}
+    </ul>
+  )
+}
+`,
+  components: {
+    './tag.tsx': `
+'use client'
+export function Tag(props: { id: string; variant: 'on' | 'off' }) {
+  return <span class={'tag-' + props.variant}>{props.id}</span>
+}
+`,
+  },
+  props: {
+    entries: [
+      { id: 'a', variant: 'on' },
+      { id: 'c', variant: 'on' },
+    ],
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <span bf-s="Tag_*" bf="s1" class="tag-on" data-key="a"><!--bf:s0-->a<!--/--></span>
+      <span bf-s="Tag_*" bf="s1" class="tag-on" data-key="c"><!--bf:s0-->c<!--/--></span>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/static-array-from-props-with-component-precomputed.ts
+++ b/packages/adapter-tests/fixtures/static-array-from-props-with-component-precomputed.ts
@@ -19,6 +19,19 @@ import { createFixture } from '../src/types'
  * server. Same refusal, two escapes, two different `ssrCost` values
  * (`ESCAPE_SSR_COST`, `packages/jsx/src/types.ts`).
  *
+ * KNOWN DIVERGENCE — go-template renders the `<ul>` EMPTY here (#2630),
+ * pinned in that adapter's `renderDivergences`. It compiles clean and
+ * `go run`s clean; the child rows simply never materialize. The sibling
+ * `static-array-from-props-precomputed` — same shape with an inline
+ * element body instead of a `<Tag>` child — renders correctly
+ * everywhere, so what this fixture pins is specifically a
+ * child-component body over a prop-backed array.
+ *
+ * That means this twin proves `prop-precompute` on eight adapters, NOT
+ * nine. The `expectedHtml` below is the reference output (correct), not
+ * what go-template currently produces, so deleting the divergence entry
+ * once #2630 is fixed turns this fixture into that fix's regression test.
+ *
  * Shape note: like its sibling, the precomputed array holds OBJECTS
  * rather than the base's `[id, t]` pairs — an array-destructured loop
  * param is itself a refusal shape on several DSL adapters (#1266), so

--- a/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts
+++ b/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts
@@ -38,7 +38,10 @@ import { createFixture } from '../src/types'
 export const fixture = createFixture({
   id: 'static-array-from-props-with-component',
   description: 'Static-array loop with childComponent body materialises rendered children on CSR (#1268)',
-  escapes: [{ kind: 'client-directive', fixture: 'static-array-from-props-with-component-client' }],
+  escapes: [
+    { kind: 'prop-precompute', fixture: 'static-array-from-props-with-component-precomputed' },
+    { kind: 'client-directive', fixture: 'static-array-from-props-with-component-client' },
+  ],
   source: `
 'use client'
 import { Tag } from './tag'

--- a/packages/adapter-tests/fixtures/static-array-from-props.ts
+++ b/packages/adapter-tests/fixtures/static-array-from-props.ts
@@ -28,7 +28,10 @@ import { createFixture } from '../src/types'
 export const fixture = createFixture({
   id: 'static-array-from-props',
   description: 'Static-array loop with prop-derived array materialises children on CSR (#1247)',
-  escapes: [{ kind: 'client-directive', fixture: 'static-array-from-props-client' }],
+  escapes: [
+    { kind: 'prop-precompute', fixture: 'static-array-from-props-precomputed' },
+    { kind: 'client-directive', fixture: 'static-array-from-props-client' },
+  ],
   source: `
 'use client'
 

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -1434,6 +1434,22 @@
       }
     }
   ],
+  "static-array-from-props-precomputed": [
+    {
+      "name": "gen:reactions:empty",
+      "props": {
+        "reactions": []
+      }
+    }
+  ],
+  "static-array-from-props-with-component-precomputed": [
+    {
+      "name": "gen:entries:empty",
+      "props": {
+        "entries": []
+      }
+    }
+  ],
   "string-concat-plus": [
     {
       "name": "gen:name:markup",

--- a/packages/adapter-tests/src/types.ts
+++ b/packages/adapter-tests/src/types.ts
@@ -112,20 +112,15 @@ export interface JSXDataPoint {
 /**
  * The kind of escape a fixture's `escapes` twin demonstrates (#2613).
  *
- * Each kind carries a fixed, typed SSR cost — not asserted by this type
- * itself, but the contract every twin of that kind must honor:
- *   - `'client-directive'` — `/* @client *\/` defers the refused expression
- *     to client-only evaluation. `ssrCost: 'client-render'` — the region is
- *     EMPTY in server HTML until hydration. That emptiness is not a bug to
- *     hide: the twin's own committed `expectedHtml` is the honest pin of it.
- *   - `'prop-precompute'` — the refused computation moves to a prop passed
- *     in already-computed, so the adapter never needs to lower the
- *     expression itself. `ssrCost: 'none'` — full SSR, the rendered result
- *     is visible in server HTML.
- *   - `'rewrite'` — the user restructures the source into an equivalent,
- *     in-subset shape (no runtime cost trade at all).
+ * Re-exported from `@barefootjs/jsx` rather than declared here: the
+ * diagnostic that CLAIMS an escape (`ErrorSuggestion.escape`) and the
+ * fixture that DEMONSTRATES one must speak the same union, or claim
+ * verification compares two independently-drifting vocabularies. The
+ * per-kind SSR cost each twin must honor lives with it, in
+ * `ESCAPE_SSR_COST`.
  */
-export type EscapeKind = 'client-directive' | 'prop-precompute' | 'rewrite'
+import type { EscapeKind } from '@barefootjs/jsx'
+export type { EscapeKind }
 
 /**
  * Declares that a refused fixture owes NO escape, by design — not merely

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -891,6 +891,7 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
           suggestion: {
             message:
               'Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.',
+            escape: [{ kind: 'prop-precompute' }, { kind: 'client-directive' }],
           },
         })
       }

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -821,6 +821,7 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
           suggestion: {
             message:
               'Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.',
+            escape: [{ kind: 'prop-precompute' }, { kind: 'client-directive' }],
           },
         })
       }

--- a/packages/compat/src/__tests__/escape-coverage.test.ts
+++ b/packages/compat/src/__tests__/escape-coverage.test.ts
@@ -105,6 +105,7 @@ import {
   evaluateFixtureEscapeCoverage,
   findMisappliedUnescapable,
   findUnescapableMissingIssue,
+  findUnprovenEscapeClaims,
 } from '../escape-coverage'
 
 const { loaded, skipped } = await loadCompatAdapters()
@@ -179,6 +180,29 @@ describe('escape coverage — every adapter refusal is escapable or self-declare
           const outcome = evaluateFixtureEscapeCoverage(adapter, fixtureId, jsxFixtures)
           if (!outcome.ok) {
             throw new Error(outcome.message)
+          }
+        })
+
+        // Claim verification (#2613 increment 3). Separate test from the
+        // coverage assertion above because the two fail for opposite
+        // reasons and want opposite fixes: that one means "no verified way
+        // out exists" (author a twin, or ledger it); this one means "the
+        // message offers a way out nothing proves" (drop the claim from
+        // `escape`, or author the twin that backs it). Collapsing them
+        // would report the second as the first and send the reader to the
+        // wrong remedy.
+        test(`[${fixtureId}] every structured escape claim is backed by a twin`, () => {
+          const fixture = jsxFixtures.find(f => f.id === fixtureId)
+          if (!fixture) return
+          const { claimed, demonstrated, unproven } = findUnprovenEscapeClaims(adapter, fixture)
+          if (unproven.length > 0) {
+            throw new Error(
+              `${adapter.id}/${fixtureId}: diagnostic claims escape kind(s) [${unproven.join(', ')}] that no twin ` +
+                `demonstrates. Claimed: [${claimed.join(', ')}]; demonstrated by this fixture's \`escapes\`: ` +
+                `[${demonstrated.join(', ')} ]. Either author a twin of that kind and declare it in \`escapes\`, or ` +
+                `remove the kind from the diagnostic's \`suggestion.escape\` (the prose may still mention it — only ` +
+                `the structured field is checked).`,
+            )
           }
         })
       }

--- a/packages/compat/src/engine.ts
+++ b/packages/compat/src/engine.ts
@@ -1,7 +1,7 @@
 // @barefootjs/compat — pure compile+reduce logic. No console output here;
 // the command layer (src/cli.ts) owns all user-facing text.
 
-import type { CompilerError, ConformancePins, TemplateAdapter } from '@barefootjs/jsx'
+import type { CompilerError, ConformancePins, EscapeKind, TemplateAdapter } from '@barefootjs/jsx'
 import { compileJSX } from '@barefootjs/jsx'
 
 export type CompatMode = 'build' | 'conformance'
@@ -11,6 +11,19 @@ export interface CompatDiagnostic {
   severity: 'error' | 'warning'
   /** Known-limitation issue URLs pulled from the adapter's `conformancePins`, sorted + deduped. */
   issues: string[]
+  /**
+   * Escape kinds the diagnostics behind this cell CLAIM, deduped and
+   * sorted (#2614). Sourced from `ErrorSuggestion.escape` — the structured
+   * half of the suggestion, never its prose: a cell aggregates adapters
+   * whose wording for the same code differs, so carrying per-adapter text
+   * into the lock would export an internal inconsistency to users and
+   * churn the committed lock on every wording edit. The enum survives both
+   * problems, and renderers turn it back into one canonical wording.
+   *
+   * Absent when no contributing diagnostic declared one — which means "not
+   * declared", not "no escape exists", since population is opportunistic.
+   */
+  escapes?: EscapeKind[]
 }
 
 export interface CompatCell {
@@ -121,11 +134,33 @@ export function buildCompatCell(errors: CompilerError[], pins: ConformancePins):
     }
   }
 
-  const diagnostics: CompatDiagnostic[] = sorted.map(({ code, severity }) => ({
-    code,
-    severity,
-    issues: [...(issuesByCode.get(code) ?? [])].sort(),
-  }))
+  // Union the structured escape claims per (code, severity), so a cell that
+  // aggregates several refusals reports every way out any of them offers.
+  // Sorted for a deterministic lock: the committed `compat.lock.json` is
+  // drift-checked, so unordered set iteration would churn it spuriously.
+  const escapesByKey = new Map<string, Set<EscapeKind>>()
+  for (const e of errors) {
+    if (e.severity === 'info') continue
+    const claimed = e.suggestion?.escape
+    if (!claimed?.length) continue
+    const key = `${e.code} ${e.severity}`
+    let set = escapesByKey.get(key)
+    if (!set) {
+      set = new Set<EscapeKind>()
+      escapesByKey.set(key, set)
+    }
+    for (const { kind } of claimed) set.add(kind)
+  }
+
+  const diagnostics: CompatDiagnostic[] = sorted.map(({ code, severity }) => {
+    const escapes = escapesByKey.get(`${code} ${severity}`)
+    return {
+      code,
+      severity,
+      issues: [...(issuesByCode.get(code) ?? [])].sort(),
+      ...(escapes?.size ? { escapes: [...escapes].sort() } : {}),
+    }
+  })
 
   return {
     ok: !diagnostics.some(d => d.severity === 'error'),

--- a/packages/compat/src/escape-coverage.ts
+++ b/packages/compat/src/escape-coverage.ts
@@ -291,3 +291,40 @@ export function findUnescapableMissingIssue(adapter: LoadedCompatAdapter): strin
     pins.filter(p => p.unescapable && !p.unescapable.issue).map(p => `${fixtureId} (${p.code})`),
   )
 }
+
+/**
+ * Claim verification (#2613 increment 3, #2614's prerequisite): the
+ * escape kinds a DIAGNOSTIC claims, minus the kinds this fixture's twins
+ * actually DEMONSTRATE.
+ *
+ * This is the half that closes the loop literally. `evaluateFixtureEscape-
+ * Coverage` above proves a twin exists and works; this proves the message
+ * a user actually reads is not promising a *different* way out than the
+ * one that was verified. Before the structured `escape` field the two were
+ * connected only by a docstring — a suggestion could offer "pre-compute
+ * and pass as a prop" with nothing anywhere proving that shape compiles,
+ * which is exactly the "refuse loudly with no working way out" failure
+ * #2613 exists to prevent, relocated from the refusal to its wording.
+ *
+ * Prose is deliberately NOT checked: `message` may legitimately offer more
+ * than the structured field (ERB's numbered list opens with an
+ * inline-rewrite option no twin proves). Prose stays authoritative for
+ * humans, `escape` for machines — so a claim reaching a machine consumer
+ * (`bf compat`'s lock, the matrix legend) is one a twin stands behind.
+ */
+export function findUnprovenEscapeClaims(
+  adapter: LoadedCompatAdapter,
+  fixture: JSXFixture,
+): { claimed: string[]; demonstrated: string[]; unproven: string[] } {
+  const errors = compileForCompat(fixture.source, `${fixture.id}.tsx`, adapter.factory(), 'conformance', fixture.components)
+  const claimed = new Set<string>()
+  for (const error of errors) {
+    for (const { kind } of error.suggestion?.escape ?? []) claimed.add(kind)
+  }
+  const demonstrated = new Set((fixture.escapes ?? []).map(e => e.kind))
+  return {
+    claimed: [...claimed].sort(),
+    demonstrated: [...demonstrated].sort(),
+    unproven: [...claimed].filter(kind => !demonstrated.has(kind)).sort(),
+  }
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -57,6 +57,9 @@ export type {
   TypeDefinition,
   SourceLocation,
   CompilerError,
+  ErrorSuggestion,
+  EscapeKind,
+  EscapeSsrCost,
   ConformancePin,
   ConformancePins,
   RenderDivergences,
@@ -185,6 +188,9 @@ export interface BarefootPaths {
 
 // AttrValue constructors
 export { AttrValueOf } from './types.ts'
+
+// Per-escape-kind SSR cost — the one place every renderer reads the trade from (#2613)
+export { ESCAPE_SSR_COST } from './types.ts'
 
 // CSS Layer Prefixer
 export { applyCssLayerPrefix } from './css-layer-prefixer.ts'

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -2192,9 +2192,62 @@ export interface CompilerError {
   suggestion?: ErrorSuggestion
 }
 
+/**
+ * The kind of escape available from a refusal — the way a user gets their
+ * legitimate, in-subset JSX to compile on an adapter that cannot host it
+ * (#2613).
+ *
+ * Lives here, next to `ErrorSuggestion`, because both halves of the
+ * "loud-or-escapable" contract must speak the SAME enum: the diagnostic
+ * CLAIMS kinds (`ErrorSuggestion.escape`) and a conformance fixture
+ * DEMONSTRATES them (`JSXFixture.escapes`, which re-exports this type —
+ * `@barefootjs/adapter-tests` depends on this package, not the reverse).
+ * `escape-coverage.test.ts` then checks claims are a subset of what the
+ * twins prove, which is only meaningful while the two share one union.
+ */
+export type EscapeKind = 'client-directive' | 'prop-precompute' | 'rewrite'
+
+/**
+ * What an escape costs at SSR. `'none'` — full server render, the result
+ * is present in the server HTML. `'client-render'` — the region is EMPTY
+ * in server HTML until hydration.
+ *
+ * Output-equivalence is explicitly NOT the bar for an escape (#2613): a
+ * `/* @client *\/` region is definitionally not equivalent, and that is a
+ * legitimate trade the user chooses. Making the cost typed and visible is
+ * the honest substitute for pretending it doesn't exist — every renderer
+ * that surfaces an escape surfaces its cost from THIS map, so the trade
+ * can never be quietly dropped on the way to a user.
+ */
+export type EscapeSsrCost = 'none' | 'client-render'
+
+export const ESCAPE_SSR_COST: Record<EscapeKind, EscapeSsrCost> = {
+  // `/* @client */` — compiles and hydrates correctly, renders nothing at SSR.
+  'client-directive': 'client-render',
+  // The refused computation moves to an already-computed prop.
+  'prop-precompute': 'none',
+  // The source is restructured into an equivalent in-subset shape.
+  rewrite: 'none',
+}
+
 export interface ErrorSuggestion {
   message: string
   replacement?: string
+  /**
+   * The escape kinds this diagnostic CLAIMS are available, structured
+   * (#2613 increment 3). Additive and one-way: `message` stays
+   * authoritative for humans — several sites have genuinely good
+   * site-specific prose no enum should flatten — while this field is
+   * authoritative for machines (`bf compat`'s legend, the docs matrix,
+   * claim verification). New and edited refusal sites populate it; older
+   * sites migrate opportunistically, so ABSENT means "not yet declared",
+   * never "no escape exists".
+   *
+   * Order carries the recommendation: list a `ssrCost: 'none'` escape
+   * before a `'client-render'` one, matching the prose rule that a
+   * full-SSR way out is offered first.
+   */
+  escape?: ReadonlyArray<{ kind: EscapeKind }>
 }
 
 /**

--- a/site/core/pages/__tests__/escape-legend.test.ts
+++ b/site/core/pages/__tests__/escape-legend.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The compat matrix's escape surfacing (#2614) has two seams that are
+ * correct only by agreement with something OUTSIDE this page, and both are
+ * silent when they break — which is why they are pinned here rather than
+ * left to review:
+ *
+ *  1. `ESCAPE_LABELS` mirrors the compiler's `EscapeKind` union. The page
+ *     re-declares it because `@barefootjs/jsx` is not a runtime dependency
+ *     of the site Worker (every other compat type here is mirrored the
+ *     same way). A kind added to the compiler and not here would be
+ *     DROPPED from the legend by `formatEscapes` — the reader would simply
+ *     never learn that escape exists.
+ *
+ *  2. Every diagnostic code the page links carries an anchor in
+ *     `docs/core/advanced/error-codes.md`. `errorCodeDocLink` computes
+ *     `#bf101` from the code alone; if the doc has no matching anchor the
+ *     link still renders and still navigates — to the top of the page,
+ *     silently landing the reader on the wrong section.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { ESCAPE_SSR_COST } from '@barefootjs/jsx'
+import { ESCAPE_LABELS, errorCodeDocLink } from '../compat-matrix'
+
+const ERROR_CODES_DOC = readFileSync(
+  resolve(import.meta.dir, '../../../../docs/core/advanced/error-codes.md'),
+  'utf-8',
+)
+
+const compatLock = JSON.parse(
+  readFileSync(resolve(import.meta.dir, '../../../../ui/compat.lock.json'), 'utf-8'),
+) as {
+  components: Record<string, Record<string, { diagnostics?: { code: string }[] }>>
+  fixtureDivergences?: { fixtures: Record<string, Record<string, { codes?: string[] }>> }
+}
+
+/** Every diagnostic code the page can render a link for, from both of its sections. */
+function codesReachableFromTheLock(): string[] {
+  const codes = new Set<string>()
+  for (const adapterMap of Object.values(compatLock.components)) {
+    for (const cell of Object.values(adapterMap)) {
+      for (const d of cell.diagnostics ?? []) codes.add(d.code)
+    }
+  }
+  for (const row of Object.values(compatLock.fixtureDivergences?.fixtures ?? {})) {
+    for (const cell of Object.values(row)) {
+      for (const code of cell.codes ?? []) codes.add(code)
+    }
+  }
+  return [...codes].sort()
+}
+
+describe('compat matrix — escape legend', () => {
+  test('ESCAPE_LABELS covers exactly the compiler\'s EscapeKind union', () => {
+    expect(Object.keys(ESCAPE_LABELS).sort()).toEqual(Object.keys(ESCAPE_SSR_COST).sort())
+  })
+
+  test('every label states its SSR cost, so the trade is never dropped on the way to a reader', () => {
+    for (const [kind, label] of Object.entries(ESCAPE_LABELS)) {
+      const cost = ESCAPE_SSR_COST[kind as keyof typeof ESCAPE_SSR_COST]
+      // `'none'` reads as "full SSR" and `'client-render'` as "no SSR
+      // content until hydration" — assert the DISTINCTION survives into
+      // the wording rather than pinning the exact sentence, which is
+      // ordinary editable prose.
+      if (cost === 'client-render') {
+        expect(label).toContain('client-render')
+      } else {
+        expect(label).toContain('full SSR')
+      }
+    }
+  })
+})
+
+describe('compat matrix — error-code doc anchors', () => {
+  const codes = codesReachableFromTheLock()
+
+  test('the lock exposes at least one diagnostic code (otherwise this suite proves nothing)', () => {
+    expect(codes.length).toBeGreaterThan(0)
+  })
+
+  for (const code of codes) {
+    test(`${code} has an anchor in error-codes.md`, () => {
+      const anchor = errorCodeDocLink(code).split('#')[1]
+      expect(ERROR_CODES_DOC).toContain(`<a id="${anchor}"></a>`)
+    })
+  }
+})

--- a/site/core/pages/compat-matrix.tsx
+++ b/site/core/pages/compat-matrix.tsx
@@ -26,6 +26,47 @@ interface CompatDiagnostic {
   code: string
   severity: 'error' | 'warning'
   issues?: string[]
+  escapes?: string[]
+}
+
+/**
+ * Canonical, enum-generated wording for each escape kind, with its SSR
+ * cost (#2614 increment 2). Rendered in the LEGEND, never in a cell: a
+ * cell aggregates adapters whose prose for the same code differs, and
+ * surfacing that variance would export an internal inconsistency — by the
+ * time an escape reaches this page it is one wording from one place.
+ *
+ * Mirrors `EscapeKind` / `ESCAPE_SSR_COST` (`packages/jsx/src/types.ts`).
+ * The page deliberately re-declares rather than imports — `@barefootjs/jsx`
+ * is not a runtime dependency of the site Worker, and every other compat
+ * type here is mirrored the same way — so
+ * `escape-legend-parity.test.ts` pins this map against the compiler's
+ * union: a new kind there fails the test here rather than silently
+ * rendering as a bare slug.
+ */
+export const ESCAPE_LABELS: Record<string, string> = {
+  'prop-precompute': 'pass the computed result as a prop (full SSR)',
+  'client-directive': '`/* @client */` (client-render; no SSR content until hydration)',
+  rewrite: 'rewrite into an in-subset shape (full SSR)',
+}
+
+/**
+ * Render a diagnostic's claimed escapes for the legend. Order is the
+ * lock's (sorted) order re-sorted by SSR cost — a full-SSR way out is
+ * listed before a client-render one, matching the prose rule that the
+ * escape which keeps server content is offered first. Unknown kinds are
+ * dropped rather than rendered raw; the parity test is what makes that
+ * safe to do silently.
+ */
+function formatEscapes(escapes: string[] | undefined): string {
+  if (!escapes?.length) return ''
+  const known = escapes.filter((kind) => kind in ESCAPE_LABELS)
+  if (known.length === 0) return ''
+  const ssrFirst = [...known].sort((a, b) => {
+    const cost = (kind: string) => (kind === 'client-directive' ? 1 : 0)
+    return cost(a) - cost(b) || a.localeCompare(b)
+  })
+  return `escapes: ${ssrFirst.map((kind) => ESCAPE_LABELS[kind]).join(', ')}`
 }
 
 interface CompatCell {
@@ -241,15 +282,16 @@ function buildTable(componentNames: string[]): string {
   return [header, divider, ...rows].join('\n')
 }
 
-/** Collect every distinct diagnostic code across all cells, with its deduped issue URLs. */
-function collectLegend(): { code: string; severity: CompatDiagnostic['severity']; issues: string[] }[] {
-  const byCode = new Map<string, { severity: CompatDiagnostic['severity']; issues: Set<string> }>()
+/** Collect every distinct diagnostic code across all cells, with its deduped issue URLs and escape claims. */
+function collectLegend(): { code: string; severity: CompatDiagnostic['severity']; issues: string[]; escapes: string[] }[] {
+  const byCode = new Map<string, { severity: CompatDiagnostic['severity']; issues: Set<string>; escapes: Set<string> }>()
 
   for (const adapterMap of Object.values(compat.components)) {
     for (const cell of Object.values(adapterMap)) {
       for (const d of cell.diagnostics ?? []) {
-        const entry = byCode.get(d.code) ?? { severity: d.severity, issues: new Set<string>() }
+        const entry = byCode.get(d.code) ?? { severity: d.severity, issues: new Set<string>(), escapes: new Set<string>() }
         for (const issue of d.issues ?? []) entry.issues.add(issue)
+        for (const kind of d.escapes ?? []) entry.escapes.add(kind)
         byCode.set(d.code, entry)
       }
     }
@@ -257,7 +299,21 @@ function collectLegend(): { code: string; severity: CompatDiagnostic['severity']
 
   return [...byCode.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([code, { severity, issues }]) => ({ code, severity, issues: [...issues] }))
+    .map(([code, { severity, issues, escapes }]) => ({ code, severity, issues: [...issues], escapes: [...escapes] }))
+}
+
+/**
+ * The error-codes reference entry for a diagnostic code (#2614 increment
+ * 1). Generated from the code alone — `docs/core/advanced/error-codes.md`
+ * carries an explicit `<a id="bf101">`-style anchor above each `### BFNNN`
+ * heading precisely so this stays a computation rather than a committed
+ * code→anchor map that could drift. The anchors are also independent of
+ * the heading wording, so rewording a section cannot break these links.
+ * `error-codes-anchors.test.ts` fails if a code reachable from the lock
+ * has no anchor in the doc.
+ */
+export function errorCodeDocLink(code: string): string {
+  return `/docs/advanced/error-codes#${code.toLowerCase()}`
 }
 
 function buildLegend(): string {
@@ -267,9 +323,13 @@ function buildLegend(): string {
   }
 
   return entries
-    .map(({ code, severity, issues }) => {
+    .map(({ code, severity, issues, escapes }) => {
       const label = severity === 'warning' ? `⚠ \`${code}\`` : `\`${code}\``
-      return `- ${label} — ${formatIssueLinks(issues, compat.knownLimitationLabel)}`
+      const linked = `[${label}](${errorCodeDocLink(code)})`
+      const parts = [formatIssueLinks(issues, compat.knownLimitationLabel)]
+      const escapeText = formatEscapes(escapes)
+      if (escapeText) parts.push(escapeText)
+      return `- ${linked} — ${parts.join(' · ')}`
     })
     .join('\n')
 }
@@ -326,7 +386,12 @@ function refusalDetailText(cell: FixtureDivergenceCell, fd: FixtureDivergences):
   // returns is escaped exactly once, at the point `buildFixtureDetails`
   // joins it into a Markdown line, same as every other fragment there.
   // Escaping twice would double-escape a literal `|` (`\|` → `\\|`).
-  const codes = (cell.codes ?? []).map((c) => `\`${c}\``).join(', ')
+  // Codes link to the error-codes reference (#2614): the detail list is
+  // where a reader actually MEETS a refusal — the component legend below
+  // is empty whenever every `ui/` component compiles clean, which is the
+  // normal state — so a code shown here without a way to the guidance is
+  // the exact gap this linking closes.
+  const codes = (cell.codes ?? []).map((c) => `[\`${c}\`](${errorCodeDocLink(c)})`).join(', ')
   const escape = cell.escape
   if (escape?.state === 'escapable') {
     const twinDoc = fd.docs?.[escape.twin]

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code marked ‡ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 322,
+    "totalFixtures": 323,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code marked ‡ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 323,
+    "totalFixtures": 324,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -2998,7 +2998,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-client"
+            "twin": "static-array-from-props-precomputed"
           }
         },
         "erb": {
@@ -3011,7 +3011,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-client"
+            "twin": "static-array-from-props-precomputed"
           }
         },
         "go-template": {
@@ -3024,7 +3024,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-client"
+            "twin": "static-array-from-props-precomputed"
           }
         },
         "jinja": {
@@ -3037,7 +3037,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-client"
+            "twin": "static-array-from-props-precomputed"
           }
         },
         "minijinja": {
@@ -3050,7 +3050,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-client"
+            "twin": "static-array-from-props-precomputed"
           }
         },
         "mojolicious": {
@@ -3063,7 +3063,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-client"
+            "twin": "static-array-from-props-precomputed"
           }
         },
         "twig": {
@@ -3076,7 +3076,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-client"
+            "twin": "static-array-from-props-precomputed"
           }
         },
         "xslate": {
@@ -3089,7 +3089,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-client"
+            "twin": "static-array-from-props-precomputed"
           }
         }
       },
@@ -3104,7 +3104,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-with-component-client"
+            "twin": "static-array-from-props-with-component-precomputed"
           }
         },
         "erb": {
@@ -3117,7 +3117,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-with-component-client"
+            "twin": "static-array-from-props-with-component-precomputed"
           }
         },
         "go-template": {
@@ -3143,7 +3143,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-with-component-client"
+            "twin": "static-array-from-props-with-component-precomputed"
           }
         },
         "minijinja": {
@@ -3156,7 +3156,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-with-component-client"
+            "twin": "static-array-from-props-with-component-precomputed"
           }
         },
         "mojolicious": {
@@ -3169,7 +3169,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-with-component-client"
+            "twin": "static-array-from-props-with-component-precomputed"
           }
         },
         "twig": {
@@ -3182,7 +3182,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-with-component-client"
+            "twin": "static-array-from-props-with-component-precomputed"
           }
         },
         "xslate": {
@@ -3195,8 +3195,14 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-with-component-client"
+            "twin": "static-array-from-props-with-component-precomputed"
           }
+        }
+      },
+      "static-array-from-props-with-component-precomputed": {
+        "go-template": {
+          "kind": "render",
+          "reason": "prop-backed child-component loop renders the loop host empty at SSR (https://github.com/piconic-ai/barefootjs/issues/2630)"
         }
       },
       "tag-cloud": {
@@ -3347,6 +3353,10 @@
         "description": "Static-array loop with childComponent body materialises rendered children on CSR (#1268)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts"
       },
+      "static-array-from-props-with-component-precomputed": {
+        "description": "prop-precompute twin of static-array-from-props-with-component — child components render at SSR…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component-precomputed.ts"
+      },
       "tag-cloud": {
         "description": "flatMap block-body tag list — hydration adoption, in-place leaf patch, add, and remove",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/tag-cloud.ts"
@@ -3395,9 +3405,9 @@
         "description": "Off-subset `.some()` predicate deferred to the client via /* @client */",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/some-typeof-predicate-client.ts"
       },
-      "static-array-from-props-client": {
-        "description": "/* @client */ twin of static-array-from-props — DSL BF101 (computed-const loop array) suppressed…",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-client.ts"
+      "static-array-from-props-precomputed": {
+        "description": "prop-precompute twin of static-array-from-props — computation moved to the caller, full SSR (#2321)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-precomputed.ts"
       },
       "static-array-from-props-with-component-client": {
         "description": "/* @client */ twin of static-array-from-props-with-component — DSL BF101 (computed-const loop…",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1026,15 +1026,15 @@
       }
     },
     "binary": {
-      "total": 90,
+      "total": 91,
       "cells": {
         "hono": {
-          "pass": 90,
-          "total": 90
+          "pass": 91,
+          "total": 91
         },
         "blade": {
-          "pass": 81,
-          "total": 90,
+          "pass": 82,
+          "total": 91,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1081,8 +1081,8 @@
           ]
         },
         "erb": {
-          "pass": 82,
-          "total": 90,
+          "pass": 83,
+          "total": 91,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1124,7 +1124,7 @@
         },
         "go-template": {
           "pass": 81,
-          "total": 90,
+          "total": 91,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1167,12 +1167,16 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component-precomputed",
+              "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 81,
-          "total": 90,
+          "pass": 82,
+          "total": 91,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1219,8 +1223,8 @@
           ]
         },
         "minijinja": {
-          "pass": 81,
-          "total": 90,
+          "pass": 82,
+          "total": 91,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1267,8 +1271,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 82,
-          "total": 90,
+          "pass": 83,
+          "total": 91,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1309,8 +1313,8 @@
           ]
         },
         "twig": {
-          "pass": 81,
-          "total": 90,
+          "pass": 82,
+          "total": 91,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1357,8 +1361,8 @@
           ]
         },
         "xslate": {
-          "pass": 81,
-          "total": 90,
+          "pass": 82,
+          "total": 91,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1422,11 @@
       }
     },
     "call": {
-      "total": 214,
+      "total": 215,
       "cells": {
         "hono": {
-          "pass": 213,
-          "total": 214,
+          "pass": 214,
+          "total": 215,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1433,8 +1437,8 @@
           ]
         },
         "blade": {
-          "pass": 199,
-          "total": 214,
+          "pass": 200,
+          "total": 215,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1509,8 +1513,8 @@
           ]
         },
         "erb": {
-          "pass": 200,
-          "total": 214,
+          "pass": 201,
+          "total": 215,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1579,8 +1583,8 @@
           ]
         },
         "go-template": {
-          "pass": 199,
-          "total": 214,
+          "pass": 200,
+          "total": 215,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1655,8 +1659,8 @@
           ]
         },
         "jinja": {
-          "pass": 199,
-          "total": 214,
+          "pass": 200,
+          "total": 215,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1731,8 +1735,8 @@
           ]
         },
         "minijinja": {
-          "pass": 199,
-          "total": 214,
+          "pass": 200,
+          "total": 215,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1807,8 +1811,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 200,
-          "total": 214,
+          "pass": 201,
+          "total": 215,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1877,8 +1881,8 @@
           ]
         },
         "twig": {
-          "pass": 199,
-          "total": 214,
+          "pass": 200,
+          "total": 215,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1953,8 +1957,8 @@
           ]
         },
         "xslate": {
-          "pass": 199,
-          "total": 214,
+          "pass": 200,
+          "total": 215,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2174,11 +2178,11 @@
       }
     },
     "identifier": {
-      "total": 303,
+      "total": 305,
       "cells": {
         "hono": {
-          "pass": 302,
-          "total": 303,
+          "pass": 304,
+          "total": 305,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2189,8 +2193,8 @@
           ]
         },
         "blade": {
-          "pass": 286,
-          "total": 303,
+          "pass": 288,
+          "total": 305,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2273,8 +2277,8 @@
           ]
         },
         "erb": {
-          "pass": 287,
-          "total": 303,
+          "pass": 289,
+          "total": 305,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2351,8 +2355,8 @@
           ]
         },
         "go-template": {
-          "pass": 286,
-          "total": 303,
+          "pass": 287,
+          "total": 305,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2429,14 +2433,18 @@
               ]
             },
             {
+              "fixture": "static-array-from-props-with-component-precomputed",
+              "issues": []
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 286,
-          "total": 303,
+          "pass": 288,
+          "total": 305,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2519,8 +2527,8 @@
           ]
         },
         "minijinja": {
-          "pass": 286,
-          "total": 303,
+          "pass": 288,
+          "total": 305,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2603,8 +2611,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 287,
-          "total": 303,
+          "pass": 289,
+          "total": 305,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2681,8 +2689,8 @@
           ]
         },
         "twig": {
-          "pass": 286,
-          "total": 303,
+          "pass": 288,
+          "total": 305,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2765,8 +2773,8 @@
           ]
         },
         "xslate": {
-          "pass": 286,
-          "total": 303,
+          "pass": 288,
+          "total": 305,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2914,15 +2922,15 @@
       }
     },
     "literal": {
-      "total": 249,
+      "total": 250,
       "cells": {
         "hono": {
-          "pass": 249,
-          "total": 249
+          "pass": 250,
+          "total": 250
         },
         "blade": {
-          "pass": 238,
-          "total": 249,
+          "pass": 239,
+          "total": 250,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2973,8 +2981,8 @@
           ]
         },
         "erb": {
-          "pass": 238,
-          "total": 249,
+          "pass": 239,
+          "total": 250,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3026,7 +3034,7 @@
         },
         "go-template": {
           "pass": 238,
-          "total": 249,
+          "total": 250,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3071,14 +3079,18 @@
               ]
             },
             {
+              "fixture": "static-array-from-props-with-component-precomputed",
+              "issues": []
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 238,
-          "total": 249,
+          "pass": 239,
+          "total": 250,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3129,8 +3141,8 @@
           ]
         },
         "minijinja": {
-          "pass": 238,
-          "total": 249,
+          "pass": 239,
+          "total": 250,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3181,8 +3193,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 238,
-          "total": 249,
+          "pass": 239,
+          "total": 250,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3233,8 +3245,8 @@
           ]
         },
         "twig": {
-          "pass": 238,
-          "total": 249,
+          "pass": 239,
+          "total": 250,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3285,8 +3297,8 @@
           ]
         },
         "xslate": {
-          "pass": 238,
-          "total": 249,
+          "pass": 239,
+          "total": 250,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3498,11 +3510,11 @@
       }
     },
     "member": {
-      "total": 167,
+      "total": 169,
       "cells": {
         "hono": {
-          "pass": 166,
-          "total": 167,
+          "pass": 168,
+          "total": 169,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3513,8 +3525,8 @@
           ]
         },
         "blade": {
-          "pass": 150,
-          "total": 167,
+          "pass": 152,
+          "total": 169,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3597,8 +3609,8 @@
           ]
         },
         "erb": {
-          "pass": 151,
-          "total": 167,
+          "pass": 153,
+          "total": 169,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3675,8 +3687,8 @@
           ]
         },
         "go-template": {
-          "pass": 150,
-          "total": 167,
+          "pass": 151,
+          "total": 169,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3753,14 +3765,18 @@
               ]
             },
             {
+              "fixture": "static-array-from-props-with-component-precomputed",
+              "issues": []
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 150,
-          "total": 167,
+          "pass": 152,
+          "total": 169,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3843,8 +3859,8 @@
           ]
         },
         "minijinja": {
-          "pass": 150,
-          "total": 167,
+          "pass": 152,
+          "total": 169,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3927,8 +3943,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 151,
-          "total": 167,
+          "pass": 153,
+          "total": 169,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4005,8 +4021,8 @@
           ]
         },
         "twig": {
-          "pass": 150,
-          "total": 167,
+          "pass": 152,
+          "total": 169,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4089,8 +4105,8 @@
           ]
         },
         "xslate": {
-          "pass": 150,
-          "total": 167,
+          "pass": 152,
+          "total": 169,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -6564,15 +6580,15 @@
       }
     },
     "binary:+": {
-      "total": 20,
+      "total": 21,
       "cells": {
         "hono": {
-          "pass": 20,
-          "total": 20
+          "pass": 21,
+          "total": 21
         },
         "blade": {
-          "pass": 19,
-          "total": 20,
+          "pass": 20,
+          "total": 21,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6583,8 +6599,8 @@
           ]
         },
         "erb": {
-          "pass": 19,
-          "total": 20,
+          "pass": 20,
+          "total": 21,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6596,19 +6612,23 @@
         },
         "go-template": {
           "pass": 19,
-          "total": 20,
+          "total": 21,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component-precomputed",
+              "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 19,
-          "total": 20,
+          "pass": 20,
+          "total": 21,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6619,8 +6639,8 @@
           ]
         },
         "minijinja": {
-          "pass": 19,
-          "total": 20,
+          "pass": 20,
+          "total": 21,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6631,8 +6651,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 19,
-          "total": 20,
+          "pass": 20,
+          "total": 21,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6643,8 +6663,8 @@
           ]
         },
         "twig": {
-          "pass": 19,
-          "total": 20,
+          "pass": 20,
+          "total": 21,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -6655,8 +6675,8 @@
           ]
         },
         "xslate": {
-          "pass": 19,
-          "total": 20,
+          "pass": 20,
+          "total": 21,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -7663,15 +7683,15 @@
       }
     },
     "literal:string": {
-      "total": 177,
+      "total": 178,
       "cells": {
         "hono": {
-          "pass": 177,
-          "total": 177
+          "pass": 178,
+          "total": 178
         },
         "blade": {
-          "pass": 169,
-          "total": 177,
+          "pass": 170,
+          "total": 178,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7710,8 +7730,8 @@
           ]
         },
         "erb": {
-          "pass": 169,
-          "total": 177,
+          "pass": 170,
+          "total": 178,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7751,7 +7771,7 @@
         },
         "go-template": {
           "pass": 169,
-          "total": 177,
+          "total": 178,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7786,12 +7806,16 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component-precomputed",
+              "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 169,
-          "total": 177,
+          "pass": 170,
+          "total": 178,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7830,8 +7854,8 @@
           ]
         },
         "minijinja": {
-          "pass": 169,
-          "total": 177,
+          "pass": 170,
+          "total": 178,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7870,8 +7894,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 169,
-          "total": 177,
+          "pass": 170,
+          "total": 178,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7910,8 +7934,8 @@
           ]
         },
         "twig": {
-          "pass": 169,
-          "total": 177,
+          "pass": 170,
+          "total": 178,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7950,8 +7974,8 @@
           ]
         },
         "xslate": {
-          "pass": 169,
-          "total": 177,
+          "pass": 170,
+          "total": 178,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",


### PR DESCRIPTION
## Summary

Implements both increments of #2614, plus the two #2613 leftovers increment 2 was blocked on.

`buildCompatCell` reduced each diagnostic to `{code, severity, issues}`, dropping `suggestion` before it reached the lockfile or the page. The matrix is where users actually meet these limitations, so the escape — which exists, and is verified — was named everywhere except there.

## Increment 1 — docs anchors

Every `### BFNNN` heading in `error-codes.md` gains an explicit `<a id="bfNNN">`; the page links codes to them. The anchor is computed from the code alone rather than kept in a committed map, and is independent of heading wording, so neither rewording a section nor adding a code can silently break the link. The BF101 section's fix prose is restructured into the canonical two-escape form, best-SSR-first.

**One deviation from the issue, deliberate.** The issue scopes the linking to `buildLegend`. But the component legend is empty whenever every `ui/` component compiles clean — **the current state, 558/558 cells** — so linking only there would ship the feature into a section nobody can see today. Codes are linked in the fixture-divergence detail list too, which is where BF101 is actually read.

## Increment 2 — structured escapes

- `EscapeKind` moves to `packages/jsx/src/types.ts` beside `ErrorSuggestion` (adapter-tests depends on jsx, not the reverse), so the diagnostic that CLAIMS an escape and the fixture that DEMONSTRATES one speak one union. `ESCAPE_SSR_COST` becomes the single place every renderer reads the trade from.
- `ErrorSuggestion.escape` is additive and one-way — prose authoritative for humans, enum for machines — populated at the eight BF101 sites behind #2320/#2321.
- `CompatDiagnostic.escapes` unions the claims per cell, sorted so the drift-checked lock stays deterministic. The legend renders one canonical wording with its SSR cost; no per-adapter prose enters the lock or the cells.

## The substantive find: `prop-precompute` was an unproven claim

All 14 existing twins are `client-directive`. So "pre-compute and pass as a prop" — the escape the diagnostic offers **first**, and the only one that keeps server content — was promised with nothing anywhere proving that shape compiles. That is #2613's *"refuse loudly with no working way out"*, relocated from the refusal to its wording.

Two `prop-precompute` twins now back it, and their `expectedHtml` pins the contrast the `ssrCost` enum only asserts:

| twin | server HTML |
|---|---|
| `static-array-from-props-with-component-client` | `<ul></ul>` — empty until hydration |
| `static-array-from-props-with-component-precomputed` | `<span>` children rendered |

Claim verification runs over **16 adapter/fixture pairs carrying a structured claim, zero unproven, no allowlist**. It is a separate test from escape coverage because the two fail for opposite reasons and want opposite fixes — collapsing them would send the reader to the wrong remedy.

## …and the twin immediately caught a real bug: #2630

**CI found what the local run could not.** The child-component twin renders its loop host **empty on go-template** — compiles clean, `go run`s clean, rows never materialize. The sibling twin (same shape, inline element body instead of a `<Tag>` child) renders correctly on all nine, so the divergence is specific to a **child-component body over a prop-backed array**.

This costs a user something concrete: the BF101 diagnostic lists pass-as-prop **first** precisely because it preserves server output, so a go-template user following that advice for a child-component loop gets an empty container at SSR with nothing reporting it — the quiet half of the loud-or-escapable contract.

Handled as the repo's three-piece set: fixture asserts the CORRECT (reference) output, go-template pinned in `renderDivergences` with the issue URL, docstring states plainly that the twin therefore proves `prop-precompute` on **eight adapters, not nine**. Deleting the entry once #2630 is fixed turns the fixture into that fix's regression test. #2630 names the likely cause (`buildDynamicChildLoopSeeding` covers only the signal-backed dynamic case, so this may be a harness gap rather than emitted-template breakage) without asserting it unconfirmed.

## Verification

| suite | result |
|---|---|
| `packages/compat` + site pins | **484 / 0** (up from 352 — claim verification) |
| `packages/jsx` | 3043 / 0 |
| `packages/adapter-erb` + `adapter-blade` | 2724 / 0 |
| go-template `static-array-from-props` family, **real Go** (`GOTOOLCHAIN=go1.25.6`) | 15 pass / 0 fail |
| `biome check` | clean, 455 files |

The three CI failures on the first push are all resolved: missing changeset; four committed artifacts the new fixtures invalidated (coverage-map, generated-data-points, compat.lock, support-matrix.lock); and the #2630 divergence above. The two failures from my first local run were exactly the artifact-freshness pins — named and fixed, not waved off as flakes.

## Before merging — a judgement call for the reviewer

#2630 means `prop-precompute` is proven on **8 of 9 adapters**. Whether #2614 should close with that gap open, or wait for #2630, is not mine to decide.

## Follow-up worth tracking separately

ERB's BF101 prose opens with an inline-rewrite option (`rewrite`) that no twin proves. The structured field deliberately claims only the two proven kinds, so nothing machine-readable overclaims — but the prose still does. Not fixed here.

Closes #2614

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcX9QTV6Ng2X6mry4HPbhT