### PR TITLE
docs(compat): scope Divergence details to the table, fold the rest away

### DIFF
--- a/site/core/pages/compat-matrix.tsx
+++ b/site/core/pages/compat-matrix.tsx
@@ -410,13 +410,22 @@ function refusalDetailText(cell: FixtureDivergenceCell, fd: FixtureDivergences):
 }
 
 /**
- * Per-fixture detail list: adapters sharing an identical reason string are
- * grouped onto one line, so the common "same divergence everywhere" case
- * reads as a single sentence instead of nine copies.
+ * Per-fixture detail list for the fixtures the table actually shows:
+ * adapters sharing an identical reason string are grouped onto one line, so
+ * the common "same divergence everywhere" case reads as a single sentence
+ * instead of nine copies.
+ *
+ * `fixtureIds` is the table's own row list, NOT every key in `fd.fixtures`.
+ * The two are very different sizes — the table is filtered to fixtures
+ * needing attention (4 of 18 today), and detailing the other 14 spent most
+ * of the page explaining cells the reader was never shown, immediately
+ * after the text told them those fixtures work. Their one useful fact
+ * (which diagnostic the `/* @client *\/` comment silences) is kept, one
+ * line each, by `buildEscapableSummary` below.
  */
-function buildFixtureDetails(fd: FixtureDivergences): string {
+function buildFixtureDetails(fd: FixtureDivergences, fixtureIds: string[]): string {
   const blocks: string[] = []
-  for (const fixtureId of Object.keys(fd.fixtures).sort()) {
+  for (const fixtureId of [...fixtureIds].sort()) {
     const row = fd.fixtures[fixtureId]
     const byText = new Map<string, string[]>()
     for (const adapterId of Object.keys(row).sort()) {
@@ -435,6 +444,41 @@ function buildFixtureDetails(fd: FixtureDivergences): string {
     blocks.push(`- ${heading}${summary}\n${lines.join('\n')}`)
   }
   return blocks.join('\n')
+}
+
+/**
+ * The folded-away half of the corpus, one line per fixture behind a
+ * disclosure: fixtures that work on EVERY adapter, some only with a
+ * `/* @client *\/` comment. They have no row in the table (nothing needs
+ * attention), so per-adapter prose about them is detail for a cell the
+ * reader never saw. What they DO raise — the headline says "14 of those
+ * need a comment", and the reader wants to know which — is answered here:
+ * the fixture, how many adapters need the comment there, and what it
+ * silences. Collapsed rather than dropped so the answer stays on the page
+ * without costing the four fixtures that need attention their prominence.
+ */
+function buildEscapableSummary(fd: FixtureDivergences, fixtureIds: string[]): string {
+  if (fixtureIds.length === 0) return ''
+  const lines = [...fixtureIds].sort().map((id) => {
+    const row = fd.fixtures[id]
+    // Only refusing adapters have a cell at all — a clean adapter is absent
+    // — so the row's own size IS "how many adapters need the comment".
+    const adapterIds = Object.keys(row)
+    const codes = [...new Set(adapterIds.flatMap((a) => row[a].codes ?? []))].sort()
+    const doc = fd.docs?.[id]
+    const label = doc?.url ? `[\`${escapeCell(id)}\`](${doc.url})` : `\`${escapeCell(id)}\``
+    const codeLinks = codes.map((c) => `[\`${c}\`](${errorCodeDocLink(c)})`).join(', ')
+    const adapterCount = `${adapterIds.length} adapter${adapterIds.length === 1 ? '' : 's'}`
+    return `- ${label} — ${adapterCount}, suppressing ${codeLinks}`
+  })
+  return `
+<details>
+<summary>The ${fixtureIds.length} fixtures that need a <code>/* @client */</code> comment — which diagnostic each silences</summary>
+
+${lines.join('\n')}
+
+</details>
+`
 }
 
 /**
@@ -513,10 +557,12 @@ ${[header, divider, ...rows].join('\n')}
 **${NOT_OWED_MARKER} Doesn't work** — by design, not a gap
 
 - \`${NOT_OWED_MARKER}${notOwedExample}\` — a code led by \`${NOT_OWED_MARKER}\`: refused on purpose, no escape will ever be offered (why: in the details below)
-
+${buildEscapableSummary(fd, fullyEscapableIds)}
 ### Divergence details
 
-${buildFixtureDetails(fd)}
+Per adapter, for the ${needsAttentionIds.length} fixtures in the table above.
+
+${buildFixtureDetails(fd, needsAttentionIds)}
 `
 }
 


### PR DESCRIPTION
## What

`Divergence details` on `/docs/advanced/compatibility-matrix` listed **every** fixture in the lock (18) while the table above it lists only fixtures needing attention (**4**). The 14 extras are folded into a collapsed one-line-each summary.

| | before | after |
| --- | --- | --- |
| entries in the detail list | 18 | 4 (+ 14 collapsed) |
| section length | 11,714 chars | 2,861 chars |

## Why

The mismatch was structural, not cosmetic: `buildFixtureDetails` iterated `Object.keys(fd.fixtures)` while the table iterated `needsAttentionIds`. So three quarters of the section was per-adapter prose about cells the reader was never shown — arriving immediately after the page told them those fixtures work on every adapter. Each entry spent a full line on eight adapter names and a near-identical *"works with a `/* @client */` comment — verified escape (†): …-client compiles clean here, suppressing BF101"* sentence, which pushed the four fixtures that actually need attention down the page.

The fix passes the table's own row list into `buildFixtureDetails`, so the two can't drift apart again.

The folded fixtures do raise one question — the headline says *"14 of those need a `/* @client */` comment"*, and a reader wants to know which. That is kept as a single line per fixture (fixture, how many adapters need the comment, which diagnostic it silences) behind a `<details>` disclosure, placed right where the headline raises it. Collapsed rather than dropped: the answer stays on the page without costing the four fixtures their prominence.

## Scope

Generated-Markdown structure only — no change to lock consumption, cell rendering, marker meaning, or the compat/support locks (both regenerate with zero drift). The CLI report is untouched; its own detail list was already scoped differently.

## Verification

- Rendered the real page through its route and the site's `renderMarkdown`: the disclosure comes out as `<details>`/`<summary>` with its markdown list intact, and the TOC is unchanged (`Matrix / Legend / Render Conformance / Divergence details / Construct Support / By kind / By axis / Data Source`).
- `bun test site/core/pages/__tests__/` — 5 pass.
- `tsc --noEmit -p site/core/tsconfig.json` — clean for `compat-matrix.tsx`.

## Related

While checking whether the `Construct Support` section was current: the data is (both locks regenerate with zero drift), but every cell citing **#2321** linked a **closed** issue. #2321 was auto-closed by #2626 merging with a closing keyword, contradicting its own recorded decision (*"Staying open as the permanent tracker the pins point at, same pattern as #2356"*) — #2626 verified the `/* @client */` escape, it did not close the SSR lowering gap. The issue has been reopened and the reason recorded there; no pin or lock change was needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Y7832bD8Ph4NHfq7B42kb)_