### PR TITLE
ci(compat): run the issue-link freshness check daily, not weekly

### DIFF
--- a/.github/workflows/compat-issue-freshness.yml
+++ b/.github/workflows/compat-issue-freshness.yml
@@ -14,8 +14,22 @@ name: Compat — issue-link freshness
 
 on:
   schedule:
-    # Weekly, Monday 00:17 UTC (off the hour to dodge the scheduler surge).
-    - cron: '17 0 * * 1'
+    # Daily, 00:17 UTC (off the hour to dodge the scheduler surge).
+    #
+    # Was weekly, which made the detection window up to 7 days wide — and
+    # that window was hit: #2321 was auto-closed by #2626's merge two days
+    # after the last Monday run, so the published matrix linked a live
+    # limitation to a completed ticket for five days before the next run
+    # would have caught it. Daily bounds that at one day.
+    #
+    # The run is cheap enough that the frequency isn't a trade: the checker
+    # reads the two committed lock files and makes one API call per DISTINCT
+    # referenced issue (4 today), with no workspace build — well inside the
+    # GITHUB_TOKEN rate limit, and every run so far has finished in 10-65s.
+    # It is also quiet by construction: the alert issue is opened
+    # or updated only when something is stale, and closes itself when
+    # nothing is, so a daily cadence adds no notification noise.
+    - cron: '17 0 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What

`compat-issue-freshness` moves from `17 0 * * 1` (weekly, Monday) to `17 0 * * *` (daily). Same minute, same everything else.

## Why

The weekly schedule made the detection window up to seven days wide, and that window was just hit:

| | |
| --- | --- |
| last run before the miss | 2026-08-10 02:35 UTC |
| #2321 auto-closed by #2626's merge | 2026-08-12 23:59 UTC |
| next scheduled run | 2026-08-17 |

So for five days the published compatibility matrix linked a live limitation to a completed ticket — the exact staleness this job exists to catch — with nothing due to notice it. (Caught by hand instead; #2321 is reopened.) Daily bounds that at one day.

## Cost

Not really a trade:

- The checker reads the two committed lock files and makes **one API call per distinct referenced issue** — 4 today — with no workspace build. Well inside the `GITHUB_TOKEN` rate limit.
- Every run so far has finished in **10–65s**.
- It stays quiet by construction: the alert issue is opened or updated **only when something is stale**, and closes itself when nothing is. Seven times the runs is not seven times the notifications.

## Verification

- `17 0 * * *` parses as a daily schedule (`[{'cron': '17 0 * * *'}]`); the rest of the workflow is untouched.
- The two claims in the new comment are from this repo, not assumed: the CLI reports `Checking 4 referenced issue(s)…`, and the four runs to date took 10s / 15s / 64s / 14s.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Y7832bD8Ph4NHfq7B42kb)_