### PR TITLE
fix(jsx): extract a prop referenced only inside /* @client */ from _p (#2634)

### DIFF
--- a/.changeset/fix-client-only-prop-extraction.md
+++ b/.changeset/fix-client-only-prop-extraction.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix a `ReferenceError` at hydrate when a destructured prop's only use in a component is inside a `/* @client */`-marked expression. The prop is now correctly extracted from `_p` before the client-side `createEffect` reads it.

--- a/packages/jsx/src/__tests__/prop-references.test.ts
+++ b/packages/jsx/src/__tests__/prop-references.test.ts
@@ -311,6 +311,78 @@ describe('ClientJS generation with semantic prop refs', () => {
   })
 })
 
+// Issue #2634 regression test: a prop used ONLY inside a `/* @client */`
+// expression was never extracted from `_p` — the identifier reached
+// `createEffect`'s body unbound, throwing `ReferenceError` at hydrate.
+// `buildReferencesGraph` (build-references.ts) deliberately skips adding a
+// `template-closure` edge for a clientOnly expression (it isn't template-
+// reachable), but was never wired to `ctx.clientOnlyElements` either, so no
+// edge of ANY kind reached `neededProps` and `emitPropsExtraction` had no
+// evidence the prop was used at all.
+describe('Issue #2634 regression', () => {
+  test('a destructured prop used only inside /* @client */ is extracted from _p', () => {
+    const source = `
+      interface Props {
+        label: string
+      }
+
+      export function LabelClientOnly({ label }: Props) {
+        return <div>{/* @client */ label.toUpperCase()}</div>
+      }
+    `
+
+    const result = compileJSX(source, 'LabelClientOnly.tsx', { adapter })
+
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    // The prop must be bound before the createEffect body reads it.
+    expect(clientJs?.content).toContain('const label = _p.label')
+    // A bare `label` reference with no preceding binding is exactly the
+    // unbound-identifier shape that threw ReferenceError at hydrate.
+    expect(clientJs?.content).toMatch(/const label = _p\.label[\s\S]*label\.toUpperCase\(\)/)
+  })
+
+  test('a props-object member used only inside /* @client */ needs no extraction (already _p.x)', () => {
+    const source = `
+      interface Props {
+        label: string
+      }
+
+      export function LabelClientOnly(props: Props) {
+        return <div>{/* @client */ props.label.toUpperCase()}</div>
+      }
+    `
+
+    const result = compileJSX(source, 'LabelClientOnly.tsx', { adapter })
+
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs?.content).toContain('_p.label.toUpperCase()')
+  })
+
+  test('a prop used both in a normal reactive position AND inside /* @client */ is still extracted once', () => {
+    const source = `
+      interface Props {
+        label: string
+      }
+
+      export function LabelBoth({ label }: Props) {
+        return <div><span>{label}</span><span>{/* @client */ label.toUpperCase()}</span></div>
+      }
+    `
+
+    const result = compileJSX(source, 'LabelBoth.tsx', { adapter })
+
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const matches = clientJs?.content.match(/const label = _p\.label/g) ?? []
+    expect(matches).toHaveLength(1)
+  })
+})
+
 // Issue #257 regression test: Double props prefix in template literals
 describe('Issue #257 regression', () => {
   test('does NOT double-wrap props.xxx when already prefixed', () => {

--- a/packages/jsx/src/ir-to-client-js/build-references.ts
+++ b/packages/jsx/src/ir-to-client-js/build-references.ts
@@ -129,6 +129,23 @@ export function buildReferencesGraph(ctx: ClientJsContext, irRoot: IRNode): Refe
     }
   }
 
+  // No identifiers.ts precedent — `clientOnlyElements` (Slot unification
+  // Step B) postdates the file this phase mirrors. A `/* @client */`
+  // expression's Phase 3 IR-walk visitor below deliberately adds no edge
+  // at all (never mind which context) so a referenced name isn't
+  // misclassified as template-reachable; without a substitute edge here,
+  // a prop used ONLY inside such an expression never reaches
+  // `neededProps` (`analyzeClientNeeds`/`init-declarations.ts`), so
+  // `emitPropsExtraction` never binds it and the emitted `createEffect`
+  // reads an unbound identifier — a real `ReferenceError` at hydrate,
+  // not a hypothetical (#2634). `'init-body'` is the same context an
+  // event handler's identifiers use (few lines up) — correct here for
+  // the same reason: the expression runs in `initX`'s scope, never the
+  // template closure.
+  for (const elem of ctx.clientOnlyElements) {
+    addExprEdges(ROOT_SOURCE, elem.expression, 'init-body')
+  }
+
   // identifiers.ts L107-135
   for (const elem of ctx.loopElements) {
     addExprEdges(ROOT_SOURCE, elem.array, 'template-closure')


### PR DESCRIPTION
## What

Fixes #2634: a destructured prop whose only use anywhere in a component is inside a `/* @client */`-marked expression was never extracted from `_p` — the emitted `createEffect` body read a bare, unbound identifier, throwing `ReferenceError` at hydrate.

```tsx
export function LabelClientOnly({ label }: { label: string }) {
  return <div>{/* @client */ label.toUpperCase()}</div>
}
```

Before → compiles clean, but `initLabelClientOnly` reads `label` with no binding anywhere above it. After → `const label = _p.label` is emitted first.

## Root cause

`buildReferencesGraph` (`packages/jsx/src/ir-to-client-js/build-references.ts`) is what `analyzeClientNeeds`/`init-declarations.ts` consult to decide which props need a `const x = _p.x` extraction. Its IR-tree walk deliberately adds **no edge** for a `/* @client */`-marked expression's identifiers — correctly, per its own comment: adding a `template-closure` edge would misclassify the name as template-reachable and defeat the BF060/BF061 usage-aware suppression in `compute-inlinability.ts`.

The gap: no *substitute* edge existed either. `ctx.clientOnlyElements` — populated by `collect-elements.ts`, consumed by `emit-reactive.ts` to actually emit the `createEffect` block — was never iterated in `build-references.ts` at all. So a prop referenced **only** inside such an expression left zero trace in the reference graph, `neededProps` never saw it, and `emitPropsExtraction` had no evidence it needed binding.

## Fix

One loop, mirroring the adjacent `clientOnlyConditionals` handling already in the same file:

```ts
for (const elem of ctx.clientOnlyElements) {
  addExprEdges(ROOT_SOURCE, elem.expression, 'init-body')
}
```

`'init-body'` is the same context event-handler identifiers already use a few lines up — safe for the same reason the file's own comment gives for why `'template-closure'` is *not* safe here (BF060/BF061 only special-cases that one context).

## Verification

- Compiled the repro and confirmed `const label = _p.label` is now emitted, in the right position (before the `createEffect` body reads it).
- Executed the generated code against a real DOM (`@happy-dom/global-registrator`, same harness `claim-slots.test.ts` uses) — no longer throws, for both a plain prop object and a JSON-round-tripped one (the real hydrate shape).
- Added 3 regression tests to `packages/jsx/src/__tests__/prop-references.test.ts`: the destructured-prop case above, a props-object variant (`props.label` — needs no extraction, already `_p.x`), and a prop used both in a normal reactive position *and* inside `/* @client */` (extracted exactly once, not duplicated).
- Full suite re-runs, all green, zero regressions: `packages/jsx` 3047 pass, `packages/compat` 480 pass, `packages/client` 625 pass, `packages/adapter-tests` 1975 pass.
- `bun run compat:lock` / `support-matrix:lock` regenerate with zero diff — no existing fixture's compile diagnostics change; this only fixes emission for shapes that already compiled clean.
- Changeset added (`@barefootjs/jsx`, patch) — this is a real behavior fix to published compiler source, not a docs-only change.

## Related, out of scope here

While verifying the `Date`-prop variant of this fix (`{/* @client */ createdAt.toLocaleDateString()}` — the exact escape BF021 itself suggests for rich-type method refusals), found that once the `ReferenceError` this PR fixes is gone, a **different** crash surfaces: the prop arrives at real hydrate as a JSON-de-riched ISO string (not a `Date` instance), so the client call throws `TypeError`. That's a separate, pre-existing transport gap (same family as #2292, but for uncatalogued/`@client`-escaped calls, which have no helper to route coercion through) — filed as #2636, not addressed in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Y7832bD8Ph4NHfq7B42kb)_