### PR TITLE
Fix #2645: /* @client */ text expression wrongly inlined into static/CSR template

### DIFF
--- a/.changeset/client-text-static-template-elision.md
+++ b/.changeset/client-text-static-template-elision.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix a SSR/CSR byte-parity violation where a `/* @client */` text expression on a bare destructured prop (e.g. `{/* @client */ createdAt.toISOString()}`) had its value inlined directly into the static/CSR client-JS template instead of being elided to an empty region like SSR. `irToComponentTemplateWithOpts`'s `'expression'` case now nests the same `clientOnly && slotId` / `markerless` elision branch `generateCsrTemplateWithOpts` already had.

--- a/packages/adapter-tests/fixtures/date-client-catalogued.ts
+++ b/packages/adapter-tests/fixtures/date-client-catalogued.ts
@@ -26,13 +26,15 @@ import { createFixture } from '../src/types'
  * (packages/client) proves it doesn't throw against a real, JSON-round-
  * tripped prop.
  *
- * CSR-skipped (`csr-skip-set.ts`): this fixture's bare-destructured-prop
- * method-call shape trips a SEPARATE, pre-existing bug (#2645,
- * `canGenerateStaticTemplate`'s `'expression'` case never checks
- * `node.clientOnly`) that inlines the `@client` value into the CSR/static
- * template instead of eliding it like SSR does — orthogonal to this
- * fixture's own #2640 fix, which the hydrate-execution test above already
- * proves sound independent of that gap.
+ * This fixture's bare-destructured-prop method-call shape also caught a
+ * SEPARATE, pre-existing bug (#2645): `irToComponentTemplateWithOpts`'s
+ * `'expression'` case never checked `node.clientOnly`, so it inlined the
+ * `@client` value into the CSR/static template instead of eliding it like
+ * SSR does (a real SSR/CSR byte-parity violation, not a harness artifact).
+ * Fixed by adding the same `clientOnly && slotId` / `markerless` branch
+ * `generateCsrTemplateWithOpts` already had — this fixture (previously
+ * `CSR_SKIP_FIXTURES`-pinned) is now that fix's CSR-conformance regression
+ * pin, alongside the #2640 hydrate-execution coverage above.
  */
 export const fixture = createFixture({
   id: 'date-client-catalogued',

--- a/packages/adapter-tests/src/csr-skip-set.ts
+++ b/packages/adapter-tests/src/csr-skip-set.ts
@@ -249,19 +249,5 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   // above (#968). Graduates to a full pass if that ordering is ever
   // unified.
   'signal-early-return',
-  // #2645: `canGenerateStaticTemplate`'s `'expression'` case never checks
-  // `node.clientOnly` — a `/* @client */` expression on a bare destructured
-  // prop (`isSimplePropExpression` treats `createdAt.toISOString()` as
-  // "simple") routes to `irToComponentTemplate`, which has no `clientOnly`
-  // awareness and inlines the value directly, instead of `generateCsrTemplate`
-  // (which correctly elides it to match SSR's empty `@client` region). A REAL
-  // divergence, not a harness artifact — SSR renders empty, CSR renders
-  // populated. Orthogonal to #2640/#2641 (which fixed the separate REACTIVE-
-  // effect emission this fixture's own hydrate-execution test,
-  // `packages/client/__tests__/runtime/date-lowering-hydration.test.ts`,
-  // already proves is sound); this is a static-template-eligibility bug in a
-  // different function. `expectedHtml` stays correct (matches SSR); only the
-  // CSR-template-eval leg is skipped here.
-  'date-client-catalogued',
 ])
 

--- a/packages/jsx/src/__tests__/client-only-date-lowering.test.ts
+++ b/packages/jsx/src/__tests__/client-only-date-lowering.test.ts
@@ -152,3 +152,31 @@ describe('#2641 — reactive attribute bindings route catalogued calls through t
     expect(clientJs).not.toContain('date(')
   })
 })
+
+describe('#2645 — /* @client */ text expressions elide in the static/CSR template like SSR', () => {
+  // `irToComponentTemplateWithOpts`'s 'expression' case never checked
+  // `node.clientOnly` — a bare-destructured-prop receiver (`isSimplePropExpression`
+  // treats `createdAt.toISOString()` as "simple") routed to this static
+  // template builder, which had no clientOnly awareness and inlined the
+  // (possibly lowered) value directly, breaking SSR/CSR byte parity: SSR
+  // renders the @client region empty, this builder rendered it populated.
+  test('markerless: the region is fully empty, matching SSR', () => {
+    const { clientJs, bf021 } = compile(`
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        return <div>{/* @client */ createdAt.toISOString()}</div>
+      }
+    `)
+    expect(bf021).toHaveLength(0)
+    expect(clientJs).toContain('template: (_p) => `<div bf="s1"></div>`')
+  })
+
+  test('marker pair (adjacent static text defeats markerless elision): empty marker pair, no inlined value', () => {
+    const { clientJs, bf021 } = compile(`
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        return <div>ISO: {/* @client */ createdAt.toISOString()}</div>
+      }
+    `)
+    expect(bf021).toHaveLength(0)
+    expect(clientJs).toContain('template: (_p) => `<div bf="s1">ISO: <!--bf:s0--><!--/--></div>`')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -1810,6 +1810,19 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
 
     case 'expression': {
       if (node.expr === 'null' || node.expr === 'undefined') return ''
+      // `/* @client */` defers the expression to hydrate — init's
+      // clientOnlyElements effect owns the value (#2645). Mirror
+      // `generateCsrTemplateWithOpts`'s identical branch byte-for-byte:
+      // empty marker pair for SSR parity, or nothing at all when the
+      // elision pass dropped the markers (`markerless` — the claim plan
+      // resolves via `elidedPath`, slot unification Step B). Without this,
+      // this builder inlined the (possibly lowered) expression value
+      // directly into the static template, breaking SSR/CSR byte parity —
+      // SSR renders the region empty, this builder rendered it populated.
+      if (node.clientOnly && node.slotId) {
+        if (node.markerless) return ''
+        return `<!--bf:${node.slotId}--><!--/-->`
+      }
       const wrapped = transformExpr(node.expr, node.templateExpr)
       // Stage 3 / D4 — join an element-array child ({out}) built by the preamble.
       const value = node.joinArrayChild
@@ -2404,10 +2417,15 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
         // `elidedPath` (a precomputed child-index path), not a marker
         // scan, so no anchor comment is needed here at all — matches SSR's
         // fully-empty output for this case byte-for-byte (#2617; this is
-        // the second of the two top-level CSR emitters `irToHtmlTemplate`
-        // and `generateCsrTemplateWithOpts` that must each consult
-        // `markerless` — see that function's own check at this file's
-        // `case 'expression'` for why the two aren't collapsed into one).
+        // one of three whole-component/CSR-path emitters — alongside
+        // `irToHtmlTemplate` (loop/conditional bodies) and
+        // `irToComponentTemplateWithOpts` (the static whole-component
+        // template — #2645 added its own identical branch after this
+        // exact gap let a `/* @client */` text expression inline its
+        // value into the static template, breaking SSR/CSR byte parity)
+        // — that must each consult `markerless` — see those functions'
+        // own checks at this file's `case 'expression'` for why the
+        // three aren't collapsed into one).
         if (node.markerless) return ''
         return `<!--bf:${node.slotId}--><!--/-->`
       }

--- a/spec/slot-unification.md
+++ b/spec/slot-unification.md
@@ -300,6 +300,23 @@ axis (`markerless`/`elidedPath`), unaffected by the correction above:
   helper). Both CSR emitters are now correct for the shipped `clientOnly`
   case; only the CSR side's GENERALIZATION past `clientOnly` (§2483) remains
   unimplemented, same as before this correction.
+- **Corrected again by #2645** — the #2617 census above missed a THIRD
+  `expression`-case emitter with the same shape: `irToComponentTemplateWithOpts`
+  (`html-template.ts`), the STATIC whole-component template builder used
+  when `canGenerateStaticTemplate` judges a component simple enough (a
+  bare-destructured-prop receiver like `createdAt.toISOString()` qualifies
+  via `isSimplePropExpression`, regardless of `clientOnly`). Unlike
+  `irToHtmlTemplate`'s narrow gap above, this one WAS reachable today: a
+  `/* @client */` text expression on a bare prop routed straight into this
+  builder, which had no `clientOnly` check at all in its `'expression'`
+  case and inlined the (possibly lowered) value unconditionally — a real
+  SSR/CSR byte-parity violation exercised by an ordinary top-level
+  `/* @client */` expression, not a generalization edge case. Fixed the
+  same way #2617 fixed `generateCsrTemplateWithOpts`: nest
+  `if (node.clientOnly && node.slotId) { if (node.markerless) return '';
+  return marker-pair }` ahead of the eager-evaluation fallback. All three
+  `expression`-case emitters are now correct for the shipped `clientOnly`
+  case.
 
 The SSR side is NOT already fully general, though — every one of the nine
 adapters' `renderExpression` nests its `if (expr.markerless) return ''`


### PR DESCRIPTION
## What

Fixes #2645: a `/* @client */` text expression on a bare destructured prop (e.g. `{/* @client */ createdAt.toISOString()}`) had its value inlined directly into the static/CSR client-JS template instead of being elided to an empty region, breaking SSR/CSR byte parity. SSR correctly renders the `@client` region empty (nothing to adopt, deferred to hydrate); the static template builder rendered it populated.

## Root cause

`irToComponentTemplateWithOpts`'s `'expression'` case (`ir-to-client-js/html-template.ts`, the static whole-component CSR template builder) never checked `node.clientOnly` — unlike its own sibling handling for attributes (`a.clientOnly`), conditionals, and component props (`p.clientOnly`) in the same function. `canGenerateStaticTemplate` routes a component to this builder whenever every expression looks "simple" (`isSimplePropExpression` treats a bare-prop method call like `createdAt.toISOString()` as simple, regardless of `clientOnly`), so a `/* @client */` text expression on a bare prop reached this builder and had its value spliced in unconditionally.

## Fix

Mirrors `generateCsrTemplateWithOpts`'s existing, correct branch for the identical case byte-for-byte: nest `if (node.clientOnly && node.slotId) { if (node.markerless) return ''; return marker-pair }` ahead of the eager-evaluation fallback.

**Why not gate `canGenerateStaticTemplate` instead** (the issue's originally proposed direction)? Routing the whole component to `generateCsrTemplate` would introduce a different, unrelated divergence risk: its `transformExpr` draws inlinable constants from a different source (`ctx.csrInlinable`) than the static path's own map, and the two can legitimately disagree (#2106). Repo precedent (#1645, #2617) fixes this exact class of bug in the emitter itself, not by routing around it.

**Attribute position** was independently verified sound and needs no change — `irToComponentTemplateWithOpts` already elides `attr.clientOnly` in its attribute loop, and `generateCsrTemplateWithOpts`'s attribute path has the identical skip, so both possible routings already produce correct output for a `/* @client */` attribute.

## Verification

- `date-client-catalogued` (landed in #2640/#2641, pinned in `CSR_SKIP_FIXTURES` citing this bug) is un-skipped — its existing `expectedHtml` already matched the fixed output.
- New compiler-unit regression tests in `packages/jsx/src/__tests__/client-only-date-lowering.test.ts` pin both the markerless case and the marker-pair case (adjacent static text defeats markerless elision), which the fixture alone didn't cover.
- `spec/slot-unification.md` updated with a `#2645` addendum: the `#2617` census of `expression`-case emitters missed this third one.
- Full suite reruns, zero regressions: `packages/jsx` 3062 pass, `packages/adapter-tests` 1999 pass (+1 from the un-skip), `packages/client` 628 pass, `packages/compat` 480 pass (one transient timeout under parallel background load, reproduced clean in isolation).
- `compat:lock` / `support-matrix:lock` regenerate with zero diff — SSR emission is untouched; this bug and fix are entirely client-JS-template-side.
- Changeset added (`@barefootjs/jsx`, patch).

## Design process

Per this session's established workflow, the fix's design/scope was produced by a separate design pass (which read the real code, verified the attribute-position soundness claim experimentally, and applied+reverted the fix locally to confirm the full suite passes before recommending it). This PR is the implementation of that plan.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Y7832bD8Ph4NHfq7B42kb)_