### PR TITLE
File trackers for Priority-12 CSR divergences and the scope-gate env-signal ledger

### DIFF
--- a/packages/adapter-tests/src/__tests__/client-js-scope.test.ts
+++ b/packages/adapter-tests/src/__tests__/client-js-scope.test.ts
@@ -41,24 +41,24 @@ interface KnownHole {
 }
 
 const KNOWN_UNDECLARED: Record<string, KnownHole> = {
-  // #2075: the env-signal getter (`searchParams` / `sp`) is a
-  // per-request binding wired at init/hydration; the template lambda
-  // references it at module scope.
+  // #2654 (open successor to the closed #2075): the env-signal getter
+  // (`searchParams` / `sp`) is a per-request binding wired at
+  // init/hydration; the template lambda references it at module scope.
   'search-params': {
     names: ['searchParams'],
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2075',
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2654',
   },
   'search-params-derived-filter': {
     names: ['searchParams'],
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2075',
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2654',
   },
   'search-params-derived-memo': {
     names: ['sp'],
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2075',
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2654',
   },
   'search-params-derived-memo-bare': {
     names: ['searchParams'],
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2075',
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2654',
   },
   // #2463 (signal-conditioned early return) is FIXED — the statement
   // form now lowers to the root-ternary insert() plan, so its template

--- a/packages/adapter-tests/src/csr-skip-set.ts
+++ b/packages/adapter-tests/src/csr-skip-set.ts
@@ -55,10 +55,10 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   'props-reactivity-comparison',
   // Memo reads the env-signal getter `sp()`, wired only at init — same class
   // as `toggle-shared`; runtime `env-signal` tests + per-adapter render
-  // conformance (#2075) cover it.
+  // conformance cover it — known limitation #2654.
   'search-params-derived-memo',
   // Bare-getter sibling: the stubbed getter yields literal `null` text where
-  // expectedHtml pins the empty per-adapter contract (#2075).
+  // expectedHtml pins the empty per-adapter contract — #2654.
   'search-params-derived-memo-bare',
   // Keyed child-component loop materializes at init — same as `static-array-from-props`.
   'todo-app',
@@ -107,17 +107,19 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   // Priority-12 sweep: REAL SSR/CSR divergences (not harness artifacts),
   // skipped until the pipeline reconciles the two paths.
   // `object-entries-map` / `nested-loop-outer-binding`: nested/tuple loops
-  // disagree on `data-key` depth suffixes between SSR and template-eval.
+  // disagree on `data-key` depth suffixes between SSR and template-eval —
+  // known limitation #2652.
   'object-entries-map',
   'nested-loop-outer-binding',
-  // Same data-key depth-suffix disagreement, one level deeper.
+  // Same data-key depth-suffix disagreement, one level deeper — #2652.
   'nested-loop-triple-depth',
   // `jsx-element-prop`: a non-children JSX prop reaches the CSR insert as an
-  // escaped string (`__BF_PARENT_SCOPE__` still embedded), not markup.
+  // escaped string (`__BF_PARENT_SCOPE__` still embedded), not markup —
+  // known limitation #2651.
   'jsx-element-prop',
   // `nested-fragments`: a multi-root fragment attaches `bf-s` to its
   // first element in CSR, while SSR carries the scope on a
-  // `<!--bf-scope:...-->` comment the normalizer strips.
+  // `<!--bf-scope:...-->` comment the normalizer strips — known limitation #2653.
   'nested-fragments',
   // `grandchild-composition`: third level reuses the parent scope id
   // (`test_s0`) in CSR instead of deriving `test_s0_s0` as SSR does. #2444


### PR DESCRIPTION
## Summary

An audit found already-acknowledged compiler divergences with no open `known-limitation` tracker, a gap in the three-piece-set convention (`CLAUDE.md`'s Testing section: fixture + issue + pin, each carrying the issue URL). This PR files the missing trackers and repoints the existing pin comments/fields to them. No behavior change — comment text and `issue:` string values only.

## Issues filed

1. **#2651** — CSR: non-children JSX element prop reaches the insert as an escaped string (`__BF_PARENT_SCOPE__` leaks), not markup. Adapter-independent (affects Hono too). Most severe of the group. Fixture: `jsx-element-prop`.
2. **#2652** — CSR: nested/tuple loops disagree with SSR on `data-key` depth-suffix numbering. Covers `object-entries-map`, `nested-loop-outer-binding`, `nested-loop-triple-depth`.
3. **#2653** — CSR: `nested-fragments` attaches `bf-s` to the first element instead of SSR's `bf-scope` comment marker.
4. **#2654** — CSR template lambdas reference init-wired env-signal getters (`searchParams`/`sp`) out of scope. Open successor to #2075, which closed 2026-07-03 (PR #2076) fixing only the SSR-side memo seeding — the CSR-side gap the scope-gate ledger's four `search-params*` entries actually pin remained open with no tracker. Repointed per the #2356/#2648 precedent (a permanent known-limitation should cite an open tracker, not a completed enabling issue); #2481 lists this as an open prerequisite.

## Changes

- `packages/adapter-tests/src/csr-skip-set.ts`: added issue citations to the 5 Priority-12 comments; repointed the two `search-params-derived-memo*` comments from #2075 to #2654.
- `packages/adapter-tests/src/__tests__/client-js-scope.test.ts`: repointed the 4 `KNOWN_UNDECLARED` `issue:` fields from #2075 to #2654; updated the ledger comment.

## Verification

- **Membership check**: extracted the quoted fixture-id keys from `CSR_SKIP_FIXTURES` and `KNOWN_UNDECLARED` before and after — both sets are byte-identical. `git diff` touches only comment lines and `issue:` string values.
- **Tests**: `bun test packages/adapter-tests/src/__tests__/csr-conformance.test.ts packages/adapter-tests/src/__tests__/client-js-scope.test.ts` → 605 pass, 2 skip, 0 fail, 881 expect() calls.

## Test plan

- [x] `bun test` on both affected test files passes
- [x] Set/ledger membership unchanged (diff limited to comments + issue URLs)
- [x] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_011Y7832bD8Ph4NHfq7B42kb)_