### PR TITLE
fix(adapter-tests): align the CSR harness mock with the production runtime

### DIFF
--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -174,11 +174,18 @@ function buildCsrEvalModule(clientJs: string, props: Record<string, unknown>): s
 const __rootScope = ${JSON.stringify(rootScope)}
 const __templates = new Map()
 const __inits = new Map()
+// Mirrors production's \`ComponentDef.comment\` (@barefootjs/client/runtime,
+// component.ts): \`comment: true\` marks a synthesized inline-JSX-callback
+// wrapper (#1211) whose render is transparent — the wrapper's own \`bf-s\` is
+// never stamped because the parsed firstChild IS the inner component's root.
+// Recorded here so the root bf-s injection below can skip it the same way.
+const __comments = new Map()
 let __lastComponent = null
 
 function hydrate(name, def) {
   if (def.template) __templates.set(name, def.template)
   if (def.init) __inits.set(name, def.init)
+  __comments.set(name, !!def.comment)
   __lastComponent = name
 }
 
@@ -197,10 +204,7 @@ function __runInit(name, props) {
 
 // Tracks the scope id a nested renderChild() call should derive from —
 // mirrors production's \`_parentScopeId\` (@barefootjs/client/runtime,
-// component.ts). Starts at \`__rootScope\` (the fixture root) and is
-// pushed/restored around each template() eval so a GRANDCHILD rendered by
-// a nested renderChild() call derives from its immediate parent's scope,
-// not the top-level root (#2444 grandchild-composition).
+// component.ts). Starts at \`__rootScope\` (the fixture root).
 let __parentScope = __rootScope
 
 function renderChild(name, props, key, suffix) {
@@ -216,25 +220,23 @@ function renderChild(name, props, key, suffix) {
   // output asserts the same shape SSR emits.
   const slotAttrs = suffix ? ' bf-h="' + __parentScope + '" bf-m="' + suffix + '"' : ''
   if (!template) return '<div bf-s="' + scopeId + '"' + slotAttrs + keyAttr + '>[' + name + ']</div>'
-  // Push this child's own scope while its template evaluates, so a nested
-  // renderChild() call (a grandchild) derives from THIS scope rather than
-  // reusing the caller's — mirrors production's push/restore around
-  // \`templateFn(props)\`.
-  const __prevParentScope = __parentScope
-  __parentScope = scopeId
-  let __rawHtml
-  try {
-    __rawHtml = template(props)
-  } finally {
-    __parentScope = __prevParentScope
-  }
+  // NOTE: does NOT push \`__parentScope\` to this child's own derived
+  // scope while \`template\` evaluates — mirrors production's renderChild
+  // (@barefootjs/client/runtime, component.ts, the NOTE above its
+  // \`templateFn(props)\` call). Pushing was tried there to fix a third
+  // composition level collapsing onto the second (\`grandchild-composition\`)
+  // but it collides with \`comment: true\` wrapper transparency's $cSingle
+  // short-suffix self-match, so production intentionally leaves
+  // grandchild-composition a known limitation (#2649) rather than pushing.
+  // This mock must reproduce that bug, not silently cure it.
+  const __rawHtml = template(props)
   // #1320: substitute the hoisted-children placeholder with the CALLER's
-  // scope (not this child's own scope pushed above). Mirrors the
-  // production renderChild in @barefootjs/client/runtime. Anchored to the
-  // exact attribute shape so user text containing the sentinel is left
-  // alone.
+  // scope (\`__parentScope\`, unchanged since renderChild doesn't push).
+  // Mirrors the production renderChild in @barefootjs/client/runtime.
+  // Anchored to the exact attribute shape so user text containing the
+  // sentinel is left alone.
   const html = __rawHtml.trim()
-    .replace(/\\s+bf-s="__BF_PARENT_SCOPE__"/g, ' bf-s="' + __prevParentScope + '"')
+    .replace(/\\s+bf-s="__BF_PARENT_SCOPE__"/g, ' bf-s="' + __parentScope + '"')
   const bfsAttr = ' bf-s="' + scopeId + '"'
   const extraAttrs = slotAttrs + keyAttr
   // Dedupe bf-s only when the child template already carries one
@@ -259,10 +261,22 @@ const $c = (...args) => new Array(args.length - 1).fill(null)
 const createSignal = (v) => [() => v, () => {}]
 const createEffect = () => {}
 const createMemo = (fn) => fn
-// Env signal (router v0.5): the template reads \`searchParams().get(k)\`; the
-// harness has no real request, so it resolves to an empty query (matching the
-// SSR conformance default).
-const searchParams = () => new URLSearchParams()
+// Env signal (router v0.5): mirrors @barefootjs/client's \`createSearchParams\`
+// import surface — production returns a \`createSignal\`-shaped
+// \`[getter, setter]\` tuple (reactive.ts's \`searchParamsTuple\`), so the mock
+// matches that shape. The harness has no real request, so the getter
+// resolves to an empty query (matching the SSR conformance default).
+//
+// Deliberately NOT also providing a bare module-scope \`searchParams\`
+// binding: generated client JS destructures the getter out of
+// \`createSearchParams()\` inside \`init...\` only — the template lambda
+// references that destructured name directly, with no import or
+// re-binding of its own (#2654, a compiler bug: the template lambda
+// should carry its own env-signal prelude but doesn't yet). A bare
+// \`searchParams\` stub here would silently paper over that
+// ReferenceError instead of reproducing it, which is exactly how the
+// bug stayed hidden until a fixture aliased the getter to \`sp\`.
+const createSearchParams = () => [() => new URLSearchParams(), () => {}]
 const onMount = () => {}
 const onCleanup = () => {}
 const insert = () => {}
@@ -410,8 +424,12 @@ __html = __html.replace(/\\s+bf-s="__BF_PARENT_SCOPE__"/g, ' bf-s="' + __rootSco
 // Inject bf-s="\${__rootScope}" on the root element to match SSR scope
 // ID convention — appended AFTER user-defined attributes, mirroring
 // Hono renderElement (#1295). Skip when the root already carries
-// bf-s from a nested renderChild call (#1320 dedup).
-if (!/^<\\w+[^>]*\\sbf-s="/.test(__html)) {
+// bf-s from a nested renderChild call (#1320 dedup), AND skip when the
+// main component itself is a \`comment: true\` transparent wrapper —
+// mirrors production's \`createComponent\` (component.ts), which leaves
+// \`scopeId === null\` for such wrappers rather than stamping their own
+// bf-s over the inner component's root (#2653).
+if (!__comments.get(__lastComponent) && !/^<\\w+[^>]*\\sbf-s="/.test(__html)) {
 if (__html.match(/^<\\w+[^>]* bf="/)) {
   __html = __html.replace(/ bf="/, ' bf-s="' + __rootScope + '" bf="')
 } else if (__html.match(/^<\\w+\\s[^>]*>/)) {

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -276,7 +276,11 @@ const createMemo = (fn) => fn
 // \`searchParams\` stub here would silently paper over that
 // ReferenceError instead of reproducing it, which is exactly how the
 // bug stayed hidden until a fixture aliased the getter to \`sp\`.
-const createSearchParams = () => [() => new URLSearchParams(), () => {}]
+// Shared tuple constant, not a fresh pair per call: production's
+// \`createSearchParams()\` returns the stable request/document-scoped
+// \`searchParamsTuple\` singleton, so per-call identity must match too.
+const __searchParamsTuple = [() => new URLSearchParams(), () => {}]
+const createSearchParams = () => __searchParamsTuple
 const onMount = () => {}
 const onCleanup = () => {}
 const insert = () => {}

--- a/packages/adapter-tests/src/csr-skip-set.ts
+++ b/packages/adapter-tests/src/csr-skip-set.ts
@@ -60,6 +60,18 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   // Bare-getter sibling: the stubbed getter yields literal `null` text where
   // expectedHtml pins the empty per-adapter contract — #2654.
   'search-params-derived-memo-bare',
+  // https://github.com/piconic-ai/barefootjs/issues/2654: the template
+  // lambda reads the `createSearchParams()`-destructured getter directly,
+  // but that getter is only bound inside `init...` — the template itself
+  // carries no import or re-binding of its own, so evaluating it standalone
+  // (as this harness does) throws a ReferenceError. Previously masked by
+  // the harness's bare module-scope `searchParams` stub, which happened to
+  // match this fixture's getter name.
+  'search-params',
+  // Same #2654 ReferenceError as `search-params`, one layer down: the
+  // `visible` memo's template read closes over `searchParams()`, itself
+  // only bound at init time. https://github.com/piconic-ai/barefootjs/issues/2654
+  'search-params-derived-filter',
   // Keyed child-component loop materializes at init — same as `static-array-from-props`.
   'todo-app',
   // #1448 Tier B — iteration shape fixtures are SSR-only prop-based
@@ -117,10 +129,6 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   // escaped string (`__BF_PARENT_SCOPE__` still embedded), not markup —
   // known limitation #2651.
   'jsx-element-prop',
-  // `nested-fragments`: a multi-root fragment attaches `bf-s` to its
-  // first element in CSR, while SSR carries the scope on a
-  // `<!--bf-scope:...-->` comment the normalizer strips — known limitation #2653.
-  'nested-fragments',
   // `grandchild-composition`: third level reuses the parent scope id
   // (`test_s0`) in CSR instead of deriving `test_s0_s0` as SSR does. #2444
   // fixed the sibling case, but deriving here via `renderChild`'s


### PR DESCRIPTION
## Summary

Stack 1/3 of the CSR Track-C fixes (#2649/#2651/#2652/#2653/#2654 investigation). The CSR conformance harness's mock runtime had drifted from the production runtime in three ways, so the suite could no longer tell the truth about production behavior — in both directions (a real bug masked as passing, and a non-bug reported as a divergence):

1. **Root `bf-s` stamping ignored `comment: true`.** Production's `createComponent` leaves transparent wrappers (fragment roots, #1211 callback wrappers) unstamped (`scopeId === null`); the eval module stamped every main component's first element. This was the entire `nested-fragments` "divergence" — the compiler was never at fault. The mock `hydrate` now records the `comment` flag and the injection skips comment wrappers. **`nested-fragments` graduates** (its CSR output now byte-matches SSR — closes #2653).
2. **A bare module-scope `searchParams` stub masked #2654.** The compiler bug (template lambdas referencing the init-scope env-signal getter) only surfaced on the one fixture that aliased the getter to `sp`; the three fixtures using the default name resolved the harness stub instead. The stub is replaced by a `createSearchParams` tuple stub mirroring the real `@barefootjs/client` import surface (`reactive.ts`'s `[getter, setter]` shape), and the two newly-throwing fixtures (`search-params`, `search-params-derived-filter`) are skip-pinned under #2654. All four now reproduce the ReferenceError, ready for the compiler fix in stack 3/3.
3. **The mock `renderChild` pushed the child scope around template eval** — a cure production deliberately does not ship (the `$cSingle` short-suffix self-match collision; see the NOTE above `templateFn(props)` in `component.ts`). This made `grandchild-composition` falsely pass, hiding #2649. The mock no longer pushes and reproduces the bug: CSR yields `bf-s="test_s0"` at depth 3 where SSR derives `test_s0_s0` — exactly the issue's symptom, correctly failing (and staying skip-pinned) again.

## Verification

- `bun test packages/adapter-tests`: green except 9 pre-existing `carousel-cross-adapter` failures (`@barefootjs/client` dist not built in this environment — identical before/after via `git stash` comparison).
- Direct harness runs: `nested-fragments` matches SSR; all four `search-params*` fixtures throw `ReferenceError`; `grandchild-composition` diverges with the documented symptom; the #2652 trio still passes.
- `escape-coverage` (the other `CSR_SKIP_FIXTURES` consumer): green.

Part of a 3-PR stack: this PR (harness truth) → skip-rot test + stale-skip graduations → #2654 compiler fix.

Refs #2653, #2654, #2649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_