### PR TITLE
test(adapter-tests): add a CSR skip-ledger rot test; graduate 25 stale skips

### DIFF
--- a/packages/adapter-tests/src/__tests__/csr-skip-rot.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-skip-rot.test.ts
@@ -1,0 +1,85 @@
+/**
+ * CSR skip-ledger rot test
+ *
+ * `CSR_SKIP_FIXTURES` (`../csr-skip-set.ts`) is a declaration that a fixture
+ * is *currently broken* under CSR conformance — each entry's comment names
+ * the known-limitation issue it's pinned to. Nothing forces that declaration
+ * to stay true: a compiler fix can silently graduate a fixture (it now
+ * passes CSR conformance) while the skip entry — and the known-limitation
+ * issue it points at — keeps claiming the fixture is broken. That drift is
+ * exactly what happened: a 2026-08 audit of this 53-entry ledger found 25
+ * entries (nearly half) were stale, having quietly started passing — this
+ * test is what caught them, and their graduation is what shrank the ledger
+ * to its current size.
+ *
+ * This test generates one `test(...)` per skip entry (mirroring
+ * `csr-conformance.test.ts`'s fixture loop) and asserts the entry is still
+ * earning its keep:
+ *   1. the id names a real fixture (catches orphans — an id that no longer
+ *      exists in `jsxFixtures`, e.g. after a fixture rename/removal);
+ *   2. that fixture carries `expectedHtml` to compare against;
+ *   3. rendering it through the CSR path (`renderCsrComponent`) still
+ *      diverges from `expectedHtml` — either by throwing, or by producing
+ *      HTML that (after the same cross-adapter normalization
+ *      `csr-conformance.test.ts` applies) does NOT match. If it DOES match,
+ *      the entry is stale and this test fails, instructing the entry be
+ *      deleted (and its tracking issue closed or updated).
+ *
+ * This is the skip-ledger twin of `data-point-conformance.ts`'s
+ * `skipDataPoints` orphan check — same discipline, extended from "does the
+ * entry still point at something real" to "is the thing it points at still
+ * actually broken".
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { jsxFixtures } from '../../fixtures'
+import { normalizeHTML, stripConditionalMarkersForCrossAdapter } from '../jsx-runner'
+import { renderCsrComponent } from '../csr-render'
+import { CSR_SKIP_FIXTURES } from '../csr-skip-set'
+
+describe('CSR skip-ledger rot', () => {
+  for (const id of CSR_SKIP_FIXTURES) {
+    // Some fixtures (e.g. `data-table`, a large multi-export UI demo) take
+    // several seconds to compile+render through the CSR harness, so staying
+    // within bun's default 5s test timeout isn't guaranteed. A slow render
+    // is not the same as "still broken"; give every entry generous headroom
+    // so a timeout can't be misread as a stale-check result either way.
+    test(`[${id}] skip entry is still earning its keep (fixture still diverges)`, async () => {
+      const fixture = jsxFixtures.find(f => f.id === id)
+      expect(fixture, `skip entry '${id}' names no fixture in jsxFixtures — orphaned entry, delete it`).toBeDefined()
+      if (!fixture) return
+
+      expect(
+        fixture.expectedHtml,
+        `skip entry '${id}' has no expectedHtml to compare against — cannot verify it's still broken`,
+      ).toBeTruthy()
+      if (!fixture.expectedHtml) return
+
+      let html: string
+      let threw = false
+      try {
+        html = await renderCsrComponent({
+          source: fixture.source,
+          // Same isolation as csr-conformance.test.ts: clone props per
+          // render so a mutating fixture (.reverse()/.sort()) can't poison
+          // the shared fixture.props object.
+          props: fixture.props !== undefined ? structuredClone(fixture.props) : undefined,
+          components: fixture.components,
+        })
+      } catch {
+        threw = true
+        html = ''
+      }
+
+      if (threw) return // still broken (throws) — entry is earning its keep
+
+      const normalizedHtml = stripConditionalMarkersForCrossAdapter(normalizeHTML(html))
+      const normalizedExpected = stripConditionalMarkersForCrossAdapter(normalizeHTML(fixture.expectedHtml))
+
+      expect(
+        normalizedHtml,
+        `skip entry '${id}' is stale — the fixture now passes CSR conformance; delete the entry (and close/update its tracking issue)`,
+      ).not.toBe(normalizedExpected)
+    }, 20_000)
+  }
+})

--- a/packages/adapter-tests/src/csr-skip-set.ts
+++ b/packages/adapter-tests/src/csr-skip-set.ts
@@ -18,6 +18,10 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   // typed shape Go's Input struct requires. Go-side expectedHtml pins the SSR
   // contract; CSR runtime parity is a tracked harness follow-up.
   'jsx-spread-props-object',
+  // #1467 multi-export class (NOT #1407): the shared source compiles several
+  // components and the harness's `__lastComponent` renders
+  // `PropsReactivityComparison`, not the pinned `ReactiveProps` — verified by
+  // the rendered output's `props-reactivity-comparison` container class.
   'reactive-props',
   // Memo reads the env-signal getter `sp()`, wired only at init; runtime
   // `env-signal` tests + per-adapter render conformance cover it —

--- a/packages/adapter-tests/src/csr-skip-set.ts
+++ b/packages/adapter-tests/src/csr-skip-set.ts
@@ -4,61 +4,27 @@
  * the same set without the two silently drifting apart.
  */
 export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
-  // Stateless components: no client JS emitted (fully server-rendered)
-  'props-static',
-  'nested-elements',
-  'void-elements',
-  'class-vs-classname',
-  'style-attribute',
-  'fragment',
-  // Local array variable (items) is not available at CSR template module scope.
-  // CSR templates only have access to props and signals, not file-scope constants.
-  'static-array-children',
-  // #2073: `.map(format)` closes over a module-scope const — same
-  // CSR-template-scope class as `static-array-children`; Hono render
-  // conformance covers the real-JS runtime.
+  // #2073: `.map(format)` closes over a module-scope const, which is not
+  // available at CSR template module scope (CSR templates only have access
+  // to props and signals); Hono render conformance covers the real-JS runtime.
   'array-map-function-reference',
   // #1247: prop-derived static loops materialize children at init time, not
   // template-eval — CSR shape covered by `static-loop-csr-materialize.test.ts`.
   'static-array-from-props',
-  // Same init-time materialization as `static-array-from-props`.
-  'sibling-loops-key-isolation',
   // #1268: same init-time materialization, childComponent variant.
   'static-array-from-props-with-component',
-  // Attribute-order divergence only: SSR emits style first, CSR injection bf-s first.
-  'style-object-static',
-  // Synthetic scope wrapper has style="display:contents" before bf-s (#968).
-  // Same attribute-ordering divergence as style-object-static/-dynamic.
-  'top-level-ternary',
-  // Same synthetic-wrapper attribute-order divergence as `top-level-ternary` (#971).
-  'return-logical-and',
-  'return-logical-or',
-  'return-nullish-coalescing',
-  'return-map',
-  // #1244: attribute-order-only divergence. A lone `<li key={id} {...rest}>`
-  // keeps the legacy inline emit (the collision-safe merge needs a non-`key`
-  // explicit attr) to preserve the unconditional `data-key` debug contract, so
-  // SSR and CSR order `data-key` vs the spread differently — identical DOM
-  // after parsing. The semantics-violating collision shape is locked by
-  // `compiler-stress-1244.test.ts`.
-  'rest-destructure-object-spread-in-map',
   // #1407: `applyRestAttrs` needs the JS spread bag in `_p`, but the harness's
   // single `props` object can't carry both the flat shape JS expects and the
   // typed shape Go's Input struct requires. Go-side expectedHtml pins the SSR
   // contract; CSR runtime parity is a tracked harness follow-up.
-  'jsx-spread-rest-prop',
   'jsx-spread-props-object',
-  // Template lambda closes over an init-wired local (`toggleItems`, `value`)
-  // — same class as `static-array-children`.
-  'toggle-shared',
   'reactive-props',
-  'props-reactivity-comparison',
-  // Memo reads the env-signal getter `sp()`, wired only at init — same class
-  // as `toggle-shared`; runtime `env-signal` tests + per-adapter render
-  // conformance cover it — known limitation #2654.
+  // Memo reads the env-signal getter `sp()`, wired only at init; runtime
+  // `env-signal` tests + per-adapter render conformance cover it —
+  // known limitation #2654.
   'search-params-derived-memo',
-  // Bare-getter sibling: the stubbed getter yields literal `null` text where
-  // expectedHtml pins the empty per-adapter contract — #2654.
+  // Bare-getter sibling: same init-only `searchParams` binding, referenced
+  // by the template lambda at module scope (ReferenceError) — #2654.
   'search-params-derived-memo-bare',
   // https://github.com/piconic-ai/barefootjs/issues/2654: the template
   // lambda reads the `createSearchParams()`-destructured getter directly,
@@ -74,19 +40,13 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   'search-params-derived-filter',
   // Keyed child-component loop materializes at init — same as `static-array-from-props`.
   'todo-app',
-  // #1448 Tier B — iteration shape fixtures are SSR-only prop-based
-  // components. The CSR template path can't resolve bare prop refs
-  // (items, etc.) without `"use client"` + signal wiring.
-  'array-entries',
-  'array-keys',
-  'array-values',
   // #1467: multi-export source — the harness's `__lastComponent` renders
   // `KbdGroup`, not the pinned `Kbd`; SSR `componentName` pin keeps Hono
   // honest, and `kbd` ships no interactions anyway.
   'kbd',
   // #1467: `placeholder` flows through `{...props}` → `applyRestAttrs` at
   // init, which the harness stubs as a noop — same class as
-  // `jsx-spread-rest-prop`; the fixture-hydrate layer exercises it for real.
+  // `jsx-spread-props-object`; the fixture-hydrate layer exercises it for real.
   'input',
   // #2131: same `applyRestAttrs`-not-modeled class as `input`; per-adapter
   // render conformance pins the SSR contract.
@@ -118,13 +78,6 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   'region-boundary',
   // Priority-12 sweep: REAL SSR/CSR divergences (not harness artifacts),
   // skipped until the pipeline reconciles the two paths.
-  // `object-entries-map` / `nested-loop-outer-binding`: nested/tuple loops
-  // disagree on `data-key` depth suffixes between SSR and template-eval —
-  // known limitation #2652.
-  'object-entries-map',
-  'nested-loop-outer-binding',
-  // Same data-key depth-suffix disagreement, one level deeper — #2652.
-  'nested-loop-triple-depth',
   // `jsx-element-prop`: a non-children JSX prop reaches the CSR insert as an
   // escaped string (`__BF_PARENT_SCOPE__` still embedded), not markup —
   // known limitation #2651.
@@ -137,7 +90,4 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   // when an inner component's first slot id coincides with the wrapper's slot
   // number (site/ui xyflow Highlight-Depth regression) — known limitation #2649.
   'grandchild-composition',
-  // Lowers to the root-ternary plan cleanly; skipped only for the same #968
-  // wrapper attribute-ordering divergence as `top-level-ternary`.
-  'signal-early-return',
 ])


### PR DESCRIPTION
## Summary

Stack 2/3 (base: #2658). `CSR_SKIP_FIXTURES` had no staleness check — unlike `skipDataPoints`, whose orphan assertion completes the pin→fix→unpin round-trip. Nothing forced a skip entry to stay true after a fix quietly landed, and an audit found **25 of the ledger's 53 entries stale** (nearly half), including the whole of #2652: the nested/tuple-loop `data-key` depth suffixes (`data-key-1` / `data-key-2`) now match SSR, verified present in raw CSR output rather than normalized away.

## Changes

- **New `csr-skip-rot.test.ts`** — one test per skip entry, asserting the entry still earns its keep: the id names a real fixture (orphan check), the fixture has `expectedHtml`, and rendering it through the CSR harness still diverges (throw or mismatch after the same normalization `csr-conformance` applies). A fixture that now byte-matches the SSR reference fails the test with a delete-the-entry message, so the ledger can no longer drift from reality. Per-test 20s timeout: `data-table` legitimately takes ~6s to compile+render, and a timeout must not be misread as a verdict.
- **25 graduations** — the audited 24 plus `fragment`, which the rot test itself caught (fixed by stack 1/3's comment-aware root stamping; the audit predated that change). Each graduated fixture now runs in `csr-conformance` as its fix's regression armor: **300 passing there, up from 275**. Group comments cleaned up where every member left; cross-references repointed to surviving ids.
- **28 entries survive**, each verified still-diverging by the same test, clustered by issue: #1467 multi-export demos (12), #2654 env-signal fixtures (4, graduating in stack 3/3), init-time static-array materialization (3), `applyRestAttrs`-not-modeled (2), default-prop-at-template-eval (2), singletons incl. #2651 / #2649 (5).

## Verification

- `csr-skip-rot.test.ts`: 28 pass / 0 fail (~27s).
- `csr-conformance.test.ts`: 300 pass / 0 fail.
- `bun test packages/adapter-tests`: green except the 9 pre-existing `carousel-cross-adapter` environment failures (`@barefootjs/client` dist not built; identical before/after).
- `escape-coverage` + `escape-coverage-additivity` (the other `CSR_SKIP_FIXTURES` consumers): green.

Closes #2652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_