### PR TITLE
fix(jsx): CSR template lambdas declare the env-signal getters they reference

### DIFF
--- a/.changeset/loud-plums-guess.md
+++ b/.changeset/loud-plums-guess.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+CSR `template:` lambdas now declare the env-signal getters (`createSearchParams()`) they reference, fixing a `ReferenceError` at template evaluation.

--- a/packages/adapter-tests/src/__tests__/client-js-scope.test.ts
+++ b/packages/adapter-tests/src/__tests__/client-js-scope.test.ts
@@ -41,25 +41,12 @@ interface KnownHole {
 }
 
 const KNOWN_UNDECLARED: Record<string, KnownHole> = {
-  // #2654 (open successor to the closed #2075): the env-signal getter
-  // (`searchParams` / `sp`) is a per-request binding wired at
-  // init/hydration; the template lambda references it at module scope.
-  'search-params': {
-    names: ['searchParams'],
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2654',
-  },
-  'search-params-derived-filter': {
-    names: ['searchParams'],
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2654',
-  },
-  'search-params-derived-memo': {
-    names: ['sp'],
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2654',
-  },
-  'search-params-derived-memo-bare': {
-    names: ['searchParams'],
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2654',
-  },
+  // #2654 (env-signal getter referenced at module scope by the template
+  // lambda) is FIXED — `buildTemplateDefPart` in `emit-registration.ts`
+  // now gives the template lambda its own `const [<getter>] =
+  // <envFactory>()` prelude, so `search-params` / `search-params-derived-filter`
+  // / `search-params-derived-memo` / `search-params-derived-memo-bare`
+  // graduated.
   // #2463 (signal-conditioned early return) is FIXED — the statement
   // form now lowers to the root-ternary insert() plan, so its template
   // substitutes the signal initial instead of leaking `loading`.

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -270,9 +270,9 @@ const createMemo = (fn) => fn
 // Deliberately NOT also providing a bare module-scope \`searchParams\`
 // binding: generated client JS destructures the getter out of
 // \`createSearchParams()\` inside \`init...\` only — the template lambda
-// references that destructured name directly, with no import or
-// re-binding of its own (#2654, a compiler bug: the template lambda
-// should carry its own env-signal prelude but doesn't yet). A bare
+// references that destructured name directly. Emitted templates now
+// carry their own env-signal prelude (\`const [sp] = createSearchParams()\`,
+// the #2654 fix), which resolves against this stub. A bare
 // \`searchParams\` stub here would silently paper over that
 // ReferenceError instead of reproducing it, which is exactly how the
 // bug stayed hidden until a fixture aliased the getter to \`sp\`.

--- a/packages/adapter-tests/src/csr-skip-set.ts
+++ b/packages/adapter-tests/src/csr-skip-set.ts
@@ -19,25 +19,6 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   // contract; CSR runtime parity is a tracked harness follow-up.
   'jsx-spread-props-object',
   'reactive-props',
-  // Memo reads the env-signal getter `sp()`, wired only at init; runtime
-  // `env-signal` tests + per-adapter render conformance cover it —
-  // known limitation #2654.
-  'search-params-derived-memo',
-  // Bare-getter sibling: same init-only `searchParams` binding, referenced
-  // by the template lambda at module scope (ReferenceError) — #2654.
-  'search-params-derived-memo-bare',
-  // https://github.com/piconic-ai/barefootjs/issues/2654: the template
-  // lambda reads the `createSearchParams()`-destructured getter directly,
-  // but that getter is only bound inside `init...` — the template itself
-  // carries no import or re-binding of its own, so evaluating it standalone
-  // (as this harness does) throws a ReferenceError. Previously masked by
-  // the harness's bare module-scope `searchParams` stub, which happened to
-  // match this fixture's getter name.
-  'search-params',
-  // Same #2654 ReferenceError as `search-params`, one layer down: the
-  // `visible` memo's template read closes over `searchParams()`, itself
-  // only bound at init time. https://github.com/piconic-ai/barefootjs/issues/2654
-  'search-params-derived-filter',
   // Keyed child-component loop materializes at init — same as `static-array-from-props`.
   'todo-app',
   // #1467: multi-export source — the harness's `__lastComponent` renders

--- a/packages/jsx/src/__tests__/env-signal-template-prelude.test.ts
+++ b/packages/jsx/src/__tests__/env-signal-template-prelude.test.ts
@@ -1,0 +1,87 @@
+/**
+ * #2654 — the CSR `template:` lambda must declare its own env-signal
+ * getter (`createSearchParams()`, #2057) before referencing it, instead
+ * of relying on `init`'s `const [<getter>] = createSearchParams()`
+ * closure — the template lambda runs at module scope and has no access
+ * to that init-local binding, so the bare call ReferenceErrors at
+ * template-evaluation time.
+ *
+ * See `buildTemplateDefPart` in `../ir-to-client-js/emit-registration.ts`.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function compileClient(source: string, fileName: string): string {
+  const result = compileJSX(source, fileName, { adapter })
+  expect(result.errors).toHaveLength(0)
+  const clientJs = result.files.find((f) => f.type === 'clientJs')
+  return clientJs?.content ?? ''
+}
+
+describe('#2654 — env-signal getter self-declared in the template lambda', () => {
+  test('default getter name (`searchParams`): template lambda declares its own copy', () => {
+    const source = `
+      import { createSearchParams } from '@barefootjs/client'
+      export function SortLabel() {
+        const [searchParams] = createSearchParams()
+        return <p>{searchParams().get('sort') ?? 'none'}</p>
+      }
+    `
+    const clientJs = compileClient(source, 'SortLabel.tsx')
+
+    // The template lambda gets a block body with its own prelude
+    // declaration ahead of the returned template literal.
+    expect(clientJs).toMatch(
+      /template:\s*\(_p\)\s*=>\s*\{\s*const \[searchParams\] = createSearchParams\(\);\s*return\s*`/,
+    )
+    // The getter call inside the template body is untouched (still a
+    // real call — csr-substitute.ts deliberately leaves env-signal
+    // getters as live calls, not baked initial values).
+    expect(clientJs).toMatch(/\$\{escapeText\(searchParams\(\)\.get\('sort'\) \?\? 'none'\)\}/)
+    // `init` keeps its own independent destructure — unaffected by the
+    // template-lambda prelude.
+    expect(clientJs).toMatch(/export function initSortLabel[\s\S]*const \[searchParams\] = createSearchParams\(\)/)
+  })
+
+  test('aliased getter name (`sp`): prelude uses the destructured alias, not the canonical name', () => {
+    const source = `
+      'use client'
+      import { createMemo, createSearchParams } from '@barefootjs/client'
+      export function SortStatus() {
+        const [sp] = createSearchParams()
+        const sort = createMemo(() => sp().get('sort') ?? 'date')
+        return <p>sort: {sort()}</p>
+      }
+    `
+    const clientJs = compileClient(source, 'SortStatus.tsx')
+
+    expect(clientJs).toMatch(
+      /template:\s*\(_p\)\s*=>\s*\{\s*const \[sp\] = createSearchParams\(\);\s*return\s*`/,
+    )
+    // The memo body substitution inlines the memo's computation, still
+    // calling the self-declared `sp()` getter — no bare, undeclared
+    // reference reaches the module-scope lambda.
+    expect(clientJs).toMatch(/sp\(\)\.get\('sort'\) \?\? 'date'/)
+  })
+
+  test('component with no env signal keeps the plain expression-body template (no prelude leak)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Counter() {
+        const [count] = createSignal(0)
+        return <p>{count()}</p>
+      }
+    `
+    const clientJs = compileClient(source, 'Counter.tsx')
+
+    // Plain expression-body form — unconditional prelude emission must
+    // not leak into components that hold no env signal.
+    expect(clientJs).toMatch(/template:\s*\(_p\)\s*=>\s*`/)
+    expect(clientJs).not.toMatch(/template:\s*\(_p\)\s*=>\s*\{/)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/csr-substitute.ts
+++ b/packages/jsx/src/ir-to-client-js/csr-substitute.ts
@@ -452,8 +452,9 @@ export function buildSignalMemoEnv(
   for (const s of signals) {
     // Env signals (#2057) have no static initial value to bake — their getter
     // is a live request-scoped read (`searchParams().get(k)`). Leave it in the
-    // CSR template as a real call, exactly as the pre-#2057 bare `searchParams()`
-    // import was (it was never a substitutable signal).
+    // CSR template as a real call; `emitRegistrationAndHydration`'s
+    // `buildTemplateDefPart` (#2654) gives the template lambda its own
+    // `const [<getter>] = <envFactory>()` prelude so the call resolves.
     if (s.envReader) continue
     substitutions.set(s.getter, {
       kind: 'call',

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -4,7 +4,7 @@
  * and the final hydrate() call emission.
  */
 
-import type { ComponentIR, IRFragment, IRNode, ReferencesGraph } from '../types.ts'
+import type { ComponentIR, IRFragment, IRNode, ReferencesGraph, SignalInfo } from '../types.ts'
 import type { ClientJsContext } from './types.ts'
 import { PROPS_PARAM } from './utils.ts'
 import { computeInlinability, toLegacyInlinability } from './compute-inlinability.ts'
@@ -115,6 +115,54 @@ export function csrInlinableConstantsFromCtx(ctx: ClientJsContext): Map<string, 
   return out
 }
 
+/**
+ * Build the `template:` ComponentDef entry text for a generated
+ * `templateHtml` string.
+ *
+ * When the component holds one or more env signals (`createSearchParams()`,
+ * #2057), the template lambda destructures its own copy of each getter in
+ * a block-body prelude before returning the template literal:
+ *
+ *     template: (_p) => { const [sp] = createSearchParams(); return `...` }
+ *
+ * instead of the plain expression-body form:
+ *
+ *     template: (_p) => `...`
+ *
+ * The template lambda runs at module scope (`render()` / `renderChild()`),
+ * but an env-signal getter is otherwise only ever destructured inside
+ * `init...` — so a template that calls the getter directly (`sp()`,
+ * `searchParams()`) ReferenceErrors the moment it runs (#2654). Before
+ * #2057, `searchParams` was a bare module-scope import and the same
+ * template-body call worked by accident; #2057 moved it behind
+ * `const [sp] = createSearchParams()` without updating template emission.
+ *
+ * The prelude is emitted whenever the component HAS an env signal —
+ * never gated on whether `templateHtml` textually mentions the getter.
+ * Scanning already-emitted template HTML for a getter name would be a
+ * string/regex parse of emitted JS, which CLAUDE.md's parse rule forbids.
+ * Unconditional emission is safe because `createSearchParams()`
+ * (`packages/client/src/reactive.ts`) only returns the shared
+ * `searchParamsTuple` module singleton — no side effect — so declaring it
+ * in a prelude the template body doesn't end up using costs nothing.
+ *
+ * `envFactory` is expected to always be set alongside `envReader` (the
+ * analyzer sets both together, #2057) — the `undefined` branch is a
+ * defensive fallback: if it's ever missing, skip that signal's prelude
+ * line entirely rather than guessing a canonical factory name, leaving
+ * that one signal's template reference exactly as unsound as before this
+ * fix (never worse).
+ */
+function buildTemplateDefPart(ctx: ClientJsContext, templateHtml: string): string {
+  const envDecls = ctx.signals
+    .filter((s): s is SignalInfo & { envFactory: string } => Boolean(s.envReader) && Boolean(s.envFactory))
+    .map((s) => `const [${s.getter}] = ${s.envFactory}()`)
+  if (envDecls.length === 0) {
+    return `template: (${PROPS_PARAM}) => \`${templateHtml}\``
+  }
+  return `template: (${PROPS_PARAM}) => { ${envDecls.join('; ')}; return \`${templateHtml}\` }`
+}
+
 /** Emit hydrate() call that registers component, template, and hydrates. */
 /**
  * Generate the closing brace for the init function and the hydrate() call.
@@ -157,7 +205,7 @@ export function emitRegistrationAndHydration(
   if (canGenerateStaticTemplate(_ir.root, propNamesForStaticCheck, inlinableConstants, unsafeLocalNames)) {
     const templateHtml = irToComponentTemplate(_ir.root, inlinableConstants, restSpreadNames, ctx.propsObjectName)
     if (templateHtml) {
-      defParts.push(`template: (${PROPS_PARAM}) => \`${templateHtml}\``)
+      defParts.push(buildTemplateDefPart(ctx, templateHtml))
     }
   } else {
     // CSR fallback: emit for all components that can't generate static templates.
@@ -173,7 +221,7 @@ export function emitRegistrationAndHydration(
       _ir.root, csrInlinableConstants, ctx, restSpreadNames, ctx.propsObjectName, unsafeLocalNames, ctx.deferredChildSlots
     )
     if (templateHtml) {
-      defParts.push(`template: (${PROPS_PARAM}) => \`${templateHtml}\``)
+      defParts.push(buildTemplateDefPart(ctx, templateHtml))
     }
   }
   // No else: top-level-only components skip template entirely (save bytes)


### PR DESCRIPTION
## Summary

Stack 3/3 (base: #2659). Fixes #2654: a component using an env signal emitted a `template:` lambda that referenced the getter (`sp` / `searchParams`) at module scope, where it is only ever destructured inside `init…` — a guaranteed `ReferenceError` the moment the template-eval path runs (CSR mount, `renderChild`).

The history explains the shape: before #2057, `searchParams` was a bare module-scope import in emitted client JS and the same template-body call worked by accident. #2057 moved the getter behind `const [sp] = createSearchParams()` in init without updating template emission — and the harness's own bare `searchParams` stub (removed in stack 1/3) kept the bug invisible for every fixture that used the default getter name.

## The fix

`emit-registration.ts` now builds the `template:` def entry through one helper shared by both template branches (static `irToComponentTemplate` and CSR-fallback `generateCsrTemplate`, so the two can't drift). When the component holds env signals, the lambda gets a block body that destructures its own copy of each getter before returning the template literal:

```js
template: (_p) => { const [sp] = createSearchParams(); return `…${escapeText((sp().get('sort') ?? 'date'))}…` }
```

Emission is keyed on the component's signal metadata (`envReader` / `envFactory` — the factory name follows aliased imports, same as init emission). It is deliberately **not** gated on whether the template text mentions the getter: scanning emitted JS for an identifier is the string-parse CLAUDE.md forbids, and an unused prelude is free — `createSearchParams()` only returns the shared module singleton (`reactive.ts`'s `searchParamsTuple`), no side effects.

## Graduations (both mechanically enforced)

- `client-js-scope.test.ts`'s `KNOWN_UNDECLARED`: all four #2654 pins deleted — the gate fails on stale pins once a fix lands.
- `CSR_SKIP_FIXTURES`: all four `search-params*` entries deleted — stack 2/3's rot test fails on skips whose fixture now passes.

The four fixtures now pass CSR conformance (304 passing, up from 300) and the scope gate, serving as the fix's regression tests. New compiler unit test `env-signal-template-prelude.test.ts` pins the prelude for the default and aliased getter names, and that non-env components keep the plain expression-body lambda.

## Verification

- `@barefootjs/jsx` build (typecheck): green.
- Focused suites on the final tree: `csr-skip-rot` + `csr-conformance` + `client-js-scope` + the new unit test — 662 tests, 0 fail.
- `bun test packages/jsx`: green except 5 pre-existing checker-path failures (`@barefootjs/client` dist not resolvable in this environment; identical before/after via `git stash` comparison). `bun test packages/adapter-tests`: green except the same pre-existing 9 `carousel-cross-adapter` environment failures.
- Changeset: `@barefootjs/jsx` patch.

Closes #2654.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_