### PR TITLE
fix(jsx,client): MathML-rooted mapArray and branch bodies clone in the MathML namespace

### DIFF
--- a/.changeset/mathml-maparray-namespace.md
+++ b/.changeset/mathml-maparray-namespace.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/client": patch
+---
+
+MathML-rooted `mapArray` / conditional-branch bodies now clone in the MathML namespace, porting the existing SVG synthetic-wrap fix (`<math>...</math>` instead of `<svg>...</svg>`) to MathML root tags (`mrow`, `mfrac`, `msup`, `msub`, `mn`, `mi`, `mtable`, ...). Previously a `.map()` or ternary body rooted at a MathML tag cloned as an `HTMLUnknownElement` in the xhtml namespace and rendered nothing. The runtime's `parseHTML` gained the matching MathML wrap for dynamically-inserted markup whose parent lives in the MathML namespace.

--- a/packages/client/__tests__/runtime/mathml-parseHTML-namespace.test.ts
+++ b/packages/client/__tests__/runtime/mathml-parseHTML-namespace.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Runtime unit test for `parseHTML`'s MathML wrap (#1096 — port of #135's
+ * SVG wrap).
+ *
+ * `template.innerHTML = '<mrow/>'` parses in the HTML namespace, cloning
+ * as an `HTMLUnknownElement` (xhtml namespace) rather than a
+ * `MathMLElement` — the same HTML5-parser foreign-content quirk the SVG
+ * wrap (`parent.namespaceURI === SVG_NS`) already handles in
+ * `src/runtime/component.ts`.
+ *
+ * KNOWN ENVIRONMENT GAP: happy-dom's HTML parser (`HTMLParser.js`,
+ * `getStartTagElement`) only special-cases the `svg` tag name / inherited
+ * SVG namespace to enter foreign content — there is no equivalent `math`
+ * branch, confirmed by reading the parser source (v20.11.2). So even with
+ * the correct wrap, `template.innerHTML = '<math>...</math>'` still comes
+ * back as a plain `HTMLUnknownElement` tree under happy-dom (verified with
+ * a standalone sanity check before writing this test) — real browsers
+ * implement the MathML insertion mode per the HTML5 parsing spec (the same
+ * mechanism that makes the SVG case work here), happy-dom does not. So the
+ * SVG sibling test below asserts the RESULTING namespaceURI (happy-dom
+ * supports that), while the MathML tests here assert the WRAP DECISION
+ * itself — that `parseHTML` sets `<math>...</math>` as the parsed markup
+ * when `parent` lives in the MathML namespace — by capturing the
+ * `<template>`'s `innerHTML` assignment. That is the exact statement the
+ * production code executes; only the parser's downstream interpretation of
+ * it is where happy-dom's fidelity gap lives.
+ */
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+const MATHML_NS = 'http://www.w3.org/1998/Math/MathML'
+
+/**
+ * Spy on `document.createElement('template')` for the duration of `fn`,
+ * capturing every string assigned to the returned template's `innerHTML`.
+ * Restores the original `createElement` afterwards regardless of outcome.
+ */
+function captureTemplateInnerHTML(fn: () => void): string[] {
+  const captured: string[] = []
+  const original = document.createElement.bind(document)
+  // @ts-expect-error -- test-only monkeypatch, restored in `finally`.
+  document.createElement = (tagName: string, options?: unknown) => {
+    const el = original(tagName, options as ElementCreationOptions)
+    if (tagName === 'template') {
+      const proto = Object.getPrototypeOf(el)
+      const descriptor = Object.getOwnPropertyDescriptor(proto, 'innerHTML')
+        ?? Object.getOwnPropertyDescriptor(HTMLTemplateElement.prototype, 'innerHTML')
+      if (descriptor?.set && descriptor?.get) {
+        Object.defineProperty(el, 'innerHTML', {
+          configurable: true,
+          get: () => descriptor.get!.call(el),
+          set: (value: string) => {
+            captured.push(value)
+            descriptor.set!.call(el, value)
+          },
+        })
+      }
+    }
+    return el
+  }
+  try {
+    fn()
+  } finally {
+    document.createElement = original
+  }
+  return captured
+}
+
+describe('#1096 — parseHTML MathML namespace wrap', () => {
+  test('a MathML parent wraps the parsed markup in <math>...</math>', async () => {
+    const { parseHTML } = await import('../../src/runtime/component')
+    const mathParent = document.createElementNS(MATHML_NS, 'math')
+
+    const captured = captureTemplateInnerHTML(() => {
+      parseHTML('<mrow><mn>1</mn></mrow>', mathParent)
+    })
+
+    expect(captured).toHaveLength(1)
+    expect(captured[0]).toBe('<math><mrow><mn>1</mn></mrow></math>')
+  })
+
+  test('an HTML parent (or no parent) keeps the bare parse — no <math> wrap', async () => {
+    const { parseHTML } = await import('../../src/runtime/component')
+    const htmlParent = document.createElement('div')
+
+    const captured = captureTemplateInnerHTML(() => {
+      parseHTML('<mrow><mn>1</mn></mrow>', htmlParent)
+    })
+
+    expect(captured).toHaveLength(1)
+    expect(captured[0]).toBe('<mrow><mn>1</mn></mrow>')
+  })
+
+  test('an SVG parent parses markup in the SVG namespace (happy-dom supports this natively)', async () => {
+    const { parseHTML } = await import('../../src/runtime/component')
+    const svgParent = document.createElementNS(SVG_NS, 'svg')
+    const frag = parseHTML('<circle r="5" />', svgParent)
+    const circle = frag.firstElementChild
+    expect(circle).not.toBeNull()
+    expect(circle!.namespaceURI).toBe(SVG_NS)
+  })
+})

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -638,26 +638,37 @@ export function escapeTextOrNode(value: unknown): string | Node {
 }
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
+const MATHML_NS = 'http://www.w3.org/1998/Math/MathML'
+
+/** Synthetic wrap tag for a parent's namespace, or null when it's plain HTML. */
+function namespaceWrapTagFor(parent: Element | null | undefined): 'svg' | 'math' | null {
+  if (!parent) return null
+  if (parent.namespaceURI === SVG_NS) return 'svg'
+  if (parent.namespaceURI === MATHML_NS) return 'math'
+  return null
+}
 
 /**
  * Parse an HTML string into a DocumentFragment, safely escaping ">" in
  * attribute values. All code that sets innerHTML on dynamic HTML should
  * use this instead of raw innerHTML assignment.
  *
- * When `parent` is provided and lives in the SVG namespace, the markup
- * is parsed under SVG foreign-content context by wrapping it in
- * `<svg>...</svg>`; the wrapper's children are moved into the returned
- * fragment so callers see the same shape as the HTML path. Without
- * this, dynamically-inserted SVG elements (e.g., a `<path>` in a
- * conditional drag preview) end up as `HTMLUnknownElement` in the
- * xhtml namespace and the SVG renderer ignores them. Surfaced by the
- * Graph/DAG Editor block (#135).
+ * When `parent` is provided and lives in the SVG or MathML namespace, the
+ * markup is parsed under the matching foreign-content context by wrapping
+ * it in `<svg>...</svg>` / `<math>...</math>`; the wrapper's children are
+ * moved into the returned fragment so callers see the same shape as the
+ * HTML path. Without this, dynamically-inserted SVG/MathML elements (e.g.,
+ * a `<path>` in a conditional drag preview, or an `<mrow>` in a dynamic
+ * equation) end up as `HTMLUnknownElement` in the xhtml namespace and the
+ * SVG/MathML renderer ignores them. Surfaced by the Graph/DAG Editor block
+ * (#135); ported to MathML in #1096.
  */
 export function parseHTML(html: string, parent?: Element | null): DocumentFragment {
   const tpl = document.createElement('template')
   const escaped = escapeAttrGt(html)
-  if (parent && parent.namespaceURI === SVG_NS) {
-    tpl.innerHTML = `<svg>${escaped}</svg>`
+  const wrapTag = namespaceWrapTagFor(parent)
+  if (wrapTag) {
+    tpl.innerHTML = `<${wrapTag}>${escaped}</${wrapTag}>`
     const wrapper = tpl.content.firstElementChild
     const frag = document.createDocumentFragment()
     if (wrapper) {

--- a/packages/jsx/src/__tests__/inner-loop-mathml-namespace.test.ts
+++ b/packages/jsx/src/__tests__/inner-loop-mathml-namespace.test.ts
@@ -1,0 +1,135 @@
+/**
+ * MathML-rooted loop item templates cloned via `template.innerHTML` (#1096).
+ *
+ * MathML port of `inner-loop-svg-namespace.test.ts` (#2219, #135/#1088).
+ * `template.innerHTML` parses in the HTML namespace, so an inner reactive
+ * loop whose item root is a MathML element (`<mrow>`, `<mfrac>`, ...)
+ * clones as an `HTMLUnknownElement` — present in the DOM but never drawn
+ * by the MathML renderer, with no error. This mirrors the SVG fix: parse
+ * `<math>${template}</math>` and descend one extra level
+ * (`.firstElementChild.firstElementChild`). HTML-rooted templates keep
+ * byte-identical output.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsFor(source: string): string {
+  const result = compileJSX(source, 'Repro.tsx', { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('inner reactive loop with a MathML element root (#1096)', () => {
+  test('MathML-rooted inner item clones inside a synthetic <math> wrap', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Sheet { id: number; terms: number[] }
+      export function Repro() {
+        const [sheets] = createSignal<Sheet[]>([])
+        return (
+          <div>
+            {sheets().map((s) => (
+              <math key={s.id}>
+                {s.terms.map((n) => (
+                  <mn key={n}>{String(n)}</mn>
+                ))}
+              </math>
+            ))}
+          </div>
+        )
+      }
+    `)
+
+    // The inner renderItem clone parses inside `<math>...</math>` and
+    // descends one extra level to reach the real `<mn>` root.
+    expect(content).toMatch(/__t\.innerHTML = `<math><mn /)
+    expect(content).toContain('return __t.content.firstElementChild.firstElementChild.cloneNode(true)')
+  })
+
+  test('conditional inner body whose branches are all MathML wraps too (#1088 shape)', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Sheet { id: number; terms: number[] }
+      export function Repro() {
+        const [sheets] = createSignal<Sheet[]>([])
+        return (
+          <div>
+            {sheets().map((s) => (
+              <math key={s.id}>
+                {s.terms.map((n) => (
+                  n > 50
+                    ? <mn key={n}>{String(n)}</mn>
+                    : <mi key={n}>x</mi>
+                ))}
+              </math>
+            ))}
+          </div>
+        )
+      }
+    `)
+
+    expect(content).toMatch(/__t\.innerHTML = `<math>\$\{/)
+    expect(content).toContain('return __t.content.firstElementChild.firstElementChild.cloneNode(true)')
+  })
+})
+
+describe('reactive multi-root fragment with a <math>-container first root (#2233-shape review)', () => {
+  test('emitMultiRootTemplateCloneLines skips the wrap for <math>-first fragments', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Eq { id: number; n: number }
+      export function Repro() {
+        const [eqs] = createSignal<Eq[]>([])
+        return (
+          <div>
+            {eqs().map((e) => (
+              <>
+                <math key={e.id}><mn>{String(e.n)}</mn></math>
+                <span>{e.id}</span>
+              </>
+            ))}
+          </div>
+        )
+      }
+    `)
+
+    // The multi-root clone parses the fragment bare — no synthetic wrap —
+    // so the HTML <span> sibling stays in the HTML namespace.
+    expect(content).not.toContain('`<math><math')
+    expect(content).toContain('__tpl.content.firstElementChild.cloneNode(true)')
+  })
+})
+
+describe('static-loop CSR materialize with a MathML element root (#1096, #1247 path)', () => {
+  test('MathML-rooted materialize clone wraps and descends the extra level', () => {
+    const content = clientJsFor(`
+      'use client'
+      type Props = { terms: Record<string, number> }
+      export function Repro(props: Props) {
+        const entries = Object.entries(props.terms ?? {}).filter(([, n]) => n > 0)
+        return (
+          <math>
+            {entries.map(([id, n]) => (
+              <mn key={id}>{String(n)}</mn>
+            ))}
+          </math>
+        )
+      }
+    `)
+
+    // Materialize branch present (unsafe prop-derived array, #1247) ...
+    expect(content).toMatch(/if \(!__iterEl\)/)
+    // ... and its template parse is namespace-aware.
+    expect(content).toMatch(/__tpl\.innerHTML = `<math><mn /)
+    expect(content).toContain('const __cloned = __tpl.content.firstElementChild.firstElementChild')
+  })
+})

--- a/packages/jsx/src/__tests__/mathml-mapArray-namespace.test.ts
+++ b/packages/jsx/src/__tests__/mathml-mapArray-namespace.test.ts
@@ -1,0 +1,230 @@
+/**
+ * BarefootJS Compiler - MathML mapArray namespace preservation (#1096).
+ *
+ * MathML port of `svg-mapArray-namespace.test.ts` (#135/#1088). When a
+ * `.map()` inside a `<math>` produces MathML elements (e.g. `<mrow>`,
+ * `<mfrac>`), the compiler-generated `renderItem` must parse its template
+ * under MathML context. The default `template.innerHTML = '<mrow/>'`
+ * produces an `HTMLUnknownElement` in xhtml namespace, so the MathML
+ * renderer ignores it — same parser quirk as the SVG case, just a smaller
+ * element vocabulary.
+ *
+ * Fix: wrap the `innerHTML` in `<math>...</math>` and descend one extra
+ * level when the loop body's root tag is a MathML element. This shares
+ * every byte of the wrap machinery with the SVG fix through
+ * `detectRootNamespaceWrapTag` / `namespaceWrapForTemplate` in
+ * `stringify/template-parse.ts` — only the wrap tag name differs.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('MathML mapArray namespace preservation (#1096)', () => {
+  test('MathML mrow/mfrac mapArray wraps innerHTML with <math> for correct namespace (issue repro shape)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      interface Term { key: string; n: string; d: string }
+
+      export function Equation() {
+        const [terms] = createSignal<Term[]>([])
+        return (
+          <math>
+            {terms().map((t) => (
+              <mrow key={t.key}>
+                <mfrac>
+                  <mn>{t.n}</mn>
+                  <mn>{t.d}</mn>
+                </mfrac>
+              </mrow>
+            ))}
+          </math>
+        )
+      }
+    `
+    const result = compileJSX(source, 'Equation.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    const content = clientJs!.content
+
+    // Must wrap with <math>...</math> for foreign-content parsing
+    expect(content).toContain('<math>')
+    expect(content).toContain('</math>')
+    // Descend one extra level
+    expect(content).toContain('.firstElementChild.firstElementChild.cloneNode(true)')
+    // The plain HTML clone path must NOT be used for MathML roots
+    expect(content).not.toMatch(/__tpl\.innerHTML = `<mrow[^`]*`/)
+  })
+
+  test('HTML li mapArray is unchanged (no MathML wrapping)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      interface Item { id: string; label: string }
+
+      export function L() {
+        const [items, setItems] = createSignal<Item[]>([])
+        return (
+          <ul>
+            {items().map((it) => (
+              <li key={it.id}>{it.label}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSX(source, 'L.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    const content = clientJs!.content
+
+    expect(content).toContain('.firstElementChild.cloneNode(true)')
+    expect(content).not.toContain('.firstElementChild.firstElementChild.cloneNode(true)')
+    expect(content).not.toContain('<math>')
+  })
+
+  /**
+   * #1088-shape port: when a `.map()` body is a ternary whose branches are
+   * all MathML tags, the wrap heuristic must still apply.
+   */
+  test('MathML ternary body wraps when both branches are MathML-rooted', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Term = { key: string; kind: 'frac' | 'sup'; value: string }
+
+      export function CondMap() {
+        const [terms] = createSignal<Term[]>([])
+        return (
+          <math>
+            {terms().map((t) =>
+              t.kind === 'frac'
+                ? <mfrac key={t.key}><mn>1</mn><mn>{t.value}</mn></mfrac>
+                : <msup key={t.key}><mn>{t.value}</mn><mn>2</mn></msup>
+            )}
+          </math>
+        )
+      }
+    `
+    const result = compileJSX(source, 'CondMap.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    const content = clientJs!.content
+
+    // Wrap with <math>...</math> for foreign-content parsing
+    expect(content).toMatch(/__tpl\.innerHTML = `<math>\$\{/)
+    expect(content).toMatch(/\}<\/math>`/)
+    // Descend one extra level
+    expect(content).toContain('.firstElementChild.firstElementChild.cloneNode(true)')
+  })
+
+  test('MathML 3-way ternary wraps recursively', () => {
+    // Mirrors the SVG "PolarGrid" 3-way-ternary regression pin: the
+    // compiler nests the inner conditional inside
+    // `<!--bf-cond-start:sX-->` markers, so the wrap heuristic must skip
+    // those and recurse into the inner `${...}`.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Term = { key: string; kind: 'frac' | 'sup' | 'sub' }
+
+      export function TermList() {
+        const [terms] = createSignal<Term[]>([])
+        return (
+          <math>
+            {terms().map((t) =>
+              t.kind === 'frac'
+                ? <mfrac key={t.key}><mn>1</mn><mn>2</mn></mfrac>
+                : t.kind === 'sup'
+                  ? <msup key={t.key}><mn>1</mn><mn>2</mn></msup>
+                  : <msub key={t.key}><mn>1</mn><mn>2</mn></msub>
+            )}
+          </math>
+        )
+      }
+    `
+    const result = compileJSX(source, 'TermList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    const content = clientJs!.content
+
+    expect(content).toMatch(/__tpl\.innerHTML = `<math>\$\{/)
+    expect(content).toContain('.firstElementChild.firstElementChild.cloneNode(true)')
+  })
+
+  test('mixed HTML/MathML ternary body falls through to no-wrap', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Item = { key: string; useMath: boolean }
+
+      export function Mixed() {
+        const [items] = createSignal<Item[]>([])
+        return (
+          <div>
+            {items().map((i) =>
+              i.useMath
+                ? <mn key={i.key}>1</mn>
+                : <span key={i.key}>x</span>
+            )}
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'Mixed.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    const content = clientJs!.content
+
+    expect(content).toContain('.firstElementChild.cloneNode(true)')
+    expect(content).not.toContain('.firstElementChild.firstElementChild.cloneNode(true)')
+  })
+
+  test('mixed SVG/MathML ternary body falls through to no-wrap', () => {
+    // Neither namespace should silently win: an SVG branch and a MathML
+    // branch in the same ternary is out of scope for the wrap heuristic,
+    // same as the pre-existing mixed HTML/SVG case.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Item = { key: string; useSvg: boolean }
+
+      export function MixedNs() {
+        const [items] = createSignal<Item[]>([])
+        return (
+          <div>
+            {items().map((i) =>
+              i.useSvg
+                ? <circle key={i.key} cx="0" cy="0" r="5" />
+                : <mn key={i.key}>1</mn>
+            )}
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'MixedNs.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    const content = clientJs!.content
+
+    expect(content).toContain('.firstElementChild.cloneNode(true)')
+    expect(content).not.toContain('.firstElementChild.firstElementChild.cloneNode(true)')
+    expect(content).not.toContain('<svg>')
+    expect(content).not.toContain('<math>')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -7,7 +7,7 @@ import type { ClientJsContext, ConditionalBranchChildComponent, ConditionalBranc
 import { attrValueToString, freeIdsFromRefs, quotePropName, PROPS_PARAM } from './utils.ts'
 import { classifyReactivity, decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts, collectLoopChildRefs, emptyLoopChildBindings, buildLoopRowScope, anyNameIn } from './reactivity.ts'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr, buildLoopSkeletonTemplate, computeSkeletonSlotPaths, renderFlatMapClientBody, renderFlatMapProjectionClientBody, flatMapCallbackHasKeyedLeaf, type SkeletonSlotPaths } from './html-template.ts'
-import { templateRootIsSvg } from './control-flow/stringify/template-parse.ts'
+import { detectRootNamespaceWrapTag } from './control-flow/stringify/template-parse.ts'
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling.ts'
 import { extractFreeIdentifiersFromText } from './csr-substitute.ts'
 import { walkIR, stopAt } from './walker.ts'
@@ -761,10 +761,11 @@ export function collectElements(
           }
           skeletonTemplate = buildLoopSkeletonTemplate(l.children[0], skeletonSafeSlots) ?? undefined
           // Direct child-index paths (perf, #2143): only attempted when the
-          // skeleton itself hoisted, and skipped for SVG roots for now (the
-          // `<svg>`-wrap namespace fix-up is orthogonal and untested against
-          // this path model — safe fallback to qsa/$t for those loops).
-          if (skeletonTemplate && !templateRootIsSvg(skeletonTemplate)) {
+          // skeleton itself hoisted, and skipped for SVG/MathML roots for
+          // now (the `<svg>`/`<math>`-wrap namespace fix-up is orthogonal
+          // and untested against this path model — safe fallback to
+          // qsa/$t for those loops).
+          if (skeletonTemplate && !detectRootNamespaceWrapTag(skeletonTemplate)) {
             skeletonPaths = computeSkeletonSlotPaths(l.children[0], skeletonSafeSlots) ?? undefined
           }
         }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
@@ -33,7 +33,7 @@
 import { keyAttrName, profileBindingId, varSlotId } from '../../utils.ts'
 import { emitComponentAndEventSetup } from '../shared.ts'
 import { emitAttrUpdate } from '../../emit-reactive.ts'
-import { emitMultiRootTemplateCloneLines, templateRootIsSvg } from './template-parse.ts'
+import { emitMultiRootTemplateCloneLines, namespaceWrapForTemplate } from './template-parse.ts'
 import { emitLoopChildRefs } from './loop.ts'
 import { claimPlanLiteral, claimWriterVarName, type ClaimSlotSpec } from './claim-plan.ts'
 import type {
@@ -83,15 +83,15 @@ function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string, pc:
     lines.push(`${innerIndent}  __innerEl${uid}.__bfExtras = __innerExtras${uid}`)
     lines.push(`${indent}  }`)
   } else {
-    // SVG-rooted item templates must parse inside a synthetic `<svg>` wrap
-    // (#2219): `template.innerHTML` parses in the HTML namespace, so a bare
-    // `<line>`/`<circle>` root clones as an HTMLUnknownElement and the SVG
-    // renderer silently draws nothing. Mirrors `templateRootIsSvg` handling
-    // on the top-level (#135/#1088) and branch-arm paths; HTML-rooted
-    // templates keep byte-identical output.
-    const isSvg = templateRootIsSvg(emit.wrappedTemplate)
-    const innerHtml = isSvg ? `<svg>${emit.wrappedTemplate}</svg>` : emit.wrappedTemplate
-    const childPath = isSvg ? '.firstElementChild.firstElementChild' : '.firstElementChild'
+    // SVG/MathML-rooted item templates must parse inside a synthetic
+    // namespace wrap (#2219, #1096): `template.innerHTML` parses in the
+    // HTML namespace, so a bare `<line>`/`<circle>`/`<mrow>` root clones as
+    // an HTMLUnknownElement and the SVG/MathML renderer silently draws
+    // nothing. Mirrors `namespaceWrapForTemplate` handling on the top-level
+    // (#135/#1088) and branch-arm paths; HTML-rooted templates keep
+    // byte-identical output.
+    const { wrapTag, childPath } = namespaceWrapForTemplate(emit.wrappedTemplate)
+    const innerHtml = wrapTag ? `<${wrapTag}>${emit.wrappedTemplate}</${wrapTag}>` : emit.wrappedTemplate
     lines.push(`${indent}  let __innerEl${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${innerHtml}\`; return __t.content${childPath}.cloneNode(true) })()`)
   }
   if (emit.wrappedKey) {

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop-child-arm.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop-child-arm.ts
@@ -14,7 +14,7 @@
 import { varSlotId, DATA_BF_PH, keyAttrName, profileBindingId } from '../../utils.ts'
 import { emitComponentAndEventSetup } from '../shared.ts'
 import { emitAttrUpdate } from '../../emit-reactive.ts'
-import { templateRootIsSvg } from './template-parse.ts'
+import { namespaceWrapForTemplate } from './template-parse.ts'
 import { emitListenerLine } from './event-listener.ts'
 import { nameForRegistryRef } from '../../component-scope.ts'
 import { claimPlanLiteral, claimWriterVarName, type ClaimSlotSpec } from './claim-plan.ts'
@@ -139,9 +139,8 @@ export function stringifyBranchInnerLoops(
       lines.push(`${indent}  ${inner.paramUnwrap}`)
     }
     {
-      const isSvg = templateRootIsSvg(inner.wrappedTemplate)
-      const innerHtml = isSvg ? `<svg>${inner.wrappedTemplate}</svg>` : inner.wrappedTemplate
-      const childPath = isSvg ? '.firstElementChild.firstElementChild' : '.firstElementChild'
+      const { wrapTag, childPath } = namespaceWrapForTemplate(inner.wrappedTemplate)
+      const innerHtml = wrapTag ? `<${wrapTag}>${inner.wrappedTemplate}</${wrapTag}>` : inner.wrappedTemplate
       lines.push(`${indent}  let __bel${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${innerHtml}\`; return __t.content${childPath}.cloneNode(true) })()`)
     }
     if (inner.wrappedKey) {

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -32,7 +32,7 @@
 import { emitRefCall, varSlotId, profileBindingId } from '../../utils.ts'
 import { emitAttrUpdate } from '../../emit-reactive.ts'
 import { stringifyReactiveEffects } from './reactive-effects.ts'
-import { emitTemplateCloneInline, emitLoopItemElementSetup, emitHoistedTemplateDecl, hoistedCloneExpr, templateRootIsSvg, multiRootTemplateNeedsSvgWrap } from './template-parse.ts'
+import { emitTemplateCloneInline, emitLoopItemElementSetup, emitHoistedTemplateDecl, hoistedCloneExpr, detectRootNamespaceWrapTag, multiRootTemplateNeedsNamespaceWrap } from './template-parse.ts'
 import { buildSkeletonPathPlan, type SkeletonPathPlan } from './skeleton-paths.ts'
 import { stringifyComponentLoop } from './component-loop.ts'
 import { stringifyCompositeLoop } from './composite-loop.ts'
@@ -401,17 +401,19 @@ export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void
   lines.push(`      let __iterEl = ${containerVar}.children[${childIndexExpr}]`)
   if (csrMaterialize) {
     lines.push(`      if (!__iterEl) {`)
-    // SVG-rooted item templates parse inside a synthetic `<svg>` wrap and
-    // descend one extra level (#2219) — `template.innerHTML` alone parses in
-    // the HTML namespace and the materialized elements would never draw.
-    // Mirrors `templateRootIsSvg` handling on the reactive clone paths;
-    // HTML-rooted templates keep byte-identical output. Multi-root fragments
-    // use the fragment-aware predicate so an `<svg>`-container-first fragment
-    // isn't over-wrapped (#2233 Copilot review).
-    const isSvg = csrMaterialize.bodyIsMultiRoot
-      ? multiRootTemplateNeedsSvgWrap(csrMaterialize.itemTemplate)
-      : templateRootIsSvg(csrMaterialize.itemTemplate)
-    const itemHtml = isSvg ? `<svg>${csrMaterialize.itemTemplate}</svg>` : csrMaterialize.itemTemplate
+    // SVG/MathML-rooted item templates parse inside a synthetic namespace
+    // wrap and descend one extra level (#2219, #1096) — `template.innerHTML`
+    // alone parses in the HTML namespace and the materialized elements
+    // would never draw. Mirrors `detectRootNamespaceWrapTag` handling on
+    // the reactive clone paths; HTML-rooted templates keep byte-identical
+    // output. Multi-root fragments use the fragment-aware predicate so a
+    // `<svg>`/`<math>`-container-first fragment isn't over-wrapped (#2233
+    // Copilot review).
+    const wrapTag = csrMaterialize.bodyIsMultiRoot
+      ? multiRootTemplateNeedsNamespaceWrap(csrMaterialize.itemTemplate)
+      : detectRootNamespaceWrapTag(csrMaterialize.itemTemplate)
+    const itemHtml = wrapTag ? `<${wrapTag}>${csrMaterialize.itemTemplate}</${wrapTag}>` : csrMaterialize.itemTemplate
+    const needsNamespaceWrap = wrapTag !== null
     if (csrMaterialize.bodyIsMultiRoot) {
       // Multi-root: clone every top-level sibling of the per-item template and
       // insert them in order. `__iterEl` is the first root (the one reactive
@@ -420,7 +422,7 @@ export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void
       lines.push(`        __mtpl.innerHTML = \`${itemHtml}\``)
       lines.push(`        const __anchor = ${containerVar}.children[${childIndexExpr}] ?? null`)
       lines.push(`        let __first = null`)
-      lines.push(`        let __sib = __mtpl.content${isSvg ? '.firstElementChild' : ''}.firstElementChild`)
+      lines.push(`        let __sib = __mtpl.content${needsNamespaceWrap ? '.firstElementChild' : ''}.firstElementChild`)
       lines.push(`        while (__sib) {`)
       lines.push(`          const __next = __sib.nextElementSibling`)
       lines.push(`          const __cloned = __sib.cloneNode(true)`)
@@ -432,7 +434,7 @@ export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void
     } else {
       lines.push(`        const __tpl = document.createElement('template')`)
       lines.push(`        __tpl.innerHTML = \`${itemHtml}\``)
-      lines.push(`        const __cloned = __tpl.content${isSvg ? '.firstElementChild' : ''}.firstElementChild`)
+      lines.push(`        const __cloned = __tpl.content${needsNamespaceWrap ? '.firstElementChild' : ''}.firstElementChild`)
       lines.push(`        if (__cloned) {`)
       lines.push(`          const __anchor = ${containerVar}.children[${childIndexExpr}] ?? null`)
       lines.push(`          ${containerVar}.insertBefore(__cloned, __anchor)`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -32,7 +32,7 @@
 import { emitRefCall, varSlotId, profileBindingId } from '../../utils.ts'
 import { emitAttrUpdate } from '../../emit-reactive.ts'
 import { stringifyReactiveEffects } from './reactive-effects.ts'
-import { emitTemplateCloneInline, emitLoopItemElementSetup, emitHoistedTemplateDecl, hoistedCloneExpr, detectRootNamespaceWrapTag, multiRootTemplateNeedsNamespaceWrap } from './template-parse.ts'
+import { emitTemplateCloneInline, emitLoopItemElementSetup, emitHoistedTemplateDecl, hoistedCloneExpr, namespaceWrapForTemplate, multiRootNamespaceWrapForTemplate, wrapHtmlForNamespace } from './template-parse.ts'
 import { buildSkeletonPathPlan, type SkeletonPathPlan } from './skeleton-paths.ts'
 import { stringifyComponentLoop } from './component-loop.ts'
 import { stringifyCompositeLoop } from './composite-loop.ts'
@@ -404,16 +404,18 @@ export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void
     // SVG/MathML-rooted item templates parse inside a synthetic namespace
     // wrap and descend one extra level (#2219, #1096) — `template.innerHTML`
     // alone parses in the HTML namespace and the materialized elements
-    // would never draw. Mirrors `detectRootNamespaceWrapTag` handling on
-    // the reactive clone paths; HTML-rooted templates keep byte-identical
+    // would never draw. Reads the wrap decision AND descent path through
+    // the same single door as the reactive clone emitters
+    // (`namespaceWrapForTemplate`, #2662 Copilot review) so a future
+    // namespace or fragment-rule tweak can't update one path and miss the
+    // other; HTML-rooted templates keep byte-identical
     // output. Multi-root fragments use the fragment-aware predicate so a
     // `<svg>`/`<math>`-container-first fragment isn't over-wrapped (#2233
     // Copilot review).
-    const wrapTag = csrMaterialize.bodyIsMultiRoot
-      ? multiRootTemplateNeedsNamespaceWrap(csrMaterialize.itemTemplate)
-      : detectRootNamespaceWrapTag(csrMaterialize.itemTemplate)
-    const itemHtml = wrapTag ? `<${wrapTag}>${csrMaterialize.itemTemplate}</${wrapTag}>` : csrMaterialize.itemTemplate
-    const needsNamespaceWrap = wrapTag !== null
+    const { wrapTag, childPath } = csrMaterialize.bodyIsMultiRoot
+      ? multiRootNamespaceWrapForTemplate(csrMaterialize.itemTemplate)
+      : namespaceWrapForTemplate(csrMaterialize.itemTemplate)
+    const itemHtml = wrapHtmlForNamespace(csrMaterialize.itemTemplate, wrapTag)
     if (csrMaterialize.bodyIsMultiRoot) {
       // Multi-root: clone every top-level sibling of the per-item template and
       // insert them in order. `__iterEl` is the first root (the one reactive
@@ -422,7 +424,7 @@ export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void
       lines.push(`        __mtpl.innerHTML = \`${itemHtml}\``)
       lines.push(`        const __anchor = ${containerVar}.children[${childIndexExpr}] ?? null`)
       lines.push(`        let __first = null`)
-      lines.push(`        let __sib = __mtpl.content${needsNamespaceWrap ? '.firstElementChild' : ''}.firstElementChild`)
+      lines.push(`        let __sib = __mtpl.content${childPath}.firstElementChild`)
       lines.push(`        while (__sib) {`)
       lines.push(`          const __next = __sib.nextElementSibling`)
       lines.push(`          const __cloned = __sib.cloneNode(true)`)
@@ -434,7 +436,7 @@ export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void
     } else {
       lines.push(`        const __tpl = document.createElement('template')`)
       lines.push(`        __tpl.innerHTML = \`${itemHtml}\``)
-      lines.push(`        const __cloned = __tpl.content${needsNamespaceWrap ? '.firstElementChild' : ''}.firstElementChild`)
+      lines.push(`        const __cloned = __tpl.content${childPath}`)
       lines.push(`        if (__cloned) {`)
       lines.push(`          const __anchor = ${containerVar}.children[${childIndexExpr}] ?? null`)
       lines.push(`          ${containerVar}.insertBefore(__cloned, __anchor)`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/template-parse.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/template-parse.ts
@@ -1,7 +1,7 @@
 /**
  * Helpers for emitting code that parses a template literal into a DOM
- * element clone, while preserving the SVG namespace when the loop body
- * root is an SVG element.
+ * element clone, while preserving the SVG/MathML namespace when the loop
+ * body root is a foreign-content element.
  *
  * Background (#135): the standard pattern
  *   `const __tpl = document.createElement('template')`
@@ -14,10 +14,14 @@
  * Editor block when a new edge `<path>` was appended via mapArray and
  * never showed up on the canvas.
  *
- * Fix: when the template's root tag is an SVG element, wrap the parsed
- * markup in a synthetic `<svg>` so the HTML5 parser walks into SVG
- * foreign content and assigns the correct namespace, then descend one
- * extra level to get the real root.
+ * Fix: when the template's root tag is an SVG (or, #1096, MathML) element,
+ * wrap the parsed markup in the matching synthetic namespace root
+ * (`<svg>` / `<math>`) so the HTML5 parser walks into foreign content and
+ * assigns the correct namespace, then descend one extra level to get the
+ * real root. The two namespaces share every byte of this machinery —
+ * only the wrap tag name differs — so `detectRootNamespaceWrapTag` and
+ * `namespaceWrapForTemplate` below are the single door every emitter
+ * (in this file and its consumers) reads the wrap decision through.
  */
 
 import { findInterpolationEnd, findTopLevelTemplateLiterals } from '../../../scanner/js-scanner.ts'
@@ -37,73 +41,140 @@ const SVG_ROOT_TAGS = new Set([
 ])
 
 /**
- * Decide whether a template literal needs SVG-context parsing.
- * Looks at the first opening tag in the literal. The check is purely
- * lexical so that interpolations inside attribute values do not
- * confuse it.
+ * MathML root tags (#1096 — port of the SVG fix above). `math` itself is
+ * included alongside the element vocabulary, mirroring how `svg` is
+ * included in `SVG_ROOT_TAGS`: a template whose bare root is the
+ * namespace container tag also needs the parser nudge (unlike the
+ * MULTI-ROOT fragment case in `multiRootTemplateNeedsNamespaceWrap`,
+ * where a container-first fragment already parses correctly on its own).
+ */
+const MATHML_ROOT_TAGS = new Set([
+  'math',
+  'mrow', 'mfrac', 'msup', 'msub', 'msubsup', 'mn', 'mi', 'mo', 'mtext',
+  'munder', 'mover', 'munderover', 'mtable', 'mtr', 'mtd',
+  'msqrt', 'mroot', 'mstyle', 'merror', 'mpadded', 'mphantom', 'menclose',
+  'semantics', 'annotation', 'annotation-xml',
+])
+
+/** Namespaces whose root tags need the synthetic-wrap parser nudge. */
+export type NamespaceWrapTag = 'svg' | 'math'
+
+/**
+ * Look up which foreign-content namespace (if any) a single tag name
+ * belongs to. Case-insensitive fallback mirrors `templateRootIsSvg`'s
+ * original comment: SVG/MathML element names are case-sensitive in JSX
+ * (e.g. `linearGradient`, `annotation-xml`) but the canonical lower-case
+ * set is checked first, then the lower-cased tag, so both spellings match.
+ */
+function namespaceForTag(tag: string): NamespaceWrapTag | null {
+  if (SVG_ROOT_TAGS.has(tag) || SVG_ROOT_TAGS.has(tag.toLowerCase())) return 'svg'
+  if (MATHML_ROOT_TAGS.has(tag) || MATHML_ROOT_TAGS.has(tag.toLowerCase())) return 'math'
+  return null
+}
+
+/**
+ * Decide whether a template literal needs foreign-content (SVG or MathML)
+ * parsing, and which. Looks at the first opening tag in the literal. The
+ * check is purely lexical so that interpolations inside attribute values
+ * do not confuse it.
  *
  * Three shapes are recognised:
- *   1. Direct element root — `<circle .../>`
+ *   1. Direct element root — `<circle .../>` / `<mrow>...</mrow>`
  *   2. Conditional body (#1088) — `${cond ? `<circle .../>` : `<rect .../>`}`
- *      where every result-position template literal starts with an SVG
- *      tag. The compiler emits this shape for `.map(s => cond ? <a/> : <b/>)`
- *      bodies; without the wrap the cloned element ends up in the xhtml
- *      namespace and renders nothing.
+ *      where every result-position template literal (recursively) resolves
+ *      to the SAME namespace. The compiler emits this shape for
+ *      `.map(s => cond ? <a/> : <b/>)` bodies; without the wrap the cloned
+ *      element ends up in the xhtml namespace and renders nothing.
  *   3. Reactive-conditional body — a branch wrapped in `<!--bf-cond-start:sX-->`
  *      / `<!--bf-cond-end:sX-->` markers (emitted for nested reactive
  *      conditionals). The check skips leading HTML comments and recurses
  *      into the inner `${...}`.
  *
- * Mixed-namespace branches (one HTML, one SVG) intentionally fall through
- * to no-wrap so the user sees the same broken output as before instead of
- * a silent over-wrap into a `<foreignObject>`-style mismatch.
+ * Mixed-namespace branches (HTML+SVG, HTML+MathML, or SVG+MathML)
+ * intentionally fall through to no-wrap so the user sees the same broken
+ * output as before instead of a silent over-wrap that would drag one
+ * branch into the wrong foreign-content namespace.
  */
-export function templateRootIsSvg(template: string): boolean {
+export function detectRootNamespaceWrapTag(template: string): NamespaceWrapTag | null {
   const stripped = stripLeadingNonContent(template)
 
   // Shape 1: direct element root.
   const m = stripped.match(/^<\s*([A-Za-z][A-Za-z0-9-]*)/)
-  if (m) {
-    // SVG element names are case-sensitive in JSX (e.g., `linearGradient`)
-    // and arrive lowercased to the renderer for the kebab-cased forms;
-    // match case-insensitively against the canonical lower-case set, but
-    // keep the canonical name's casing in the lookup table so JSX names
-    // like `clipPath` still match.
-    const tag = m[1]
-    if (SVG_ROOT_TAGS.has(tag)) return true
-    return SVG_ROOT_TAGS.has(tag.toLowerCase())
-  }
+  if (m) return namespaceForTag(m[1])
 
   // Shapes 2 & 3: single `${...}` interpolation whose result-position
-  // template literals all (recursively) resolve to SVG roots (Option A in
-  // #1088).
+  // template literals all (recursively) resolve to the SAME namespace
+  // (Option A in #1088, generalised to MathML in #1096).
   const branches = extractConditionalBranchTemplates(stripped)
-  if (branches === null || branches.length === 0) return false
-  return branches.every(templateRootIsSvg)
+  if (branches === null || branches.length === 0) return null
+  let result: NamespaceWrapTag | null | undefined
+  for (const branch of branches) {
+    const branchNs = detectRootNamespaceWrapTag(branch)
+    if (result === undefined) {
+      result = branchNs
+    } else if (result !== branchNs) {
+      return null
+    }
+  }
+  return result ?? null
 }
 
 /**
  * Wrap decision for MULTI-ROOT (fragment) templates, where the synthetic
- * `<svg>` wrap swallows every sibling root at once (#2233 Copilot review).
+ * namespace wrap swallows every sibling root at once (#2233 Copilot
+ * review, generalised to MathML in #1096).
  *
- * `templateRootIsSvg` inspects only the FIRST root tag. For single-root
- * templates that's exact, but a fragment whose first root is an `<svg>`
- * CONTAINER (`<><svg/><span/></>`) doesn't need the wrap at all — the
- * HTML parser enters foreign content at `<svg>` on its own — and wrapping
- * would drag the HTML siblings into the SVG namespace (`<span>` becomes an
- * SVGUnknownElement, silently undrawn). So `<svg>`-first fragments skip
- * the wrap; only leaf-rooted fragments (`<line>`, `<circle>`, ...) get it.
+ * `detectRootNamespaceWrapTag` inspects only the FIRST root tag. For
+ * single-root templates that's exact, but a fragment whose first root is
+ * the namespace CONTAINER itself (`<><svg/><span/></>`, `<><math/><span/></>`)
+ * doesn't need the wrap at all — the HTML parser enters foreign content at
+ * `<svg>`/`<math>` on its own — and wrapping would drag the HTML siblings
+ * into the foreign namespace (`<span>` becomes an SVGUnknownElement/etc.,
+ * silently undrawn). So container-first fragments skip the wrap; only
+ * leaf-rooted fragments (`<line>`, `<circle>`, `<mrow>`, ...) get it.
  *
- * Known edge (degenerate, pre-existing): an `<svg>`-first fragment with
- * SVG-LEAF siblings (`<><svg/><line/></>`) leaves the bare leaf siblings
- * in the HTML namespace — exactly the pre-#2219 behavior. Deciding that
- * shape correctly needs a scan of every top-level root tag; not worth the
- * parser until a real component hits it.
+ * Known edge (degenerate, pre-existing): a container-first fragment with
+ * LEAF siblings of the same namespace (`<><svg/><line/></>`) leaves the
+ * bare leaf siblings in the HTML namespace — exactly the pre-#2219
+ * behavior. Deciding that shape correctly needs a scan of every top-level
+ * root tag; not worth the parser until a real component hits it.
  */
-export function multiRootTemplateNeedsSvgWrap(template: string): boolean {
+export function multiRootTemplateNeedsNamespaceWrap(template: string): NamespaceWrapTag | null {
   const m = stripLeadingNonContent(template).match(/^<\s*([A-Za-z][A-Za-z0-9-]*)/)
-  if (m && m[1].toLowerCase() === 'svg') return false
-  return templateRootIsSvg(template)
+  if (m) {
+    const tagLower = m[1].toLowerCase()
+    if (tagLower === 'svg' || tagLower === 'math') return null
+  }
+  return detectRootNamespaceWrapTag(template)
+}
+
+/**
+ * Single door for the "wrap tag + descent path" pair every namespace-aware
+ * clone site needs. Consumers outside this file (`inner-loop.ts`,
+ * `loop-child-arm.ts`, `loop.ts`) read the wrap decision through this
+ * function instead of re-deriving `isSvg ? '<svg>' : ...` locally — keeps
+ * the SVG/MathML wrap code path in exactly one place (#1096).
+ */
+export function namespaceWrapForTemplate(template: string): { wrapTag: NamespaceWrapTag | null; childPath: string } {
+  const wrapTag = detectRootNamespaceWrapTag(template)
+  return {
+    wrapTag,
+    childPath: wrapTag ? '.firstElementChild.firstElementChild' : '.firstElementChild',
+  }
+}
+
+/** `namespaceWrapForTemplate`, but for the multi-root fragment predicate. */
+export function multiRootNamespaceWrapForTemplate(template: string): { wrapTag: NamespaceWrapTag | null; childPath: string } {
+  const wrapTag = multiRootTemplateNeedsNamespaceWrap(template)
+  return {
+    wrapTag,
+    childPath: wrapTag ? '.firstElementChild' : '',
+  }
+}
+
+/** Wrap `html` in the namespace's synthetic root tag, or return it as-is. */
+function wrapHtmlForNamespace(html: string, wrapTag: NamespaceWrapTag | null): string {
+  return wrapTag ? `<${wrapTag}>${html}</${wrapTag}>` : html
 }
 
 /**
@@ -159,14 +230,13 @@ function extractConditionalBranchTemplates(template: string): string[] | null {
  *
  *   ` const __tpl = document.createElement('template'); __tpl.innerHTML = \`${template}\`; return __tpl.content.firstElementChild.cloneNode(true) `
  *
- * For SVG roots, the `innerHTML` is wrapped in `<svg>...</svg>` and the
- * traversal descends one extra level.
+ * For SVG/MathML roots, the `innerHTML` is wrapped in the matching
+ * namespace root tag and the traversal descends one extra level.
  */
 export function emitTemplateCloneInline(template: string): string {
-  if (templateRootIsSvg(template)) {
-    return `const __tpl = document.createElement('template'); __tpl.innerHTML = \`<svg>${template}</svg>\`; return __tpl.content.firstElementChild.firstElementChild.cloneNode(true)`
-  }
-  return `const __tpl = document.createElement('template'); __tpl.innerHTML = \`${template}\`; return __tpl.content.firstElementChild.cloneNode(true)`
+  const { wrapTag, childPath } = namespaceWrapForTemplate(template)
+  const html = wrapHtmlForNamespace(template, wrapTag)
+  return `const __tpl = document.createElement('template'); __tpl.innerHTML = \`${html}\`; return __tpl.content${childPath}.cloneNode(true)`
 }
 
 /**
@@ -177,13 +247,14 @@ export function emitTemplateCloneInline(template: string): string {
  * STATIC-ONLY skeleton produced by `buildLoopSkeletonTemplate` (dynamic attrs
  * omitted, text markers empty) — never the per-row interpolated `template`.
  *
- * SVG namespace wrap mirrors `emitTemplateCloneLines` (#135 / #1088):
- * `templateRootIsSvg` is re-checked against the skeleton (same root tag as
- * the interpolated template, so the same wrap decision applies).
+ * Namespace wrap mirrors `emitTemplateCloneLines` (#135 / #1088 / #1096):
+ * `detectRootNamespaceWrapTag` is re-checked against the skeleton (same
+ * root tag as the interpolated template, so the same wrap decision
+ * applies).
  */
 export function emitHoistedTemplateDecl(lines: string[], indent: string, tplVar: string, skeletonTemplate: string): void {
-  const isSvg = templateRootIsSvg(skeletonTemplate)
-  const html = isSvg ? `<svg>${skeletonTemplate}</svg>` : skeletonTemplate
+  const { wrapTag } = namespaceWrapForTemplate(skeletonTemplate)
+  const html = wrapHtmlForNamespace(skeletonTemplate, wrapTag)
   lines.push(`${indent}const ${tplVar} = document.createElement('template')`)
   lines.push(`${indent}${tplVar}.innerHTML = \`${html}\``)
 }
@@ -194,9 +265,7 @@ export function emitHoistedTemplateDecl(lines: string[], indent: string, tplVar:
  * `emitTemplateCloneInline` / `emitTemplateCloneLines` parse-and-clone.
  */
 export function hoistedCloneExpr(tplVar: string, skeletonTemplate: string): string {
-  return templateRootIsSvg(skeletonTemplate)
-    ? `${tplVar}.content.firstElementChild.firstElementChild.cloneNode(true)`
-    : `${tplVar}.content.firstElementChild.cloneNode(true)`
+  return `${tplVar}.content${namespaceWrapForTemplate(skeletonTemplate).childPath}.cloneNode(true)`
 }
 
 /**
@@ -204,17 +273,12 @@ export function hoistedCloneExpr(tplVar: string, skeletonTemplate: string): stri
  * Returns three statements with no trailing newlines.
  */
 export function emitTemplateCloneLines(template: string, indent: string): string[] {
-  if (templateRootIsSvg(template)) {
-    return [
-      `${indent}const __tpl = document.createElement('template')`,
-      `${indent}__tpl.innerHTML = \`<svg>${template}</svg>\``,
-      `${indent}return __tpl.content.firstElementChild.firstElementChild.cloneNode(true)`,
-    ]
-  }
+  const { wrapTag, childPath } = namespaceWrapForTemplate(template)
+  const html = wrapHtmlForNamespace(template, wrapTag)
   return [
     `${indent}const __tpl = document.createElement('template')`,
-    `${indent}__tpl.innerHTML = \`${template}\``,
-    `${indent}return __tpl.content.firstElementChild.cloneNode(true)`,
+    `${indent}__tpl.innerHTML = \`${html}\``,
+    `${indent}return __tpl.content${childPath}.cloneNode(true)`,
   ]
 }
 
@@ -312,13 +376,13 @@ export function emitMultiRootTemplateCloneLines(
   varEl: string,
   varExtras: string,
 ): string[] {
-  const isSvg = multiRootTemplateNeedsSvgWrap(template)
-  // Wrap in `<svg>` so the parser walks into SVG foreign content; we then
-  // descend one level to pick up the per-item roots.
-  const innerHtmlExpr = isSvg ? `\`<svg>${template}</svg>\`` : `\`${template}\``
+  const { wrapTag, childPath } = multiRootNamespaceWrapForTemplate(template)
+  // Wrap in the namespace's root tag so the parser walks into foreign
+  // content; we then descend one level to pick up the per-item roots.
+  const innerHtmlExpr = `\`${wrapHtmlForNamespace(template, wrapTag)}\``
   // `parent` is the element whose direct children are the per-item roots
-  // (the `<svg>` wrap for SVG, the template's content for HTML).
-  const parentExpr = isSvg ? `__tpl.content.firstElementChild` : `__tpl.content`
+  // (the namespace wrap for SVG/MathML, the template's content for HTML).
+  const parentExpr = `__tpl.content${childPath}`
   return [
     `${indent}const __tpl = document.createElement('template')`,
     `${indent}__tpl.innerHTML = ${innerHtmlExpr}`,

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/template-parse.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/template-parse.ts
@@ -173,7 +173,7 @@ export function multiRootNamespaceWrapForTemplate(template: string): { wrapTag: 
 }
 
 /** Wrap `html` in the namespace's synthetic root tag, or return it as-is. */
-function wrapHtmlForNamespace(html: string, wrapTag: NamespaceWrapTag | null): string {
+export function wrapHtmlForNamespace(html: string, wrapTag: NamespaceWrapTag | null): string {
   return wrapTag ? `<${wrapTag}>${html}</${wrapTag}>` : html
 }
 


### PR DESCRIPTION
## Summary

Track-C stack 1/2. Fixes #1096, the MathML port of the SVG foreign-content fix (#1070/#1088/#1095): `template.innerHTML` parses a MathML root tag (`mrow`, `mfrac`, …) as an xhtml `HTMLUnknownElement`, so a `.map()` body or conditional branch rooted in MathML cloned into elements the MathML renderer never draws.

## Changes

- **`template-parse.ts`** — `MATHML_ROOT_TAGS` added; the SVG-only `templateRootIsSvg` / `multiRootTemplateNeedsSvgWrap` generalize to `detectRootNamespaceWrapTag(): 'svg' | 'math' | null` / `multiRootTemplateNeedsNamespaceWrap`, and every emitter reads the wrap through one shared door (`namespaceWrapForTemplate`). Mixed-namespace ternary branches (now including the new SVG+MathML combination) keep the conservative no-wrap fallthrough.
- **`inner-loop.ts` / `loop-child-arm.ts` / `loop.ts`** — each had its own hand-duplicated `isSvg ? '<svg>'+t+'</svg>' : t` ternary; all three now use the shared helper, so nested inner loops, branch arms, and the CSR-materialize path are MathML-aware without per-file copies.
- **`collect-elements.ts`** — the #2143 direct-child-index fast path now also skips for MathML roots (same untested-path reasoning as the existing SVG skip).
- **`packages/client` `parseHTML`** — `<math>` wrap when the parent is in the MathML namespace, sharing the wrap/unwrap logic with the SVG branch.
- Changeset: `@barefootjs/jsx` + `@barefootjs/client` patch.

## Tests

`mathml-mapArray-namespace.test.ts` and `inner-loop-mathml-namespace.test.ts` mirror their SVG siblings (issue repro shape, 2-/3-way ternary bodies, mixed-namespace no-wrap, container-first fragment skip, CSR-materialize); `mathml-parseHTML-namespace.test.ts` covers the runtime. One caveat, documented in the tests: happy-dom implements the SVG insertion mode but **not** MathML's (verified in its `HTMLParser` source), so the runtime tests assert the wrap decision via the string handed to `template.innerHTML` rather than the resulting `namespaceURI` — a test-environment gap, not a fix gap.

No conformance fixture is added deliberately: a fixture would obligate all 9 SSR adapters whose MathML posture hasn't been surveyed; the compiler/runtime unit tests pin the client-side behavior this issue is about. `<foreignObject>`-style boundary handling stays out of scope per the issue.

## Verification

- `@barefootjs/jsx` + `@barefootjs/client` builds: green.
- `bun test packages/jsx`: 3095 pass / 0 fail. `packages/client`: 631 pass / 0 fail. New + SVG-family namespace tests: 31 pass. `csr-conformance`: 304 pass.

Closes #1096.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_