### PR TITLE
fix(go-template): seed prop-backed static child-component loops in the render harness

### DIFF
--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -5,14 +5,16 @@
  * one object, so the skip list and the declaration can't drift. Keep the
  * file even when the set is empty — the next divergence lands here, not in
  * a re-created file.
+ *
+ * Empty — #2630's `static-array-from-props-with-component-precomputed`
+ * divergence graduated once the harness (`test-render.ts`'s
+ * `buildDynamicChildLoopSeeding`, despite the name — see its doc comment)
+ * learned to seed a prop-backed static child-component loop's Props slice
+ * the same way it already seeded a signal-backed dynamic one: the adapter's
+ * own `emission` was never the bug, only this harness's route-handler
+ * stand-in was missing the prop-derived case.
  */
 
 import type { RenderDivergences } from '@barefootjs/jsx'
 
-export const renderDivergences: RenderDivergences = {
-  // #2630: the exact shape BF101's pass-as-prop suggestion (#2321) steers
-  // go-template users into — compiles clean, runs clean, silently renders the
-  // loop host empty. Full analysis in the issue.
-  'static-array-from-props-with-component-precomputed':
-    'prop-backed child-component loop renders the loop host empty at SSR (https://github.com/piconic-ai/barefootjs/issues/2630)',
-}
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -706,16 +706,29 @@ function buildDynamicChildLoopSeeding(
     }
     if (!datumField) continue
 
+    // All-or-nothing (Copilot review on #2630's PR): a prop that is
+    // legitimately SSR-irrelevant (event handler, `key`, dashed debug
+    // attrs) is exempt, but any OTHER prop this resolver can't express as
+    // an `item` read means the seeded `<Name>Input{...}` would carry Go
+    // zero values for it — silently wrong SSR instead of the loudly-empty
+    // host the unseeded path produces. Bail on the whole component in
+    // that case rather than seed an incomplete slice.
     const inputFields: string[] = []
+    let unresolvableProp = false
     for (const prop of nested.props) {
       if (prop.isEventHandler) continue
       if (prop.name === 'key' || prop.name.includes('-')) continue
-      if (prop.value.kind !== 'expression' || !prop.value.parsed) continue
-      const itemExpr = goItemExprForLoopProp(prop.value.parsed, nested.loopParam)
-      if (itemExpr === null) continue
+      const itemExpr =
+        prop.value.kind === 'expression' && prop.value.parsed
+          ? goItemExprForLoopProp(prop.value.parsed, nested.loopParam)
+          : null
+      if (itemExpr === null) {
+        unresolvableProp = true
+        break
+      }
       inputFields.push(`${capitalizeFieldName(prop.name)}: ${itemExpr}`)
     }
-    if (inputFields.length === 0) continue
+    if (unresolvableProp || inputFields.length === 0) continue
 
     lines.push(`\tprops.${nested.name}s = make([]${nested.name}Props, len(props.${capitalizeFieldName(datumField)}))`)
     lines.push(`\tfor i, item := range props.${capitalizeFieldName(datumField)} {`)

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -587,55 +587,133 @@ function findBaseSignalGetter(expr: ParsedExpr | undefined, signalGetters: Reado
 }
 
 /**
- * (#2209 part 2) Replicate, in the generated `main.go`, the documented
- * "the route handler populates the loop-body child-component slice at
- * request time" contract for a signal-backed dynamic loop —
- * `generateNewPropsFunction`'s doc comment on `<Name>s []<Name>Props`
- * in `adapter/go-template-adapter.ts`. The constructor only ever seeds
- * the loop's DATUM slice (e.g. `.Todos`, straight from the caller's
- * Input); the child-component Props slice the template actually
- * ranges over (`.TodoItems`) has no server-side population path in
- * this harness — the Hono reference materializes it by literally
- * executing the component, so this closes the gap the same way:
- * derive each item's child Props from the datum slice, exactly as a
- * real route handler is documented to.
+ * (#2630) Resolve a `isPropDerived` loop's `arrayParsed` to the JS-level
+ * prop name it reads. `isArrayExprDirectPropRef` (`jsx-to-ir.ts`) is what
+ * sets `isPropDerivedArray` in the first place, and it only recognizes two
+ * shapes — a bare destructured-prop identifier (`entries.map(...)` inside
+ * `function({ entries })`) or a direct `props.<name>` member access — so
+ * unlike `findBaseSignalGetter` there is no `call`/chain walking to do; the
+ * compiler already restricted the shape. Returns the prop's LOCAL binding
+ * name; the caller resolves it to the CALLER-FACING field
+ * (`sourceName ?? name`) via `propsParams`, matching how
+ * `generateInputStruct`/`generateNewPropsFunction` key the Go field and how
+ * `buildGoPropsInit` keys the harness's own prop initializer (both by the
+ * JS `props` object's key, not the local destructure binding).
+ */
+function findLoopPropField(expr: ParsedExpr | undefined): string | null {
+  if (!expr) return null
+  if (expr.kind === 'identifier') return expr.name
+  if (expr.kind === 'member' && expr.object.kind === 'identifier') return expr.property
+  return null
+}
+
+/**
+ * Resolve a loop-body child prop's VALUE expression to the Go expression
+ * that reads it off the per-row `item` local: a bare pass-through of the
+ * loop param (`todo={todo}` → `item`) or a member access on it
+ * (`variant={entry.variant}` → `item.Variant`, #2630 — the
+ * `static-array-from-props-with-component-precomputed` fixture's `<Tag
+ * id={entry.id} variant={entry.variant} />`). `null` for anything else (a
+ * prop that doesn't derive from the loop row at all).
+ */
+function goItemExprForLoopProp(parsed: ParsedExpr, loopParam: string): string | null {
+  if (parsed.kind === 'identifier' && parsed.name === loopParam) return 'item'
+  if (
+    parsed.kind === 'member' &&
+    !parsed.computed &&
+    parsed.object.kind === 'identifier' &&
+    parsed.object.name === loopParam
+  ) {
+    return `item.${capitalizeFieldName(parsed.property)}`
+  }
+  return null
+}
+
+/**
+ * (#2209 part 2, extended by #2630) Replicate, in the generated `main.go`,
+ * the documented "the route handler populates the loop-body child-component
+ * slice at request time" contract from `generateNewPropsFunction`'s doc
+ * comment on `<Name>s []<Name>Props` in `adapter/go-template-adapter.ts`.
+ * Covers TWO loop shapes that both leave `.<Name>s` unpopulated in this
+ * harness, for different reasons:
+ *
+ *  - **Signal-backed dynamic** (`isDynamic && !isPropDerived`, e.g.
+ *    `todos().map(...)`): the constructor only ever seeds the loop's DATUM
+ *    slice (`.Todos`, straight from the caller's Input) — the child Props
+ *    slice the template ranges over (`.TodoItems`) is documented as
+ *    handler-populated and never touched by `NewXxxProps` at all.
+ *  - **Prop-backed static** (`isPropDerived`, e.g. `props.entries.map(...)`,
+ *    #2630): `NewXxxProps` DOES try to build `.Tags` from `in.Tags` — but
+ *    `in.Tags` is a SEPARATE Input field from the driving prop (`Entries`)
+ *    whenever the child's plural name doesn't literally coincide with the
+ *    prop's own name (`propDerivedNestedArrayFields`/`isNestedArrayShadowed`
+ *    in the real adapter), and this harness's `buildGoPropsInit` only ever
+ *    populates fields from the JS `props` object's own keys — `tags` isn't
+ *    one. `in.Tags` stays a nil slice, so the constructor's own range over
+ *    it produces zero rows. Both shapes are closed the same way: derive
+ *    each item's child Props from the resolved datum slice AFTER
+ *    construction, overwriting whatever (empty, for the prop-backed case)
+ *    slice the constructor built — exactly as a real route handler is
+ *    documented to.
+ *
+ * The Hono reference needs none of this because it materializes children by
+ * literally executing the component.
  *
  * Deliberately narrow: only fires for a loop whose (a) array source
- * resolves, through `call`/`member` chains, to a component signal
- * getter, (b) generated Go TEMPLATE text actually ranges over
+ * resolves to a signal getter (dynamic) or a direct prop reference
+ * (prop-derived) — never a `call`/member chain beyond what each shape's own
+ * resolver recognizes, (b) generated Go TEMPLATE text actually ranges over
  * `.<Name>s` (a plain substring check on GENERATED GO OUTPUT — not JS
- * parsing — so a `/* @client *\/`-marked loop, whose SSR template has
- * no such range, is untouched by construction), and (c) at least one
- * child prop is a bare pass-through of the loop item (`todo={todo}`).
- * Returns the Go statements to splice into `main()` plus whether `fmt`
- * needs importing.
+ * parsing — so a `/* @client *\/`-marked loop, whose SSR template has no
+ * such range, is untouched by construction), and (c) every resolved child
+ * prop is either a bare pass-through of the loop item (`todo={todo}`) or a
+ * member access on it (`variant={entry.variant}`). Returns the Go
+ * statements to splice into `main()` plus whether `fmt` needs importing.
  */
 function buildDynamicChildLoopSeeding(
   ir: ComponentIR,
   template: string,
 ): { lines: string[]; needsFmt: boolean } {
   const signalGetters = new Set(ir.metadata.signals.map(s => s.getter))
+  const propsParams = ir.metadata.propsParams
   const lines: string[] = []
   let needsFmt = false
   for (const nested of findNestedComponents(ir.root) as NestedComponentInfo[]) {
-    if (!nested.isDynamic || nested.isPropDerived) continue
     if (nested.bodyChildren && nested.bodyChildren.length > 0) continue
     if (!nested.loopParam) continue
     if (!template.includes(`:= .${nested.name}s}}`)) continue
-    const datumField = findBaseSignalGetter(nested.loopArrayParsed, signalGetters)
+
+    let datumField: string | null
+    if (nested.isPropDerived) {
+      const localName = findLoopPropField(nested.loopArrayParsed)
+      const param = localName ? propsParams.find(p => p.name === localName) : undefined
+      datumField = param ? (param.sourceName ?? param.name) : null
+      // (#2627/#2628 shadowing) When the driving prop's Go field name
+      // coincides with the child's own plural (`tags` prop → `Tag`
+      // component), the REAL adapter's `isNestedArrayShadowed` drops the
+      // prop's separate field entirely — `props.Tags` IS the only field,
+      // pre-shaped `TagInput` rows and all, already populated straight from
+      // the harness's own `buildGoPropsInit` (which types the literal
+      // against the Input struct's declared `[]TagInput` field). Seeding
+      // here would `range` the very slice it just emptied with `make` on
+      // the line above it — skip so that already-correct path stays
+      // untouched.
+      if (datumField && capitalizeFieldName(datumField) === capitalizeFieldName(`${nested.name}s`)) continue
+    } else if (nested.isDynamic) {
+      datumField = findBaseSignalGetter(nested.loopArrayParsed, signalGetters)
+    } else {
+      continue
+    }
     if (!datumField) continue
 
     const inputFields: string[] = []
     for (const prop of nested.props) {
       if (prop.isEventHandler) continue
       if (prop.name === 'key' || prop.name.includes('-')) continue
-      if (
-        prop.value.kind === 'expression' &&
-        prop.value.parsed?.kind === 'identifier' &&
-        prop.value.parsed.name === nested.loopParam
-      ) {
-        inputFields.push(`${capitalizeFieldName(prop.name)}: item`)
-      }
+      if (prop.value.kind !== 'expression' || !prop.value.parsed) continue
+      const itemExpr = goItemExprForLoopProp(prop.value.parsed, nested.loopParam)
+      if (itemExpr === null) continue
+      inputFields.push(`${capitalizeFieldName(prop.name)}: ${itemExpr}`)
     }
     if (inputFields.length === 0) continue
 

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -3213,7 +3213,7 @@
           ],
           "escape": {
             "state": "escapable",
-            "twin": "static-array-from-props-with-component-client"
+            "twin": "static-array-from-props-with-component-precomputed"
           }
         },
         "jinja": {
@@ -3280,12 +3280,6 @@
             "state": "escapable",
             "twin": "static-array-from-props-with-component-precomputed"
           }
-        }
-      },
-      "static-array-from-props-with-component-precomputed": {
-        "go-template": {
-          "kind": "render",
-          "reason": "prop-backed child-component loop renders the loop host empty at SSR (https://github.com/piconic-ai/barefootjs/issues/2630)"
         }
       },
       "tag-cloud": {
@@ -3440,10 +3434,6 @@
         "description": "Static-array loop with childComponent body materialises rendered children on CSR (#1268)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts"
       },
-      "static-array-from-props-with-component-precomputed": {
-        "description": "prop-precompute twin of static-array-from-props-with-component — child components render at SSR…",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component-precomputed.ts"
-      },
       "tag-cloud": {
         "description": "flatMap block-body tag list — hydration adoption, in-place leaf patch, add, and remove",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/tag-cloud.ts"
@@ -3496,9 +3486,9 @@
         "description": "prop-precompute twin of static-array-from-props — computation moved to the caller, full SSR (#2321)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-precomputed.ts"
       },
-      "static-array-from-props-with-component-client": {
-        "description": "/* @client */ twin of static-array-from-props-with-component — DSL BF101 (computed-const loop…",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component-client.ts"
+      "static-array-from-props-with-component-precomputed": {
+        "description": "prop-precompute twin of static-array-from-props-with-component — child components render at SSR…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component-precomputed.ts"
       }
     }
   },

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1123,7 +1123,7 @@
           ]
         },
         "go-template": {
-          "pass": 81,
+          "pass": 82,
           "total": 91,
           "gaps": [
             {
@@ -1167,10 +1167,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component-precomputed",
-              "issues": []
             }
           ]
         },
@@ -2355,7 +2351,7 @@
           ]
         },
         "go-template": {
-          "pass": 290,
+          "pass": 291,
           "total": 308,
           "gaps": [
             {
@@ -2431,10 +2427,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component-precomputed",
-              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -3033,7 +3025,7 @@
           ]
         },
         "go-template": {
-          "pass": 238,
+          "pass": 239,
           "total": 250,
           "gaps": [
             {
@@ -3077,10 +3069,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component-precomputed",
-              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -3687,7 +3675,7 @@
           ]
         },
         "go-template": {
-          "pass": 155,
+          "pass": 156,
           "total": 173,
           "gaps": [
             {
@@ -3763,10 +3751,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component-precomputed",
-              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -6611,7 +6595,7 @@
           ]
         },
         "go-template": {
-          "pass": 19,
+          "pass": 20,
           "total": 21,
           "gaps": [
             {
@@ -6619,10 +6603,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component-precomputed",
-              "issues": []
             }
           ]
         },
@@ -7770,7 +7750,7 @@
           ]
         },
         "go-template": {
-          "pass": 169,
+          "pass": 170,
           "total": 178,
           "gaps": [
             {
@@ -7806,10 +7786,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-array-from-props-with-component-precomputed",
-              "issues": []
             }
           ]
         },


### PR DESCRIPTION
## Summary

Track-C stack 2/2 (base: #2662). Fixes #2630: `static-array-from-props-with-component-precomputed` compiled and `go run`-ed clean on go-template but rendered its loop host empty.

**Diagnosis confirmed by inspection** (the issue asked for this before assuming adapter fault): the generated template ranges over the child Props slice (`{{range $_, $entry := .Tags}}`), and the harness's route-handler stand-in — `buildDynamicChildLoopSeeding` in `test-render.ts` — only populated such slices for signal-backed dynamic loops; its guard explicitly skipped `isPropDerived`. The prop's own Input field (`Entries`) was populated fine, but nothing bridged it to `.Tags`. **The adapter's emission was never at fault** — this was a harness gap, exactly as the issue suspected.

## Changes

- **`test-render.ts`** — the seeding now covers both shapes through the same splice:
  - prop-derived datum resolution goes `ParsedExpr` → local binding → caller-facing prop field via `propsParams` (`sourceName ?? name`) — structural, no string parsing, and deliberately limited to the two shapes `isArrayExprDirectPropRef` can produce;
  - child props accept member access on the loop item (`variant={entry.variant}` → `item.Variant`) in addition to the existing bare pass-through;
  - a defensive skip preserves the `isNestedArrayShadowed` name-coincidence path (a `tags` prop feeding a `<Tag>` loop), where the constructor already populates the slice — seeding there would `make`-empty and re-range the very slice that was already correct.
- **`render-divergences.ts`** — the graduated entry is deleted; the ledger is empty again (header updated per the file's keep-when-empty convention).
- **`ui/compat.lock.json` / `ui/support-matrix.lock.json`** — regenerated; the fixture's divergence/gap rows disappear and go-template's per-axis pass counts tick up.

Harness + ledger + lockfiles only — the published adapter's emission is unchanged, so no changeset.

## Why it matters

BF101's diagnostic for the #2321 loop-source shape lists **pass-as-prop first** because it keeps full server output. That claim was proven for the plain-element shape but silently false for child-component bodies on go-template — the quiet half of the loud-or-escapable contract. With this fix the fixture (already asserting the correct output since #2629) flips into the claim's regression test.

## Verification (real Go backend)

- Graduated fixture: 4/4 pass.
- Full `bun test packages/adapter-go-template`: 1679 pass / 0 fail in the implementation worktree; re-verified on this stacked branch (one intermediate run showed a single non-reproducing failure under concurrent load — two subsequent full runs clean).
- Sibling families (`static-array-from-props*`, `todo-app*` — the refactored dynamic path): no regressions.
- `bun test packages/compat`: 488 pass / 0 fail against the regenerated lockfiles.

Closes #2630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_