### PR TITLE
chore(deps): bump changesets/action to v2.1.0 with input migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,12 +75,11 @@ jobs:
 
       - name: Changesets — version or publish
         id: changesets
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
         with:
-          version: bunx changeset version
-          publish: bun run release:publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          version-script: bunx changeset version
+          publish-script: bun run release:publish
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # Mirror whatever Changesets just published to npm onto JSR. Delegates to
   # the reusable jsr-publish.yml so the release-driven path and the manual


### PR DESCRIPTION
## Summary

- Supersedes #2671 (Dependabot's `changesets/action` v1.9.0 → v2.1.0 bump), which as-authored would silently break the release workflow.
- `changesets/action` v2.0.0 renamed the `version`/`publish` inputs to `version-script`/`publish-script`, and made the GitHub API the default push mode, which requires `github-token` to be passed explicitly — the `GITHUB_TOKEN` env var and `actions/checkout` credentials are no longer accepted as substitutes.
- Updated `.github/workflows/release.yml` to use the v2 pin (`198f833` / `v2.1.0`) together with the renamed inputs and an explicit `github-token` input, so the "Version Packages" / publish automation keeps working after the bump.

## Test plan

- [ ] No local test surface for this change (GitHub Actions workflow file); verify by watching the next `release.yml` run on `main` (either a "Version Packages" PR being opened, or a real publish) after this merges.
- [ ] Close/dismiss #2671 once this is merged, since it duplicates the version bump without the input fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3sF4q1ba3Fb9EMUrpkwf2)_