### PR TITLE
perf(integrations): cut container idle billing and pin the instance type

### DIFF
--- a/integrations/axum/container.ts
+++ b/integrations/axum/container.ts
@@ -15,7 +15,11 @@ type Env = {
 
 export class AxumContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/axum/container.ts
+++ b/integrations/axum/container.ts
@@ -16,10 +16,10 @@ type Env = {
 export class AxumContainer extends Container<Env> {
   defaultPort = 8080
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
-  sleepAfter = '2m'
+  // window is the cost knob. This stack starts fast enough that a cold start
+  // is barely visible, so the tail is kept at the floor. The slower-booting
+  // examples (rails, laravel, django) hold 2m instead.
+  sleepAfter = '1m'
 }
 
 export default {

--- a/integrations/axum/wrangler.toml
+++ b/integrations/axum/wrangler.toml
@@ -10,6 +10,10 @@ image = "./Dockerfile"
 # ../../packages/adapter-rust/runtime can resolve inside the image.
 image_build_context = "../.."
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "AXUM_CONTAINER"

--- a/integrations/blade/container.ts
+++ b/integrations/blade/container.ts
@@ -11,7 +11,11 @@ type Env = {
 
 export class PhpContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/blade/container.ts
+++ b/integrations/blade/container.ts
@@ -12,10 +12,10 @@ type Env = {
 export class PhpContainer extends Container<Env> {
   defaultPort = 8080
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
-  sleepAfter = '2m'
+  // window is the cost knob. This stack starts fast enough that a cold start
+  // is barely visible, so the tail is kept at the floor. The slower-booting
+  // examples (rails, laravel, django) hold 2m instead.
+  sleepAfter = '1m'
 }
 
 export default {

--- a/integrations/blade/wrangler.toml
+++ b/integrations/blade/wrangler.toml
@@ -7,6 +7,10 @@ compatibility_flags = ["nodejs_compat"]
 class_name = "PhpContainer"
 image = "./Dockerfile"
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "PHP_CONTAINER"

--- a/integrations/chi/container.ts
+++ b/integrations/chi/container.ts
@@ -16,10 +16,10 @@ type Env = {
 export class ChiContainer extends Container<Env> {
   defaultPort = 8082
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
-  sleepAfter = '2m'
+  // window is the cost knob. This stack starts fast enough that a cold start
+  // is barely visible, so the tail is kept at the floor. The slower-booting
+  // examples (rails, laravel, django) hold 2m instead.
+  sleepAfter = '1m'
 }
 
 export default {

--- a/integrations/chi/container.ts
+++ b/integrations/chi/container.ts
@@ -15,7 +15,11 @@ type Env = {
 
 export class ChiContainer extends Container<Env> {
   defaultPort = 8082
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/chi/wrangler.toml
+++ b/integrations/chi/wrangler.toml
@@ -10,6 +10,10 @@ image = "./Dockerfile"
 # ../../packages/adapter-go-template/runtime can resolve inside the image.
 image_build_context = "../.."
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "CHI_CONTAINER"

--- a/integrations/django/container.ts
+++ b/integrations/django/container.ts
@@ -12,9 +12,9 @@ type Env = {
 export class DjangoContainer extends Container<Env> {
   defaultPort = 8080
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
+  // window is the cost knob. Held at 2m where the other examples use 1m:
+  // startup reads settings and builds the app registry, so a cold start is felt.
+  // A visitor reading one page should still get a warm container next click.
   sleepAfter = '2m'
 }
 

--- a/integrations/django/container.ts
+++ b/integrations/django/container.ts
@@ -11,7 +11,11 @@ type Env = {
 
 export class DjangoContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/django/wrangler.toml
+++ b/integrations/django/wrangler.toml
@@ -7,6 +7,10 @@ compatibility_flags = ["nodejs_compat"]
 class_name = "DjangoContainer"
 image = "./Dockerfile"
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "DJANGO_CONTAINER"

--- a/integrations/echo/container.ts
+++ b/integrations/echo/container.ts
@@ -16,10 +16,10 @@ type Env = {
 export class EchoContainer extends Container<Env> {
   defaultPort = 8080
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
-  sleepAfter = '2m'
+  // window is the cost knob. This stack starts fast enough that a cold start
+  // is barely visible, so the tail is kept at the floor. The slower-booting
+  // examples (rails, laravel, django) hold 2m instead.
+  sleepAfter = '1m'
 }
 
 export default {

--- a/integrations/echo/container.ts
+++ b/integrations/echo/container.ts
@@ -15,7 +15,11 @@ type Env = {
 
 export class EchoContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/echo/wrangler.toml
+++ b/integrations/echo/wrangler.toml
@@ -10,6 +10,10 @@ image = "./Dockerfile"
 # ../../packages/adapter-go-template/runtime can resolve inside the image.
 image_build_context = "../.."
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "ECHO_CONTAINER"

--- a/integrations/fastapi/container.ts
+++ b/integrations/fastapi/container.ts
@@ -11,7 +11,11 @@ type Env = {
 
 export class FastapiContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/fastapi/container.ts
+++ b/integrations/fastapi/container.ts
@@ -12,10 +12,10 @@ type Env = {
 export class FastapiContainer extends Container<Env> {
   defaultPort = 8080
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
-  sleepAfter = '2m'
+  // window is the cost knob. This stack starts fast enough that a cold start
+  // is barely visible, so the tail is kept at the floor. The slower-booting
+  // examples (rails, laravel, django) hold 2m instead.
+  sleepAfter = '1m'
 }
 
 export default {

--- a/integrations/fastapi/wrangler.toml
+++ b/integrations/fastapi/wrangler.toml
@@ -7,6 +7,10 @@ compatibility_flags = ["nodejs_compat"]
 class_name = "FastapiContainer"
 image = "./Dockerfile"
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "FASTAPI_CONTAINER"

--- a/integrations/flask/container.ts
+++ b/integrations/flask/container.ts
@@ -12,10 +12,10 @@ type Env = {
 export class FlaskContainer extends Container<Env> {
   defaultPort = 8080
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
-  sleepAfter = '2m'
+  // window is the cost knob. This stack starts fast enough that a cold start
+  // is barely visible, so the tail is kept at the floor. The slower-booting
+  // examples (rails, laravel, django) hold 2m instead.
+  sleepAfter = '1m'
 }
 
 export default {

--- a/integrations/flask/container.ts
+++ b/integrations/flask/container.ts
@@ -11,7 +11,11 @@ type Env = {
 
 export class FlaskContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/flask/wrangler.toml
+++ b/integrations/flask/wrangler.toml
@@ -7,6 +7,10 @@ compatibility_flags = ["nodejs_compat"]
 class_name = "FlaskContainer"
 image = "./Dockerfile"
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "FLASK_CONTAINER"

--- a/integrations/gin/container.ts
+++ b/integrations/gin/container.ts
@@ -15,7 +15,11 @@ type Env = {
 
 export class GinContainer extends Container<Env> {
   defaultPort = 8081
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/gin/container.ts
+++ b/integrations/gin/container.ts
@@ -16,10 +16,10 @@ type Env = {
 export class GinContainer extends Container<Env> {
   defaultPort = 8081
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
-  sleepAfter = '2m'
+  // window is the cost knob. This stack starts fast enough that a cold start
+  // is barely visible, so the tail is kept at the floor. The slower-booting
+  // examples (rails, laravel, django) hold 2m instead.
+  sleepAfter = '1m'
 }
 
 export default {

--- a/integrations/gin/wrangler.toml
+++ b/integrations/gin/wrangler.toml
@@ -10,6 +10,10 @@ image = "./Dockerfile"
 # ../../packages/adapter-go-template/runtime can resolve inside the image.
 image_build_context = "../.."
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "GIN_CONTAINER"

--- a/integrations/laravel/container.ts
+++ b/integrations/laravel/container.ts
@@ -11,7 +11,11 @@ type Env = {
 
 export class LaravelContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/laravel/container.ts
+++ b/integrations/laravel/container.ts
@@ -12,9 +12,9 @@ type Env = {
 export class LaravelContainer extends Container<Env> {
   defaultPort = 8080
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
+  // window is the cost knob. Held at 2m where the other examples use 1m:
+  // `artisan serve` boots the framework kernel first, so a cold start is felt.
+  // A visitor reading one page should still get a warm container next click.
   sleepAfter = '2m'
 }
 

--- a/integrations/laravel/wrangler.toml
+++ b/integrations/laravel/wrangler.toml
@@ -7,6 +7,10 @@ compatibility_flags = ["nodejs_compat"]
 class_name = "LaravelContainer"
 image = "./Dockerfile"
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "LARAVEL_CONTAINER"

--- a/integrations/mojolicious/container.ts
+++ b/integrations/mojolicious/container.ts
@@ -12,10 +12,10 @@ type Env = {
 export class MojoContainer extends Container<Env> {
   defaultPort = 8080
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
-  sleepAfter = '2m'
+  // window is the cost knob. This stack starts fast enough that a cold start
+  // is barely visible, so the tail is kept at the floor. The slower-booting
+  // examples (rails, laravel, django) hold 2m instead.
+  sleepAfter = '1m'
 }
 
 export default {

--- a/integrations/mojolicious/container.ts
+++ b/integrations/mojolicious/container.ts
@@ -11,7 +11,11 @@ type Env = {
 
 export class MojoContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/mojolicious/wrangler.toml
+++ b/integrations/mojolicious/wrangler.toml
@@ -7,6 +7,10 @@ compatibility_flags = ["nodejs_compat"]
 class_name = "MojoContainer"
 image = "./Dockerfile"
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "MOJO_CONTAINER"

--- a/integrations/nethttp/container.ts
+++ b/integrations/nethttp/container.ts
@@ -16,10 +16,10 @@ type Env = {
 export class NethttpContainer extends Container<Env> {
   defaultPort = 8083
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
-  sleepAfter = '2m'
+  // window is the cost knob. This stack starts fast enough that a cold start
+  // is barely visible, so the tail is kept at the floor. The slower-booting
+  // examples (rails, laravel, django) hold 2m instead.
+  sleepAfter = '1m'
 }
 
 export default {

--- a/integrations/nethttp/container.ts
+++ b/integrations/nethttp/container.ts
@@ -15,7 +15,11 @@ type Env = {
 
 export class NethttpContainer extends Container<Env> {
   defaultPort = 8083
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/nethttp/wrangler.toml
+++ b/integrations/nethttp/wrangler.toml
@@ -10,6 +10,10 @@ image = "./Dockerfile"
 # ../../packages/adapter-go-template/runtime can resolve inside the image.
 image_build_context = "../.."
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "NETHTTP_CONTAINER"

--- a/integrations/php/container.ts
+++ b/integrations/php/container.ts
@@ -11,7 +11,11 @@ type Env = {
 
 export class PhpContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/php/container.ts
+++ b/integrations/php/container.ts
@@ -12,10 +12,10 @@ type Env = {
 export class PhpContainer extends Container<Env> {
   defaultPort = 8080
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
-  sleepAfter = '2m'
+  // window is the cost knob. This stack starts fast enough that a cold start
+  // is barely visible, so the tail is kept at the floor. The slower-booting
+  // examples (rails, laravel, django) hold 2m instead.
+  sleepAfter = '1m'
 }
 
 export default {

--- a/integrations/php/wrangler.toml
+++ b/integrations/php/wrangler.toml
@@ -7,6 +7,10 @@ compatibility_flags = ["nodejs_compat"]
 class_name = "PhpContainer"
 image = "./Dockerfile"
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "PHP_CONTAINER"

--- a/integrations/rails/container.ts
+++ b/integrations/rails/container.ts
@@ -11,7 +11,11 @@ type Env = {
 
 export class RailsContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/rails/container.ts
+++ b/integrations/rails/container.ts
@@ -12,9 +12,9 @@ type Env = {
 export class RailsContainer extends Container<Env> {
   defaultPort = 8080
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
+  // window is the cost knob. Held at 2m where the other examples use 1m:
+  // Puma has to boot railties and every initializer, so a cold start is felt.
+  // A visitor reading one page should still get a warm container next click.
   sleepAfter = '2m'
 }
 

--- a/integrations/rails/wrangler.toml
+++ b/integrations/rails/wrangler.toml
@@ -7,6 +7,10 @@ compatibility_flags = ["nodejs_compat"]
 class_name = "RailsContainer"
 image = "./Dockerfile"
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "RAILS_CONTAINER"

--- a/integrations/sinatra/container.ts
+++ b/integrations/sinatra/container.ts
@@ -11,7 +11,11 @@ type Env = {
 
 export class SinatraContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/sinatra/container.ts
+++ b/integrations/sinatra/container.ts
@@ -12,10 +12,10 @@ type Env = {
 export class SinatraContainer extends Container<Env> {
   defaultPort = 8080
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
-  sleepAfter = '2m'
+  // window is the cost knob. This stack starts fast enough that a cold start
+  // is barely visible, so the tail is kept at the floor. The slower-booting
+  // examples (rails, laravel, django) hold 2m instead.
+  sleepAfter = '1m'
 }
 
 export default {

--- a/integrations/sinatra/wrangler.toml
+++ b/integrations/sinatra/wrangler.toml
@@ -7,6 +7,10 @@ compatibility_flags = ["nodejs_compat"]
 class_name = "SinatraContainer"
 image = "./Dockerfile"
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "SINATRA_CONTAINER"

--- a/integrations/xslate/container.ts
+++ b/integrations/xslate/container.ts
@@ -12,10 +12,10 @@ type Env = {
 export class XslateContainer extends Container<Env> {
   defaultPort = 8080
   // Billing runs for every second the instance is up, idle included, so this
-  // window is the cost knob. Short enough that one crawler hit does not keep
-  // the instance warm for the rest of the hour, long enough that a visitor
-  // reading a page still lands on a warm container for the next click.
-  sleepAfter = '2m'
+  // window is the cost knob. This stack starts fast enough that a cold start
+  // is barely visible, so the tail is kept at the floor. The slower-booting
+  // examples (rails, laravel, django) hold 2m instead.
+  sleepAfter = '1m'
 }
 
 export default {

--- a/integrations/xslate/container.ts
+++ b/integrations/xslate/container.ts
@@ -11,7 +11,11 @@ type Env = {
 
 export class XslateContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '10m'
+  // Billing runs for every second the instance is up, idle included, so this
+  // window is the cost knob. Short enough that one crawler hit does not keep
+  // the instance warm for the rest of the hour, long enough that a visitor
+  // reading a page still lands on a warm container for the next click.
+  sleepAfter = '2m'
 }
 
 export default {

--- a/integrations/xslate/wrangler.toml
+++ b/integrations/xslate/wrangler.toml
@@ -7,6 +7,10 @@ compatibility_flags = ["nodejs_compat"]
 class_name = "XslateContainer"
 image = "./Dockerfile"
 max_instances = 1
+# Memory and disk are billed on the instance type's provisioned size, so pin it
+# rather than inherit a platform default that could move the bill silently.
+# `lite` (256 MiB / 1/16 vCPU / 2 GB) is the smallest and fits this demo.
+instance_type = "lite"
 
 [[durable_objects.bindings]]
 name = "XSLATE_CONTAINER"


### PR DESCRIPTION
## What

Reduces the Cloudflare Containers bill for the 15 container-backed integration examples.

- `sleepAfter` `'10m'` → `'1m'`, except three slow-booting examples held at `'2m'`
- `instance_type = "lite"` pinned in every `integrations/*/wrangler.toml`

| `sleepAfter` | Examples | Why |
|---|---|---|
| `'1m'` | `axum`, `chi`, `echo`, `gin`, `nethttp` (compiled binaries); `php`, `blade` (PHP CLI server — no persistent boot to redo); `flask`, `fastapi`, `sinatra`, `mojolicious`, `xslate` (light stack load) | Cold start is barely visible, so the idle tail sits at the floor |
| `'2m'` | `rails` (Puma brings up railties + initializers), `laravel` (`artisan serve` boots the kernel first), `django` (settings + app registry) | A full framework boots on every start, so a cold start is felt |

The three Worker-only examples (`hono`, `h3`, `elysia`) are untouched — they have no container.

## Why

Containers bill provisioned memory and disk for **every second the instance is up, idle included**; only CPU is usage-based. With `sleepAfter = '10m'`, a single request held an instance for ten more minutes. A crawler touching each example once an hour kept all 15 warm roughly 3 h/day, for traffic that lasted seconds.

At `lite` (256 MiB / 2 GB disk) that is ~$0.00275 per container-hour, against an account allowance of ~100 container-hours/month. 15 examples × 3 h/day ≈ 1,350 h/month — about 13× the allowance. Going to `'1m'` cuts the idle tail by 90%, and if request spacing drops under the window (the case where `'10m'` pinned everything permanently warm) the saving is larger still.

Pinning `instance_type` changes no cost today — `lite` is already the platform default, so these examples have always run on it. It means a change to that default cannot move the bill for 15 workers silently.

## On the Durable Object bindings

The `[[durable_objects.bindings]]` blocks and the `new_sqlite_classes` migrations stay. `@cloudflare/containers`' `Container` **is** a `DurableObject` subclass, so those bindings are how a Container gets addressed at all — not a separate feature layered on top. There is no way to keep Containers and drop the DO.

Worth recording: no example uses DO storage. `grep` for `ctx.storage` / `state.storage` / `sql.exec` across all 15 `container.ts` files returns nothing — each one is the same short `Container` subclass plus an `idFromName('singleton')` forward. So the DO surface here is already at its floor; container uptime is the only thing left to tune.

Static prerendering was considered and does not work: the examples serve a session-cookie Todo REST API (`POST/PUT/DELETE /api/todos`) and an SSE stream (`/api/ai-chat`), both of which need a live per-stack server. That is the point of the showcase.

## Verification

- All 15 `wrangler.toml` files re-parsed with `tomllib`; `containers[0].instance_type == "lite"` and `max_instances == 1` confirmed on each, with the key landing in the `[[containers]]` table (not a stray `[containers.configuration]`).
- Tier split confirmed by grep: 12 files at `'1m'`, 3 at `'2m'`, no other value anywhere under `integrations/`.
- `biome check` ignores `integrations/*/container.ts` per `biome.jsonc`, so there is no lint delta.
- No changeset needed: `changeset-check.yml` only triggers on published `packages/*/src` paths.

Not verified here: actual post-deploy cost, and whether these windows feel right against real traffic on `barefootjs.dev`. Both want a look at the Cloudflare dashboard after this ships. The boot-cost tiering is a reading of each `Dockerfile`'s `CMD`, not a measurement — if a `'1m'` example turns out to have a cold start worth avoiding, moving it is one line.