### PR TITLE
feat(site): serve robots.txt excluding the integration demos from crawlers

### DIFF
--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -14,7 +14,7 @@
  * - dist/uno.css + dist/static/globals.css (tokens + globals + landing)
  * - dist/static/logos/, dist/static/snippets/, icons
  * - dist/playground/ (worker + page script + Monaco type bundle)
- * - dist/_headers, dist/llms.txt
+ * - dist/_headers, dist/llms.txt, dist/robots.txt
  */
 
 import { mkdir, readdir } from 'node:fs/promises'
@@ -342,5 +342,24 @@ const coreDocs = scanCoreDocs(CONTENT_DIR)
 const coreLlmsTxt = generateCoreLlmsTxt(coreDocs, 'https://barefootjs.dev/docs')
 await Bun.write(resolve(DIST_DIR, 'llms.txt'), coreLlmsTxt)
 console.log('Generated: dist/llms.txt')
+
+// ── 10. Write robots.txt ──────────────────────────────────────
+// Everything under /integrations/<adapter>/ is a live demo server backed by a
+// Cloudflare Container, billed for every second it runs. A crawl of all of them
+// wakes fifteen containers to render what is, to a crawler, the same page
+// fifteen times — the examples share one set of components and differ only in
+// the backend that renders them. Nothing is gained by indexing them.
+//
+// The trailing slash matters: it excludes the demos while leaving the bare
+// /integrations catalog page (served from these static assets, no container)
+// crawlable, so the examples stay discoverable even though they are not indexed.
+//
+// This is advisory — well-behaved crawlers honor it, others do not. Blocking
+// the rest takes a WAF rule on the zone, which runs before the Worker.
+const robotsTxt = `User-agent: *
+Disallow: /integrations/
+`
+await Bun.write(resolve(DIST_DIR, 'robots.txt'), robotsTxt)
+console.log('Generated: dist/robots.txt')
 
 console.log('\nBuild complete!')


### PR DESCRIPTION
## What

`site/core/build.ts` now emits `dist/robots.txt`, following the same pattern as the adjacent `dist/_headers` and `dist/llms.txt` steps:

```
User-agent: *
Disallow: /integrations/
```

## Why

Each `/integrations/<adapter>/` path is a live demo server behind a Cloudflare Container, billed for every second it runs. A crawl walks all fifteen and wakes all fifteen — to fetch what is, to a crawler, the same page fifteen times. The examples share one set of components and differ only in which backend renders them, so indexing them buys nothing and each visit costs a container wake.

The Durable Object namespace view on the Cloudflare dashboard shows 2.2k–4.6k requests per example. For a project this size that is not plausibly human traffic, and it lines up with the cost: at the previous `sleepAfter = '10m'`, requests arriving every ~12 minutes on average kept the containers effectively awake around the clock.

Note that request volume was never the problem on its own — ~50k DO requests sits far under the 1M/month included allowance. What it drives is *uptime*, which is the billed dimension.

## The trailing slash is load-bearing

`Disallow: /integrations/` excludes the demos while leaving the bare `/integrations` catalog page crawlable — robots.txt matches by prefix, and `/integrations` does not start with `/integrations/`. Verified against the live site:

- `/integrations` → 200, served from these static assets (`app.route('/integrations', ...)` in `site/core/app.tsx`), no container behind it
- `/integrations/` → 404
- `/integrations/rails` etc. → the container-backed demos

So the examples stay discoverable through an indexed catalog page without any of them being crawled.

## Interaction with Cloudflare's managed robots.txt

`https://barefootjs.dev/robots.txt` already returns 200 today, serving Cloudflare's auto-generated Content Signals Policy — comments only, no `User-agent` or `Disallow` directives. Cloudflare appends those signals to an origin robots.txt when one exists, so this file should end up carrying both. Worth re-checking the deployed output after this lands, since the merge behavior is Cloudflare's and not something this repo controls.

## Limits

Advisory only. This stops well-behaved crawlers and nothing else. Enforcing it against the rest needs a WAF rule on the zone, which runs ahead of the Worker and so costs no Worker, DO, or container time at all — that is a dashboard change, not a repo change.

## Verification

- `bun build --no-bundle` over `site/core/build.ts` parses clean.
- Live behavior of `/integrations` vs `/integrations/` confirmed by request, as above.
- Not verified here: the generated `dist/robots.txt` itself, since a full `bun run build` needs the vite component build and a populated workspace. The deploy job runs it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNsY8Loae5x6Bodc77qQNM)_