### PR TITLE
fix(ci): pin changesets/action back to v1 so releases publish again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,13 @@ updates:
       actions:
         patterns:
           - '*'
+    ignore:
+      # changesets/action v2 requires Changesets CLI v3; we run CLI ^2.31.0.
+      # Taking the action major on its own breaks every release run with
+      # "This version of the Changesets action is designed to work with
+      # Changesets CLI v3". Lift this together with the CLI v3 migration
+      # (ESM-only CLI, Node ^22.11 || ^24 || >=26, `changeset tag` renamed to
+      # `git-tag`, private packages no longer versioned by default,
+      # `changeset version` exiting 1 when there are no changesets).
+      - dependency-name: changesets/action
+        update-types: [version-update:semver-major]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,13 +73,21 @@ jobs:
 
       - run: bun install
 
+      # The action's major version is coupled to the Changesets CLI major
+      # version in package.json: v2 of the action refuses to run against CLI
+      # v2 ("designed to work with Changesets CLI v3"), and v1 is the one
+      # built for CLI v2. We pin @changesets/cli to ^2.31.0, so this must stay
+      # on v1 — see the matching Dependabot ignore in .github/dependabot.yml.
+      # Bumping either side alone breaks every release (run #798-#801, which
+      # left 0.31.9 versioned on main but unpublished).
       - name: Changesets — version or publish
         id: changesets
-        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          version-script: bunx changeset version
-          publish-script: bun run release:publish
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: bunx changeset version
+          publish: bun run release:publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Mirror whatever Changesets just published to npm onto JSR. Delegates to
   # the reusable jsr-publish.yml so the release-driven path and the manual


### PR DESCRIPTION
## What broke

When `changesets/action` was bumped to v2.1.0 (#2671, input migration in 94b7aa8), the Changesets CLI stayed on `^2.31.0`. v2 of the action refuses to run against CLI v2 before doing any work:

```
Error: This version of the Changesets action is designed to work with Changesets CLI v3.
Changesets CLI v2 is not supported; use Changesets action v1 instead, which is compatible with CLI v2.
```

So every push to main since the bump has failed the Release job at that step (runs #798–#801; #797 was the last green one).

- Run #799 was the merge of the Version Packages PR #2665. **main now carries 0.31.9, but nothing was ever published.**
- npm latest is still 0.31.8, and no `@barefootjs/*@0.31.9` tags or GitHub releases exist.
- Everything downstream is gated on `needs: release` + `published == 'true'`, so JSR / CPAN / PyPI / RubyGems / crates.io / Packagist are all missing 0.31.9 as well.

## What this PR does

Pins `changesets/action` back to v1.9.0 (`a45c4d5`), the last combination known to work. The step is byte-identical to its pre-94b7aa8 form (`version:` / `publish:` inputs, `GITHUB_TOKEN` via `env`); the only addition is a comment recording that the action major and the CLI major are coupled.

It also adds a Dependabot ignore for semver-major updates to `changesets/action`. All actions are bumped as one group, so without it the same major would be re-proposed next week and re-break the release.

## After merge

The push to main runs Release, and with no `.changeset/*.md` files present it takes the publish path. `scripts/changeset-publish.ts` compares against the registry and skips anything already published, so only the pending 0.31.9 goes out — and from there the downstream jobs fire.

## Follow-up (deliberately not in this PR)

Migrating to CLI v3 is more than a version bump, so it belongs in its own change. Breaking changes that affect this repo:

- The CLI becomes ESM-only.
- `engines` requires Node `^22.11 || ^24 || >=26` and npm `>=10.9.0`.
- `changeset tag` is renamed to `changeset git-tag`.
- Private packages are no longer versioned by default (opt in via `privatePackages`).
- `changeset version` exits 1 when there are no unreleased changesets.
- `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH` handling changed (`.changeset/config.json` uses `onlyUpdatePeerDependentsWhenOutOfRange`).
- Peer dependency updates bump dependents by `patch` instead of `major`.

Drop the Dependabot ignore as part of that migration.