### PR TITLE
fix(jsx): seed a self-derived signal's stash var from the raw prop, not its evaluated value (#2669)

### DIFF
--- a/.changeset/ssr-defaults-self-derived-signal-2669.md
+++ b/.changeset/ssr-defaults-self-derived-signal-2669.md
@@ -1,0 +1,20 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/erb": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/blade": patch
+"@barefootjs/twig": patch
+"@barefootjs/rust": patch
+"@barefootjs/xslate": patch
+---
+
+A signal or memo whose name collides with the prop its own initializer derives from now seeds its SSR template variable from the RAW prop instead of the derived value (#2669)
+
+`extractSsrDefaults` builds its manifest map in three passes — prop entries, then signals, then memos — and the last two unconditionally overwrote a same-named prop entry, discarding its `propName`. The collision only arises in the bare-props-arg form (`function C(props: P)`), since `function C({ label })` alongside `const [label] = …` is a redeclaration error.
+
+Template-stash adapters lower such a signal to an in-template recompute that READS the stash variable as its input (the raw caller prop) and OVERWRITES it with the derived value under the same name — `{% set label = (label if (label is defined and label is not none) else 'Default') %}`. With `propName` discarded, the manifest consumer (`_derive_stash_from_defaults` and its per-language twins) seeded that variable with the DERIVED value, so the recompute saw a non-nullish value and kept it: a caller-supplied `label='Hello'` could never win, and the SSR body rendered `Default` while `bf-p` correctly carried `Hello`. A non-idempotent derivation was wrong even with no caller props at all — `createSignal((props.count ?? 1) * 2)` seeded with the evaluated `2` re-derived to `2 * 2 = 4`.
+
+Such an entry is now a prop entry (`propName` set, `value: null`), letting the template's own `?? <default>` guard supply the fallback and a caller-supplied prop win. This establishes an invariant consumers can rely on: a signal/memo entry carries `propName` if and only if it is one of these self-derivation collisions. A collision whose initializer does NOT read the same-named prop is unchanged.
+
+**Text::Xslate is the exception.** Kolon's `: my $x = …` is a fresh lexical already in scope inside its own initializer, so a self-referencing derived step cannot be lowered to an in-template recompute at all and the adapter skips it. Xslate therefore has nowhere to perform the derivation at SSR time: a caller-supplied prop passes through un-derived, and an absent prop now renders empty rather than the static default it previously reached by coincidence. That gap is declared in the adapter's published fixture divergences and tracked in #2679.

--- a/.changeset/xslate-self-derived-signal-seed-2679.md
+++ b/.changeset/xslate-self-derived-signal-seed-2679.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/xslate": patch
+---
+
+A self-referencing derived signal/memo (getter shares its name with the prop it derives from, e.g. `const [size] = createSignal(props.size ?? 'icon')`) now seeds correctly in-template on Text::Xslate instead of rendering empty for an absent prop or passing a non-idempotent derivation through un-derived (#2679)
+
+`generateDerivedMemoSeed` previously skipped this shape entirely: Kolon's `: my $x = …` is a fresh lexical already in scope inside its own initializer, so `: my $size = $size // 'icon'` would read the just-declared `undef` rather than the stash variable — a real hazard the skip was right to avoid. But #2669 changed what a same-named entry's static seed now carries (the RAW prop, not the pre-derived value), so with no in-template recompute the derivation silently never ran. `PaginationLink`'s `const size = createMemo(() => props.size ?? 'icon')` lost its `size-9` class on every rendered link.
+
+The fix captures before shadowing: the self-referencing lowering is emitted as two statements instead of one, `: my $__bf_seed_<name> = <kolon>;` followed by `: my $<name> = $__bf_seed_<name>;`. In the first line `$<name>` still resolves to the stash variable — nothing has been declared under that name yet — so the lowered Kolon runs verbatim, unchanged; the second line then shadows `$<name>` with the already-evaluated result, exactly like every other derived step. The `__bf_seed_` prefix follows the adapter's existing internal-temporary convention (`__bf_item` / `__bf_pair`), and suffixing with the step's own name keeps multiple derived steps in one template collision-free.
+
+This graduates all three fixtures `signal-prop-same-name`, `signal-prop-same-name-derived`, and `signal-default-from-jsx` off the adapter's `render-divergences.ts` ledger — Xslate now matches the other six template-stash adapters, and issue #2679 is fully resolved.

--- a/packages/adapter-blade/src/test-render.ts
+++ b/packages/adapter-blade/src/test-render.ts
@@ -593,6 +593,12 @@ function buildBladeProps(
     // Env signals (#2057) are bound below via `SearchParams('')`, not from a
     // static initial value.
     if (signal.envReader) continue
+    // #2669: a self-derivation collision already got the correct RAW-prop
+    // seed above via `derivedProps` — `extractSsrDefaults` marks that with
+    // a `propName`-carrying entry (see its docstring's invariant). Skip
+    // re-seeding here or this harness's own `evaluateSignalInit` recompute
+    // clobbers the correctly-derived caller value.
+    if (rootSsrDefaults[signal.getter]?.propName !== undefined) continue
     const value = evaluateSignalInit(signal.initialValue.trim(), props)
     if (value !== null) {
       setEntry(signal.getter, value)
@@ -602,6 +608,8 @@ function buildBladeProps(
   // Memo values seeded from the statically-evaluated ssrDefaults, same
   // as the production plugin's before_render hook.
   for (const memo of ir.metadata.memos) {
+    // #2669: same self-derivation skip as the signal loop above.
+    if (rootSsrDefaults[memo.name]?.propName !== undefined) continue
     const entry = rootSsrDefaults[memo.name]
     const value = entry ? entry.value : 0
     setEntry(memo.name, value ?? 0)

--- a/packages/adapter-erb/src/test-render.ts
+++ b/packages/adapter-erb/src/test-render.ts
@@ -605,6 +605,16 @@ function buildRubyProps(
     // Env signals (#2057 / #1922) are bound below via `search_params('')`,
     // not from a static initial value.
     if (signal.envReader) continue
+    // #2669: a self-derivation collision (the signal's own initializer
+    // derives from a same-named prop, e.g. `createSignal(props.label ??
+    // 'Default')`) already got the correct RAW-prop seed above via
+    // `derivedProps` / `obj[param.name]` — `extractSsrDefaults` marks that
+    // with a `propName`-carrying entry (see its docstring's invariant).
+    // Re-seeding here with this harness's OWN recompute
+    // (`evaluateSignalInit`) would clobber the correctly-derived caller
+    // value with the harness's evaluated-from-static-props number, papering
+    // over the exact production bug this fixture exists to catch.
+    if (rootSsrDefaults[signal.getter]?.propName !== undefined) continue
     const value = evaluateSignalInit(signal.initialValue.trim(), props)
     if (value !== null) {
       obj[signal.getter] = value
@@ -614,6 +624,12 @@ function buildRubyProps(
   // Memo values seeded from the statically-evaluated ssrDefaults, same
   // as the production plugin's before_render hook.
   for (const memo of ir.metadata.memos) {
+    // #2669: same self-derivation skip as the signal loop above — a
+    // `propName`-carrying memo entry already stands as the correctly
+    // prop-derived seed; don't clobber it with the memo's OWN evaluated
+    // value (which for a non-idempotent derivation is already the WRONG,
+    // double-applied number).
+    if (rootSsrDefaults[memo.name]?.propName !== undefined) continue
     obj[memo.name] = rootSsrDefaults[memo.name]?.value ?? 0
   }
 

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -6,15 +6,29 @@
  * file even when the set is empty — the next divergence lands here, not in
  * a re-created file.
  *
- * Empty — #2630's `static-array-from-props-with-component-precomputed`
- * divergence graduated once the harness (`test-render.ts`'s
+ * (#2630's `static-array-from-props-with-component-precomputed` divergence
+ * graduated once the harness (`test-render.ts`'s
  * `buildDynamicChildLoopSeeding`, despite the name — see its doc comment)
  * learned to seed a prop-backed static child-component loop's Props slice
  * the same way it already seeded a signal-backed dynamic one: the adapter's
  * own `emission` was never the bug, only this harness's route-handler
- * stand-in was missing the prop-derived case.
+ * stand-in was missing the prop-derived case.)
  */
 
 import type { RenderDivergences } from '@barefootjs/jsx'
 
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // #2683: the props-struct emitter (`go-template-adapter.ts`) skips a
+  // signal whose Go field name collides with a prop field, keyed purely on
+  // the NAME collision — never on whether `extractPropFallback` actually
+  // matched a supported `props.x ?? <default>` shape. For a non-idempotent
+  // derivation (`createSignal((props.count ?? 1) * 2)`) the fallback
+  // extractor correctly declines to fold `* 2` into the struct default, but
+  // the `continue` fires anyway on the name match alone, so the emitted
+  // struct field silently drops the `* 2` and the signal's initial value
+  // renders as the raw prop instead of its derived value. Not a one-liner:
+  // two Go struct fields can't share an identifier, so simply removing the
+  // skip emits a duplicate field — the real fix needs its own PR.
+  'signal-prop-same-name-derived':
+    'self-derived signal collides with its prop field name in the generated Go props struct — the non-idempotent `* 2` derivation is dropped and the signal renders the raw prop value instead (https://github.com/piconic-ai/barefootjs/issues/2683)',
+}

--- a/packages/adapter-jinja/src/test-render.ts
+++ b/packages/adapter-jinja/src/test-render.ts
@@ -600,6 +600,12 @@ function buildPythonProps(
     // Env signals (#2057) are bound below via `SearchParams('')`, not from a
     // static initial value.
     if (signal.envReader) continue
+    // #2669: a self-derivation collision already got the correct RAW-prop
+    // seed above via `derivedProps` — `extractSsrDefaults` marks that with
+    // a `propName`-carrying entry (see its docstring's invariant). Skip
+    // re-seeding here or this harness's own `evaluateSignalInit` recompute
+    // clobbers the correctly-derived caller value.
+    if (rootSsrDefaults[signal.getter]?.propName !== undefined) continue
     const value = evaluateSignalInit(signal.initialValue.trim(), props)
     if (value !== null) {
       fullEntries.push(`${pyStr(signal.getter)}: ${toPyLiteral(value)}`)
@@ -609,6 +615,8 @@ function buildPythonProps(
   // Memo values seeded from the statically-evaluated ssrDefaults, same
   // as the production plugin's before_render hook.
   for (const memo of ir.metadata.memos) {
+    // #2669: same self-derivation skip as the signal loop above.
+    if (rootSsrDefaults[memo.name]?.propName !== undefined) continue
     const entry = rootSsrDefaults[memo.name]
     const value = entry ? entry.value : 0
     fullEntries.push(`${pyStr(memo.name)}: ${toPyLiteral(value ?? 0)}`)

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -514,11 +514,37 @@ function buildChildDefaultsPerl(ir: ComponentIR): string {
   // semantic divergence from those adapters.
   for (const signal of ir.metadata.signals) {
     if (signal.envReader) continue // env signal is the request reader, not a stashed value (#2057)
+    // #2669: a self-derivation collision (the signal's initializer derives
+    // from a same-named prop) gets a `propName`-carrying entry from
+    // `extractSsrDefaults` (see its docstring's invariant) — that entry
+    // MUST stay a hashref so `_derive_stash_from_defaults` resolves it
+    // against the REAL child props at runtime; the declared-prop loop above
+    // already emitted it for a DECLARED prop, so only an undeclared one
+    // needs adding here. Either way, do NOT fall through to this harness's
+    // own `evaluateSignalInit(..., undefined)` recompute below — that call
+    // sees no props at all and would silently re-flatten the collision back
+    // to a bare, non-caller-overridable value.
+    const d = ssrDefaults[signal.getter]
+    if (d?.propName !== undefined) {
+      if (!declared.has(signal.getter)) {
+        entries.push(`${signal.getter} => ${ssrDefaultEntryToPerl(d)}`)
+        declared.add(signal.getter)
+      }
+      continue
+    }
     const value = evaluateSignalInit(signal.initialValue.trim(), undefined)
     entries.push(`${signal.getter} => ${value !== null ? toPerlLiteral(value) : 'undef'}`)
   }
   for (const memo of ir.metadata.memos) {
     const entry = ssrDefaults[memo.name]
+    // #2669: same self-derivation handling as the signal loop above.
+    if (entry?.propName !== undefined) {
+      if (!declared.has(memo.name)) {
+        entries.push(`${memo.name} => ${ssrDefaultEntryToPerl(entry)}`)
+        declared.add(memo.name)
+      }
+      continue
+    }
     const value = entry ? entry.value : undefined
     entries.push(
       `${memo.name} => ${value !== undefined && value !== null ? toPerlLiteral(value) : 'undef'}`,
@@ -720,6 +746,12 @@ function buildPerlProps(
   // rule `buildChildDefaultsPerl` applies to child signals (#1897).
   for (const signal of ir.metadata.signals) {
     if (signal.envReader) continue // env signal bound below via search_params('') (#2057)
+    // #2669: a self-derivation collision already got the correct RAW-prop
+    // seed above via `derivedProps` — `extractSsrDefaults` marks that with
+    // a `propName`-carrying entry (see its docstring's invariant). Skip
+    // re-seeding here or this harness's own `evaluateSignalInit` recompute
+    // clobbers the correctly-derived caller value.
+    if (rootSsrDefaults[signal.getter]?.propName !== undefined) continue
     const value = evaluateSignalInit(signal.initialValue.trim(), props)
     entries.push(`${signal.getter} => ${value !== null ? toPerlLiteral(value) : 'undef'}`)
   }
@@ -731,6 +763,8 @@ function buildPerlProps(
   // from the plugin: hard-coding `0` masked memos with non-zero
   // initial values until #1423 added a fixture that exposed the gap.
   for (const memo of ir.metadata.memos) {
+    // #2669: same self-derivation skip as the signal loop above.
+    if (rootSsrDefaults[memo.name]?.propName !== undefined) continue
     const entry = rootSsrDefaults[memo.name]
     const value = entry ? entry.value : 0
     entries.push(`${memo.name} => ${toPerlLiteral(value ?? 0)}`)

--- a/packages/adapter-rust/src/test-render.ts
+++ b/packages/adapter-rust/src/test-render.ts
@@ -506,6 +506,12 @@ function buildVars(
     // Env signals (#2057) are bound below via `search_params`, not from a
     // static initial value.
     if (signal.envReader) continue
+    // #2669: a self-derivation collision already got the correct RAW-prop
+    // seed above via `derivedProps` — `extractSsrDefaults` marks that with
+    // a `propName`-carrying entry (see its docstring's invariant). Skip
+    // re-seeding here or this harness's own `evaluateSignalInit` recompute
+    // clobbers the correctly-derived caller value.
+    if (rootSsrDefaults[signal.getter]?.propName !== undefined) continue
     const value = evaluateSignalInit(signal.initialValue.trim(), props)
     if (value !== null) {
       vars[signal.getter] = value
@@ -515,6 +521,8 @@ function buildVars(
   // Memo values seeded from the statically-evaluated ssrDefaults, same
   // as the production plugin's before_render hook.
   for (const memo of ir.metadata.memos) {
+    // #2669: same self-derivation skip as the signal loop above.
+    if (rootSsrDefaults[memo.name]?.propName !== undefined) continue
     const entry = rootSsrDefaults[memo.name]
     vars[memo.name] = entry ? (entry.value ?? 0) : 0
   }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -4318,6 +4318,24 @@
         "text"
       ]
     },
+    "signal-prop-same-name-derived": {
+      "kinds": [
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "logical",
+        "member"
+      ],
+      "axes": [
+        "binary:*",
+        "literal:number",
+        "logical:??"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "signal-with-fallback": {
       "kinds": [
         "call",
@@ -5295,14 +5313,14 @@
     "array-literal": 80,
     "array-method": 69,
     "arrow": 69,
-    "binary": 91,
-    "call": 219,
+    "binary": 92,
+    "call": 220,
     "conditional": 25,
-    "identifier": 308,
+    "identifier": 309,
     "index-access": 14,
-    "literal": 250,
-    "logical": 45,
-    "member": 173,
+    "literal": 251,
+    "logical": 46,
+    "member": 174,
     "object-literal": 57,
     "template-literal": 30,
     "unary": 23,
@@ -5335,7 +5353,7 @@
     "array-method:trimStart": 1,
     "binary:!=": 2,
     "binary:!==": 9,
-    "binary:*": 10,
+    "binary:*": 11,
     "binary:+": 21,
     "binary:-": 11,
     "binary:/": 1,
@@ -5345,10 +5363,10 @@
     "binary:>=": 1,
     "literal:boolean": 49,
     "literal:null": 23,
-    "literal:number": 104,
+    "literal:number": 105,
     "literal:string": 178,
     "logical:&&": 7,
-    "logical:??": 39,
+    "logical:??": 40,
     "logical:||": 14,
     "member:computed": 8,
     "member:optional": 1,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -102,6 +102,7 @@ import { fixture as signalWithFallback } from './signal-with-fallback'
 import { fixture as signalDefaultFromJsx } from './signal-default-from-jsx'
 import { fixture as controlledSignal } from './controlled-signal'
 import { fixture as signalPropSameName } from './signal-prop-same-name'
+import { fixture as signalPropSameNameDerived } from './signal-prop-same-name-derived'
 import { fixture as memo } from './memo'
 import { fixture as effect } from './effect'
 import { fixture as multipleSignals } from './multiple-signals'
@@ -553,6 +554,7 @@ export const jsxFixtures: JSXFixture[] = [
   signalDefaultFromJsx,
   controlledSignal,
   signalPropSameName,
+  signalPropSameNameDerived,
   memo,
   effect,
   multipleSignals,

--- a/packages/adapter-tests/fixtures/signal-prop-same-name-derived.ts
+++ b/packages/adapter-tests/fixtures/signal-prop-same-name-derived.ts
@@ -1,0 +1,36 @@
+import { createFixture } from '../src/types'
+
+// #2669 (shape B): `signal-prop-same-name` pins the IDEMPOTENT collision
+// (`props.label ?? 'Default'`), which hid the bug — a stash re-seeded with
+// the already-derived value only becomes visibly wrong once you try a
+// caller-supplied prop, and even then only via the harness-bypassing
+// production path, not this conformance suite. This fixture pins the
+// NON-idempotent flavor: `(props.count ?? 1) * 2`. Seeding the
+// template-stash variable `count` with the pre-fix EVALUATED signal value
+// (10, for `count: 5`) makes the emitted template's own `{% set count =
+// (count if count is defined else 1) * 2 %}` recompute apply the `* 2` a
+// SECOND time — `10 * 2 = 20` — wrong even though the caller DID supply a
+// prop. The correct seed is the RAW prop (5); the template's own
+// derivation computes `5 * 2 = 10` exactly once.
+//
+// `expectedHtml` is HAND-AUTHORED to the correct value (not auto-generated
+// from the Hono reference adapter, even though Hono itself is unaffected
+// by this template-stash-only bug) per CLAUDE.md's fixture rule, and this
+// id is registered in `generate-expected-html.ts`'s `SKIP_AUTO_UPDATE` so
+// a regeneration pass can't silently overwrite the intent.
+export const fixture = createFixture({
+  id: 'signal-prop-same-name-derived',
+  description: 'Signal initialized from a NON-IDEMPOTENT derivation of a prop with the identical name',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function SignalPropSameNameDerived(props: { count?: number }) {
+  const [count, setCount] = createSignal((props.count ?? 1) * 2)
+  return <span>{count()}</span>
+}
+`,
+  props: { count: 5 },
+  expectedHtml: `
+    <span bf-s="test" bf="s1"><!--bf:s0-->10<!--/--></span>
+  `,
+})

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -1546,6 +1546,30 @@
       }
     }
   ],
+  "signal-prop-same-name-derived": [
+    {
+      "name": "gen:count:absent",
+      "props": {}
+    },
+    {
+      "name": "gen:count:zero",
+      "props": {
+        "count": 0
+      }
+    },
+    {
+      "name": "gen:count:negative",
+      "props": {
+        "count": -7
+      }
+    },
+    {
+      "name": "gen:count:large",
+      "props": {
+        "count": 1234567890
+      }
+    }
+  ],
   "signal-with-fallback": [
     {
       "name": "gen:initial:absent",

--- a/packages/adapter-tests/scripts/generate-expected-html.ts
+++ b/packages/adapter-tests/scripts/generate-expected-html.ts
@@ -47,7 +47,12 @@ function resolveFixturePath(id: string): string | null {
 // fixture exists specifically to pin that gap). Auto-update would
 // overwrite the intentional value with the bug's output, so we skip
 // regeneration here.
-const SKIP_AUTO_UPDATE = new Set<string>([])
+const SKIP_AUTO_UPDATE = new Set<string>([
+  // #2669 (shape B): hand-authored to the CORRECT non-idempotent-derivation
+  // value; must not be silently overwritten by a future regeneration pass.
+  // See the fixture file's docstring for the full mechanism.
+  'signal-prop-same-name-derived',
+])
 
 async function main() {
   let updated = 0

--- a/packages/adapter-twig/src/test-render.ts
+++ b/packages/adapter-twig/src/test-render.ts
@@ -591,6 +591,12 @@ function buildTwigProps(
     // Env signals (#2057) are bound below via `SearchParams('')`, not from a
     // static initial value.
     if (signal.envReader) continue
+    // #2669: a self-derivation collision already got the correct RAW-prop
+    // seed above via `derivedProps` — `extractSsrDefaults` marks that with
+    // a `propName`-carrying entry (see its docstring's invariant). Skip
+    // re-seeding here or this harness's own `evaluateSignalInit` recompute
+    // clobbers the correctly-derived caller value.
+    if (rootSsrDefaults[signal.getter]?.propName !== undefined) continue
     const value = evaluateSignalInit(signal.initialValue.trim(), props)
     if (value !== null) {
       setEntry(signal.getter, value)
@@ -600,6 +606,8 @@ function buildTwigProps(
   // Memo values seeded from the statically-evaluated ssrDefaults, same
   // as the production plugin's before_render hook.
   for (const memo of ir.metadata.memos) {
+    // #2669: same self-derivation skip as the signal loop above.
+    if (rootSsrDefaults[memo.name]?.propName !== undefined) continue
     const entry = rootSsrDefaults[memo.name]
     const value = entry ? entry.value : 0
     setEntry(memo.name, value ?? 0)

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -199,9 +199,11 @@ export function Item(props: { defaultOn?: boolean }) {
     expect(template).toContain(': my $on = ($defaultOn // 0);')
   })
 
-  // Kolon can't `: my $x = … $x …`; a same-name signal stays on the existing
-  // (harness/manifest) seeding rather than an in-template seed.
-  test('does NOT in-template-seed a same-name signal', () => {
+  // Kolon can't `: my $x = … $x …` directly (the declaration shadows the
+  // RHS's own reference), so a same-name signal captures the lowered
+  // expression into a throwaway `__bf_seed_<name>` local BEFORE `$x` is
+  // declared, then binds `$x` off that capture (#2679).
+  test('in-template-seeds a same-name signal via capture-before-shadow', () => {
     const { template } = compileAndGenerate(`
 'use client'
 import { createSignal } from '@barefootjs/client'
@@ -210,7 +212,8 @@ export function C(props: { x?: number }) {
   return <span>{x()}</span>
 }
 `)
-    expect(template).not.toContain(': my $x =')
+    expect(template).toContain(': my $__bf_seed_x = ($x // 7);')
+    expect(template).toContain(': my $x = $__bf_seed_x;')
   })
 
   test('emits data_key_attr on the component root', () => {

--- a/packages/adapter-xslate/src/adapter/memo/seed.ts
+++ b/packages/adapter-xslate/src/adapter/memo/seed.ts
@@ -53,13 +53,19 @@ export function generateContextConsumerSeed(ir: ComponentIR): string {
  * backend-specific emit guards: skip an empty lowering, skip a lowering that
  * references no `$var` at all (a constant init/body — e.g. a `derived` step
  * with empty `frees` — keeps the existing static ssr-defaults seed instead),
- * and skip a self-referencing lowering (Kolon's `my` shadows the RHS, so
- * `: my $x = … $x …` would read the just-declared undefined lexical rather
- * than the render var — the plan rules out SOURCE-level self-refs, but a
- * lowered canonical name could still collide, so this stays as the cheap
- * defense it always was). `env-reader` and `opaque` steps emit nothing (the
- * runtime supplies the reader, or the adapter's ssr-defaults path already
- * covers it). (#1297, #2075)
+ * and capture-before-shadow a self-referencing lowering (Kolon's `my`
+ * shadows the RHS, so `: my $x = … $x …` would read the just-declared
+ * undefined lexical rather than the render var — the plan rules out
+ * SOURCE-level self-refs, but a lowered canonical name could still collide,
+ * e.g. `createMemo(() => props.size ?? 'icon')` lowers `props.size` straight
+ * to the stash var `$size`, colliding with the memo's own name). The
+ * self-referencing case still emits the SAME verbatim Kolon — nothing about
+ * `kolon` changes — just as the RHS of a throwaway `__bf_seed_*` local
+ * declared BEFORE `$<name>` is shadowed, so `$<name>` inside `kolon` still
+ * resolves to the stash var, not the fresh lexical; a second statement then
+ * binds the real name off the already-evaluated capture. `env-reader` and
+ * `opaque` steps emit nothing (the runtime supplies the reader, or the
+ * adapter's ssr-defaults path already covers it). (#1297, #2075, #2679)
  */
 export function generateDerivedMemoSeed(ctx: XslateMemoContext, ir: ComponentIR): string {
   // Package G attached this to metadata at compile time; the `??` fallback
@@ -71,7 +77,21 @@ export function generateDerivedMemoSeed(ctx: XslateMemoContext, ir: ComponentIR)
     if (step.kind !== 'derived') continue
     const kolon = ctx.convertExpressionToKolon(step.expr, step.parsed)
     if (kolon === '' || !/\$[A-Za-z_]\w*/.test(kolon)) continue
-    if (new RegExp(`\\$${step.name}\\b`).test(kolon)) continue
+    if (new RegExp(`\\$${step.name}\\b`).test(kolon)) {
+      // Self-referencing lowering (#2679): capture the RHS into a
+      // throwaway local BEFORE `$<name>` is declared — `$<name>` inside
+      // `kolon` still reads the stash var at this point, nothing is
+      // shadowed yet — then bind the real name off the capture. The
+      // `__bf_seed_` prefix follows the adapter's established internal-
+      // temporary convention (`__bf_item` / `__bf_pair` in the loop
+      // lowering); suffixing with `step.name` keeps two derived steps in
+      // the same template from colliding, since `step.name` is itself
+      // unique per plan (each step declares a distinct local).
+      const tmp = `__bf_seed_${step.name}`
+      lines.push(`: my $${tmp} = ${kolon};`)
+      lines.push(`: my $${step.name} = $${tmp};`)
+      continue
+    }
     lines.push(`: my $${step.name} = ${kolon};`)
   }
   return lines.length > 0 ? lines.join('\n') + '\n' : ''

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -9,22 +9,11 @@
 
 import type { RenderDivergences } from '@barefootjs/jsx'
 
-export const renderDivergences: RenderDivergences = {
-  // #2679: Kolon's `: my $x = …` is a fresh lexical declaration already in
-  // scope inside its own initializer, so a self-referencing derived signal/
-  // memo (getter shares its name with the prop it derives from) can't be
-  // lowered to an in-template recompute the way the other six template-
-  // stash backends do — `generateDerivedMemoSeed` skips it. No caller
-  // override ever applies (the derivation never re-runs at SSR), and with
-  // no caller prop there is no in-template fallback either.
-  'signal-prop-same-name':
-    'self-derived signal has no in-template recompute — a caller-supplied prop is never re-derived and an absent prop renders empty instead of the static default (https://github.com/piconic-ai/barefootjs/issues/2679)',
-  'signal-prop-same-name-derived':
-    'self-derived signal has no in-template recompute — a caller-supplied prop passes through raw (unmultiplied) and an absent prop renders empty instead of the statically-derived default (https://github.com/piconic-ai/barefootjs/issues/2679)',
-  // Same #2679 defect, surfaced by the same self-name collision
-  // (`createSignal(props.x ?? 7)`) — the caller omits `x`, so with no
-  // in-template recompute the stash seed (`propName: 'x', value: null`)
-  // has nothing to fall back to; the dependent memo inherits the gap.
-  'signal-default-from-jsx':
-    'self-derived signal has no in-template recompute — an absent prop renders empty instead of the JSX-time default, and the dependent memo inherits the gap (https://github.com/piconic-ai/barefootjs/issues/2679)',
-}
+// #2679 graduated (capture-before-shadow in `generateDerivedMemoSeed`,
+// packages/adapter-xslate/src/adapter/memo/seed.ts): a self-referencing
+// derived signal/memo now seeds a throwaway `__bf_seed_<name>` local from
+// the RAW-stash-var Kolon lowering BEFORE `$<name>` is declared, then binds
+// the real name off that capture — the same in-template recompute the other
+// six template-stash backends already had. Keep the file even when the set
+// is empty — the next divergence lands here, not in a re-created file.
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -10,4 +10,21 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
+  // #2679: Kolon's `: my $x = …` is a fresh lexical declaration already in
+  // scope inside its own initializer, so a self-referencing derived signal/
+  // memo (getter shares its name with the prop it derives from) can't be
+  // lowered to an in-template recompute the way the other six template-
+  // stash backends do — `generateDerivedMemoSeed` skips it. No caller
+  // override ever applies (the derivation never re-runs at SSR), and with
+  // no caller prop there is no in-template fallback either.
+  'signal-prop-same-name':
+    'self-derived signal has no in-template recompute — a caller-supplied prop is never re-derived and an absent prop renders empty instead of the static default (https://github.com/piconic-ai/barefootjs/issues/2679)',
+  'signal-prop-same-name-derived':
+    'self-derived signal has no in-template recompute — a caller-supplied prop passes through raw (unmultiplied) and an absent prop renders empty instead of the statically-derived default (https://github.com/piconic-ai/barefootjs/issues/2679)',
+  // Same #2679 defect, surfaced by the same self-name collision
+  // (`createSignal(props.x ?? 7)`) — the caller omits `x`, so with no
+  // in-template recompute the stash seed (`propName: 'x', value: null`)
+  // has nothing to fall back to; the dependent memo inherits the gap.
+  'signal-default-from-jsx':
+    'self-derived signal has no in-template recompute — an absent prop renders empty instead of the JSX-time default, and the dependent memo inherits the gap (https://github.com/piconic-ai/barefootjs/issues/2679)',
 }

--- a/packages/adapter-xslate/src/test-render.ts
+++ b/packages/adapter-xslate/src/test-render.ts
@@ -564,29 +564,20 @@ function buildPerlProps(
   }
 
   // Signal values evaluated from props (after user props).
-  //
-  // #2669 note — this loop DELIBERATELY does NOT skip a `propName`-carrying
-  // self-derivation-collision entry the way the ERB / Jinja / Mojo / Blade /
-  // Twig / Rust harnesses now do (see their matching comment). Those six
-  // backends lower a self-referencing derived step in-template (`{% set
-  // count = (count if defined else 1) * 2 %}` and siblings), so the
-  // `deriveStashFromDefaults`-resolved RAW prop is enough — the template
-  // finishes the derivation. Xslate's Kolon target language cannot: its
-  // `: my $x = …` is a fresh lexical DECLARATION, so a self-referencing RHS
-  // would read the just-declared (undefined) lexical instead of the stash
-  // value — `computeSsrSeedPlan`'s consumer in
-  // `packages/adapter-xslate/src/adapter/memo/seed.ts` therefore skips
-  // lowering a self-referencing derived step entirely, permanently (a
-  // pre-existing, documented Kolon limitation, not a #2669 regression to
-  // fix here). With no in-template recompute possible, this harness's own
-  // `evaluateSignalInit(initializer, props)` — evaluating the initializer
-  // against the REAL caller props — is the only place a self-derived
-  // signal's correct value can be produced at all, so it must keep running
-  // unconditionally, including for `propName`-carrying entries.
   for (const signal of ir.metadata.signals) {
     // Env signals (#2057) are bound below via `search_params('')`, not from a
     // static initial value.
     if (signal.envReader) continue
+    // #2669 / #2679: a self-derivation collision (the signal's own
+    // initializer derives from a same-named prop) already got the correct
+    // RAW-prop seed above via `derivedProps` / the user-props loop —
+    // `extractSsrDefaults` marks that with a `propName`-carrying entry.
+    // Re-seeding here with this harness's own recompute
+    // (`evaluateSignalInit`) would clobber it with the harness's
+    // evaluated-from-static-props number — the exact leniency #2679 tracks
+    // Xslate as unable to reproduce faithfully (Kolon has no in-template
+    // recompute for this shape; see `render-divergences.ts`).
+    if (rootSsrDefaults[signal.getter]?.propName !== undefined) continue
     const value = evaluateSignalInit(signal.initialValue.trim(), props)
     if (value !== null) {
       entries.push(`${signal.getter} => ${toPerlLiteral(value)}`)
@@ -594,10 +585,10 @@ function buildPerlProps(
   }
 
   // Memo values seeded from the statically-evaluated ssrDefaults, same
-  // as the production plugin's before_render hook. Same #2669 note as the
-  // signal loop above: no skip for `propName`-carrying entries, for the
-  // same Kolon self-ref-lowering limitation.
+  // as the production plugin's before_render hook.
   for (const memo of ir.metadata.memos) {
+    // #2669 / #2679: same self-derivation skip as the signal loop above.
+    if (rootSsrDefaults[memo.name]?.propName !== undefined) continue
     const entry = rootSsrDefaults[memo.name]
     const value = entry ? entry.value : 0
     entries.push(`${memo.name} => ${toPerlLiteral(value ?? 0)}`)

--- a/packages/adapter-xslate/src/test-render.ts
+++ b/packages/adapter-xslate/src/test-render.ts
@@ -564,6 +564,25 @@ function buildPerlProps(
   }
 
   // Signal values evaluated from props (after user props).
+  //
+  // #2669 note — this loop DELIBERATELY does NOT skip a `propName`-carrying
+  // self-derivation-collision entry the way the ERB / Jinja / Mojo / Blade /
+  // Twig / Rust harnesses now do (see their matching comment). Those six
+  // backends lower a self-referencing derived step in-template (`{% set
+  // count = (count if defined else 1) * 2 %}` and siblings), so the
+  // `deriveStashFromDefaults`-resolved RAW prop is enough — the template
+  // finishes the derivation. Xslate's Kolon target language cannot: its
+  // `: my $x = …` is a fresh lexical DECLARATION, so a self-referencing RHS
+  // would read the just-declared (undefined) lexical instead of the stash
+  // value — `computeSsrSeedPlan`'s consumer in
+  // `packages/adapter-xslate/src/adapter/memo/seed.ts` therefore skips
+  // lowering a self-referencing derived step entirely, permanently (a
+  // pre-existing, documented Kolon limitation, not a #2669 regression to
+  // fix here). With no in-template recompute possible, this harness's own
+  // `evaluateSignalInit(initializer, props)` — evaluating the initializer
+  // against the REAL caller props — is the only place a self-derived
+  // signal's correct value can be produced at all, so it must keep running
+  // unconditionally, including for `propName`-carrying entries.
   for (const signal of ir.metadata.signals) {
     // Env signals (#2057) are bound below via `search_params('')`, not from a
     // static initial value.
@@ -575,7 +594,9 @@ function buildPerlProps(
   }
 
   // Memo values seeded from the statically-evaluated ssrDefaults, same
-  // as the production plugin's before_render hook.
+  // as the production plugin's before_render hook. Same #2669 note as the
+  // signal loop above: no skip for `propName`-carrying entries, for the
+  // same Kolon self-ref-lowering limitation.
   for (const memo of ir.metadata.memos) {
     const entry = rootSsrDefaults[memo.name]
     const value = entry ? entry.value : 0

--- a/packages/adapter-xslate/src/test-render.ts
+++ b/packages/adapter-xslate/src/test-render.ts
@@ -568,15 +568,15 @@ function buildPerlProps(
     // Env signals (#2057) are bound below via `search_params('')`, not from a
     // static initial value.
     if (signal.envReader) continue
-    // #2669 / #2679: a self-derivation collision (the signal's own
-    // initializer derives from a same-named prop) already got the correct
-    // RAW-prop seed above via `derivedProps` / the user-props loop —
-    // `extractSsrDefaults` marks that with a `propName`-carrying entry.
-    // Re-seeding here with this harness's own recompute
-    // (`evaluateSignalInit`) would clobber it with the harness's
-    // evaluated-from-static-props number — the exact leniency #2679 tracks
-    // Xslate as unable to reproduce faithfully (Kolon has no in-template
-    // recompute for this shape; see `render-divergences.ts`).
+    // #2669: a self-derivation collision (the signal's own initializer
+    // derives from a same-named prop, e.g. `createSignal(props.label ??
+    // 'Default')`) already got the correct RAW-prop seed above via
+    // `derivedProps` / the user-props loop — `extractSsrDefaults` marks that
+    // with a `propName`-carrying entry (see its docstring's invariant).
+    // Re-seeding here with this harness's OWN recompute
+    // (`evaluateSignalInit`) would clobber the correctly-derived caller
+    // value with the harness's evaluated-from-static-props number, papering
+    // over the exact production bug this fixture exists to catch.
     if (rootSsrDefaults[signal.getter]?.propName !== undefined) continue
     const value = evaluateSignalInit(signal.initialValue.trim(), props)
     if (value !== null) {
@@ -587,7 +587,11 @@ function buildPerlProps(
   // Memo values seeded from the statically-evaluated ssrDefaults, same
   // as the production plugin's before_render hook.
   for (const memo of ir.metadata.memos) {
-    // #2669 / #2679: same self-derivation skip as the signal loop above.
+    // #2669: same self-derivation skip as the signal loop above — a
+    // `propName`-carrying memo entry already stands as the correctly
+    // prop-derived seed; don't clobber it with the memo's OWN evaluated
+    // value (which for a non-idempotent derivation is already the WRONG,
+    // double-applied number).
     if (rootSsrDefaults[memo.name]?.propName !== undefined) continue
     const entry = rootSsrDefaults[memo.name]
     const value = entry ? entry.value : 0

--- a/packages/jsx/src/__tests__/ssr-defaults.test.ts
+++ b/packages/jsx/src/__tests__/ssr-defaults.test.ts
@@ -103,6 +103,98 @@ describe('extractSsrDefaults', () => {
     expect(defaults?.n).toEqual({ value: 0 })
   })
 
+  test('self-derived signal collision (#2669, shape A): entry stays a PROP entry, not the evaluated signal value', () => {
+    // `props.label` and the signal getter `label` share a name — the
+    // bare-props-arg form is the only shape where this collides (a
+    // destructured-arg `function C({ label })` + `const [label] = ...`
+    // is a JS redeclaration error, so it can't happen there). The
+    // emitted template reads the stash var `label` as the RAW caller
+    // prop and OVERWRITES it with the derived signal value under that
+    // SAME name (`{% set label = (label if label is defined else
+    // 'Default') %}`). Seeding the stash with the pre-fix `{ value:
+    // 'Default' }` (the EVALUATED signal value, discarding `propName`)
+    // means a caller-passed `label` can never win — production seeds
+    // 'Default', the template sees a non-none value, and keeps it. The
+    // fix: this entry must stay a PROP entry (`propName` set, `value:
+    // null`) so the template's own `?? 'Default'` guard supplies the
+    // real fallback, and a caller-supplied prop still wins via
+    // `propName`.
+    const metadata = metadataFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function C(props: { label?: string }) {
+        const [label, setLabel] = createSignal(props.label ?? 'Default')
+        return <span>{label()}</span>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.label).toEqual({ propName: 'label', value: null })
+  })
+
+  test('self-derived signal collision (#2669, shape B): non-idempotent derivation must not seed the pre-fix double-applied value', () => {
+    // `(props.count ?? 1) * 2` is NOT idempotent: seeding the stash with
+    // the pre-fix EVALUATED value (2, for no caller prop) makes the
+    // template's own recompute apply the `* 2` a second time (`2 * 2 =
+    // 4`) — wrong even with no caller props at all. Pin that the entry
+    // is the RAW-prop shape (`value: null`), not `{ value: 2 }`.
+    const metadata = metadataFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function C(props: { count?: number }) {
+        const [count, setCount] = createSignal((props.count ?? 1) * 2)
+        return <span>{count()}</span>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.count).toEqual({ propName: 'count', value: null })
+  })
+
+  test('self-derived memo collision (#2669): the same rule applies to a memo whose computation derives from a same-named prop', () => {
+    // Same collision, memo flavor: `createMemo(() => (props.label ??
+    // 'Default') + n())` — the memo's OWN name (`label`) is the
+    // template variable the emitted template both reads (raw prop) and
+    // overwrites (derived memo value). `n` is an unrelated ordinary
+    // signal and must be unaffected (plain `{ value }` entry, no
+    // `propName`).
+    const metadata = metadataFor(`
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/client'
+      function C(props: { label?: string }) {
+        const [n, setN] = createSignal(0)
+        const label = createMemo(() => (props.label ?? 'Default') + n())
+        return <span>{label()}</span>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.label).toEqual({ propName: 'label', value: null })
+    expect(defaults?.n).toEqual({ value: 0 })
+  })
+
+  test('NON-self-derived collision (#2669, shape C — out of scope, must be unchanged): signal value still wins, no `propName`', () => {
+    // Same-named `label` getter and `label` prop, but the signal's OWN
+    // initializer does NOT derive from `props.label` (it's a plain
+    // string literal) — the JSX body separately reads `label()` AND
+    // `props.label`. That's a template-variable-ALIASING defect (both
+    // expressions lower to the same template variable, so no seeding
+    // choice can be right for both readers) — a different bug, tracked
+    // separately, and this fix must leave it byte-identical: the entry
+    // stays the plain evaluated-signal-value shape with no `propName`.
+    const metadata = metadataFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function C(props: { label?: string }) {
+        const [label, setLabel] = createSignal('sig')
+        return <span>{label()}{props.label}</span>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.label).toEqual({ value: 'sig' })
+  })
+
   test('aliased destructured prop (#2460): `propName` is the CALLER-facing key, not the local binding', () => {
     // `{ n: count }` — the caller passes `n`, the template variable (and
     // stash entry key) is the local binding `count`. The manifest
@@ -300,6 +392,31 @@ describe('deriveStashFromDefaults', () => {
       count: { propName: 'n', value: 99 },
     }
     expect(deriveStashFromDefaults(defaults, { n: 0 })).toEqual({ count: 0 })
+  })
+
+  test('self-derived signal collision (#2669): the caller-supplied prop now wins, and an absent prop falls back to null', () => {
+    // End-to-end proof of the fix's effect at the `deriveStashFromDefaults`
+    // layer: run the real `extractSsrDefaults` output for shape A through
+    // the seeding function. Pre-fix, this entry was `{ value: 'Default' }`
+    // (propName-less) so a caller's `label: 'Hello'` was IGNORED —
+    // `deriveStashFromDefaults` had no `propName` to resolve against and
+    // always used the static value. Post-fix the entry is a PROP entry, so
+    // the caller's value wins, and an absent prop resolves to the RAW
+    // fallback `null` (not the old evaluated `'Default'`) — the emitted
+    // template's own `?? 'Default'` guard supplies the real default from
+    // there.
+    const metadata = metadataFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function C(props: { label?: string }) {
+        const [label, setLabel] = createSignal(props.label ?? 'Default')
+        return <span>{label()}</span>
+      }
+    `)
+    const defaults = extractSsrDefaults(metadata)!
+
+    expect(deriveStashFromDefaults(defaults, { label: 'Hello' })).toEqual({ label: 'Hello' })
+    expect(deriveStashFromDefaults(defaults, {})).toEqual({ label: null })
   })
 
   test('propName-less entry (signal / memo local): always uses the static value', () => {

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -52,6 +52,16 @@ export interface SsrDefault {
    * (`{ variant = 'default' }`) where the template variable maps 1:1
    * to a caller-supplied prop. Omitted for signal / memo entries that
    * are internal to the component.
+   *
+   * Invariant (#2669): a signal / memo entry carries `propName` IF AND
+   * ONLY IF it's a self-derivation collision — the signal/memo's own
+   * template variable shares a name with the prop its initializer
+   * derives from (`const [label] = createSignal(props.label ?? 'x')`).
+   * Every OTHER signal/memo entry is `propName`-less. Consumers (e.g.
+   * every template-stash adapter's conformance harness, `test-render.ts`)
+   * rely on this to know a signal/memo's stash seed must defer to the
+   * already-derived prop value rather than re-seeding from its own
+   * evaluated initial — see `extractSsrDefaults`'s signal/memo loops.
    */
   propName?: string
   /**
@@ -225,14 +235,73 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
     // baked initial value.
     if (sig.envReader) continue
     const value = tryStaticEval(sig.initialValue, { bindings, propsLike })
-    out[sig.getter] = { value: resultToJsonable(value) }
+    // Self-derivation collision (#2669): a signal whose getter shares its
+    // name with the prop its OWN initializer derives from
+    // (`const [label] = createSignal(props.label ?? 'Default')`) gets a
+    // template-stash variable that the emitted template both READS (as the
+    // raw caller prop) and OVERWRITES (with the derived signal value) under
+    // that SAME name — see the Mojo/Jinja/etc. emitter's `{% set label =
+    // (label if label is defined else 'Default') %}`. Seeding the stash
+    // with the DERIVED value here would either permanently lock out a
+    // caller-supplied prop (idempotent derivations like `?? 'Default'` hide
+    // this — a caller's real value can never win) or double-apply a
+    // non-idempotent derivation (`(props.count ?? 1) * 2` seeded with the
+    // evaluated `2` re-derives to `2 * 2 = 4`). The correct seed is the RAW
+    // prop, so the entry must be a PROP entry (`propName` set, `value:
+    // null`) instead of a plain signal-value entry — the template's own
+    // `?? <default>` / `is not none` guard performs the real derivation,
+    // exactly like the bare-props safety net below.
+    //
+    // NOT self-derived (the initializer references a DIFFERENT prop, or no
+    // prop at all) keeps today's behavior: the signal's evaluated value
+    // wins the entry outright. This also correctly leaves alone the
+    // separate (out-of-scope) case where the signal's OWN initializer does
+    // NOT reference the same-named prop but the JSX body separately reads
+    // both `label()` and `props.label` — that's a template-variable-
+    // aliasing defect, not this one, and must render byte-identically.
+    //
+    // Invariant this establishes (relied on by every template-stash
+    // conformance harness's seeding loops — see `test-render.ts`): a
+    // signal/memo entry carries `propName` IF AND ONLY IF it went through
+    // this collision path. An ordinary signal/memo entry never has
+    // `propName` — that's exclusively how a harness (or a production
+    // manifest consumer) can tell "this local's stash seed must come from
+    // the caller-facing prop, not the local's own evaluated value" apart
+    // from "this is an internal signal/memo the caller cannot override".
+    if (metadata.propsObjectName !== null && referencesOwnProp(sig.initialValue, metadata.propsObjectName, sig.getter)) {
+      // Pass 1 above already wrote the prop entry when the prop is
+      // *declared* on the props type — leave it as-is. An undeclared
+      // (untyped / inline-typed) prop has no pass-1 entry yet; create it
+      // here so the collision is still resolved for that shape.
+      if (!(sig.getter in out)) {
+        out[sig.getter] = { propName: sig.getter, value: null }
+      }
+    } else {
+      out[sig.getter] = { value: resultToJsonable(value) }
+    }
+    // `bindings` always gets the EVALUATED value regardless of which stash
+    // seed the entry above ended up with — a later memo referencing this
+    // getter (`createMemo(() => label() + '!')`) must keep resolving
+    // through the chain exactly as before; only the manifest's own seed
+    // choice changes, not the static-eval semantics.
     bindings[sig.getter] = value
   }
 
   for (const memo of metadata.memos) {
     if (memo.isModule) continue
     const value = tryStaticEval(memo.computation, { bindings, propsLike })
-    out[memo.name] = { value: resultToJsonable(value) }
+    // Same self-derivation collision as signals above, for a memo whose
+    // computation derives from a same-named prop
+    // (`createMemo(() => (props.label ?? 'Default') + n())`). See the
+    // signal loop's comment for the full mechanism and the `propName`
+    // invariant this relies on.
+    if (metadata.propsObjectName !== null && referencesOwnProp(memo.computation, metadata.propsObjectName, memo.name)) {
+      if (!(memo.name in out)) {
+        out[memo.name] = { propName: memo.name, value: null }
+      }
+    } else {
+      out[memo.name] = { value: resultToJsonable(value) }
+    }
     bindings[memo.name] = value
   }
 
@@ -266,6 +335,24 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
   }
 
   return Object.keys(out).length === 0 ? undefined : out
+}
+
+/**
+ * Does `expr` (a signal initializer or memo computation) read
+ * `propsObjectName.<name>` where `name` is that SAME signal's getter / that
+ * SAME memo's name? This is the #2669 self-derivation test: reuses
+ * `collectPropRefs` (never a bespoke walker — see the CLAUDE.md rule this
+ * file already follows for `props.X` collection) and just checks membership
+ * of the one name we care about.
+ */
+function referencesOwnProp(
+  expr: string | undefined,
+  propsObjectName: string,
+  name: string,
+): boolean {
+  const referenced = new Set<string>()
+  collectPropRefs(expr, propsObjectName, referenced)
+  return referenced.has(name)
 }
 
 /**

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2988,6 +2988,12 @@
           ]
         }
       },
+      "signal-prop-same-name-derived": {
+        "go-template": {
+          "kind": "render",
+          "reason": "self-derived signal collides with its prop field name in the generated Go props struct — the non-idempotent `* 2` derivation is dropped and the signal renders the raw prop value instead (https://github.com/piconic-ai/barefootjs/issues/2683)"
+        }
+      },
       "some-typeof-predicate": {
         "blade": {
           "kind": "refusal",
@@ -3421,6 +3427,10 @@
       "rich-prop-client-read": {
         "description": "A Map-typed prop used by client code (even via a method call, since BF021 never sees a handler…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/rich-prop-client-read.ts"
+      },
+      "signal-prop-same-name-derived": {
+        "description": "Signal initialized from a NON-IDEMPOTENT derivation of a prop with the identical name",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/signal-prop-same-name-derived.ts"
       },
       "some-typeof-predicate": {
         "description": "Off-subset `.some()` predicate (typeof) — JS-runtime faithful, DSL diagnostic",

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2988,24 +2988,6 @@
           ]
         }
       },
-      "signal-default-from-jsx": {
-        "xslate": {
-          "kind": "render",
-          "reason": "self-derived signal has no in-template recompute — an absent prop renders empty instead of the JSX-time default, and the dependent memo inherits the gap (https://github.com/piconic-ai/barefootjs/issues/2679)"
-        }
-      },
-      "signal-prop-same-name": {
-        "xslate": {
-          "kind": "render",
-          "reason": "self-derived signal has no in-template recompute — a caller-supplied prop is never re-derived and an absent prop renders empty instead of the static default (https://github.com/piconic-ai/barefootjs/issues/2679)"
-        }
-      },
-      "signal-prop-same-name-derived": {
-        "xslate": {
-          "kind": "render",
-          "reason": "self-derived signal has no in-template recompute — a caller-supplied prop passes through raw (unmultiplied) and an absent prop renders empty instead of the statically-derived default (https://github.com/piconic-ai/barefootjs/issues/2679)"
-        }
-      },
       "some-typeof-predicate": {
         "blade": {
           "kind": "refusal",
@@ -3439,18 +3421,6 @@
       "rich-prop-client-read": {
         "description": "A Map-typed prop used by client code (even via a method call, since BF021 never sees a handler…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/rich-prop-client-read.ts"
-      },
-      "signal-default-from-jsx": {
-        "description": "JSX-time signal default propagates to SSR when caller omits the prop (#1423)",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/signal-default-from-jsx.ts"
-      },
-      "signal-prop-same-name": {
-        "description": "Signal initialized from prop with identical name",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/signal-prop-same-name.ts"
-      },
-      "signal-prop-same-name-derived": {
-        "description": "Signal initialized from a NON-IDEMPOTENT derivation of a prop with the identical name",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/signal-prop-same-name-derived.ts"
       },
       "some-typeof-predicate": {
         "description": "Off-subset `.some()` predicate (typeof) — JS-runtime faithful, DSL diagnostic",

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 330,
+    "totalFixtures": 331,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -2988,6 +2988,24 @@
           ]
         }
       },
+      "signal-default-from-jsx": {
+        "xslate": {
+          "kind": "render",
+          "reason": "self-derived signal has no in-template recompute — an absent prop renders empty instead of the JSX-time default, and the dependent memo inherits the gap (https://github.com/piconic-ai/barefootjs/issues/2679)"
+        }
+      },
+      "signal-prop-same-name": {
+        "xslate": {
+          "kind": "render",
+          "reason": "self-derived signal has no in-template recompute — a caller-supplied prop is never re-derived and an absent prop renders empty instead of the static default (https://github.com/piconic-ai/barefootjs/issues/2679)"
+        }
+      },
+      "signal-prop-same-name-derived": {
+        "xslate": {
+          "kind": "render",
+          "reason": "self-derived signal has no in-template recompute — a caller-supplied prop passes through raw (unmultiplied) and an absent prop renders empty instead of the statically-derived default (https://github.com/piconic-ai/barefootjs/issues/2679)"
+        }
+      },
       "some-typeof-predicate": {
         "blade": {
           "kind": "refusal",
@@ -3421,6 +3439,18 @@
       "rich-prop-client-read": {
         "description": "A Map-typed prop used by client code (even via a method call, since BF021 never sees a handler…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/rich-prop-client-read.ts"
+      },
+      "signal-default-from-jsx": {
+        "description": "JSX-time signal default propagates to SSR when caller omits the prop (#1423)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/signal-default-from-jsx.ts"
+      },
+      "signal-prop-same-name": {
+        "description": "Signal initialized from prop with identical name",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/signal-prop-same-name.ts"
+      },
+      "signal-prop-same-name-derived": {
+        "description": "Signal initialized from a NON-IDEMPOTENT derivation of a prop with the identical name",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/signal-prop-same-name-derived.ts"
       },
       "some-typeof-predicate": {
         "description": "Off-subset `.some()` predicate (typeof) — JS-runtime faithful, DSL diagnostic",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1123,7 +1123,7 @@
           ]
         },
         "go-template": {
-          "pass": 83,
+          "pass": 82,
           "total": 92,
           "gaps": [
             {
@@ -1156,6 +1156,10 @@
             },
             {
               "fixture": "preamble-cells",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -1579,7 +1583,7 @@
           ]
         },
         "go-template": {
-          "pass": 205,
+          "pass": 204,
           "total": 220,
           "gaps": [
             {
@@ -1630,6 +1634,10 @@
             },
             {
               "fixture": "reduce-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -2351,7 +2359,7 @@
           ]
         },
         "go-template": {
-          "pass": 292,
+          "pass": 291,
           "total": 309,
           "gaps": [
             {
@@ -2410,6 +2418,10 @@
             },
             {
               "fixture": "reduce-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -3025,7 +3037,7 @@
           ]
         },
         "go-template": {
-          "pass": 240,
+          "pass": 239,
           "total": 251,
           "gaps": [
             {
@@ -3058,6 +3070,10 @@
             },
             {
               "fixture": "reduce-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -3389,9 +3405,13 @@
           ]
         },
         "go-template": {
-          "pass": 44,
+          "pass": 43,
           "total": 46,
           "gaps": [
+            {
+              "fixture": "signal-prop-same-name-derived",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3675,7 +3695,7 @@
           ]
         },
         "go-template": {
-          "pass": 157,
+          "pass": 156,
           "total": 174,
           "gaps": [
             {
@@ -3734,6 +3754,10 @@
             },
             {
               "fixture": "reduce-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -6527,8 +6551,14 @@
           "total": 11
         },
         "go-template": {
-          "pass": 11,
-          "total": 11
+          "pass": 10,
+          "total": 11,
+          "gaps": [
+            {
+              "fixture": "signal-prop-same-name-derived",
+              "issues": []
+            }
+          ]
         },
         "jinja": {
           "pass": 11,
@@ -7494,7 +7524,7 @@
           ]
         },
         "go-template": {
-          "pass": 100,
+          "pass": 99,
           "total": 105,
           "gaps": [
             {
@@ -7511,6 +7541,10 @@
             },
             {
               "fixture": "reduce-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -8094,9 +8128,13 @@
           ]
         },
         "go-template": {
-          "pass": 38,
+          "pass": 37,
           "total": 40,
           "gaps": [
+            {
+              "fixture": "signal-prop-same-name-derived",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props",
               "issues": [

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1357,7 +1357,7 @@
           ]
         },
         "xslate": {
-          "pass": 81,
+          "pass": 83,
           "total": 92,
           "gaps": [
             {
@@ -1390,14 +1390,6 @@
             },
             {
               "fixture": "preamble-cells",
-              "issues": []
-            },
-            {
-              "fixture": "signal-default-from-jsx",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -1961,7 +1953,7 @@
           ]
         },
         "xslate": {
-          "pass": 202,
+          "pass": 205,
           "total": 220,
           "gaps": [
             {
@@ -2012,18 +2004,6 @@
             },
             {
               "fixture": "reduce-typeof-body",
-              "issues": []
-            },
-            {
-              "fixture": "signal-default-from-jsx",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -2785,7 +2765,7 @@
           ]
         },
         "xslate": {
-          "pass": 289,
+          "pass": 292,
           "total": 309,
           "gaps": [
             {
@@ -2844,18 +2824,6 @@
             },
             {
               "fixture": "reduce-typeof-body",
-              "issues": []
-            },
-            {
-              "fixture": "signal-default-from-jsx",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -3317,7 +3285,7 @@
           ]
         },
         "xslate": {
-          "pass": 237,
+          "pass": 240,
           "total": 251,
           "gaps": [
             {
@@ -3350,18 +3318,6 @@
             },
             {
               "fixture": "reduce-typeof-body",
-              "issues": []
-            },
-            {
-              "fixture": "signal-default-from-jsx",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -3513,21 +3469,9 @@
           ]
         },
         "xslate": {
-          "pass": 41,
+          "pass": 44,
           "total": 46,
           "gaps": [
-            {
-              "fixture": "signal-default-from-jsx",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name-derived",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -4145,7 +4089,7 @@
           ]
         },
         "xslate": {
-          "pass": 154,
+          "pass": 157,
           "total": 174,
           "gaps": [
             {
@@ -4204,18 +4148,6 @@
             },
             {
               "fixture": "reduce-typeof-body",
-              "issues": []
-            },
-            {
-              "fixture": "signal-default-from-jsx",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -6615,14 +6547,8 @@
           "total": 11
         },
         "xslate": {
-          "pass": 10,
-          "total": 11,
-          "gaps": [
-            {
-              "fixture": "signal-prop-same-name-derived",
-              "issues": []
-            }
-          ]
+          "pass": 11,
+          "total": 11
         }
       },
       "source": {
@@ -6729,13 +6655,9 @@
           ]
         },
         "xslate": {
-          "pass": 19,
+          "pass": 20,
           "total": 21,
           "gaps": [
-            {
-              "fixture": "signal-default-from-jsx",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -7702,7 +7624,7 @@
           ]
         },
         "xslate": {
-          "pass": 98,
+          "pass": 100,
           "total": 105,
           "gaps": [
             {
@@ -7719,14 +7641,6 @@
             },
             {
               "fixture": "reduce-typeof-body",
-              "issues": []
-            },
-            {
-              "fixture": "signal-default-from-jsx",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -8036,7 +7950,7 @@
           ]
         },
         "xslate": {
-          "pass": 169,
+          "pass": 170,
           "total": 178,
           "gaps": [
             {
@@ -8061,10 +7975,6 @@
             },
             {
               "fixture": "preamble-cells",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name",
               "issues": []
             },
             {
@@ -8264,21 +8174,9 @@
           ]
         },
         "xslate": {
-          "pass": 35,
+          "pass": 38,
           "total": 40,
           "gaps": [
-            {
-              "fixture": "signal-default-from-jsx",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name",
-              "issues": []
-            },
-            {
-              "fixture": "signal-prop-same-name-derived",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1026,15 +1026,15 @@
       }
     },
     "binary": {
-      "total": 91,
+      "total": 92,
       "cells": {
         "hono": {
-          "pass": 91,
-          "total": 91
+          "pass": 92,
+          "total": 92
         },
         "blade": {
-          "pass": 82,
-          "total": 91,
+          "pass": 83,
+          "total": 92,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1081,8 +1081,8 @@
           ]
         },
         "erb": {
-          "pass": 83,
-          "total": 91,
+          "pass": 84,
+          "total": 92,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1123,8 +1123,8 @@
           ]
         },
         "go-template": {
-          "pass": 82,
-          "total": 91,
+          "pass": 83,
+          "total": 92,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1171,8 +1171,8 @@
           ]
         },
         "jinja": {
-          "pass": 82,
-          "total": 91,
+          "pass": 83,
+          "total": 92,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1219,8 +1219,8 @@
           ]
         },
         "minijinja": {
-          "pass": 82,
-          "total": 91,
+          "pass": 83,
+          "total": 92,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1267,8 +1267,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 83,
-          "total": 91,
+          "pass": 84,
+          "total": 92,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1309,8 +1309,8 @@
           ]
         },
         "twig": {
-          "pass": 82,
-          "total": 91,
+          "pass": 83,
+          "total": 92,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1357,8 +1357,8 @@
           ]
         },
         "xslate": {
-          "pass": 82,
-          "total": 91,
+          "pass": 81,
+          "total": 92,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1390,6 +1390,14 @@
             },
             {
               "fixture": "preamble-cells",
+              "issues": []
+            },
+            {
+              "fixture": "signal-default-from-jsx",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -1418,11 +1426,11 @@
       }
     },
     "call": {
-      "total": 219,
+      "total": 220,
       "cells": {
         "hono": {
-          "pass": 218,
-          "total": 219,
+          "pass": 219,
+          "total": 220,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1433,8 +1441,8 @@
           ]
         },
         "blade": {
-          "pass": 204,
-          "total": 219,
+          "pass": 205,
+          "total": 220,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1509,8 +1517,8 @@
           ]
         },
         "erb": {
-          "pass": 205,
-          "total": 219,
+          "pass": 206,
+          "total": 220,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1579,8 +1587,8 @@
           ]
         },
         "go-template": {
-          "pass": 204,
-          "total": 219,
+          "pass": 205,
+          "total": 220,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1655,8 +1663,8 @@
           ]
         },
         "jinja": {
-          "pass": 204,
-          "total": 219,
+          "pass": 205,
+          "total": 220,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1731,8 +1739,8 @@
           ]
         },
         "minijinja": {
-          "pass": 204,
-          "total": 219,
+          "pass": 205,
+          "total": 220,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1807,8 +1815,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 205,
-          "total": 219,
+          "pass": 206,
+          "total": 220,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1877,8 +1885,8 @@
           ]
         },
         "twig": {
-          "pass": 204,
-          "total": 219,
+          "pass": 205,
+          "total": 220,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1953,8 +1961,8 @@
           ]
         },
         "xslate": {
-          "pass": 204,
-          "total": 219,
+          "pass": 202,
+          "total": 220,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2004,6 +2012,18 @@
             },
             {
               "fixture": "reduce-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "signal-default-from-jsx",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -2174,11 +2194,11 @@
       }
     },
     "identifier": {
-      "total": 308,
+      "total": 309,
       "cells": {
         "hono": {
-          "pass": 307,
-          "total": 308,
+          "pass": 308,
+          "total": 309,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2189,8 +2209,8 @@
           ]
         },
         "blade": {
-          "pass": 291,
-          "total": 308,
+          "pass": 292,
+          "total": 309,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2273,8 +2293,8 @@
           ]
         },
         "erb": {
-          "pass": 292,
-          "total": 308,
+          "pass": 293,
+          "total": 309,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2351,8 +2371,8 @@
           ]
         },
         "go-template": {
-          "pass": 291,
-          "total": 308,
+          "pass": 292,
+          "total": 309,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2435,8 +2455,8 @@
           ]
         },
         "jinja": {
-          "pass": 291,
-          "total": 308,
+          "pass": 292,
+          "total": 309,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2519,8 +2539,8 @@
           ]
         },
         "minijinja": {
-          "pass": 291,
-          "total": 308,
+          "pass": 292,
+          "total": 309,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2603,8 +2623,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 292,
-          "total": 308,
+          "pass": 293,
+          "total": 309,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2681,8 +2701,8 @@
           ]
         },
         "twig": {
-          "pass": 291,
-          "total": 308,
+          "pass": 292,
+          "total": 309,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2765,8 +2785,8 @@
           ]
         },
         "xslate": {
-          "pass": 291,
-          "total": 308,
+          "pass": 289,
+          "total": 309,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2824,6 +2844,18 @@
             },
             {
               "fixture": "reduce-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "signal-default-from-jsx",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -2914,15 +2946,15 @@
       }
     },
     "literal": {
-      "total": 250,
+      "total": 251,
       "cells": {
         "hono": {
-          "pass": 250,
-          "total": 250
+          "pass": 251,
+          "total": 251
         },
         "blade": {
-          "pass": 239,
-          "total": 250,
+          "pass": 240,
+          "total": 251,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2973,8 +3005,8 @@
           ]
         },
         "erb": {
-          "pass": 239,
-          "total": 250,
+          "pass": 240,
+          "total": 251,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3025,8 +3057,8 @@
           ]
         },
         "go-template": {
-          "pass": 239,
-          "total": 250,
+          "pass": 240,
+          "total": 251,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3077,8 +3109,8 @@
           ]
         },
         "jinja": {
-          "pass": 239,
-          "total": 250,
+          "pass": 240,
+          "total": 251,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3129,8 +3161,8 @@
           ]
         },
         "minijinja": {
-          "pass": 239,
-          "total": 250,
+          "pass": 240,
+          "total": 251,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3181,8 +3213,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 239,
-          "total": 250,
+          "pass": 240,
+          "total": 251,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3233,8 +3265,8 @@
           ]
         },
         "twig": {
-          "pass": 239,
-          "total": 250,
+          "pass": 240,
+          "total": 251,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3285,8 +3317,8 @@
           ]
         },
         "xslate": {
-          "pass": 239,
-          "total": 250,
+          "pass": 237,
+          "total": 251,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3318,6 +3350,18 @@
             },
             {
               "fixture": "reduce-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "signal-default-from-jsx",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -3350,15 +3394,15 @@
       }
     },
     "logical": {
-      "total": 45,
+      "total": 46,
       "cells": {
         "hono": {
-          "pass": 45,
-          "total": 45
+          "pass": 46,
+          "total": 46
         },
         "blade": {
-          "pass": 43,
-          "total": 45,
+          "pass": 44,
+          "total": 46,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3373,8 +3417,8 @@
           ]
         },
         "erb": {
-          "pass": 43,
-          "total": 45,
+          "pass": 44,
+          "total": 46,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3389,8 +3433,8 @@
           ]
         },
         "go-template": {
-          "pass": 43,
-          "total": 45,
+          "pass": 44,
+          "total": 46,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3405,8 +3449,8 @@
           ]
         },
         "jinja": {
-          "pass": 43,
-          "total": 45,
+          "pass": 44,
+          "total": 46,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3421,8 +3465,8 @@
           ]
         },
         "minijinja": {
-          "pass": 43,
-          "total": 45,
+          "pass": 44,
+          "total": 46,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3437,8 +3481,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 43,
-          "total": 45,
+          "pass": 44,
+          "total": 46,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3453,8 +3497,8 @@
           ]
         },
         "twig": {
-          "pass": 43,
-          "total": 45,
+          "pass": 44,
+          "total": 46,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3469,9 +3513,21 @@
           ]
         },
         "xslate": {
-          "pass": 43,
-          "total": 45,
+          "pass": 41,
+          "total": 46,
           "gaps": [
+            {
+              "fixture": "signal-default-from-jsx",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-derived",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3498,11 +3554,11 @@
       }
     },
     "member": {
-      "total": 173,
+      "total": 174,
       "cells": {
         "hono": {
-          "pass": 172,
-          "total": 173,
+          "pass": 173,
+          "total": 174,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3513,8 +3569,8 @@
           ]
         },
         "blade": {
-          "pass": 156,
-          "total": 173,
+          "pass": 157,
+          "total": 174,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3597,8 +3653,8 @@
           ]
         },
         "erb": {
-          "pass": 157,
-          "total": 173,
+          "pass": 158,
+          "total": 174,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3675,8 +3731,8 @@
           ]
         },
         "go-template": {
-          "pass": 156,
-          "total": 173,
+          "pass": 157,
+          "total": 174,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3759,8 +3815,8 @@
           ]
         },
         "jinja": {
-          "pass": 156,
-          "total": 173,
+          "pass": 157,
+          "total": 174,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3843,8 +3899,8 @@
           ]
         },
         "minijinja": {
-          "pass": 156,
-          "total": 173,
+          "pass": 157,
+          "total": 174,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3927,8 +3983,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 157,
-          "total": 173,
+          "pass": 158,
+          "total": 174,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4005,8 +4061,8 @@
           ]
         },
         "twig": {
-          "pass": 156,
-          "total": 173,
+          "pass": 157,
+          "total": 174,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4089,8 +4145,8 @@
           ]
         },
         "xslate": {
-          "pass": 156,
-          "total": 173,
+          "pass": 154,
+          "total": 174,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4148,6 +4204,18 @@
             },
             {
               "fixture": "reduce-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "signal-default-from-jsx",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -6512,43 +6580,49 @@
       }
     },
     "binary:*": {
-      "total": 10,
+      "total": 11,
       "cells": {
         "hono": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "blade": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "erb": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "go-template": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "jinja": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "minijinja": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "mojolicious": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "twig": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "xslate": {
           "pass": 10,
-          "total": 10
+          "total": 11,
+          "gaps": [
+            {
+              "fixture": "signal-prop-same-name-derived",
+              "issues": []
+            }
+          ]
         }
       },
       "source": {
@@ -6655,9 +6729,13 @@
           ]
         },
         "xslate": {
-          "pass": 20,
+          "pass": 19,
           "total": 21,
           "gaps": [
+            {
+              "fixture": "signal-default-from-jsx",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
@@ -7435,15 +7513,15 @@
       }
     },
     "literal:number": {
-      "total": 104,
+      "total": 105,
       "cells": {
         "hono": {
-          "pass": 104,
-          "total": 104
+          "pass": 105,
+          "total": 105
         },
         "blade": {
-          "pass": 99,
-          "total": 104,
+          "pass": 100,
+          "total": 105,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7468,8 +7546,8 @@
           ]
         },
         "erb": {
-          "pass": 99,
-          "total": 104,
+          "pass": 100,
+          "total": 105,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7494,8 +7572,8 @@
           ]
         },
         "go-template": {
-          "pass": 99,
-          "total": 104,
+          "pass": 100,
+          "total": 105,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7520,8 +7598,8 @@
           ]
         },
         "jinja": {
-          "pass": 99,
-          "total": 104,
+          "pass": 100,
+          "total": 105,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7546,8 +7624,8 @@
           ]
         },
         "minijinja": {
-          "pass": 99,
-          "total": 104,
+          "pass": 100,
+          "total": 105,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7572,8 +7650,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 99,
-          "total": 104,
+          "pass": 100,
+          "total": 105,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7598,8 +7676,8 @@
           ]
         },
         "twig": {
-          "pass": 99,
-          "total": 104,
+          "pass": 100,
+          "total": 105,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7624,8 +7702,8 @@
           ]
         },
         "xslate": {
-          "pass": 99,
-          "total": 104,
+          "pass": 98,
+          "total": 105,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7641,6 +7719,14 @@
             },
             {
               "fixture": "reduce-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "signal-default-from-jsx",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-derived",
               "issues": []
             },
             {
@@ -7950,7 +8036,7 @@
           ]
         },
         "xslate": {
-          "pass": 170,
+          "pass": 169,
           "total": 178,
           "gaps": [
             {
@@ -7975,6 +8061,10 @@
             },
             {
               "fixture": "preamble-cells",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name",
               "issues": []
             },
             {
@@ -8055,15 +8145,15 @@
       }
     },
     "logical:??": {
-      "total": 39,
+      "total": 40,
       "cells": {
         "hono": {
-          "pass": 39,
-          "total": 39
+          "pass": 40,
+          "total": 40
         },
         "blade": {
-          "pass": 37,
-          "total": 39,
+          "pass": 38,
+          "total": 40,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8078,8 +8168,8 @@
           ]
         },
         "erb": {
-          "pass": 37,
-          "total": 39,
+          "pass": 38,
+          "total": 40,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8094,8 +8184,8 @@
           ]
         },
         "go-template": {
-          "pass": 37,
-          "total": 39,
+          "pass": 38,
+          "total": 40,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8110,8 +8200,8 @@
           ]
         },
         "jinja": {
-          "pass": 37,
-          "total": 39,
+          "pass": 38,
+          "total": 40,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8126,8 +8216,8 @@
           ]
         },
         "minijinja": {
-          "pass": 37,
-          "total": 39,
+          "pass": 38,
+          "total": 40,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8142,8 +8232,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 37,
-          "total": 39,
+          "pass": 38,
+          "total": 40,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8158,8 +8248,8 @@
           ]
         },
         "twig": {
-          "pass": 37,
-          "total": 39,
+          "pass": 38,
+          "total": 40,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8174,9 +8264,21 @@
           ]
         },
         "xslate": {
-          "pass": 37,
-          "total": 39,
+          "pass": 35,
+          "total": 40,
           "gaps": [
+            {
+              "fixture": "signal-default-from-jsx",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-derived",
+              "issues": []
+            },
             {
               "fixture": "static-array-from-props",
               "issues": [


### PR DESCRIPTION
Fixes #2669. Fixes #2679. First of a three-PR stack from the bf-p audit; #2672 and #2677 follow on top of this branch.

## The defect

`extractSsrDefaults` builds its manifest map in three passes — prop entries, then signals, then memos — and the last two **unconditionally overwrite** a same-named prop entry, discarding its `propName`. The collision only arises in the bare-props-arg form (`function C(props: P)`), since `function C({ label })` alongside `const [label] = …` is a redeclaration error.

What the emitted template actually does (jinja shown; the whole template-stash family is the same):

```jinja
{% set label = (label if (label is defined and label is not none) else 'Default') %}
```
`test.ssr-defaults.json` → `{"label":{"value":"Default"}}`

The template READS the stash var as its **input** (the raw caller prop) and OVERWRITES it with the **output** (the derived value) under the same name. The defaults map stored the output and carried no `propName`, so production's `_derive_stash_from_defaults` seeded `label='Default'`; the recompute then saw a non-nullish value and kept it. A caller passing `label='Hello'` could never win. Measured in a real Flask app: the SSR body rendered `Default` while `bf-p` correctly carried `Hello`; the `rows` shape went further and 500'd on `'NoneType' object is not iterable`.

A non-idempotent derivation was broken even with no caller props:

```jinja
{% set count = ((count if (count is defined and count is not none) else 1)) * 2 %}
```
Seeding the evaluated `2` made the template compute `2 * 2 = 4`. #2669 escaped notice for so long only because `?? 'Default'` happens to be idempotent.

## The rule

> When a signal's or memo's template variable is the same name as a prop variable its own initializer derives from, the stash seed must be the **raw prop**, never the derived value — the emitted template performs the derivation itself.

Applied in two places:

- **`packages/jsx/src/ssr-defaults.ts`** — the signal and memo loops detect self-derivation by reusing `collectPropRefs` (no bespoke walker, no regex over expression text) and keep/create the prop entry `{ propName, value: null }` instead of overwriting. `bindings` still receives the evaluated value, so a later memo referencing the getter resolves exactly as before. This establishes a load-bearing invariant, documented on `SsrDefault.propName`: **a signal/memo entry carries `propName` if and only if it came through this collision path.**

- **the template-stash conformance harnesses** — the signal (`evaluateSignalInit`) and memo seeding loops skip an entry carrying `propName`. Those loops are a harness-only runtime recompute production does not have, and that leniency is precisely why `signal-prop-same-name` was green while production was broken. The manifest shape is the discriminator, so the rule is not copy-pasted into seven harnesses.

Deliberately unchanged: a **non**-self-derived collision (`const [label] = createSignal('sig')` alongside a `props.label` read) emits no recompute at all and collapses both reads onto one template variable. That is a separate template-variable-aliasing defect; no seeding choice can be right for it, and it renders byte-identically here.

## Xslate had no recompute to seed into — so it got one (#2679)

Xslate could not join the family. `generateDerivedMemoSeed` declined to lower any derived step whose Kolon output referenced its own target, because `: my $x = …` is a fresh lexical already in scope inside its own initializer — `: my $size = $size // 'icon'` reads the just-declared `undef`. With the seed moved to the raw prop, that skip stopped being harmless.

This is not hypothetical: `PaginationLink` (`ui/components/ui/pagination/index.tsx`) contains `const size = createMemo(() => props.size ?? 'icon')`. Bisection against `59adb074d` confirmed the `[pagination]` conformance test went green → red, with `size-9` dropping out of every link because `sizeClasses[size()]` missed. Declaring that as a divergence would have meant shipping a regression to a real component, so it is fixed instead.

The shadowing problem dissolves by capturing **before** shadowing — no expression rewriting and no `ParsedExpr` renamer needed, the lowered Kolon is used verbatim:

```
: my $__bf_seed_size = ($size // 'icon');
: my $size = $__bf_seed_size;
```

In the first line `$size` still refers to the stash variable (the declaration is `$__bf_seed_size`, so nothing is shadowed yet); the second then binds the real name off an already-evaluated capture. Verified through real `perl -MText::Xslate`: `signal-prop-same-name-derived` emits `: my $__bf_seed_count = (($count // 1)) * 2;` and renders `10` — one application of `* 2`, not the pre-fix `20` or the interim `5`.

With that in place Xslate takes the same shared `propName` skip as the other six adapters, `[pagination]` is green again, and `render-divergences.ts` is back to empty — the three fixtures pinned mid-review (`signal-prop-same-name`, `signal-prop-same-name-derived`, `signal-default-from-jsx`) all graduated. An existing unit test that pinned the old skip was inverted to assert the two emitted lines.

## One pin remains, for a defect this PR did not cause (#2683)

go-template fails the new fixture — `10` expected, `5` rendered. It does not consume `extractSsrDefaults` or `SsrDefault` at all (zero references); the bug is in its own props-struct emitter, which skips a signal whose Go field name collides with a prop field keyed **purely on the name collision**, never on whether `extractPropFallback` actually matched. For `(props.count ?? 1) * 2` the fallback extractor correctly declines and the `continue` fires anyway, dropping the `* 2`. The new fixture is simply the first of that shape, so it surfaced a pre-existing defect.

Not fixed here — two Go struct fields cannot share an identifier, so removing the skip emits a duplicate field; the real fix needs its own PR. Pinned in `packages/adapter-go-template/src/render-divergences.ts` against #2683, with the fixture's `expectedHtml` left asserting the correct `10`.

## Coverage

New conformance fixture `signal-prop-same-name-derived` pins the non-idempotent shape: it rendered `20` before this change and `10` after (verified by swapping the pre-fix extractor back in). Six new unit tests in `ssr-defaults.test.ts` cover both collision shapes, a self-derived memo, the non-self-derived negative, and `deriveStashFromDefaults` end-to-end.

## Verification

`adapter-xslate` full suite 1401 pass / 20 skip · `adapter-tests` full suite 2098 pass / 2 skip / 0 fail · `packages/compat` 488/0 with both lockfiles regenerated · `packages/jsx` `ssr-defaults.test.ts` 30/30 and the package suite 3105 pass (2 pre-existing failures in `map-body-no-silent-divergence.test.ts`, identical on unmodified main) · `adapter-jinja` 1398/0 · `adapter-erb` and `adapter-mojolicious` clean apart from a sandbox-only missing `DateTime::TimeZone` that breaks `date-tolocale-named-tz` · targeted `signal-prop-same-name*` green on all seven backends · `tsgo --noEmit` and `biome check` clean.

Not run locally: `adapter-go-template`'s suite — this sandbox has Go 1.24.7 and the adapter's runtime `go.mod` requires 1.25.6. CI covers it. Hono is unaffected (no `extractSsrDefaults` reference) and served as the reference oracle throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13