### PR TITLE
chore(deps): migrate Changesets to CLI v3 and action v2

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [["@barefootjs/*", "create-barefootjs"]],

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,3 @@ updates:
       actions:
         patterns:
           - '*'
-    ignore:
-      # changesets/action v2 requires Changesets CLI v3; we run CLI ^2.31.0.
-      # Taking the action major on its own breaks every release run with
-      # "This version of the Changesets action is designed to work with
-      # Changesets CLI v3". Lift this together with the CLI v3 migration
-      # (ESM-only CLI, Node ^22.11 || ^24 || >=26, `changeset tag` renamed to
-      # `git-tag`, private packages no longer versioned by default,
-      # `changeset version` exiting 1 when there are no changesets).
-      - dependency-name: changesets/action
-        update-types: [version-update:semver-major]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,8 @@ jobs:
     timeout-minutes: 30
     outputs:
       published: ${{ steps.changesets.outputs.published }}
-      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+      # Not dot access: the hyphen would parse as subtraction.
+      publishedPackages: ${{ steps.changesets.outputs['published-packages'] }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -73,21 +74,15 @@ jobs:
 
       - run: bun install
 
-      # The action's major version is coupled to the Changesets CLI major
-      # version in package.json: v2 of the action refuses to run against CLI
-      # v2 ("designed to work with Changesets CLI v3"), and v1 is the one
-      # built for CLI v2. We pin @changesets/cli to ^2.31.0, so this must stay
-      # on v1 — see the matching Dependabot ignore in .github/dependabot.yml.
-      # Bumping either side alone breaks every release (run #798-#801, which
-      # left 0.31.9 versioned on main but unpublished).
+      # Do not bump this major without @changesets/cli's: v1 pairs with CLI v3
+      # silently wrong (it bundles its own v2-era readers) rather than refusing.
       - name: Changesets — version or publish
         id: changesets
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
         with:
-          version: bunx changeset version
-          publish: bun run release:publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          version-script: bunx changeset version
+          publish-script: bun run release:publish
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # Mirror whatever Changesets just published to npm onto JSR. Delegates to
   # the reusable jsr-publish.yml so the release-driven path and the manual

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/core": "^7.26.0",
     "@babel/preset-typescript": "^7.26.0",
     "@biomejs/biome": "2.4.16",
-    "@changesets/cli": "^2.31.0",
+    "@changesets/cli": "^3.0.1",
     "@happy-dom/global-registrator": "^20.0.11",
     "@playwright/test": "^1.57.0",
     "@types/bun": "latest",

--- a/scripts/changeset-publish.ts
+++ b/scripts/changeset-publish.ts
@@ -20,7 +20,7 @@
 //   bun scripts/changeset-publish.ts
 
 import { resolve } from 'node:path'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { appendFileSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { $ } from 'bun'
 
@@ -106,9 +106,6 @@ try {
       continue
     }
 
-    // Create a local git tag so changesets/action can detect the publish.
-    // The action parses stdout for "New tag: <name>@<version>" lines to set
-    // its `published` output and to create GitHub Releases.
     const tag = `${pkg.name}@${pkg.version}`
     const t = await $`git tag ${tag}`.cwd(repoRoot).quiet().nothrow()
     const tagAlreadyExists = t.exitCode !== 0 && t.stderr.toString().includes('already exists')
@@ -117,7 +114,17 @@ try {
       errors.push(`${tag} (tag)`)
       continue
     }
-    console.log(`New tag: ${tag}`)
+    // Not stdout: changesets/action v2 reads only this file, and a publish it
+    // cannot see is one it never tags, releases, or gates downstream jobs on.
+    // Unset outside the action.
+    const outputFile = process.env.CHANGESETS_OUTPUT
+    if (outputFile) {
+      appendFileSync(
+        outputFile,
+        `${JSON.stringify({ type: 'git-tag', tag, packageName: pkg.name })}\n`,
+      )
+    }
+    console.log(`  tagged  ${tag}`)
 
     published++
   }


### PR DESCRIPTION
Follow-up to #2681. Takes the major that runs #798–#801 tried to take one half of, this time on both sides at once.

## Why both sides move together

The action's major is coupled to the CLI's, and only one direction is loud:

- **action v2 + CLI v2** → refuses to start (`This version of the Changesets action is designed to work with Changesets CLI v3`). This is what broke every release run until #2681.
- **action v1 + CLI v3** → no guard at all. v1 bundles its own v2-era `@changesets/*` libraries to read `.changeset/`, so it misreads rather than complains.

So this PR moves `@changesets/cli` to `^3.0.1` and `changesets/action` to v2.1.0 (`198f833`) together, and drops the Dependabot ignore added alongside the v1 pin.

## Two v2 changes 94b7aa8 missed

The input rename (`version`/`publish` → `version-script`/`publish-script`, explicit `github-token`) was already handled there. Two more matter here, and both fail **silently** rather than loudly:

**1. The `published-packages` output was renamed** (was `publishedPackages`). The hyphen makes `steps.changesets.outputs.published-packages` parse as subtraction in a GitHub expression, so it has to be read with the index form:

```yaml
publishedPackages: ${{ steps.changesets.outputs['published-packages'] }}
```

The job output keeps its camelCase name, so the six downstream native-registry gates (`contains(fromJSON(needs.release.outputs.publishedPackages).*.name, …)`) are untouched.

**2. A custom publish script no longer reports through stdout.** v1 scraped it for `New tag: <name>@<version>` lines; v2 ignores stdout and reads NDJSON events from the file it points `$CHANGESETS_OUTPUT` at:

```json
{"type":"git-tag","tag":"@barefootjs/jsx@0.31.10","packageName":"@barefootjs/jsx"}
```

Left unchanged, `scripts/changeset-publish.ts` would still publish to npm but report nothing, so the action would conclude nothing was published — no git tags, no GitHub releases, and every JSR / CPAN / PyPI / RubyGems / crates.io / Packagist job skipped, with a green run. The script now appends one event per publish.

## What was verified

- **NDJSON shape** — ran the emitted line through `readChangesetsOutput` / `isChangesetsOutputEvent` copied verbatim from the pinned action commit; both events parse.
- **`changeset version` dry run under CLI v3** — bumps the same 23 publishable packages and no others (private packages, already excluded via `ignore`, stay untouched under v3's new `privatePackages` default), regenerates the changelogs, and reports no config errors.
- **`changeset status`** — parses the config clean.
- `scripts/changeset-publish.ts` transpiles (`bun build`) and typechecks (`tsc --noEmit`). It is outside Biome's scan set, so `bun run lint` doesn't cover it.

## CLI v3 breaking changes that turned out inert here

| Change | Why it doesn't bite |
| --- | --- |
| `changeset tag` → `changeset git-tag` | Nothing invokes it; the publish script tags directly. |
| `changeset version` exits 1 with no changesets | The action only runs the version script when changesets exist. |
| Private packages no longer versioned by default | Already excluded via `ignore`; dry run confirms no change. |
| `prettier` config key removed in favor of `format` | Never set. |
| `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH` | `onlyUpdatePeerDependentsWhenOutOfRange` is still in the v4 config schema. |
| ESM-only CLI | Invoked as a binary (`bunx changeset`), never imported. |
| engines `^22.11 \|\| ^24 \|\| >=26`, npm `>=10.9.0` | The release runner is on Node 24 / npm 11. |
| Peer deps bump dependents by `patch` not `major` | No peer-dependency edges between published packages here. |

`.changeset/config.json`'s `$schema` moves to `@changesets/config@4.0.0`. The `ignore` list is deliberately left as-is even though v3 no longer needs it for private packages — `changeset-check.yml` and `scripts/verify-released.ts` both derive from it.

## What can't be verified before merge

The publish path only runs on `main` after a Version Packages PR merges. The next release is the first real exercise of the `$CHANGESETS_OUTPUT` contract and the renamed output; the failure mode to watch for is a green `release` job that reports `published=false` and skips the downstream registry jobs.

## Changelog formatting note

Under v3 a dependency bump renders as a flat bullet (`- @barefootjs/shared@0.31.10`) where v2 nested it under the preceding entry. Cosmetic, affects only new entries.

---
_Generated by [Claude Code](https://claude.ai/code/session_016UaXDZcUrbETPogGBq84uC)_