### PR TITLE
fix(jsx): resolve structural types for destructured props parameters (#2677)

### DIFF
--- a/.changeset/destructured-prop-structural-types-2677.md
+++ b/.changeset/destructured-prop-structural-types-2677.md
@@ -1,0 +1,23 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Analyzer resolves structural (array/object) types for destructured-parameter props, closing a `unknown`-degradation asymmetry with the `props`-object form (#2677)
+
+`collectMemberTypes` (`packages/jsx/src/analyzer.ts`) gated every destructured-parameter member's `TypeInfo` through a primitives-plus-catalogued-rich-types-only predicate — anything else, including a perfectly well-formed inline array or object type, degraded to `kind: 'unknown'`. That gate was `#2150`'s fix for a real problem (a non-primitive `TypeInfo` used to mean a typed adapter would emit an unchecked scalar assertion that panics for a shape the template layer had no representation for), but the reasoning went stale for structural types once `#2674`/`#2676` taught go-template's `emitSynthPropStructs` to synthesize a real, json-tagged Go struct for any anonymous object type reachable through `ir.metadata.propsParams[].type` — array-element positions included. The gate itself was never widened to match, so the exact same declared type resolved differently depending on parameter syntax:
+
+```tsx
+function TagList(props: { items: { id: string; tags: string[] }[] }) { ... }        // resolved fully
+function TagList({ items }: { items: { id: string; tags: string[] }[] }) { ... }    // degraded to unknown
+```
+
+The gate (renamed `isResolvableMemberType`, still living in `analyzer.ts`) now also admits `kind: 'array'` (with a resolvable element type) and `kind: 'object'` (with every property resolvable), recursively — matching the full recursive shape `typeNodeToTypeInfo` already builds. It still declines a union, a function, and an un-catalogued named type (`Map`, `Set`, a local type alias) reached ANYWHERE inside the structure — declining the WHOLE member, not just the offending leaf, since this is an all-or-nothing gate and per-field graceful degradation (`interface{}` for what a typed adapter can't represent) is `typeInfoToGo`'s job downstream, not this gate's.
+
+**go-template**: the widened `propsParams[].type` is exactly the input `emitSynthPropStructs`'s "walk root 2" (every props param's own `TypeInfo` tree) already consumes — no adapter code changed. A destructured array-of-object or plain-object prop now synthesizes the same named, json-tagged struct the `props`-object form already got, replacing the historical `interface{}` / PascalCase-keyed `map[string]interface{}` fallback. Fixes the silent `bf-p` hydration-payload casing divergence measured in `#2677` (destructured `{ users }: { users: { name: string }[] }` shipped `{"users":[{"Name":"Ada"}]}` instead of the reference `{"users":[{"name":"Ada"}]}`) for `array-map-value-field`, `array-flatmap-tuple`, and `flatmap-expression-body`, plus every other destructured-parameter fixture with an array/object-typed prop across the corpus (`array-flat`, `array-flat-depth`, `array-flat-infinity`, `array-flatmap-self`, `array-flat-dynamic-depth`, and more) — those previously fell to `interface{}`-backed `[]any`/`map[string]interface{}` and now bake through the typed struct/slice path instead.
+
+Also fixes a latent test-harness-only bug the widening surfaced: `test-render.ts`'s `buildGoPropsInit` convenience literal-builder (used only to seed the Go conformance harness's `main.go`, not shipped as part of the adapter) didn't recurse into a doubly-nested array VALUE when baking a typed slice literal, so a newly-concrete `[][]int` field (`{ rows }: { rows: number[][] }`, previously `interface{}`) received an untyped `[]any{…}` inner literal and failed to compile. `goTypedSliceLiteralFromArray` now recurses with the inner element type for a nested-array value, matching what the production adapter's own `typeInfoToGo` already did correctly.
+
+Every other adapter (Hono, ERB, Jinja, Twig, Xslate, Blade, Mojolicious, Rust/minijinja) was verified to emit byte-identical output for every fixture in the corpus — none of them key adapter behavior off a destructured prop's `TypeInfo` kind beyond primitive-vs-not, so the widened structural cases pass through unchanged.
+
+New conformance fixture `destructured-object-prop-nested` covers the shapes `#2676`'s three array-of-object fixtures didn't: a destructured prop that is itself a plain (non-array-wrapped) object type, with a nested array-of-primitives property and a nested object property, both newly resolvable.

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -914,11 +914,28 @@ function goSliceElemType(
  * `[]any{…}`/`map[string]interface{}{…}` for that field no longer compiles
  * against it the way it always did against the old `map[string]interface{}`
  * element type.
+ *
+ * An ARRAY element (`elemType` itself starting with `[]`, i.e. the field is
+ * doubly-nested — `Rows [][]int`) recurses with the INNER element type
+ * (`int`) instead of falling to `goArrayLiteralFromArray`'s generic
+ * `[]any{…}` — #2677 widened the analyzer's destructured-parameter gate to
+ * resolve a nested-array prop (`{ rows }: { rows: number[][] }`) to a real
+ * `[][]int` field (previously `unknown` → `interface{}` → `[]any`, which
+ * `goArrayLiteralFromArray`'s untyped literal always compiled against fine).
+ * Without this, the harness's OWN convenience literal-builder — not the
+ * production adapter's `typeInfoToGo`, which already recurses correctly —
+ * bakes `[]any{1, 2}` for a `[1, 2]` row, and `[][]int{[]any{1, 2}, …}`
+ * fails to compile against the now-concrete field.
  */
 function goTypedSliceLiteralFromArray(arr: unknown[], elemType: string, goTypes?: string): string {
   const entries = arr.map(v => {
     if (v instanceof Date) return goStringLit(v.toISOString())
-    if (v && typeof v === 'object' && !Array.isArray(v)) {
+    if (Array.isArray(v)) {
+      return elemType.startsWith('[]')
+        ? goTypedSliceLiteralFromArray(v, elemType.slice(2), goTypes)
+        : goArrayLiteralFromArray(v)
+    }
+    if (v && typeof v === 'object') {
       return goStructLiteral(v as Record<string, unknown>, elemType, goTypes)
     }
     if (typeof v === 'string') return `"${v.replace(/"/g, '\\"')}"`

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1793,6 +1793,21 @@
         "text"
       ]
     },
+    "destructured-object-prop-nested": {
+      "kinds": [
+        "array-method",
+        "identifier",
+        "literal",
+        "member"
+      ],
+      "axes": [
+        "array-method:join",
+        "literal:string"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "details-open": {
       "kinds": [
         "call",
@@ -5311,16 +5326,16 @@
   },
   "kindCounts": {
     "array-literal": 80,
-    "array-method": 69,
+    "array-method": 70,
     "arrow": 69,
     "binary": 92,
     "call": 220,
     "conditional": 25,
-    "identifier": 309,
+    "identifier": 310,
     "index-access": 14,
-    "literal": 251,
+    "literal": 252,
     "logical": 46,
-    "member": 174,
+    "member": 175,
     "object-literal": 57,
     "template-literal": 30,
     "unary": 23,
@@ -5333,7 +5348,7 @@
     "array-method:flat": 4,
     "array-method:includes": 12,
     "array-method:indexOf": 1,
-    "array-method:join": 41,
+    "array-method:join": 42,
     "array-method:lastIndexOf": 1,
     "array-method:padEnd": 1,
     "array-method:padStart": 1,
@@ -5364,7 +5379,7 @@
     "literal:boolean": 49,
     "literal:null": 23,
     "literal:number": 105,
-    "literal:string": 178,
+    "literal:string": 179,
     "logical:&&": 7,
     "logical:??": 40,
     "logical:||": 14,

--- a/packages/adapter-tests/fixtures/destructured-object-prop-nested.ts
+++ b/packages/adapter-tests/fixtures/destructured-object-prop-nested.ts
@@ -1,0 +1,41 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A destructured props param whose inline type is a PLAIN OBJECT (not
+ * array-wrapped) carrying both a nested array-of-primitives property and a
+ * nested object property (#2677).
+ *
+ * Before #2677, `collectMemberTypes`'s destructured-parameter gate degraded
+ * ANY non-primitive member — including this shape — to `kind: 'unknown'`,
+ * so a typed adapter's `bf-p` hydration payload for `user` fell back to a
+ * PascalCase-keyed `map[string]interface{}` (`{"Name":..., "Tags":[...],
+ * "Address":{"City":...}}`) instead of the caller-facing camelCase JSON
+ * (`{"name":..., "tags":[...], "address":{"city":...}}`). SSR text output
+ * was already correct either way — this fixture's `expectedHtml` alone
+ * doesn't observe the divergence (see `hydration-props-inventory.ts` for
+ * the bf-p-level check); it exists for the change-time coupling rule
+ * (`spec/subset-conformance.md`) covering the newly-admitted shapes:
+ *
+ *   - a top-level destructured member that is itself `kind: 'object'`
+ *     (not wrapped in an array) — none of #2676's three array-of-object
+ *     fixtures (`array-map-value-field`, `array-flatmap-tuple`,
+ *     `flatmap-expression-body`) exercise this.
+ *   - an object member with a nested ARRAY-of-primitives property
+ *     (`tags`) — "object-of-arrays".
+ *   - an object member with a nested OBJECT property (`address`) —
+ *     recursion into `properties`, not `elementType`.
+ */
+export const fixture = createFixture({
+  id: 'destructured-object-prop-nested',
+  description: 'Destructured plain-object prop with nested array and nested object properties renders every field',
+  source: `
+function ProfileCard({ user }: { user: { name: string; tags: string[]; address: { city: string } } }) {
+  return <div>{user.name} ({user.tags.join(', ')}) — {user.address.city}</div>
+}
+export { ProfileCard }
+`,
+  props: { user: { name: 'Ada', tags: ['math', 'computing'], address: { city: 'London' } } },
+  expectedHtml: `
+    <div bf-s="test" bf="s3"><!--bf:s0-->Ada<!--/--> (<!--bf:s1-->math, computing<!--/-->) — <!--bf:s2-->London<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -508,6 +508,11 @@ import { fixture as controlledRadioChecked } from './controlled-radio-checked'
 import { fixture as detailsOpen } from './details-open'
 import { fixture as dialogOpen } from './dialog-open'
 import { fixture as progressMeterValue } from './progress-meter-value'
+// #2677: the analyzer's destructured-parameter member-type gate widened to
+// admit structural (array/object) shapes, not just primitives — a
+// plain-object (non-array-wrapped) destructured prop with a nested array
+// and a nested object property.
+import { fixture as destructuredObjectPropNested } from './destructured-object-prop-nested'
 
 import type { JSXFixture } from '../src/types'
 
@@ -866,5 +871,6 @@ export const jsxFixtures: JSXFixture[] = [
   detailsOpen,
   dialogOpen,
   progressMeterValue,
+  destructuredObjectPropNested,
   loopPreambleConditionalReactive,
 ]

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -63,7 +63,124 @@
       }
     }
   ],
+  "array-at": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-at-default": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-concat": [
+    {
+      "name": "gen:left:empty",
+      "props": {
+        "left": [],
+        "right": [
+          "c",
+          "d"
+        ]
+      }
+    },
+    {
+      "name": "gen:right:empty",
+      "props": {
+        "left": [
+          "a",
+          "b"
+        ],
+        "right": []
+      }
+    }
+  ],
+  "array-concat-copy": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-entries": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-every": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-find": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-findIndex": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-findLast": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-findLastIndex": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-flat": [
+    {
+      "name": "gen:rows:empty",
+      "props": {
+        "rows": []
+      }
+    }
+  ],
+  "array-flat-depth": [
+    {
+      "name": "gen:rows:empty",
+      "props": {
+        "rows": []
+      }
+    }
+  ],
   "array-flat-dynamic-depth": [
+    {
+      "name": "gen:rows:empty",
+      "props": {
+        "rows": [],
+        "depth": 2
+      }
+    },
     {
       "name": "gen:depth:zero",
       "props": {
@@ -137,7 +254,71 @@
       }
     }
   ],
+  "array-flat-infinity": [
+    {
+      "name": "gen:rows:empty",
+      "props": {
+        "rows": []
+      }
+    }
+  ],
+  "array-flatmap-field": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-flatmap-nested-filter-join": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-flatmap-nested-map": [
+    {
+      "name": "gen:posts:empty",
+      "props": {
+        "posts": []
+      }
+    }
+  ],
+  "array-flatmap-self": [
+    {
+      "name": "gen:rows:empty",
+      "props": {
+        "rows": []
+      }
+    }
+  ],
+  "array-flatmap-thisarg": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": [],
+        "ctx": null
+      }
+    }
+  ],
+  "array-flatmap-tuple": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
   "array-includes": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": [],
+        "target": "b"
+      }
+    },
     {
       "name": "gen:target:empty",
       "props": {
@@ -174,6 +355,13 @@
   ],
   "array-indexOf": [
     {
+      "name": "gen:items:empty",
+      "props": {
+        "items": [],
+        "target": "b"
+      }
+    },
+    {
       "name": "gen:target:empty",
       "props": {
         "items": [
@@ -207,7 +395,38 @@
       }
     }
   ],
+  "array-join": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-join-default": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-keys": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
   "array-lastIndexOf": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": [],
+        "target": "b"
+      }
+    },
     {
       "name": "gen:target:empty",
       "props": {
@@ -245,6 +464,142 @@
           "d"
         ],
         "target": "日本語"
+      }
+    }
+  ],
+  "array-map-function-reference": [
+    {
+      "name": "gen:tags:empty",
+      "props": {
+        "tags": []
+      }
+    }
+  ],
+  "array-map-value-field": [
+    {
+      "name": "gen:users:empty",
+      "props": {
+        "users": []
+      }
+    }
+  ],
+  "array-map-value-template": [
+    {
+      "name": "gen:tags:empty",
+      "props": {
+        "tags": []
+      }
+    }
+  ],
+  "array-reverse": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-slice": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-slice-copy": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-some": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-sort-field-asc": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-sort-field-desc": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-sort-fnref": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-sort-locale": [
+    {
+      "name": "gen:names:empty",
+      "props": {
+        "names": []
+      }
+    }
+  ],
+  "array-sort-multikey": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-sort-primitive": [
+    {
+      "name": "gen:nums:empty",
+      "props": {
+        "nums": []
+      }
+    }
+  ],
+  "array-sort-ternary": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-toReversed": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "array-toSorted": [
+    {
+      "name": "gen:nums:empty",
+      "props": {
+        "nums": []
+      }
+    }
+  ],
+  "array-values": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
       }
     }
   ],
@@ -953,6 +1308,20 @@
       }
     }
   ],
+  "destructured-object-prop-nested": [
+    {
+      "name": "gen:user:object:minimal",
+      "props": {
+        "user": {
+          "name": "",
+          "tags": [],
+          "address": {
+            "city": ""
+          }
+        }
+      }
+    }
+  ],
   "else-if-chain": [
     {
       "name": "gen:level:markup",
@@ -964,6 +1333,14 @@
       "name": "gen:level:multibyte",
       "props": {
         "level": "日本語"
+      }
+    }
+  ],
+  "flatmap-expression-body": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
       }
     }
   ],
@@ -1187,6 +1564,14 @@
       }
     }
   ],
+  "loop-destructured-param-condition": [
+    {
+      "name": "gen:rows:empty",
+      "props": {
+        "rows": []
+      }
+    }
+  ],
   "loop-param-shadows-bool-prop": [
     {
       "name": "gen:active:false",
@@ -1196,6 +1581,21 @@
           "on",
           "off"
         ]
+      }
+    },
+    {
+      "name": "gen:flags:empty",
+      "props": {
+        "active": true,
+        "flags": []
+      }
+    }
+  ],
+  "loop-param-shadows-const-key": [
+    {
+      "name": "gen:rows:empty",
+      "props": {
+        "rows": []
       }
     }
   ],
@@ -1232,9 +1632,40 @@
           3
         ]
       }
+    },
+    {
+      "name": "gen:values:empty",
+      "props": {
+        "label": "Item",
+        "values": []
+      }
+    }
+  ],
+  "loop-param-shadows-record-const": [
+    {
+      "name": "gen:rows:empty",
+      "props": {
+        "rows": []
+      }
+    }
+  ],
+  "loop-param-shadows-record-template-span": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": [],
+        "k": "a"
+      }
     }
   ],
   "loop-param-shadows-spread-const": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": [],
+        "big": true
+      }
+    },
     {
       "name": "gen:big:false",
       "props": {
@@ -1249,6 +1680,46 @@
           }
         ],
         "big": false
+      }
+    }
+  ],
+  "map-array-builder-body": [
+    {
+      "name": "gen:rows:empty",
+      "props": {
+        "rows": []
+      }
+    }
+  ],
+  "map-array-builder-escaping": [
+    {
+      "name": "gen:rows:empty",
+      "props": {
+        "rows": []
+      }
+    }
+  ],
+  "map-if-chain-body": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "map-preamble-branch-body": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "map-switch-fallthrough-body": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
       }
     }
   ],
@@ -1474,6 +1945,46 @@
       }
     }
   ],
+  "reduce-concat": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "reduce-product": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "reduce-right-concat": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "reduce-sum-field": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
+  "reduce-sum-self": [
+    {
+      "name": "gen:nums:empty",
+      "props": {
+        "nums": []
+      }
+    }
+  ],
   "return-logical-or": [
     {
       "name": "gen:label:empty",
@@ -1499,6 +2010,27 @@
       "name": "gen:items:empty",
       "props": {
         "items": []
+      }
+    }
+  ],
+  "sibling-loops-key-isolation": [
+    {
+      "name": "gen:fruits:empty",
+      "props": {
+        "fruits": [],
+        "veggies": [
+          "carrot"
+        ]
+      }
+    },
+    {
+      "name": "gen:veggies:empty",
+      "props": {
+        "fruits": [
+          "apple",
+          "plum"
+        ],
+        "veggies": []
       }
     }
   ],

--- a/packages/jsx/src/__tests__/date-lowering.test.ts
+++ b/packages/jsx/src/__tests__/date-lowering.test.ts
@@ -101,7 +101,7 @@ describe('datePlugin matcher recognition (#2274)', () => {
     // destructured path reads the type from propsType, not propsParams, so
     // the widening isn't load-bearing for the matcher above, but propsParams
     // is itself observable IR metadata this plugin's existence is meant to
-    // unlock (see analyzer.ts's docstring on `isResolvablePrimitive`).
+    // unlock (see analyzer.ts's docstring on `isResolvableMemberType`).
     const md = metadata(`
       export function Foo({ createdAt }: { createdAt: Date }) {
         return <div>{createdAt.toISOString()}</div>

--- a/packages/jsx/src/__tests__/props-destructuring.test.ts
+++ b/packages/jsx/src/__tests__/props-destructuring.test.ts
@@ -426,7 +426,13 @@ describe('Destructured props keep their declared types (BF043 fixture #2150)', (
     })
   })
 
-  test('leaves NON-primitive members (arrays/objects) as unknown', () => {
+  // #2677: a STRUCTURAL member (array/object) built entirely out of
+  // primitives resolves fully now — go-template's `emitSynthPropStructs`
+  // (#2674/#2676) can synthesize a real struct for either shape, so the
+  // #2150 "unchecked assertion" concern doesn't apply to them any more.
+  // `rows: number[][]` is a nested array of primitives; `meta: { id:
+  // string }` is an inline object literal with a primitive property.
+  test('resolves STRUCTURAL members (nested arrays / inline objects) built entirely out of primitives (#2677)', () => {
     const source = `
       type Props = { rows: number[][]; meta: { id: string } }
 
@@ -437,7 +443,38 @@ describe('Destructured props keep their declared types (BF043 fixture #2150)', (
 
     const ctx = analyzeComponent(source, 'Component.tsx')
 
-    expect(typeOf(ctx, 'rows')).toEqual({ kind: 'unknown', raw: 'unknown' })
-    expect(typeOf(ctx, 'meta')).toEqual({ kind: 'unknown', raw: 'unknown' })
+    expect(typeOf(ctx, 'rows')).toEqual({
+      kind: 'array',
+      raw: 'number[][]',
+      elementType: { kind: 'array', raw: 'number[]', elementType: { kind: 'primitive', raw: 'number', primitive: 'number' } },
+    })
+    expect(typeOf(ctx, 'meta')).toEqual({
+      kind: 'object',
+      raw: '{ id: string }',
+      properties: [{ name: 'id', type: { kind: 'primitive', raw: 'string', primitive: 'string' }, optional: false, readonly: false }],
+    })
+  })
+
+  // A structural member declines WHOLLY (not per-leaf) when ANY reachable
+  // leaf is a union, a function, or an un-catalogued named type — the same
+  // three shapes `isResolvableMemberType` declines at the top level.
+  test('declines a structural member when a nested leaf is a union/function/un-catalogued named type (#2677)', () => {
+    const source = `
+      type Props = {
+        variants: { id: string; kind: 'a' | 'b' }[]
+        handlers: { onClick: () => void }
+        configs: { data: Map<string, string> }
+      }
+
+      export function Component({ variants, handlers, configs }: Props) {
+        return <div>{variants.length}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    expect(typeOf(ctx, 'variants')).toEqual({ kind: 'unknown', raw: 'unknown' })
+    expect(typeOf(ctx, 'handlers')).toEqual({ kind: 'unknown', raw: 'unknown' })
+    expect(typeOf(ctx, 'configs')).toEqual({ kind: 'unknown', raw: 'unknown' })
   })
 })

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -3430,6 +3430,82 @@ function collectKeysFromMembers(
 }
 
 /**
+ * Decide whether a member's `TypeInfo` is admissible for
+ * `collectMemberTypes`'s destructured-parameter resolution (#2677 —
+ * widened from the original string/number/boolean-only gate).
+ *
+ * #2150 originally restricted the gate to string/number/boolean, because a
+ * non-primitive `TypeInfo` there used to mean "the typed adapters will emit
+ * an unchecked scalar assertion (`in.X.(int)`) that panics" for a shape the
+ * template layer had no representation for. That reasoning does NOT extend
+ * to a rich type with a CATALOGUED lowering (#2274: `Date` → the `date`
+ * helper): its propsParams `TypeInfo` is consumed only as call-site
+ * evidence for `resolveReceiverType` (rich-type-evidence.ts) — never
+ * emitted as a concrete field type (`typeInfoToGo`'s `interface` case falls
+ * through to `interface{}` for an unbacked host name exactly as `unknown`
+ * already did) — so there is no assertion to panic. Gating on
+ * `CATALOGUED_RICH_TYPE_NAMES` specifically (not `HOST_RICH_TYPE_NAMES`
+ * wholesale) keeps an un-catalogued rich type (`Map`, `Set`, …) at
+ * `unknown`, i.e. avoids resurrecting the #2150 mistake for a shape no
+ * lowering plugin exists for yet.
+ *
+ * Nor does it extend to a STRUCTURAL shape (`kind: 'array'` /
+ * `kind: 'object'`) any more. `typeNodeToTypeInfo` already builds these
+ * fully recursively (`elementType`, `properties`) — the same walk the
+ * `props`-object form (`extractPropsFromTypeMembers`) always got — and
+ * go-template's `emitSynthPropStructs` (#2674/#2676) synthesizes a real,
+ * json-tagged Go struct for any anonymous object type it reaches through
+ * `ir.metadata.propsParams[].type`, array-element positions included. A
+ * structural `TypeInfo` is representable today, so admitting it here no
+ * longer resurrects #2150 either — it lets `propsParams[].type` carry the
+ * SAME shape the props-object form already resolved, closing the
+ * asymmetry #2677 reports (`{ items }: { items: {...}[] }` degrading to
+ * `unknown` while `(props: { items: {...}[] })` resolved fully).
+ *
+ * `array`/`object` admit only when EVERY reachable leaf resolves — an
+ * array's element type and an object's every property type must pass this
+ * same check, recursively. A union, a function, or an un-catalogued named
+ * type reachable ANYWHERE inside the shape declines the WHOLE member (not
+ * just that one leaf): `collectMemberTypes` is an all-or-nothing gate per
+ * member, so a partially-resolvable structural type must still decline —
+ * per-field graceful degradation is `typeInfoToGo`'s job downstream, not
+ * this gate's.
+ *
+ * The `object` arm requires `properties` to be PRESENT, not merely falsy-
+ * coalesced to `[]` — an absent-members claim and a zero-members claim are
+ * different things, and `.every()` on a defaulted-to-`[]` array would admit
+ * both identically (vacuously `true`), which is the #2150 failure mode
+ * wearing a different hat: a concrete representation with no evidence
+ * behind it. `typeNodeToTypeInfo`'s `object` arm DOES omit `properties`
+ * entirely in its `synthetic` mode (the checker-driven `tsTypeToTypeInfo`
+ * path, used for e.g. `createMemo` inference off a resolved `ts.Type`,
+ * which has no source positions for `membersToProperties`' `getText()`).
+ * This gate's only caller (`collectMemberTypes`'s `fromMembers`) always
+ * calls the NON-synthetic 2-arg form, so `properties` is in practice always
+ * at least `[]` here today — but `isResolvableMemberType` is a module-level
+ * function, not a closure scoped to that one caller, so it guards the
+ * general case rather than trust a caller-specific invariant. A genuinely
+ * EMPTY object literal (`{}`, real zero members) DOES resolve — an empty
+ * synthesized struct is exactly as faithful a representation as the type
+ * itself claims, nothing is being guessed.
+ */
+function isResolvableMemberType(info: TypeInfo): boolean {
+  switch (info.kind) {
+    case 'primitive':
+      return info.primitive === 'string' || info.primitive === 'number' || info.primitive === 'boolean'
+    case 'interface':
+      return CATALOGUED_RICH_TYPE_NAMES.has(baseTypeName(info.raw))
+    case 'array':
+      return !!info.elementType && isResolvableMemberType(info.elementType)
+    case 'object':
+      return info.properties !== undefined && info.properties.every(prop => isResolvableMemberType(prop.type))
+    // Unions, functions, and `unknown` all decline — see docstring.
+    default:
+      return false
+  }
+}
+
+/**
  * Build a property-name -> { type, optional } map from a props type
  * annotation, for destructured params (`{ value }: Props`) so they carry the
  * same per-prop TypeInfo and optionality the props-object path
@@ -3443,36 +3519,17 @@ function collectKeysFromMembers(
  *   degraded to `unknown` -> `interface{}` for attribute omission, because
  *   #2252's nullish-flip machinery supplies the nillable representation
  *   exactly where absence is semantically observable (#2259).
- * - Only PRIMITIVE members (string/number/boolean) resolve a type. Those are
- *   the types that otherwise produce an unchecked scalar assertion (`in.X.(int)`)
- *   that panics. Arrays/objects/functions are left as `unknown` because typed
- *   adapters lower them through interface{}-based helpers (`bf_flat`, spread,
- *   `bf_json`); giving them concrete types would break that lowering and is a
- *   larger, separate change.
+ * - A member resolves a type when it is a PRIMITIVE (string/number/boolean),
+ *   a CATALOGUED rich type (`Date`), or a STRUCTURAL shape (array/object)
+ *   built entirely out of those, recursively (#2677). Unions, functions, and
+ *   un-catalogued named types (`Map`, `Set`, …) are left as `unknown` — see
+ *   `isResolvableMemberType`'s own docstring for why the structural cases
+ *   are safe to admit and why those three still are not.
  */
 function collectMemberTypes(
   typeNode: ts.TypeNode,
   ctx: AnalyzerContext
 ): Map<string, { type: TypeInfo | null; optional: boolean }> | null {
-  // #2150 originally restricted this gate to string/number/boolean only,
-  // because a non-primitive TypeInfo here used to mean "the typed adapters
-  // will emit an unchecked scalar assertion (`in.X.(int)`) that panics" for
-  // a shape the template layer has no representation for. That reasoning
-  // does NOT extend to a rich type with a CATALOGUED lowering (#2274: `Date`
-  // → the `date` helper): its propsParams TypeInfo is consumed only as
-  // call-site evidence for `resolveReceiverType` (rich-type-evidence.ts) —
-  // never emitted as a concrete field type (`typeInfoToGo`'s `interface`
-  // case falls through to `interface{}` for an unbacked host name exactly
-  // as `unknown` already did) — so there is no assertion to panic. Gating on
-  // `CATALOGUED_RICH_TYPE_NAMES` specifically (not `HOST_RICH_TYPE_NAMES`
-  // wholesale) keeps an un-catalogued rich type (`Map`, `Set`, …) at
-  // `unknown`, i.e. avoids resurrecting the #2150 mistake for a shape no
-  // lowering plugin exists for yet.
-  const isResolvablePrimitive = (info: TypeInfo): boolean =>
-    (info.kind === 'primitive' &&
-      (info.primitive === 'string' || info.primitive === 'number' || info.primitive === 'boolean')) ||
-    (info.kind === 'interface' && CATALOGUED_RICH_TYPE_NAMES.has(baseTypeName(info.raw)))
-
   const fromMembers = (
     members: ts.NodeArray<ts.TypeElement>
   ): Map<string, { type: TypeInfo | null; optional: boolean }> => {
@@ -3481,7 +3538,7 @@ function collectMemberTypes(
       if (ts.isPropertySignature(member) && member.name) {
         const info = member.type ? typeNodeToTypeInfo(member.type, ctx.sourceFile) : null
         map.set(member.name.getText(ctx.sourceFile), {
-          type: info && isResolvablePrimitive(info) ? info : null,
+          type: info && isResolvableMemberType(info) ? info : null,
           optional: !!member.questionToken,
         })
       }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 331,
+    "totalFixtures": 332,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -486,15 +486,15 @@
       }
     },
     "array-method": {
-      "total": 69,
+      "total": 70,
       "cells": {
         "hono": {
-          "pass": 69,
-          "total": 69
+          "pass": 70,
+          "total": 70
         },
         "blade": {
-          "pass": 66,
-          "total": 69,
+          "pass": 67,
+          "total": 70,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -511,8 +511,8 @@
           ]
         },
         "erb": {
-          "pass": 66,
-          "total": 69,
+          "pass": 67,
+          "total": 70,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -529,8 +529,8 @@
           ]
         },
         "go-template": {
-          "pass": 66,
-          "total": 69,
+          "pass": 67,
+          "total": 70,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -547,8 +547,8 @@
           ]
         },
         "jinja": {
-          "pass": 66,
-          "total": 69,
+          "pass": 67,
+          "total": 70,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -565,8 +565,8 @@
           ]
         },
         "minijinja": {
-          "pass": 66,
-          "total": 69,
+          "pass": 67,
+          "total": 70,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -583,8 +583,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 66,
-          "total": 69,
+          "pass": 67,
+          "total": 70,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -601,8 +601,8 @@
           ]
         },
         "twig": {
-          "pass": 66,
-          "total": 69,
+          "pass": 67,
+          "total": 70,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -619,8 +619,8 @@
           ]
         },
         "xslate": {
-          "pass": 66,
-          "total": 69,
+          "pass": 67,
+          "total": 70,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -2182,11 +2182,11 @@
       }
     },
     "identifier": {
-      "total": 309,
+      "total": 310,
       "cells": {
         "hono": {
-          "pass": 308,
-          "total": 309,
+          "pass": 309,
+          "total": 310,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2197,8 +2197,8 @@
           ]
         },
         "blade": {
-          "pass": 292,
-          "total": 309,
+          "pass": 293,
+          "total": 310,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2281,8 +2281,8 @@
           ]
         },
         "erb": {
-          "pass": 293,
-          "total": 309,
+          "pass": 294,
+          "total": 310,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2359,8 +2359,8 @@
           ]
         },
         "go-template": {
-          "pass": 291,
-          "total": 309,
+          "pass": 292,
+          "total": 310,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2447,8 +2447,8 @@
           ]
         },
         "jinja": {
-          "pass": 292,
-          "total": 309,
+          "pass": 293,
+          "total": 310,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2531,8 +2531,8 @@
           ]
         },
         "minijinja": {
-          "pass": 292,
-          "total": 309,
+          "pass": 293,
+          "total": 310,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2615,8 +2615,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 293,
-          "total": 309,
+          "pass": 294,
+          "total": 310,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2693,8 +2693,8 @@
           ]
         },
         "twig": {
-          "pass": 292,
-          "total": 309,
+          "pass": 293,
+          "total": 310,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2777,8 +2777,8 @@
           ]
         },
         "xslate": {
-          "pass": 292,
-          "total": 309,
+          "pass": 293,
+          "total": 310,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2926,15 +2926,15 @@
       }
     },
     "literal": {
-      "total": 251,
+      "total": 252,
       "cells": {
         "hono": {
-          "pass": 251,
-          "total": 251
+          "pass": 252,
+          "total": 252
         },
         "blade": {
-          "pass": 240,
-          "total": 251,
+          "pass": 241,
+          "total": 252,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2985,8 +2985,8 @@
           ]
         },
         "erb": {
-          "pass": 240,
-          "total": 251,
+          "pass": 241,
+          "total": 252,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3037,8 +3037,8 @@
           ]
         },
         "go-template": {
-          "pass": 239,
-          "total": 251,
+          "pass": 240,
+          "total": 252,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3093,8 +3093,8 @@
           ]
         },
         "jinja": {
-          "pass": 240,
-          "total": 251,
+          "pass": 241,
+          "total": 252,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3145,8 +3145,8 @@
           ]
         },
         "minijinja": {
-          "pass": 240,
-          "total": 251,
+          "pass": 241,
+          "total": 252,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3197,8 +3197,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 240,
-          "total": 251,
+          "pass": 241,
+          "total": 252,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3249,8 +3249,8 @@
           ]
         },
         "twig": {
-          "pass": 240,
-          "total": 251,
+          "pass": 241,
+          "total": 252,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3301,8 +3301,8 @@
           ]
         },
         "xslate": {
-          "pass": 240,
-          "total": 251,
+          "pass": 241,
+          "total": 252,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3518,11 +3518,11 @@
       }
     },
     "member": {
-      "total": 174,
+      "total": 175,
       "cells": {
         "hono": {
-          "pass": 173,
-          "total": 174,
+          "pass": 174,
+          "total": 175,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3533,8 +3533,8 @@
           ]
         },
         "blade": {
-          "pass": 157,
-          "total": 174,
+          "pass": 158,
+          "total": 175,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3617,8 +3617,8 @@
           ]
         },
         "erb": {
-          "pass": 158,
-          "total": 174,
+          "pass": 159,
+          "total": 175,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3695,8 +3695,8 @@
           ]
         },
         "go-template": {
-          "pass": 156,
-          "total": 174,
+          "pass": 157,
+          "total": 175,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3783,8 +3783,8 @@
           ]
         },
         "jinja": {
-          "pass": 157,
-          "total": 174,
+          "pass": 158,
+          "total": 175,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3867,8 +3867,8 @@
           ]
         },
         "minijinja": {
-          "pass": 157,
-          "total": 174,
+          "pass": 158,
+          "total": 175,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3951,8 +3951,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 158,
-          "total": 174,
+          "pass": 159,
+          "total": 175,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4029,8 +4029,8 @@
           ]
         },
         "twig": {
-          "pass": 157,
-          "total": 174,
+          "pass": 158,
+          "total": 175,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4113,8 +4113,8 @@
           ]
         },
         "xslate": {
-          "pass": 157,
-          "total": 174,
+          "pass": 158,
+          "total": 175,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -5369,15 +5369,15 @@
       }
     },
     "array-method:join": {
-      "total": 41,
+      "total": 42,
       "cells": {
         "hono": {
-          "pass": 41,
-          "total": 41
+          "pass": 42,
+          "total": 42
         },
         "blade": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5390,8 +5390,8 @@
           ]
         },
         "erb": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5404,8 +5404,8 @@
           ]
         },
         "go-template": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5418,8 +5418,8 @@
           ]
         },
         "jinja": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5432,8 +5432,8 @@
           ]
         },
         "minijinja": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5446,8 +5446,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5460,8 +5460,8 @@
           ]
         },
         "twig": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -5474,8 +5474,8 @@
           ]
         },
         "xslate": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7697,15 +7697,15 @@
       }
     },
     "literal:string": {
-      "total": 178,
+      "total": 179,
       "cells": {
         "hono": {
-          "pass": 178,
-          "total": 178
+          "pass": 179,
+          "total": 179
         },
         "blade": {
-          "pass": 170,
-          "total": 178,
+          "pass": 171,
+          "total": 179,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7744,8 +7744,8 @@
           ]
         },
         "erb": {
-          "pass": 170,
-          "total": 178,
+          "pass": 171,
+          "total": 179,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7784,8 +7784,8 @@
           ]
         },
         "go-template": {
-          "pass": 170,
-          "total": 178,
+          "pass": 171,
+          "total": 179,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7824,8 +7824,8 @@
           ]
         },
         "jinja": {
-          "pass": 170,
-          "total": 178,
+          "pass": 171,
+          "total": 179,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7864,8 +7864,8 @@
           ]
         },
         "minijinja": {
-          "pass": 170,
-          "total": 178,
+          "pass": 171,
+          "total": 179,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7904,8 +7904,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 170,
-          "total": 178,
+          "pass": 171,
+          "total": 179,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7944,8 +7944,8 @@
           ]
         },
         "twig": {
-          "pass": 170,
-          "total": 178,
+          "pass": 171,
+          "total": 179,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7984,8 +7984,8 @@
           ]
         },
         "xslate": {
-          "pass": 170,
-          "total": 178,
+          "pass": 171,
+          "total": 179,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",


### PR DESCRIPTION
Fixes #2677. **Third and last of a three-PR stack** — based on #2685 (#2672), which is based on #2682 (#2669). Review only the top commit.

## The defect

`collectMemberTypes` gated every member type through a string/number/boolean-only predicate, so the declared type of a **destructured** props parameter never reached any adapter:

```tsx
function TagList({ items }: { items: { id: string; tags: string[] }[] }) {
```

`items` resolved to `{ kind: 'unknown' }`. What makes this a bug rather than a design position is the asymmetry: the **bare-props form** `(props: { items: {...}[] })` resolves the identical declared type fully, because it goes through `extractPropsFromTypeMembers` instead. Same type, two answers, decided by parameter syntax.

The gate's #2150 rationale — a non-primitive `TypeInfo` meant a typed adapter would emit an unchecked scalar assertion (`in.X.(int)`) for a shape the template layer could not represent — has gone stale for **structural** types. `42d9cd4e5` added `emitSynthPropStructs`, which synthesizes a real json-tagged Go struct for any anonymous object type reachable through `propsParams[].type`, array-element positions included.

## The change

`isResolvableMemberType` replaces the inlined predicate:

```ts
case 'primitive': return info.primitive === 'string' || info.primitive === 'number' || info.primitive === 'boolean'
case 'interface': return CATALOGUED_RICH_TYPE_NAMES.has(baseTypeName(info.raw))
case 'array':     return !!info.elementType && isResolvableMemberType(info.elementType)
case 'object':    return info.properties !== undefined && info.properties.every(p => isResolvableMemberType(p.type))
default:          return false
```

All-or-nothing per member: a union, a function, or an un-catalogued named type (`Map`, `Set`, a local alias) reached **anywhere** inside a shape declines the whole member. Per-field graceful degradation stays `typeInfoToGo`'s job downstream, not this gate's — which keeps #2150 from coming back for the arms where its reasoning is still live.

The `object` arm requires `properties !== undefined` rather than defaulting to `[]`. `TypeInfo.properties` is optional and `typeNodeToTypeInfo` can produce it undefined in its checker-driven path, and `.every()` on an empty array is vacuously true — so the lazy version would have admitted "we reached this object but captured no members" as "fully resolved", synthesizing a fieldless struct to stand in for a shape with no evidence behind it. That is #2150's failure mode wearing a different hat. A genuinely empty object literal (`{}`, `properties: []`) still resolves, deliberately: an empty struct is a faithful representation of a type with no fields.

## Correction to the issue's framing

#2677 expected pins on the three #2676 fixtures (`array-map-value-field`, `array-flatmap-tuple`, `flatmap-expression-body`) to graduate here. **There were none** — grep across `skipJsx` / `renderDivergences` / csr skips / `SKIP_AUTO_UPDATE` comes up empty for all three ids. The divergence was only ever measured by the un-wired `hydration-props-inventory.ts` script, never asserted in CI, so there was nothing to un-pin. The fix was verified directly instead: pre-fix `bf-p` carried PascalCase keys (`{"Name":"Ada"}`, `{"ID":..,"Tags":..}`), post-fix camelCase matching the Hono reference — **with zero changes to the go-template adapter**, which is the acceptance signal the issue asked for.

Those three fixtures already satisfy the change-time coupling rule, so none were edited. One fixture is new — `destructured-object-prop-nested` — covering what they do not: a plain, non-array-wrapped destructured object prop with both a nested array-of-primitives property and a nested object property. `generateTypes()` now synthesizes a real `ProfileCardUser` / `ProfileCardUserAddress` struct pair where it previously emitted `interface{}`.

## Blast radius

The analyzer is shared, so every adapter's suite was run in full, not sampled:

| adapter | result |
|---|---|
| `@barefootjs/jsx` | 3067 pass / 0 fail |
| hono | 1541 / 0 |
| go-template | 1754 / 0 |
| jinja | 1468 / 0 |
| blade | 1468 / 0 |
| twig | 1476 / 0 |
| rust (minijinja) | 1466 / 0 — never reads `.type` off `propsParams`, structurally unaffected |
| erb | 1429 pass / 8 fail — all `date-tolocale-named-tz`, missing `tzinfo` gem |
| mojolicious | 1627 pass / 8 fail — same fixture, same tzdata gap |
| xslate | 1467 pass / 1 fail — same |

Every failure above was confirmed pre-existing by stashing the change and re-running, not assumed.

## One real regression, found and fixed

Widening the gate surfaced a latent bug in the go-template **test harness** (not the production adapter): `test-render.ts`'s `goTypedSliceLiteralFromArray` did not recurse into a nested-array value, so a newly-concrete `[][]int` field (`{ rows }: { rows: number[][] }`) got an untyped `[]any{…}` inner literal that failed to compile. `typeInfoToGo` in the production adapter already recursed correctly — only the harness's convenience literal-builder was behind. 13 failures (`array-flat`, `array-flat-depth`, `array-flat-infinity`, `array-flatmap-self`, `array-flat-dynamic-depth`) → 0.

## Generated artifacts

`coverage-map.json` (+1 fixture, count bumps), `generated-data-points.json` (new empty-array boundary points for every fixture whose destructured array prop now resolves structurally), `ui/compat.lock.json` (`totalFixtures: 331→332`), `ui/support-matrix.lock.json` (counter bumps only — **zero new or removed gaps**). `integrations/{chi,echo,gin,nethttp}/components.go` regenerated after rebuilding go-template's `dist` first: **zero diff**, since no demo component uses the newly-admitted shapes.

`date-lowering.test.ts`'s one-line change is a docstring rename following the predicate; no assertion touched.

Not run: `bunx changeset status` — this shallow clone has no synced `main` to diverge against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13