### PR TITLE
fix(ci): create the changesets output file before publishing anything

### DIFF
--- a/scripts/changeset-publish.ts
+++ b/scripts/changeset-publish.ts
@@ -20,12 +20,21 @@
 //   bun scripts/changeset-publish.ts
 
 import { resolve } from 'node:path'
-import { appendFileSync, mkdtempSync, rmSync } from 'node:fs'
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { $ } from 'bun'
 
 const repoRoot = resolve(import.meta.dir, '..')
 const tmpDir = mkdtempSync(`${tmpdir()}/bf-publish-`)
+
+// Unset when the script is run by hand outside changesets/action.
+const outputFile = process.env.CHANGESETS_OUTPUT
+// Not left to the first append: the action names this file but never creates
+// it, so a run that publishes nothing would leave it missing and the action
+// warns that the script failed to report -- the same warning it gives when
+// reporting is genuinely broken. An empty file says "nothing published" in a
+// way that stays distinct from that.
+if (outputFile) writeFileSync(outputFile, '')
 
 // Publish order: dependencies before dependents.
 const PUBLISHABLE = [
@@ -116,8 +125,6 @@ try {
     }
     // Not stdout: changesets/action v2 reads only this file, and a publish it
     // cannot see is one it never tags, releases, or gates downstream jobs on.
-    // Unset outside the action.
-    const outputFile = process.env.CHANGESETS_OUTPUT
     if (outputFile) {
       appendFileSync(
         outputFile,


### PR DESCRIPTION
Follow-up to #2686, from what its first release run actually printed.

## What run #803 showed

The migration works — the `Changesets — version or publish` step ran clean under action v2 + CLI v3 — but the step ended with:

```
  Done: 0 published, 23 skipped
##[warning]Failed to read changesets output at .../changesets-output-*.ndjson.
GitHub releases and git tags cannot be created without this output.
Ensure the custom publish script passes CHANGESETS_OUTPUT to the Changesets CLI.
```

The action names the `$CHANGESETS_OUTPUT` file but does not create it; that is the publish script's job. #2686 only wrote to it via `appendFileSync` inside the publish loop, so a run with nothing to publish never touched the path and the action found no file.

## Why it is worth fixing

Nothing broke: no packages were published, so `published=false` and the downstream registry jobs skipped — correct for a no-op release.

But this is the same warning the action emits when reporting is *genuinely* broken, which is precisely the failure mode #2686 could not verify ahead of a real release. Every no-op release run would print it, and by the time a real one mattered the warning would read as background noise.

Writing the file empty up front keeps the two distinguishable:

- **missing** → the script never got that far
- **empty** → it ran and published nothing
- **one line per package** → it published those

---
_Generated by [Claude Code](https://claude.ai/code/session_016UaXDZcUrbETPogGBq84uC)_