### PR TITLE
fix(jsx): resolve #2669 self-derivation collisions through a component-scope const hop

### DIFF
--- a/.changeset/go-prop-fallback-const-hop-2685.md
+++ b/.changeset/go-prop-fallback-const-hop-2685.md
@@ -1,0 +1,23 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix `go-template`'s props-struct field-default baking for a signal initialized through a component-scope `const` hop from a same-named prop:
+
+```tsx
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function C(props: { label?: string }) {
+  const mid = props.label
+  const [label, setLabel] = createSignal(mid ?? 'Default')
+  return <span>{label()}</span>
+}
+```
+
+An absent `label` prop rendered empty instead of falling back to `'Default'` — the direct form (`createSignal(props.label ?? 'Default')`) already worked (#2669/#2683), but the const hop defeated it on go-template specifically, even after `#2685`'s `computeSsrSeedPlan` fix (`resolveThroughLocalConsts` in `packages/jsx/src/ssr-seed-plan.ts`) taught the shared seed plan to see through the hop.
+
+The remaining gap was go-template-side: `extractPropFallbackFromParsed` (structural `props.X ?? <literal>` recognizer feeding the props-struct constructor's field-default baking) and `collectNullishConsumedPropNames`'s signal-seed loop (decides whether the field needs the `interface{}` nil-vs-zero-value flip, #2248) both matched against the signal's own best-effort `parsed` tree — `mid ?? 'Default'` — never the const-inlined form `computeSsrSeedPlan` already computes and attaches at `ir.metadata.ssrSeedPlan`. `mid` is a bare identifier, not `props.<name>`, so both matchers silently declined and the field kept Go's `""` zero value.
+
+Fixed by threading the seed plan's already-const-hop-inlined `ParsedExpr` (its `derived` step for the signal) through both matchers instead of the signal's raw `parsed` — a single shared `resolveSignalParsedThroughSeedPlan` helper (`packages/adapter-go-template/src/adapter/lib/compile-state.ts`) so the two matchers can't drift from each other again. Fixing only the fallback-var extraction and not the nullish-consumed classification left the two disagreeing on the const-hop shape: the field-default baked in correctly for an ABSENT prop, but the field stayed a concrete (non-`interface{}`) Go string, so the fallback's zero-value conflation (an accepted trade-off for the direct form's own field, where `interface{}` already made "absent" distinguishable from an explicit `""`) newly swallowed an EXPLICIT empty-string prop into the const's default too. Both matchers now resolve identically, so the const-hop shape gets the same nil-vs-zero-value handling as the direct form.
+
+The `-derived` (non-idempotent, self-referencing) sibling shapes stay pinned per #2683/#2684 — this fix is scoped to the idempotent const-hop fold only.

--- a/.changeset/ssr-defaults-self-derived-via-const-2685.md
+++ b/.changeset/ssr-defaults-self-derived-via-const-2685.md
@@ -1,0 +1,32 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/erb": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/blade": patch
+"@barefootjs/twig": patch
+"@barefootjs/rust": patch
+"@barefootjs/xslate": patch
+"@barefootjs/go-template": patch
+---
+
+The #2669 self-derivation fix now sees THROUGH a component-scope `const` sitting between a signal/memo's initializer and the prop it derives from, closing the gap found in review
+
+```tsx
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function C(props: { label?: string }) {
+  const mid = props.label
+  const [label, setLabel] = createSignal(mid ?? 'Default')
+  return <span>{label()}</span>
+}
+```
+
+#2669's fix (`referencesOwnProp` in `packages/jsx/src/ssr-defaults.ts`) only recognized a DIRECT `props.<name>` access in the initializer expression. One hop of pure indirection defeated it on both sides of the pipeline:
+
+- **Manifest**: `collectPropRefs` (both the self-derivation check and the bare-props-arg safety net that seeds a prop a signal/memo initializer reads, #1297/#2126) never looked through a local `const` — the `label` entry lost `propName` and fell back to `{ value: 'Default' }`, so a caller-supplied `label='Hello'` could never win.
+- **Template**: even with `propName` restored, `computeSsrSeedPlan` (`packages/jsx/src/ssr-seed-plan.ts`) classified the signal as `opaque` because `mid` (a component-scope const) wasn't part of its `baseScope` — no adapter emitted an in-template recompute at all, so an absent prop rendered permanently empty instead of falling back to `'Default'`.
+
+Both now resolve transitively through any chain of component-scope `const` locals (`collectPropRefsTransitive` on the manifest side; `resolveThroughLocalConsts`, reusing the same structural `inlineBinding` let-inline step `foldBlockToExpr` already performs for a block-bodied memo's own locals, on the seed-plan side) — never string splicing, per this repo's write-side rule. The seed-plan fix lives in the shared `computeSsrSeedPlan`, so every template-stash adapter's existing self-referencing-lowering handling (Jinja/Twig/Blade/Rust's re-read-before-reassign `{% set %}` semantics, Xslate's capture-before-shadow `: my $__bf_seed_*` lowering) picks it up with no adapter-side changes.
+
+**go-template**: the manifest/seed-plan fix applies equally, but the pre-existing #2683 props-struct field-name-collision bug (keyed on the signal's name colliding with its prop field, independent of how the initializer reaches that prop) still drops the derivation for the non-idempotent via-const shape — pinned in `render-divergences.ts` alongside the direct-access form #2683 already covers.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -119,7 +119,7 @@ import type {
 } from "./lib/types.ts"
 import { collectRootScopeNodes } from "./lib/ir-scope.ts"
 import { GO_TEMPLATE_PRIMITIVES } from "./lib/constants.ts"
-import { CompileState } from "./lib/compile-state.ts"
+import { CompileState, resolveSignalParsedThroughSeedPlan } from "./lib/compile-state.ts"
 import { hasClientInteractivity, findNestedComponents } from "./analysis/component-tree.ts"
 import { analyzeBakeableStaticChildLoop, scalarToGoLiteral, type BakedStaticChildLoop } from "./analysis/static-child-loop-bake.ts"
 import { analyzeBakeableStaticElementLoop } from "./analysis/static-element-loop-bake.ts"
@@ -1948,7 +1948,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (propFieldNames.has(fieldName)) continue
       // `props.X ?? N` reuses the hoisted fallback var so signal and memo share
       // one value.
-      const fallbackMatch = this.extractPropFallback(signal.initialValue, signal.parsed)
+      const fallbackMatch = this.extractPropFallback(signal.initialValue, this.resolvedSignalParsed(signal))
       const hoisted = fallbackMatch ? propFallbackVars.get(fallbackMatch.propName) : undefined
       if (hoisted) {
         lines.push(`\t\t${fieldName}: ${hoisted.varName},`)
@@ -3588,7 +3588,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     const propTypeOverrides = buildPropTypeOverrides(this.emitCtx, ir)
     for (const signal of ir.metadata.signals) {
-      const match = this.extractPropFallback(signal.initialValue, signal.parsed)
+      const match = this.extractPropFallback(signal.initialValue, this.resolvedSignalParsed(signal))
       if (!match) continue
       if (result.has(match.propName)) continue
       const param = ir.metadata.propsParams.find(p => p.name === match.propName)
@@ -3651,6 +3651,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       })
     }
     return result
+  }
+
+  /**
+   * Resolve a signal's initializer through the SSR seed plan's const-hop
+   * inlining (#2685) before prop-fallback extraction — see
+   * {@link resolveSignalParsedThroughSeedPlan} (shared with
+   * `collectNullishConsumedPropNames`'s signal-seed loop, the single door
+   * both consumers of this resolution go through).
+   */
+  private resolvedSignalParsed(signal: { getter: string; parsed?: ParsedExpr }): ParsedExpr | undefined {
+    return resolveSignalParsedThroughSeedPlan(this.state, signal)
   }
 
   /**

--- a/packages/adapter-go-template/src/adapter/lib/compile-state.ts
+++ b/packages/adapter-go-template/src/adapter/lib/compile-state.ts
@@ -22,6 +22,7 @@ import type {
   IRNode,
   LoweringMatcher,
   MemoInfo,
+  ParsedExpr,
   SsrSeedPlan,
   TypeDefinition,
   TypeInfo,
@@ -261,4 +262,37 @@ export class CompileState {
   /** Set when a constructor-context lowering emits a `strings.` call, so
    *  `strings` is added to the generated types file's import block. */
   needsStringsImport = false
+}
+
+/**
+ * Resolve a signal's initializer through the SSR seed plan's const-hop
+ * inlining (#2685, `resolveThroughLocalConsts` in
+ * `packages/jsx/src/ssr-seed-plan.ts`) before prop-fallback shape matching,
+ * so a component-scope `const` sitting between a `props.X` read and
+ * `createSignal` (`const mid = props.label; createSignal(mid ?? 'Default')`)
+ * doesn't hide the `props.X ?? <literal>` shape from
+ * `extractPropFallbackFromParsed` / `collectNullishConsumedPropNames`'s
+ * signal-seed loop — both need the SAME resolved tree (single door, not two
+ * divergent walks: a mismatch between them is exactly what let the field-type
+ * flip and the fallback-var construction disagree on nullish handling for
+ * the const-hop shape).
+ *
+ * Falls back to the signal's own `parsed` when the plan didn't classify this
+ * signal `derived` (opaque for an unrelated reason, e.g. a free identifier
+ * genuinely out of scope) — never invents a substitution the plan itself
+ * didn't make.
+ *
+ * `signal` takes the minimal structural shape (not the internal `SignalInfo`
+ * type, which `@barefootjs/jsx`'s public index doesn't export — the same
+ * inline-shape convention `memo-compute.ts`'s extracted helpers already use
+ * for signal params).
+ */
+export function resolveSignalParsedThroughSeedPlan(
+  state: CompileState,
+  signal: { getter: string; parsed?: ParsedExpr },
+): ParsedExpr | undefined {
+  const step = state.ssrSeedPlan.steps.find(
+    s => s.kind === 'derived' && s.origin === 'signal' && s.name === signal.getter,
+  )
+  return step?.kind === 'derived' ? step.parsed : signal.parsed
 }

--- a/packages/adapter-go-template/src/adapter/props/prop-types.ts
+++ b/packages/adapter-go-template/src/adapter/props/prop-types.ts
@@ -9,6 +9,7 @@ import type { ComponentIR, IRMetadata, IRNode, ParsedExpr } from '@barefootjs/js
 import { isBooleanAttr } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
+import { resolveSignalParsedThroughSeedPlan } from '../lib/compile-state.ts'
 import { typeInfoToGo } from '../type/type-codegen.ts'
 
 /**
@@ -218,7 +219,12 @@ export function collectNullishConsumedPropNames(ctx: GoEmitContext, ir: Componen
   // tree — reuse the seam's existing `props.X ?? <literal>` recognizer. The
   // zero-equivalent exclusion matches on the Go-formatted fallback literal.
   for (const signal of ir.metadata.signals) {
-    const match = ctx.extractPropFallback(signal.initialValue, signal.parsed)
+    // Resolved through the seed plan's const-hop inlining (#2685) — see
+    // `resolveSignalParsedThroughSeedPlan` — so a component-scope `const`
+    // between `props.X` and `createSignal` doesn't leave this loop and
+    // `collectPropFallbackVars`'s identical extraction disagreeing on
+    // whether the prop needs the nillable flip.
+    const match = ctx.extractPropFallback(signal.initialValue, resolveSignalParsedThroughSeedPlan(ctx.state, signal))
     if (!match || !optionalParams.has(match.propName)) continue
     const f = match.goFallback
     if (f === '""' || f === 'false' || f === 'nil' || Number(f) === 0) continue

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -31,4 +31,14 @@ export const renderDivergences: RenderDivergences = {
   // skip emits a duplicate field — the real fix needs its own PR.
   'signal-prop-same-name-derived':
     'self-derived signal collides with its prop field name in the generated Go props struct — the non-idempotent `* 2` derivation is dropped and the signal renders the raw prop value instead (https://github.com/piconic-ai/barefootjs/issues/2683)',
+  // #2685 review: same #2683 bug, one hop of const indirection removed —
+  // the props-struct field-name collision is keyed on the SIGNAL's name,
+  // not on how its initializer reaches the prop, so
+  // `const mid = props.count; createSignal((mid ?? 1) * 2)` collides
+  // exactly like the direct-access form above. This is go's PRE-EXISTING
+  // #2683 defect surfacing through a new fixture, not a regression from
+  // the #2685 review fix (which lands correctly on every other
+  // template-stash adapter — see those adapters' conformance runs).
+  'signal-prop-same-name-via-const-derived':
+    'self-derived signal (reached through a component-scope const) collides with its prop field name in the generated Go props struct — the non-idempotent `* 2` derivation is dropped and the signal renders the raw prop value instead (https://github.com/piconic-ai/barefootjs/issues/2683)',
 }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -4351,6 +4351,40 @@
         "text"
       ]
     },
+    "signal-prop-same-name-via-const": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal",
+        "logical",
+        "member"
+      ],
+      "axes": [
+        "literal:string",
+        "logical:??"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
+    "signal-prop-same-name-via-const-derived": {
+      "kinds": [
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "logical",
+        "member"
+      ],
+      "axes": [
+        "binary:*",
+        "literal:number",
+        "logical:??"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "signal-with-fallback": {
       "kinds": [
         "call",
@@ -5328,14 +5362,14 @@
     "array-literal": 80,
     "array-method": 70,
     "arrow": 69,
-    "binary": 92,
-    "call": 220,
+    "binary": 93,
+    "call": 222,
     "conditional": 25,
-    "identifier": 310,
+    "identifier": 312,
     "index-access": 14,
-    "literal": 252,
-    "logical": 46,
-    "member": 175,
+    "literal": 254,
+    "logical": 48,
+    "member": 177,
     "object-literal": 57,
     "template-literal": 30,
     "unary": 23,
@@ -5368,7 +5402,7 @@
     "array-method:trimStart": 1,
     "binary:!=": 2,
     "binary:!==": 9,
-    "binary:*": 11,
+    "binary:*": 12,
     "binary:+": 21,
     "binary:-": 11,
     "binary:/": 1,
@@ -5378,10 +5412,10 @@
     "binary:>=": 1,
     "literal:boolean": 49,
     "literal:null": 23,
-    "literal:number": 105,
-    "literal:string": 179,
+    "literal:number": 106,
+    "literal:string": 180,
     "logical:&&": 7,
-    "logical:??": 40,
+    "logical:??": 42,
     "logical:||": 14,
     "member:computed": 8,
     "member:optional": 1,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -103,6 +103,8 @@ import { fixture as signalDefaultFromJsx } from './signal-default-from-jsx'
 import { fixture as controlledSignal } from './controlled-signal'
 import { fixture as signalPropSameName } from './signal-prop-same-name'
 import { fixture as signalPropSameNameDerived } from './signal-prop-same-name-derived'
+import { fixture as signalPropSameNameViaConst } from './signal-prop-same-name-via-const'
+import { fixture as signalPropSameNameViaConstDerived } from './signal-prop-same-name-via-const-derived'
 import { fixture as memo } from './memo'
 import { fixture as effect } from './effect'
 import { fixture as multipleSignals } from './multiple-signals'
@@ -560,6 +562,8 @@ export const jsxFixtures: JSXFixture[] = [
   controlledSignal,
   signalPropSameName,
   signalPropSameNameDerived,
+  signalPropSameNameViaConst,
+  signalPropSameNameViaConstDerived,
   memo,
   effect,
   multipleSignals,

--- a/packages/adapter-tests/fixtures/signal-prop-same-name-via-const-derived.ts
+++ b/packages/adapter-tests/fixtures/signal-prop-same-name-via-const-derived.ts
@@ -1,0 +1,37 @@
+import { createFixture } from '../src/types'
+
+// #2685 review: the NON-IDEMPOTENT sibling of `signal-prop-same-name-via-const`
+// — mirrors how `signal-prop-same-name-derived` pins the direct-access
+// non-idempotent shape. Restoring `propName` alone (Half 1 of the fix) is
+// not enough here: with no in-template recompute, the emitted template
+// would read the RAW seeded prop (`count: 5`) with no `* 2` applied at all
+// — wrong in a different way than before the fix, not merely "still wrong".
+// The derivation must actually run in-template, exactly once, over the
+// caller-supplied prop:
+//
+//   const mid = props.count
+//   const [count, setCount] = createSignal((mid ?? 1) * 2)
+//
+// `expectedHtml` is HAND-AUTHORED to the correct value (not auto-generated
+// from the Hono reference adapter, even though Hono itself is unaffected by
+// this template-stash-only bug — real JS naturally resolves the `const`
+// chain) per CLAUDE.md's fixture rule, and this id is registered in
+// `generate-expected-html.ts`'s `SKIP_AUTO_UPDATE` so a regeneration pass
+// can't silently overwrite the intent.
+export const fixture = createFixture({
+  id: 'signal-prop-same-name-via-const-derived',
+  description: 'Signal initialized from a NON-IDEMPOTENT derivation of a same-named prop through one component-scope const hop',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function SignalPropSameNameViaConstDerived(props: { count?: number }) {
+  const mid = props.count
+  const [count, setCount] = createSignal((mid ?? 1) * 2)
+  return <span>{count()}</span>
+}
+`,
+  props: { count: 5 },
+  expectedHtml: `
+    <span bf-s="test" bf="s1"><!--bf:s0-->10<!--/--></span>
+  `,
+})

--- a/packages/adapter-tests/fixtures/signal-prop-same-name-via-const.ts
+++ b/packages/adapter-tests/fixtures/signal-prop-same-name-via-const.ts
@@ -1,0 +1,35 @@
+import { createFixture } from '../src/types'
+
+// #2685 review: `signal-prop-same-name` pins the DIRECT self-derivation
+// collision (`createSignal(props.label ?? 'Default')`); this fixture pins
+// the SAME collision one hop of pure indirection removed — a component-scope
+// `const` sitting between the prop read and the signal initializer:
+//
+//   const mid = props.label
+//   const [label, setLabel] = createSignal(mid ?? 'Default')
+//
+// `ssr-defaults.ts`'s `referencesOwnProp` (built on `collectPropRefs`) only
+// saw a DIRECT `props.<name>` access in the initializer expression, so this
+// shape defeated the #2669 detection: the manifest entry lost `propName`
+// (falling back to the plain evaluated signal value, `'Default'`), and the
+// emitted template had no in-template recompute at all — so a caller-passed
+// `label` NEVER won, on every template-stash backend. `expectedHtml` is the
+// caller-supplied value (`Hello`); it must NOT silently fall back to
+// `'Default'` (the pre-fix behavior on every template-stash adapter).
+export const fixture = createFixture({
+  id: 'signal-prop-same-name-via-const',
+  description: 'Signal initialized from a same-named prop through one component-scope const hop',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function SignalPropSameNameViaConst(props: { label?: string }) {
+  const mid = props.label
+  const [label, setLabel] = createSignal(mid ?? 'Default')
+  return <span>{label()}</span>
+}
+`,
+  props: { label: 'Hello' },
+  expectedHtml: `
+    <span bf-s="test" bf="s1"><!--bf:s0-->Hello<!--/--></span>
+  `,
+})

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -2102,6 +2102,54 @@
       }
     }
   ],
+  "signal-prop-same-name-via-const": [
+    {
+      "name": "gen:label:absent",
+      "props": {}
+    },
+    {
+      "name": "gen:label:empty",
+      "props": {
+        "label": ""
+      }
+    },
+    {
+      "name": "gen:label:markup",
+      "props": {
+        "label": "<b>&\"'</b>"
+      }
+    },
+    {
+      "name": "gen:label:multibyte",
+      "props": {
+        "label": "日本語"
+      }
+    }
+  ],
+  "signal-prop-same-name-via-const-derived": [
+    {
+      "name": "gen:count:absent",
+      "props": {}
+    },
+    {
+      "name": "gen:count:zero",
+      "props": {
+        "count": 0
+      }
+    },
+    {
+      "name": "gen:count:negative",
+      "props": {
+        "count": -7
+      }
+    },
+    {
+      "name": "gen:count:large",
+      "props": {
+        "count": 1234567890
+      }
+    }
+  ],
   "signal-with-fallback": [
     {
       "name": "gen:initial:absent",

--- a/packages/adapter-tests/scripts/generate-expected-html.ts
+++ b/packages/adapter-tests/scripts/generate-expected-html.ts
@@ -52,6 +52,9 @@ const SKIP_AUTO_UPDATE = new Set<string>([
   // value; must not be silently overwritten by a future regeneration pass.
   // See the fixture file's docstring for the full mechanism.
   'signal-prop-same-name-derived',
+  // #2685 review: same reasoning, one hop of const indirection removed.
+  // See the fixture file's docstring for the full mechanism.
+  'signal-prop-same-name-via-const-derived',
 ])
 
 async function main() {

--- a/packages/jsx/src/__tests__/ssr-defaults.test.ts
+++ b/packages/jsx/src/__tests__/ssr-defaults.test.ts
@@ -195,6 +195,119 @@ describe('extractSsrDefaults', () => {
     expect(defaults?.label).toEqual({ value: 'sig' })
   })
 
+  test('self-derived signal collision THROUGH a component-scope const (#2685 review): entry stays a PROP entry', () => {
+    // One hop of pure indirection past #2669's shape A: `referencesOwnProp`
+    // (built on `collectPropRefs`) only saw a DIRECT `props.<name>` access
+    // in the initializer — a `const mid = props.label` sitting between the
+    // prop read and `createSignal(mid ?? 'Default')` defeated the
+    // detection, so this entry regressed to the pre-#2669 `{ value:
+    // 'Default' }` shape (no `propName`) even after the #2669 fix landed.
+    // Same fix, widened: `collectPropRefsTransitive` now looks through
+    // component-scope const locals.
+    const metadata = metadataFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function C(props: { label?: string }) {
+        const mid = props.label
+        const [label, setLabel] = createSignal(mid ?? 'Default')
+        return <span>{label()}</span>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.label).toEqual({ propName: 'label', value: null })
+  })
+
+  test('self-derived memo collision THROUGH a component-scope const (#2685 review)', () => {
+    const metadata = metadataFor(`
+      'use client'
+      import { createMemo } from '@barefootjs/client'
+      function C(props: { label?: string }) {
+        const mid = props.label
+        const label = createMemo(() => mid ?? 'Default')
+        return <span>{label()}</span>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.label).toEqual({ propName: 'label', value: null })
+  })
+
+  test('multi-hop const chain resolves transitively (#2685 review): `const a = props.x; const b = a`', () => {
+    // Two hops of indirection (`b` reads `a`, `a` reads `props.x`) — the
+    // signal here is named `count`, a DIFFERENT name from the prop `x`, so
+    // this exercises the bare-props safety net's transitive resolution
+    // (not the self-derivation `propName` collision path above): `x` must
+    // still be seeded, or the template-stash adapters' bare-scalar
+    // recompute for `x` aborts at render time (#1297/#2126).
+    const metadata = metadataFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function C(props: { x?: number }) {
+        const a = props.x
+        const b = a
+        const [count, setCount] = createSignal(b ?? 1)
+        return <span>{count()}</span>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.count).toEqual({ value: 1 })
+    expect(defaults?.x).toEqual({ propName: 'x', value: null })
+  })
+
+  test('safety-net seeding sees a prop through a component-scope const (#2685 review)', () => {
+    // The #1297/#2126 bare-props safety net (`collectPropRefs` at the
+    // bottom of `extractSsrDefaults`) only saw a DIRECT `props.X` access
+    // too — this is that same gap, single hop: `const mid = props.initial;
+    // createSignal(mid ?? 0)` misses seeding `initial`, which is a
+    // `Global symbol "$initial" requires explicit package name` render
+    // abort on Perl-strict backends. `count` (the signal's own name) is
+    // unrelated to `initial`, so this is NOT the self-collision path —
+    // purely the safety net.
+    const metadata = metadataFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function Counter(props: { initial?: number }) {
+        const mid = props.initial
+        const [count, setCount] = createSignal(mid ?? 0)
+        return <p>{count()}</p>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.count).toEqual({ value: 0 })
+    expect(defaults?.initial).toEqual({ propName: 'initial', value: null })
+  })
+
+  test('NEGATIVE (#2685 review): a const NOT derived from props keeps the signal-wins behavior', () => {
+    // Same-named `label` getter and `label` prop, wrapped in a const — but
+    // the const's OWN value doesn't read `props` at all, so
+    // `collectPropRefsTransitive` must NOT report a collision here. Must
+    // stay the plain evaluated-signal-value shape with no `propName` — the
+    // const-chain widening only ever ADDS prop references it finds by
+    // actually walking through `props.X`, never invents one.
+    //
+    // (The value resolves to `null`, not `'sig'`: `tryStaticEval` doesn't
+    // bind component-scope const locals into its evaluation `bindings` —
+    // see the signal loop's `bindings` comment above — so `mid` itself is
+    // unresolved for VALUE purposes independent of this fix; only the
+    // separate `propName`-detection walk this test is pinning follows the
+    // const chain.)
+    const metadata = metadataFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function C(props: { label?: string }) {
+        const mid = 'sig'
+        const [label, setLabel] = createSignal(mid)
+        return <span>{label()}{props.label}</span>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.label).toEqual({ value: null })
+  })
+
   test('aliased destructured prop (#2460): `propName` is the CALLER-facing key, not the local binding', () => {
     // `{ n: count }` — the caller passes `n`, the template variable (and
     // stash entry key) is the local binding `count`. The manifest

--- a/packages/jsx/src/__tests__/ssr-seed-plan.test.ts
+++ b/packages/jsx/src/__tests__/ssr-seed-plan.test.ts
@@ -209,4 +209,76 @@ describe('computeSsrSeedPlan', () => {
       expect(on.frees).toEqual(['props'])
     }
   })
+
+  test('prop-derived signal init THROUGH a component-scope const (#2685 review): still derived, resolves to the prop free', () => {
+    // Pre-fix, `mid` (a component-scope const, not part of `baseScope`)
+    // was a free identifier `classify` couldn't find in `available`, so
+    // this step fell to `opaque` — no adapter emits an in-template
+    // recompute for it at all (a DIFFERENT, worse-than-#2669 defect: even
+    // with `propName` restored on the manifest side, an absent caller prop
+    // would render permanently empty instead of the signal's own
+    // `'Default'`). `resolveThroughLocalConsts` inlines `mid` to
+    // `props.defaultOn` before classification, so this now derives exactly
+    // like the direct-access form above.
+    const plan = planFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function Toggle(props: { defaultOn?: boolean }) {
+        const mid = props.defaultOn
+        const [on, setOn] = createSignal(mid ?? false)
+        return <button aria-pressed={on()}>t</button>
+      }
+    `)
+
+    const on = step(plan, 'on')
+    expect(on.kind).toBe('derived')
+    if (on.kind === 'derived') {
+      expect(on.origin).toBe('signal')
+      // The RESOLVED free set names `props` (what the inlined form reads),
+      // never the intermediate const `mid` — a consumer emitting `on`'s
+      // seed line never needs to know `mid` existed.
+      expect(on.frees).toEqual(['props'])
+    }
+  })
+
+  test('multi-hop const chain THROUGH TWO component-scope consts (#2685 review): still derived', () => {
+    const plan = planFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function C(props: { x?: number }) {
+        const a = props.x
+        const b = a
+        const [count, setCount] = createSignal(b ?? 1)
+        return <p>{count()}</p>
+      }
+    `)
+
+    const count = step(plan, 'count')
+    expect(count.kind).toBe('derived')
+    if (count.kind === 'derived') {
+      expect(count.frees).toEqual(['props'])
+    }
+  })
+
+  test('const chain that bottoms out on an UNAVAILABLE name → opaque (fails safe, not a wrong substitution)', () => {
+    // `mid` inlines to `laterMemo`, a memo declared AFTER `on` in source —
+    // per the plan's ordering guarantee, `laterMemo` is not yet in
+    // `available` when `on` is classified, so this must stay `opaque`
+    // exactly like a direct forward-reference would (mirrors the existing
+    // "forward reference … → opaque" case above, one hop of const
+    // indirection removed).
+    const plan = planFor(`
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/client'
+      function C() {
+        const mid = laterMemo()
+        const [on, setOn] = createSignal(mid ?? false)
+        const laterMemo = createMemo(() => true)
+        return <button aria-pressed={on()}>{laterMemo()}</button>
+      }
+    `)
+
+    const on = step(plan, 'on')
+    expect(on.kind).toBe('opaque')
+  })
 })

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -3037,8 +3037,17 @@ function usesPerPath(name: string, expr: ParsedExpr): { min: number; max: number
  * leaves that inner reference untouched (it is the parameter, not the binding).
  * Mirrors the structural walk of `substituteDestructuredFields`; every
  * `ParsedExpr` kind is handled so a new kind surfaces as a compile error here.
+ *
+ * Exported for `computeSsrSeedPlan` (`ssr-seed-plan.ts`), which reuses this
+ * SAME let-inline step to resolve a signal/memo initializer through
+ * component-scope `const` locals sitting between it and the prop it reads
+ * (`const mid = props.label; createSignal(mid ?? 'Default')`) — the
+ * structural (never string-splicing) analogue of what `foldBlockToExpr`
+ * already does for a block-bodied memo's own internal `const`s, and of what
+ * the CSR client-JS emitter's `csrSubstitute` does over TS source text for
+ * the compiled JS domain (#2685 review).
  */
-function inlineBinding(
+export function inlineBinding(
   expr: ParsedExpr,
   name: string,
   value: ParsedExpr,

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -30,6 +30,7 @@
 // `undef`, which Mojo renders as empty string).
 
 import ts from 'typescript'
+import { extractFreeIdentifiersFromNode } from './analyzer.ts'
 import type { IRMetadata } from './types.ts'
 
 /**
@@ -214,6 +215,11 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
   // fed into the bindings map so subsequent memos can reference earlier
   // signals (Counter's `doubled = createMemo(() => count() * 2)`).
   const bindings: Record<string, EvalResult> = {}
+  // Component-scope const locals, for the transitive prop-reference
+  // resolution both `referencesOwnProp` calls below and the bare-props
+  // safety net (further down) use — computed once so every caller shares
+  // the same table.
+  const localConsts = localConstValuesByName(metadata)
 
   // (#checkbox) Seed module-scope constants so a memo template-literal that
   // references them resolves to a concrete string. Checkbox's `classes` memo
@@ -268,7 +274,7 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
     // manifest consumer) can tell "this local's stash seed must come from
     // the caller-facing prop, not the local's own evaluated value" apart
     // from "this is an internal signal/memo the caller cannot override".
-    if (metadata.propsObjectName !== null && referencesOwnProp(sig.initialValue, metadata.propsObjectName, sig.getter)) {
+    if (metadata.propsObjectName !== null && referencesOwnProp(sig.initialValue, metadata.propsObjectName, sig.getter, localConsts)) {
       // Pass 1 above already wrote the prop entry when the prop is
       // *declared* on the props type — leave it as-is. An undeclared
       // (untyped / inline-typed) prop has no pass-1 entry yet; create it
@@ -295,7 +301,7 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
     // (`createMemo(() => (props.label ?? 'Default') + n())`). See the
     // signal loop's comment for the full mechanism and the `propName`
     // invariant this relies on.
-    if (metadata.propsObjectName !== null && referencesOwnProp(memo.computation, metadata.propsObjectName, memo.name)) {
+    if (metadata.propsObjectName !== null && referencesOwnProp(memo.computation, metadata.propsObjectName, memo.name, localConsts)) {
       if (!(memo.name in out)) {
         out[memo.name] = { propName: memo.name, value: null }
       }
@@ -320,11 +326,11 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
     const referenced = new Set<string>()
     for (const sig of metadata.signals) {
       if (!sig.getter || sig.isModule || sig.envReader) continue
-      collectPropRefs(sig.initialValue, metadata.propsObjectName, referenced)
+      collectPropRefsTransitive(sig.initialValue, metadata.propsObjectName, localConsts, referenced)
     }
     for (const memo of metadata.memos) {
       if (memo.isModule) continue
-      collectPropRefs(memo.computation, metadata.propsObjectName, referenced)
+      collectPropRefsTransitive(memo.computation, metadata.propsObjectName, localConsts, referenced)
     }
     for (const name of referenced) {
       // Don't clobber a signal / memo (or already-seeded prop) of the same
@@ -338,20 +344,43 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
 }
 
 /**
+ * Component-scope (non-module) `const` locals, by name → value source text.
+ * `referencesOwnProp` and `collectPropRefsTransitive` (below) use this to
+ * see PAST one hop of pure indirection between a prop read and the
+ * signal/memo that derives from it — `const mid = props.label;
+ * createSignal(mid ?? 'Default')` (#2685 review, one hop past #2669's
+ * direct-access-only detection). Module-scope consts are excluded: a
+ * MODULE const's value is fixed at compile time and isn't a `props.X` read
+ * (a module const referencing `props` isn't legal JS — `props` is a
+ * function parameter), so it can never contribute a prop reference here.
+ */
+function localConstValuesByName(metadata: IRMetadata): ReadonlyMap<string, string> {
+  const out = new Map<string, string>()
+  for (const c of metadata.localConstants ?? []) {
+    if (c.isModule || c.value === undefined) continue
+    out.set(c.name, c.value)
+  }
+  return out
+}
+
+/**
  * Does `expr` (a signal initializer or memo computation) read
  * `propsObjectName.<name>` where `name` is that SAME signal's getter / that
- * SAME memo's name? This is the #2669 self-derivation test: reuses
- * `collectPropRefs` (never a bespoke walker — see the CLAUDE.md rule this
- * file already follows for `props.X` collection) and just checks membership
- * of the one name we care about.
+ * SAME memo's name — directly, or through a chain of component-scope
+ * `const` locals? This is the #2669 self-derivation test (widened by
+ * #2685 review to see through indirection): reuses `collectPropRefsTransitive`
+ * (never a bespoke walker — see the CLAUDE.md rule this file already
+ * follows for `props.X` collection) and just checks membership of the one
+ * name we care about.
  */
 function referencesOwnProp(
   expr: string | undefined,
   propsObjectName: string,
   name: string,
+  localConsts: ReadonlyMap<string, string>,
 ): boolean {
   const referenced = new Set<string>()
-  collectPropRefs(expr, propsObjectName, referenced)
+  collectPropRefsTransitive(expr, propsObjectName, localConsts, referenced)
   return referenced.has(name)
 }
 
@@ -363,6 +392,11 @@ function referencesOwnProp(
  * prop `a`: adapters lower that to `$a->{b}`, so the bare `$a` needs
  * seeding just the same — the walk stops at the first
  * `propsObjectName.<name>` match and collects `a` (not `b`).
+ *
+ * Direct-access only — does NOT look through a component-scope `const`
+ * that itself reads `propsObjectName.X`. Callers that need to see past
+ * that indirection use `collectPropRefsTransitive` below, which wraps this
+ * function rather than duplicating its walk.
  */
 function collectPropRefs(
   expr: string | undefined,
@@ -389,6 +423,46 @@ function collectPropRefs(
     ts.forEachChild(n, visit)
   }
   visit(node)
+}
+
+/**
+ * `collectPropRefs`, widened to look THROUGH component-scope `const`
+ * locals (#2685 review): a signal/memo initializer often reads a prop one
+ * hop removed — `const mid = props.label; createSignal(mid ?? 'Default')`
+ * — rather than `propsObjectName.X` directly. Runs the existing
+ * direct-access walk over `expr` first (unchanged behavior for the common
+ * case), then finds every VALUE-POSITION identifier `expr` references
+ * (via the analyzer's `extractFreeIdentifiersFromNode` — never a bespoke
+ * identifier scan, so a property-access tail like `foo.mid` or an
+ * object-literal key like `{ mid: 1 }` is correctly NOT mistaken for a
+ * read of a local named `mid`) and, for each one that names a local
+ * const, recurses into THAT const's own value expression the same way.
+ *
+ * `visited` guards re-entering the same const twice — both for the
+ * (source-impossible, since JS TDZ forbids a const referencing itself)
+ * pathological-cycle case, and for the ordinary diamond case (two
+ * branches of `expr` both reading the same local) so it isn't walked
+ * twice. Fresh per top-level call via the default parameter, so unrelated
+ * calls for different signals/memos don't share state.
+ */
+function collectPropRefsTransitive(
+  expr: string | undefined,
+  propsObjectName: string,
+  localConsts: ReadonlyMap<string, string>,
+  out: Set<string>,
+  visited: Set<string> = new Set(),
+): void {
+  if (!expr || !expr.trim()) return
+  collectPropRefs(expr, propsObjectName, out)
+  const node = parseExpression(expr)
+  if (!node) return
+  for (const id of extractFreeIdentifiersFromNode(node)) {
+    if (visited.has(id)) continue
+    const constValue = localConsts.get(id)
+    if (constValue === undefined) continue
+    visited.add(id)
+    collectPropRefsTransitive(constValue, propsObjectName, localConsts, out, visited)
+  }
 }
 
 function resultToJsonable(v: EvalResult): unknown {
@@ -453,12 +527,16 @@ function evalStatementsForReturn(
 
 function parseExpression(expr: string): ts.Expression | null {
   // Wrap in parens so a leading `{}` parses as an object literal rather
-  // than an empty block statement.
+  // than an empty block statement. Parent nodes ARE set (unlike a bare
+  // parse) so `collectPropRefsTransitive` can call the analyzer's
+  // `extractFreeIdentifiersFromNode` — which needs `.parent` to tell a
+  // value-position identifier from a property-access tail / object-literal
+  // key / parameter name — on the result.
   const sf = ts.createSourceFile(
     '__ssr_default__.ts',
     `(${expr})`,
     ts.ScriptTarget.Latest,
-    false,
+    true,
     ts.ScriptKind.TS,
   )
   const stmt = sf.statements[0]

--- a/packages/jsx/src/ssr-seed-plan.ts
+++ b/packages/jsx/src/ssr-seed-plan.ts
@@ -35,6 +35,7 @@ import { envSignalReaderFor, type EnvSignalReader } from './adapters/env-signal.
 import {
   extractArrowBodyExpression,
   freeIdentifiers,
+  inlineBinding,
   isSupported,
   parseExpression,
   type ParsedExpr,
@@ -98,6 +99,72 @@ function classify(
 }
 
 /**
+ * Component-scope (non-module) `const` locals, by name, parsed to their
+ * `ParsedExpr` value — the substitution table `resolveThroughLocalConsts`
+ * inlines through. Module-scope consts are excluded: they're already part
+ * of `baseScope` (every adapter compile-time-inlines them to their literal
+ * value, so a reference to one is never a template-variable read — see the
+ * module doc), and a `let` has no stable value to substitute.
+ */
+function localConstExprsByName(metadata: IRMetadata): ReadonlyMap<string, ParsedExpr> {
+  const out = new Map<string, ParsedExpr>()
+  for (const c of metadata.localConstants ?? []) {
+    if (c.isModule || c.declarationKind !== 'const' || c.value === undefined) continue
+    out.set(c.name, c.parsed ?? parseExpression(c.value.trim()))
+  }
+  return out
+}
+
+/**
+ * Resolve a signal/memo's parsed expression through any component-scope
+ * `const` locals it references, so a hop of pure indirection between a
+ * prop read and its derived signal/memo — `const mid = props.label;
+ * createSignal(mid ?? 'Default')` — classifies from the SAME scope its
+ * fully-inlined form (`props.label ?? 'Default'`) would (#2685 review, the
+ * jsx-side twin of `ssr-defaults.ts`'s own `collectPropRefs` closure).
+ *
+ * Structural substitution only (never string splicing, per CLAUDE.md):
+ * reuses `inlineBinding`, the exact "let-inline" step `foldBlockToExpr`
+ * already performs for a block-bodied memo's own internal `const`s. A
+ * chained const (`const a = props.x; const b = a; createSignal(b ?? 1)`)
+ * closes the same way — each pass substitutes whatever local consts are
+ * still free in the current form, so `b` resolves to `a` first and `a`
+ * resolves to `props.x` on the next pass. Bounded to `localConsts.size + 1`
+ * iterations (the longest possible chain) purely as a cycle guard; a real
+ * cycle is impossible in valid source (JS TDZ forbids a const referencing
+ * itself, directly or transitively).
+ *
+ * `inlineBinding` returns `null` only on a capture hazard (the const's own
+ * free variable would be shadowed by a nested callback parameter of the
+ * same name inside the current form) — that occurrence is left un-inlined,
+ * so its name simply stays free and later fails `classify`'s availability
+ * check like any other out-of-scope reference (fails safe to `opaque`,
+ * never a wrong substitution).
+ */
+function resolveThroughLocalConsts(
+  parsed: ParsedExpr,
+  localConsts: ReadonlyMap<string, ParsedExpr>,
+): ParsedExpr {
+  let current = parsed
+  const maxIter = localConsts.size + 1
+  for (let i = 0; i < maxIter; i++) {
+    const frees = freeIdentifiers(current)
+    if (frees === null) break
+    let changed = false
+    for (const name of frees) {
+      const value = localConsts.get(name)
+      if (!value) continue
+      const inlined = inlineBinding(current, name, value)
+      if (inlined === null) continue
+      current = inlined
+      changed = true
+    }
+    if (!changed) break
+  }
+  return current
+}
+
+/**
  * Compute the component's SSR seed plan from its metadata. See the module
  * doc for the contract. Memo steps are gated to EXPRESSION-BODIED memos
  * (`extractArrowBodyExpression` returns the body): a block-bodied memo is
@@ -111,6 +178,7 @@ export function computeSsrSeedPlan(metadata: IRMetadata): SsrSeedPlan {
   }
 
   const available = new Set<string>(baseScope)
+  const localConsts = localConstExprsByName(metadata)
   const steps: SsrSeedStep[] = []
 
   for (const signal of metadata.signals) {
@@ -126,7 +194,13 @@ export function computeSsrSeedPlan(metadata: IRMetadata): SsrSeedPlan {
     steps.push(
       expr === ''
         ? { kind: 'opaque', name: signal.getter, origin: 'signal' }
-        : classify(signal.getter, 'signal', expr, parseExpression(expr), available),
+        : classify(
+            signal.getter,
+            'signal',
+            expr,
+            resolveThroughLocalConsts(parseExpression(expr), localConsts),
+            available,
+          ),
     )
     available.add(signal.getter)
   }
@@ -137,7 +211,13 @@ export function computeSsrSeedPlan(metadata: IRMetadata): SsrSeedPlan {
     steps.push(
       expr === ''
         ? { kind: 'opaque', name: memo.name, origin: 'memo' }
-        : classify(memo.name, 'memo', expr, memo.parsed ?? parseExpression(expr), available),
+        : classify(
+            memo.name,
+            'memo',
+            expr,
+            resolveThroughLocalConsts(memo.parsed ?? parseExpression(expr), localConsts),
+            available,
+          ),
     )
     available.add(memo.name)
   }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 332,
+    "totalFixtures": 334,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -2994,6 +2994,12 @@
           "reason": "self-derived signal collides with its prop field name in the generated Go props struct — the non-idempotent `* 2` derivation is dropped and the signal renders the raw prop value instead (https://github.com/piconic-ai/barefootjs/issues/2683)"
         }
       },
+      "signal-prop-same-name-via-const-derived": {
+        "go-template": {
+          "kind": "render",
+          "reason": "self-derived signal (reached through a component-scope const) collides with its prop field name in the generated Go props struct — the non-idempotent `* 2` derivation is dropped and the signal renders the raw prop value instead (https://github.com/piconic-ai/barefootjs/issues/2683)"
+        }
+      },
       "some-typeof-predicate": {
         "blade": {
           "kind": "refusal",
@@ -3431,6 +3437,10 @@
       "signal-prop-same-name-derived": {
         "description": "Signal initialized from a NON-IDEMPOTENT derivation of a prop with the identical name",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/signal-prop-same-name-derived.ts"
+      },
+      "signal-prop-same-name-via-const-derived": {
+        "description": "Signal initialized from a NON-IDEMPOTENT derivation of a same-named prop through one…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/signal-prop-same-name-via-const-derived.ts"
       },
       "some-typeof-predicate": {
         "description": "Off-subset `.some()` predicate (typeof) — JS-runtime faithful, DSL diagnostic",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1026,15 +1026,15 @@
       }
     },
     "binary": {
-      "total": 92,
+      "total": 93,
       "cells": {
         "hono": {
-          "pass": 92,
-          "total": 92
+          "pass": 93,
+          "total": 93
         },
         "blade": {
-          "pass": 83,
-          "total": 92,
+          "pass": 84,
+          "total": 93,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1081,8 +1081,8 @@
           ]
         },
         "erb": {
-          "pass": 84,
-          "total": 92,
+          "pass": 85,
+          "total": 93,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1124,7 +1124,7 @@
         },
         "go-template": {
           "pass": 82,
-          "total": 92,
+          "total": 93,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1163,6 +1163,10 @@
               "issues": []
             },
             {
+              "fixture": "signal-prop-same-name-via-const-derived",
+              "issues": []
+            },
+            {
               "fixture": "some-typeof-predicate",
               "issues": []
             },
@@ -1175,8 +1179,8 @@
           ]
         },
         "jinja": {
-          "pass": 83,
-          "total": 92,
+          "pass": 84,
+          "total": 93,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1223,8 +1227,8 @@
           ]
         },
         "minijinja": {
-          "pass": 83,
-          "total": 92,
+          "pass": 84,
+          "total": 93,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1271,8 +1275,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 84,
-          "total": 92,
+          "pass": 85,
+          "total": 93,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1313,8 +1317,8 @@
           ]
         },
         "twig": {
-          "pass": 83,
-          "total": 92,
+          "pass": 84,
+          "total": 93,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1361,8 +1365,8 @@
           ]
         },
         "xslate": {
-          "pass": 83,
-          "total": 92,
+          "pass": 84,
+          "total": 93,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1422,11 +1426,11 @@
       }
     },
     "call": {
-      "total": 220,
+      "total": 222,
       "cells": {
         "hono": {
-          "pass": 219,
-          "total": 220,
+          "pass": 221,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1437,8 +1441,8 @@
           ]
         },
         "blade": {
-          "pass": 205,
-          "total": 220,
+          "pass": 207,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1513,8 +1517,8 @@
           ]
         },
         "erb": {
-          "pass": 206,
-          "total": 220,
+          "pass": 208,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1583,8 +1587,8 @@
           ]
         },
         "go-template": {
-          "pass": 204,
-          "total": 220,
+          "pass": 205,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1641,6 +1645,10 @@
               "issues": []
             },
             {
+              "fixture": "signal-prop-same-name-via-const-derived",
+              "issues": []
+            },
+            {
               "fixture": "some-typeof-predicate",
               "issues": []
             },
@@ -1663,8 +1671,8 @@
           ]
         },
         "jinja": {
-          "pass": 205,
-          "total": 220,
+          "pass": 207,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1739,8 +1747,8 @@
           ]
         },
         "minijinja": {
-          "pass": 205,
-          "total": 220,
+          "pass": 207,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1815,8 +1823,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 206,
-          "total": 220,
+          "pass": 208,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1885,8 +1893,8 @@
           ]
         },
         "twig": {
-          "pass": 205,
-          "total": 220,
+          "pass": 207,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1961,8 +1969,8 @@
           ]
         },
         "xslate": {
-          "pass": 205,
-          "total": 220,
+          "pass": 207,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2182,11 +2190,11 @@
       }
     },
     "identifier": {
-      "total": 310,
+      "total": 312,
       "cells": {
         "hono": {
-          "pass": 309,
-          "total": 310,
+          "pass": 311,
+          "total": 312,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2197,8 +2205,8 @@
           ]
         },
         "blade": {
-          "pass": 293,
-          "total": 310,
+          "pass": 295,
+          "total": 312,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2281,8 +2289,8 @@
           ]
         },
         "erb": {
-          "pass": 294,
-          "total": 310,
+          "pass": 296,
+          "total": 312,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2359,8 +2367,8 @@
           ]
         },
         "go-template": {
-          "pass": 292,
-          "total": 310,
+          "pass": 293,
+          "total": 312,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2425,6 +2433,10 @@
               "issues": []
             },
             {
+              "fixture": "signal-prop-same-name-via-const-derived",
+              "issues": []
+            },
+            {
               "fixture": "some-typeof-predicate",
               "issues": []
             },
@@ -2447,8 +2459,8 @@
           ]
         },
         "jinja": {
-          "pass": 293,
-          "total": 310,
+          "pass": 295,
+          "total": 312,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2531,8 +2543,8 @@
           ]
         },
         "minijinja": {
-          "pass": 293,
-          "total": 310,
+          "pass": 295,
+          "total": 312,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2615,8 +2627,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 294,
-          "total": 310,
+          "pass": 296,
+          "total": 312,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2693,8 +2705,8 @@
           ]
         },
         "twig": {
-          "pass": 293,
-          "total": 310,
+          "pass": 295,
+          "total": 312,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2777,8 +2789,8 @@
           ]
         },
         "xslate": {
-          "pass": 293,
-          "total": 310,
+          "pass": 295,
+          "total": 312,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2926,15 +2938,15 @@
       }
     },
     "literal": {
-      "total": 252,
+      "total": 254,
       "cells": {
         "hono": {
-          "pass": 252,
-          "total": 252
+          "pass": 254,
+          "total": 254
         },
         "blade": {
-          "pass": 241,
-          "total": 252,
+          "pass": 243,
+          "total": 254,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2985,8 +2997,8 @@
           ]
         },
         "erb": {
-          "pass": 241,
-          "total": 252,
+          "pass": 243,
+          "total": 254,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3037,8 +3049,8 @@
           ]
         },
         "go-template": {
-          "pass": 240,
-          "total": 252,
+          "pass": 241,
+          "total": 254,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3077,6 +3089,10 @@
               "issues": []
             },
             {
+              "fixture": "signal-prop-same-name-via-const-derived",
+              "issues": []
+            },
+            {
               "fixture": "some-typeof-predicate",
               "issues": []
             },
@@ -3093,8 +3109,8 @@
           ]
         },
         "jinja": {
-          "pass": 241,
-          "total": 252,
+          "pass": 243,
+          "total": 254,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3145,8 +3161,8 @@
           ]
         },
         "minijinja": {
-          "pass": 241,
-          "total": 252,
+          "pass": 243,
+          "total": 254,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3197,8 +3213,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 241,
-          "total": 252,
+          "pass": 243,
+          "total": 254,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3249,8 +3265,8 @@
           ]
         },
         "twig": {
-          "pass": 241,
-          "total": 252,
+          "pass": 243,
+          "total": 254,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3301,8 +3317,8 @@
           ]
         },
         "xslate": {
-          "pass": 241,
-          "total": 252,
+          "pass": 243,
+          "total": 254,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3366,15 +3382,15 @@
       }
     },
     "logical": {
-      "total": 46,
+      "total": 48,
       "cells": {
         "hono": {
-          "pass": 46,
-          "total": 46
+          "pass": 48,
+          "total": 48
         },
         "blade": {
-          "pass": 44,
-          "total": 46,
+          "pass": 46,
+          "total": 48,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3389,8 +3405,8 @@
           ]
         },
         "erb": {
-          "pass": 44,
-          "total": 46,
+          "pass": 46,
+          "total": 48,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3405,11 +3421,15 @@
           ]
         },
         "go-template": {
-          "pass": 43,
-          "total": 46,
+          "pass": 44,
+          "total": 48,
           "gaps": [
             {
               "fixture": "signal-prop-same-name-derived",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-via-const-derived",
               "issues": []
             },
             {
@@ -3425,8 +3445,8 @@
           ]
         },
         "jinja": {
-          "pass": 44,
-          "total": 46,
+          "pass": 46,
+          "total": 48,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3441,8 +3461,8 @@
           ]
         },
         "minijinja": {
-          "pass": 44,
-          "total": 46,
+          "pass": 46,
+          "total": 48,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3457,8 +3477,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 44,
-          "total": 46,
+          "pass": 46,
+          "total": 48,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3473,8 +3493,8 @@
           ]
         },
         "twig": {
-          "pass": 44,
-          "total": 46,
+          "pass": 46,
+          "total": 48,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3489,8 +3509,8 @@
           ]
         },
         "xslate": {
-          "pass": 44,
-          "total": 46,
+          "pass": 46,
+          "total": 48,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3518,11 +3538,11 @@
       }
     },
     "member": {
-      "total": 175,
+      "total": 177,
       "cells": {
         "hono": {
-          "pass": 174,
-          "total": 175,
+          "pass": 176,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3533,8 +3553,8 @@
           ]
         },
         "blade": {
-          "pass": 158,
-          "total": 175,
+          "pass": 160,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3617,8 +3637,8 @@
           ]
         },
         "erb": {
-          "pass": 159,
-          "total": 175,
+          "pass": 161,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3695,8 +3715,8 @@
           ]
         },
         "go-template": {
-          "pass": 157,
-          "total": 175,
+          "pass": 158,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3761,6 +3781,10 @@
               "issues": []
             },
             {
+              "fixture": "signal-prop-same-name-via-const-derived",
+              "issues": []
+            },
+            {
               "fixture": "some-typeof-predicate",
               "issues": []
             },
@@ -3783,8 +3807,8 @@
           ]
         },
         "jinja": {
-          "pass": 158,
-          "total": 175,
+          "pass": 160,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3867,8 +3891,8 @@
           ]
         },
         "minijinja": {
-          "pass": 158,
-          "total": 175,
+          "pass": 160,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3951,8 +3975,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 159,
-          "total": 175,
+          "pass": 161,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4029,8 +4053,8 @@
           ]
         },
         "twig": {
-          "pass": 158,
-          "total": 175,
+          "pass": 160,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4113,8 +4137,8 @@
           ]
         },
         "xslate": {
-          "pass": 158,
-          "total": 175,
+          "pass": 160,
+          "total": 177,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -6536,49 +6560,53 @@
       }
     },
     "binary:*": {
-      "total": 11,
+      "total": 12,
       "cells": {
         "hono": {
-          "pass": 11,
-          "total": 11
+          "pass": 12,
+          "total": 12
         },
         "blade": {
-          "pass": 11,
-          "total": 11
+          "pass": 12,
+          "total": 12
         },
         "erb": {
-          "pass": 11,
-          "total": 11
+          "pass": 12,
+          "total": 12
         },
         "go-template": {
           "pass": 10,
-          "total": 11,
+          "total": 12,
           "gaps": [
             {
               "fixture": "signal-prop-same-name-derived",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-via-const-derived",
               "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 11,
-          "total": 11
+          "pass": 12,
+          "total": 12
         },
         "minijinja": {
-          "pass": 11,
-          "total": 11
+          "pass": 12,
+          "total": 12
         },
         "mojolicious": {
-          "pass": 11,
-          "total": 11
+          "pass": 12,
+          "total": 12
         },
         "twig": {
-          "pass": 11,
-          "total": 11
+          "pass": 12,
+          "total": 12
         },
         "xslate": {
-          "pass": 11,
-          "total": 11
+          "pass": 12,
+          "total": 12
         }
       },
       "source": {
@@ -7465,15 +7493,15 @@
       }
     },
     "literal:number": {
-      "total": 105,
+      "total": 106,
       "cells": {
         "hono": {
-          "pass": 105,
-          "total": 105
+          "pass": 106,
+          "total": 106
         },
         "blade": {
-          "pass": 100,
-          "total": 105,
+          "pass": 101,
+          "total": 106,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7498,8 +7526,8 @@
           ]
         },
         "erb": {
-          "pass": 100,
-          "total": 105,
+          "pass": 101,
+          "total": 106,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7525,7 +7553,7 @@
         },
         "go-template": {
           "pass": 99,
-          "total": 105,
+          "total": 106,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7548,14 +7576,18 @@
               "issues": []
             },
             {
+              "fixture": "signal-prop-same-name-via-const-derived",
+              "issues": []
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 100,
-          "total": 105,
+          "pass": 101,
+          "total": 106,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7580,8 +7612,8 @@
           ]
         },
         "minijinja": {
-          "pass": 100,
-          "total": 105,
+          "pass": 101,
+          "total": 106,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7606,8 +7638,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 100,
-          "total": 105,
+          "pass": 101,
+          "total": 106,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7632,8 +7664,8 @@
           ]
         },
         "twig": {
-          "pass": 100,
-          "total": 105,
+          "pass": 101,
+          "total": 106,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7658,8 +7690,8 @@
           ]
         },
         "xslate": {
-          "pass": 100,
-          "total": 105,
+          "pass": 101,
+          "total": 106,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7697,15 +7729,15 @@
       }
     },
     "literal:string": {
-      "total": 179,
+      "total": 180,
       "cells": {
         "hono": {
-          "pass": 179,
-          "total": 179
+          "pass": 180,
+          "total": 180
         },
         "blade": {
-          "pass": 171,
-          "total": 179,
+          "pass": 172,
+          "total": 180,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7744,8 +7776,8 @@
           ]
         },
         "erb": {
-          "pass": 171,
-          "total": 179,
+          "pass": 172,
+          "total": 180,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7784,8 +7816,8 @@
           ]
         },
         "go-template": {
-          "pass": 171,
-          "total": 179,
+          "pass": 172,
+          "total": 180,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7824,8 +7856,8 @@
           ]
         },
         "jinja": {
-          "pass": 171,
-          "total": 179,
+          "pass": 172,
+          "total": 180,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7864,8 +7896,8 @@
           ]
         },
         "minijinja": {
-          "pass": 171,
-          "total": 179,
+          "pass": 172,
+          "total": 180,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7904,8 +7936,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 171,
-          "total": 179,
+          "pass": 172,
+          "total": 180,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7944,8 +7976,8 @@
           ]
         },
         "twig": {
-          "pass": 171,
-          "total": 179,
+          "pass": 172,
+          "total": 180,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7984,8 +8016,8 @@
           ]
         },
         "xslate": {
-          "pass": 171,
-          "total": 179,
+          "pass": 172,
+          "total": 180,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8089,15 +8121,15 @@
       }
     },
     "logical:??": {
-      "total": 40,
+      "total": 42,
       "cells": {
         "hono": {
-          "pass": 40,
-          "total": 40
+          "pass": 42,
+          "total": 42
         },
         "blade": {
-          "pass": 38,
-          "total": 40,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8112,8 +8144,8 @@
           ]
         },
         "erb": {
-          "pass": 38,
-          "total": 40,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8128,11 +8160,15 @@
           ]
         },
         "go-template": {
-          "pass": 37,
-          "total": 40,
+          "pass": 38,
+          "total": 42,
           "gaps": [
             {
               "fixture": "signal-prop-same-name-derived",
+              "issues": []
+            },
+            {
+              "fixture": "signal-prop-same-name-via-const-derived",
               "issues": []
             },
             {
@@ -8148,8 +8184,8 @@
           ]
         },
         "jinja": {
-          "pass": 38,
-          "total": 40,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8164,8 +8200,8 @@
           ]
         },
         "minijinja": {
-          "pass": 38,
-          "total": 40,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8180,8 +8216,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 38,
-          "total": 40,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8196,8 +8232,8 @@
           ]
         },
         "twig": {
-          "pass": 38,
-          "total": 40,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8212,8 +8248,8 @@
           ]
         },
         "xslate": {
-          "pass": 38,
-          "total": 40,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "static-array-from-props",


### PR DESCRIPTION
Follow-up to #2682, found in its post-merge-readiness review. **Fourth PR of the stack** — based on #2687, which is based on #2685, which is based on #2682. Review only the top commit.

## The defect

#2682's rule is correct — a signal/memo whose template variable collides with the prop its own initializer derives from must seed from the RAW prop, with the template performing the derivation — but its detector, `referencesOwnProp`, only saw a **direct** `props.<name>` access in the initializer. One intervening component-scope const defeats both halves of the fix:

```tsx
const mid = props.label
const [label, setLabel] = createSignal(mid ?? 'Default')
```

Verified pre-fix on jinja: the template emits **no recompute at all** (the seed plan classified the step `opaque` because `mid` is not in its available set), and the manifest reads `{"label":{"value":"Default"}}` — `propName` discarded, exactly the #2669 shape. A caller's `label='Hello'` can never win; SSR renders `Default` while the client — whose emitter already inlines the const chain to `(_p.label) ?? 'Default'` — hydrates to `Hello`. The compiler solved this resolution once for the CSR domain and simply never applied it on the SSR side.

## The fix — both halves, or the error only relocates

**Manifest (`ssr-defaults.ts`)**: `collectPropRefsTransitive` wraps the existing direct-access walk, then finds the expression's value-position identifiers via the analyzer's `extractFreeIdentifiersFromNode` (so a property-access tail like `foo.mid` or an object-literal key is not mistaken for a local read) and recurses into any that name a component-scope const, `visited`-guarded. Both consumers migrated: `referencesOwnProp` (signals and memos) and the bare-props safety net — whose shallowness was the same bug in the #2126/#1297 costume: `const mid = props.initial; createSignal(mid ?? 0)` failed to seed `initial`, a Perl-strict render abort on stash backends. #2682's invariant is preserved exactly: a signal/memo entry carries `propName` **iff** it is a self-derivation collision.

**Template (`ssr-seed-plan.ts`)**: `resolveThroughLocalConsts` inlines component-scope consts into the signal/memo's `ParsedExpr` **before** classification, reusing `inlineBinding` (now exported from `expression-parser.ts`) — the exact structural let-inline step `foldBlockToExpr` already performs for a block-bodied memo's own locals. Never string splicing. Chained consts (`const a = props.x; const b = a; …`) converge over a bounded loop; a capture hazard leaves that occurrence un-inlined and the step fails safe to `opaque`, never a wrong substitution. Because this lives in the shared `computeSsrSeedPlan`, every template-stash backend's existing self-referencing lowering picked it up with **zero adapter-side changes** — Jinja's read-before-reassign `{% set %}` and Xslate's capture-before-shadow both confirmed empirically:

```
jinja:  {% set count = ((count if (count is defined and count is not none) else 1)) * 2 %}
xslate: : my $__bf_seed_count = (($count // 1)) * 2;
        : my $count = $__bf_seed_count;
```

## Before / after (real renders)

| fixture | props | before | after |
|---|---|---|---|
| `signal-prop-same-name-via-const` | `{label:'Hello'}` | `Default` | `Hello` |
| `signal-prop-same-name-via-const-derived` | `{count:5}` | `2` | `10` |

## Coverage

Two new conformance fixtures (the shapes above), five `ssr-defaults.test.ts` tests (transitive signal, transitive memo, multi-hop chain, safety-net-via-const, and a negative pinning that a const NOT derived from props keeps signal-wins behavior), three `ssr-seed-plan.test.ts` tests (via-const derived, multi-hop, fail-safe-to-opaque).

`signal-prop-same-name-via-const-derived` additionally surfaces go-template's pre-existing #2683 props-struct field-collision bug (renders `5` for the same reason the direct-form fixture does) — pinned in `render-divergences.ts` with the #2683 URL. Confirmed not a regression of this change: the idempotent fixture passes cleanly on go.

## Verification

`packages/jsx` full 3114 pass (2 pre-existing `map-body-no-silent-divergence`, stash-confirmed) · `adapter-tests` full 2116/0 · per-adapter full conformance: jinja 1415/0, blade 1415/0, twig 1415/0, rust 1415/0, xslate 1456 pass/1 pre-existing, mojolicious 1568/8 pre-existing, erb 1438/8 pre-existing (all pre-existing = the known `date-tolocale-named-tz` tz-data gap, individually confirmed) · go-template targeted `signal-prop-same-name*` 12 pass / 2 expected pins under `GOTOOLCHAIN=go1.25.6` — the full go suite was not run locally (time budget); CI covers it · `compat` suites green with both locks regenerated after rebuilding jsx/go-template dist · `tsgo --noEmit` and `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_