### PR TITLE
Derive grandchild CSR scopes from the child's own scope; make wrapper self-lookup structural (#2649)

### DIFF
--- a/.changeset/grandchild-composition-scope-2649.md
+++ b/.changeset/grandchild-composition-scope-2649.md
@@ -1,0 +1,10 @@
+---
+"@barefootjs/client": patch
+"@barefootjs/jsx": patch
+---
+
+Fix #2649: a third level of stateless composition (grandchild) used to reuse its parent's `bf-s` scope id instead of deriving its own, silently colliding with the parent's scope on CSR (`test_s0` reused instead of `test_s0_s0`, diverging from the SSR reference — #2444 had already fixed the sibling case). `renderChild` now pushes `_parentScopeId` to a child's own derived scope while that child's template evaluates, so a grandchild's scope is derived from the child, not the grandparent.
+
+That push alone reopens a different bug for a `comment: true` synthesized wrapper (e.g. `<Flow renderNode={(n) => <Body id={n.id} />}>`, #1211): the wrapper's element IS its single real child's element, and its init used to resolve that child through `$c(scope, 's0')`'s self-match fallback — once the child's own first grandchild also derives a `bf-s` ending in the same slot suffix, the precise `$c` search matches the grandchild instead of falling through to self-match, silently misrouting `initChild` onto the wrong element (an early attempt at this fix broke `site/ui`'s xyflow Highlight-Depth demo). Fixed at its source: a `comment: true` component's own root-level child needs no `$c` lookup at all — it already IS `__scope`, and the client-JS codegen (`ClientJsContext.commentScopeRootSlotId`) now references `__scope` directly instead of re-deriving it through `$c`.
+
+`grandchild-composition` graduates out of the CSR conformance skip set.

--- a/packages/adapter-tests/fixtures/__snapshots__/accordion.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/accordion.client.js
@@ -2870,7 +2870,7 @@ export function initAccordionSingleOpenDemo(__scope, _p = {}) {
 
   const [openItem, setOpenItem] = createSignal('item-1')
 
-  const [_s9, _s2, _s0, _s1, _s5, _s3, _s4, _s8, _s6, _s7] = $c(__scope, 's9', 's2', 's0', 's1', 's5', 's3', 's4', 's8', 's6', 's7')
+  const [_s2, _s0, _s1, _s5, _s3, _s4, _s8, _s6, _s7] = $c(__scope, 's2', 's0', 's1', 's5', 's3', 's4', 's8', 's6', 's7')
 
 
   // Reactive child component props
@@ -2890,7 +2890,7 @@ export function initAccordionSingleOpenDemo(__scope, _p = {}) {
   })
 
   // Initialize child components with props
-  initChild('Accordion', _s9, {})
+  initChild('Accordion', __scope, {})
   initChild('AccordionItem', _s2, { value: "item-1", get open() { return openItem() === 'item-1' }, onOpenChange: (v) => setOpenItem(v ? 'item-1' : null) })
   initChild('AccordionTrigger', _s0, {})
   initChild('AccordionContent', _s1, {})
@@ -2956,7 +2956,7 @@ export function initAccordionMultipleOpenDemo(__scope, _p = {}) {
   const [item2Open, setItem2Open] = createSignal(false)
   const [item3Open, setItem3Open] = createSignal(false)
 
-  const [_s2, _s5, _s8, _s9, _s0, _s1, _s3, _s4, _s6, _s7] = $c(__scope, 's2', 's5', 's8', 's9', 's0', 's1', 's3', 's4', 's6', 's7')
+  const [_s2, _s5, _s8, _s0, _s1, _s3, _s4, _s6, _s7] = $c(__scope, 's2', 's5', 's8', 's0', 's1', 's3', 's4', 's6', 's7')
 
 
   // Reactive prop bindings
@@ -2989,7 +2989,7 @@ export function initAccordionMultipleOpenDemo(__scope, _p = {}) {
   })
 
   // Initialize child components with props
-  initChild('Accordion', _s9, {})
+  initChild('Accordion', __scope, {})
   initChild('AccordionItem', _s2, { value: "item-1", get open() { return item1Open() }, onOpenChange: setItem1Open })
   initChild('AccordionTrigger', _s0, {})
   initChild('AccordionContent', _s1, {})

--- a/packages/adapter-tests/fixtures/__snapshots__/command.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.client.js
@@ -3362,14 +3362,13 @@ export function initCommandDialog(__scope, _p = {}) {
 
   const commandDialogContentClasses = 'overflow-hidden p-0'
 
-  const [_s3, _s0, _s2, _s1] = $c(__scope, 's3', 's0', 's2', 's1')
+  const [_s0, _s2, _s1] = $c(__scope, 's0', 's2', 's1')
 
 
   // Reactive child component props
   createEffect(() => {
-    const [__Dialog_s3El] = $c(__scope, 's3')
-    if (__Dialog_s3El) {
-      __Dialog_s3El.open = !!(_p.open ?? false)
+    if (__scope) {
+      __scope.open = !!(_p.open ?? false)
     }
     const [__Command_s1El] = $c(__scope, 's1')
     if (__Command_s1El) {
@@ -3379,7 +3378,7 @@ export function initCommandDialog(__scope, _p = {}) {
   })
 
   // Initialize child components with props
-  initChild('Dialog', _s3, { get open() { return _p.open ?? false }, onOpenChange: _p.onOpenChange ?? (() => {}) })
+  initChild('Dialog', __scope, { get open() { return _p.open ?? false }, onOpenChange: _p.onOpenChange ?? (() => {}) })
   initChild('DialogOverlay', _s0, {})
   initChild('DialogContent', _s2, { get className() { return `${commandDialogContentClasses} max-w-lg p-0` } })
   initChild('Command', _s1, { get id() { return _p.id }, get filter() { return _p.filter }, get className() { return `[&_[data-slot=command-input-wrapper]]:h-12` } })
@@ -3539,11 +3538,11 @@ export function initCommandPreviewDemo(__scope, _p = {}) {
   if (!__scope) return
   const __scopeId = __scope.getAttribute('bf-s')
 
-  const [_s15, _s0, _s14, _s1, _s5, _s2, _s3, _s4, _s6, _s13, _s8, _s7, _s10, _s9, _s12, _s11] = $c(__scope, 's15', 's0', 's14', 's1', 's5', 's2', 's3', 's4', 's6', 's13', 's8', 's7', 's10', 's9', 's12', 's11')
+  const [_s0, _s14, _s1, _s5, _s2, _s3, _s4, _s6, _s13, _s8, _s7, _s10, _s9, _s12, _s11] = $c(__scope, 's0', 's14', 's1', 's5', 's2', 's3', 's4', 's6', 's13', 's8', 's7', 's10', 's9', 's12', 's11')
 
 
   // Initialize child components with props
-  initChild('Command', _s15, { className: "rounded-lg border shadow-md md:min-w-[450px]" })
+  initChild('Command', __scope, { className: "rounded-lg border shadow-md md:min-w-[450px]" })
   initChild('CommandInput', _s0, { placeholder: "Type a command or search..." })
   initChild('CommandList', _s14, {})
   initChild('CommandEmpty', _s1, {})
@@ -3637,7 +3636,7 @@ export function initCommandFilterDemo(__scope, _p = {}) {
     return value.toLowerCase().startsWith(search.toLowerCase())
   }
 
-  const [_s10, _s0, _s9, _s1, _s8, _s2, _s3, _s4, _s5, _s6, _s7] = $c(__scope, 's10', 's0', 's9', 's1', 's8', 's2', 's3', 's4', 's5', 's6', 's7')
+  const [_s0, _s9, _s1, _s8, _s2, _s3, _s4, _s5, _s6, _s7] = $c(__scope, 's0', 's9', 's1', 's8', 's2', 's3', 's4', 's5', 's6', 's7')
 
 
   // Initialize child components with props

--- a/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
@@ -3328,26 +3328,25 @@ export function initDropdownMenuBasicDemo(__scope, _p = {}) {
 
   const [open, setOpen] = createSignal(false)
 
-  const [_s8, _s0, _s7, _s1, _s2, _s3, _s4, _s5, _s6] = $c(__scope, 's8', 's0', 's7', 's1', 's2', 's3', 's4', 's5', 's6')
+  const [_s0, _s7, _s1, _s2, _s3, _s4, _s5, _s6] = $c(__scope, 's0', 's7', 's1', 's2', 's3', 's4', 's5', 's6')
 
 
   // Reactive prop bindings
   createEffect(() => {
-    if (_s8) {
-      _s8.open = !!(open())
+    if (__scope) {
+      __scope.open = !!(open())
     }
   })
 
   // Reactive child component props
   createEffect(() => {
-    const [__DropdownMenu_s8El] = $c(__scope, 's8')
-    if (__DropdownMenu_s8El) {
-      __DropdownMenu_s8El.open = !!(open())
+    if (__scope) {
+      __scope.open = !!(open())
     }
   })
 
   // Initialize child components with props
-  initChild('DropdownMenu', _s8, { get open() { return open() }, onOpenChange: setOpen })
+  initChild('DropdownMenu', __scope, { get open() { return open() }, onOpenChange: setOpen })
   initChild('DropdownMenuTrigger', _s0, {})
   initChild('DropdownMenuContent', _s7, {})
   initChild('DropdownMenuLabel', _s1, {})
@@ -3368,13 +3367,13 @@ export function initDropdownMenuCheckboxDemo(__scope, _p = {}) {
   const [showStatus, setShowStatus] = createSignal(true)
   const [showActivity, setShowActivity] = createSignal(false)
 
-  const [_s6, _s3, _s4, _s0, _s5, _s1, _s2] = $c(__scope, 's6', 's3', 's4', 's0', 's5', 's1', 's2')
+  const [_s3, _s4, _s0, _s5, _s1, _s2] = $c(__scope, 's3', 's4', 's0', 's5', 's1', 's2')
 
 
   // Reactive prop bindings
   createEffect(() => {
-    if (_s6) {
-      _s6.open = !!(open())
+    if (__scope) {
+      __scope.open = !!(open())
     }
     if (_s3) {
       _s3.checked = !!(showStatus())
@@ -3386,9 +3385,8 @@ export function initDropdownMenuCheckboxDemo(__scope, _p = {}) {
 
   // Reactive child component props
   createEffect(() => {
-    const [__DropdownMenu_s6El] = $c(__scope, 's6')
-    if (__DropdownMenu_s6El) {
-      __DropdownMenu_s6El.open = !!(open())
+    if (__scope) {
+      __scope.open = !!(open())
     }
     const [__DropdownMenuCheckboxItem_s3El] = $c(__scope, 's3')
     if (__DropdownMenuCheckboxItem_s3El) {
@@ -3401,7 +3399,7 @@ export function initDropdownMenuCheckboxDemo(__scope, _p = {}) {
   })
 
   // Initialize child components with props
-  initChild('DropdownMenu', _s6, { get open() { return open() }, onOpenChange: setOpen })
+  initChild('DropdownMenu', __scope, { get open() { return open() }, onOpenChange: setOpen })
   initChild('DropdownMenuTrigger', _s0, {})
   initChild('DropdownMenuContent', _s5, {})
   initChild('DropdownMenuLabel', _s1, {})
@@ -3421,13 +3419,13 @@ export function initDropdownMenuProfileDemo(__scope, _p = {}) {
   const [showToolbar, setShowToolbar] = createSignal(false)
   const [language, setLanguage] = createSignal('en')
 
-  const [_s25, _s11, _s18, _s19, _s0, _s24, _s1, _s2, _s16, _s5, _s3, _s4, _s13, _s7, _s6, _s12, _s8, _s9, _s10, _s15, _s14, _s17, _s20, _s21, _s23, _s22] = $c(__scope, 's25', 's11', 's18', 's19', 's0', 's24', 's1', 's2', 's16', 's5', 's3', 's4', 's13', 's7', 's6', 's12', 's8', 's9', 's10', 's15', 's14', 's17', 's20', 's21', 's23', 's22')
+  const [_s11, _s18, _s19, _s0, _s24, _s1, _s2, _s16, _s5, _s3, _s4, _s13, _s7, _s6, _s12, _s8, _s9, _s10, _s15, _s14, _s17, _s20, _s21, _s23, _s22] = $c(__scope, 's11', 's18', 's19', 's0', 's24', 's1', 's2', 's16', 's5', 's3', 's4', 's13', 's7', 's6', 's12', 's8', 's9', 's10', 's15', 's14', 's17', 's20', 's21', 's23', 's22')
 
 
   // Reactive prop bindings
   createEffect(() => {
-    if (_s25) {
-      _s25.open = !!(open())
+    if (__scope) {
+      __scope.open = !!(open())
     }
     if (_s11) {
       const __val = String(language())
@@ -3443,9 +3441,8 @@ export function initDropdownMenuProfileDemo(__scope, _p = {}) {
 
   // Reactive child component props
   createEffect(() => {
-    const [__DropdownMenu_s25El] = $c(__scope, 's25')
-    if (__DropdownMenu_s25El) {
-      __DropdownMenu_s25El.open = !!(open())
+    if (__scope) {
+      __scope.open = !!(open())
     }
     const [__DropdownMenuRadioGroup_s11El] = $c(__scope, 's11')
     if (__DropdownMenuRadioGroup_s11El) {
@@ -3463,7 +3460,7 @@ export function initDropdownMenuProfileDemo(__scope, _p = {}) {
   })
 
   // Initialize child components with props
-  initChild('DropdownMenu', _s25, { get open() { return open() }, onOpenChange: setOpen })
+  initChild('DropdownMenu', __scope, { get open() { return open() }, onOpenChange: setOpen })
   initChild('DropdownMenuTrigger', _s0, { className: "rounded-full p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background" })
   initChild('DropdownMenuContent', _s24, { align: "end" })
   initChild('DropdownMenuLabel', _s1, {})

--- a/packages/adapter-tests/fixtures/__snapshots__/pagination.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/pagination.client.js
@@ -2890,11 +2890,11 @@ export function initPaginationBasicDemo(__scope, _p = {}) {
   if (!__scope) return
   const __scopeId = __scope.getAttribute('bf-s')
 
-  const [_s13, _s12, _s1, _s0, _s3, _s2, _s5, _s4, _s7, _s6, _s9, _s8, _s11, _s10] = $c(__scope, 's13', 's12', 's1', 's0', 's3', 's2', 's5', 's4', 's7', 's6', 's9', 's8', 's11', 's10')
+  const [_s12, _s1, _s0, _s3, _s2, _s5, _s4, _s7, _s6, _s9, _s8, _s11, _s10] = $c(__scope, 's12', 's1', 's0', 's3', 's2', 's5', 's4', 's7', 's6', 's9', 's8', 's11', 's10')
 
 
   // Initialize child components with props
-  initChild('Pagination', _s13, {})
+  initChild('Pagination', __scope, {})
   initChild('PaginationContent', _s12, {})
   initChild('PaginationItem', _s1, {})
   initChild('PaginationPrevious', _s0, { href: "#" })

--- a/packages/adapter-tests/fixtures/__snapshots__/popover.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/popover.client.js
@@ -220,26 +220,25 @@ export function initPopoverPreviewDemo(__scope, _p = {}) {
 
   const [open, setOpen] = createSignal(false)
 
-  const [_s2, _s0, _s1] = $c(__scope, 's2', 's0', 's1')
+  const [_s0, _s1] = $c(__scope, 's0', 's1')
 
 
   // Reactive prop bindings
   createEffect(() => {
-    if (_s2) {
-      _s2.open = !!(open())
+    if (__scope) {
+      __scope.open = !!(open())
     }
   })
 
   // Reactive child component props
   createEffect(() => {
-    const [__Popover_s2El] = $c(__scope, 's2')
-    if (__Popover_s2El) {
-      __Popover_s2El.open = !!(open())
+    if (__scope) {
+      __scope.open = !!(open())
     }
   })
 
   // Initialize child components with props
-  initChild('Popover', _s2, { get open() { return open() }, onOpenChange: setOpen })
+  initChild('Popover', __scope, { get open() { return open() }, onOpenChange: setOpen })
   initChild('PopoverTrigger', _s0, {})
   initChild('PopoverContent', _s1, { className: "w-80" })
 }
@@ -252,26 +251,25 @@ export function initPopoverBasicDemo(__scope, _p = {}) {
 
   const [open, setOpen] = createSignal(false)
 
-  const [_s2, _s0, _s1] = $c(__scope, 's2', 's0', 's1')
+  const [_s0, _s1] = $c(__scope, 's0', 's1')
 
 
   // Reactive prop bindings
   createEffect(() => {
-    if (_s2) {
-      _s2.open = !!(open())
+    if (__scope) {
+      __scope.open = !!(open())
     }
   })
 
   // Reactive child component props
   createEffect(() => {
-    const [__Popover_s2El] = $c(__scope, 's2')
-    if (__Popover_s2El) {
-      __Popover_s2El.open = !!(open())
+    if (__scope) {
+      __scope.open = !!(open())
     }
   })
 
   // Initialize child components with props
-  initChild('Popover', _s2, { get open() { return open() }, onOpenChange: setOpen })
+  initChild('Popover', __scope, { get open() { return open() }, onOpenChange: setOpen })
   initChild('PopoverTrigger', _s0, {})
   initChild('PopoverContent', _s1, {})
 }
@@ -293,7 +291,7 @@ export function initPopoverFormDemo(__scope, _p = {}) {
   }
 
   const [_s3, _s2] = $(__scope, '^s3', '^s2')
-  const [_s5, _s0, _s4, _s1] = $c(__scope, 's5', 's0', 's4', 's1')
+  const [_s0, _s4, _s1] = $c(__scope, 's0', 's4', 's1')
 
   insert(__scope, '^s2', () => saved(), {
     template: () => { const __slots = []; return { html: `<!--bf-cond-start:^s2-->${__bfSlot('Saved!', __slots)}<!--bf-cond-end:^s2-->`, slots: __slots } },
@@ -309,21 +307,20 @@ export function initPopoverFormDemo(__scope, _p = {}) {
 
   // Reactive prop bindings
   createEffect(() => {
-    if (_s5) {
-      _s5.open = !!(open())
+    if (__scope) {
+      __scope.open = !!(open())
     }
   })
 
   // Reactive child component props
   createEffect(() => {
-    const [__Popover_s5El] = $c(__scope, 's5')
-    if (__Popover_s5El) {
-      __Popover_s5El.open = !!(open())
+    if (__scope) {
+      __scope.open = !!(open())
     }
   })
 
   // Initialize child components with props
-  initChild('Popover', _s5, { get open() { return open() }, onOpenChange: setOpen })
+  initChild('Popover', __scope, { get open() { return open() }, onOpenChange: setOpen })
   initChild('PopoverTrigger', _s0, {})
   initChild('PopoverContent', _s4, { align: "start", className: "w-80" })
   initChild('PopoverClose', _s1, { className: "inline-flex items-center justify-center rounded-md border bg-background px-3 py-1.5 text-sm hover:bg-accent" })

--- a/packages/adapter-tests/fixtures/__snapshots__/tabs.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/tabs.client.js
@@ -131,14 +131,14 @@ export function initTabsBasicDemo(__scope, _p = {}) {
   const isAccountSelected = createMemo(() => activeTab() === 'account')
   const isPasswordSelected = createMemo(() => activeTab() === 'password')
 
-  const [_s5, _s0, _s1, _s3, _s4, _s2] = $c(__scope, 's5', 's0', 's1', 's3', 's4', 's2')
+  const [_s0, _s1, _s3, _s4, _s2] = $c(__scope, 's0', 's1', 's3', 's4', 's2')
 
 
   // Reactive prop bindings
   createEffect(() => {
-    if (_s5) {
+    if (__scope) {
       const __val = String(activeTab())
-      if (_s5.value !== __val) _s5.value = __val
+      if (__scope.value !== __val) __scope.value = __val
     }
     if (_s0) {
       _s0.setAttribute('aria-selected', String(isAccountSelected()))
@@ -170,10 +170,9 @@ export function initTabsBasicDemo(__scope, _p = {}) {
 
   // Reactive child component props
   createEffect(() => {
-    const [__Tabs_s5El] = $c(__scope, 's5')
-    if (__Tabs_s5El) {
+    if (__scope) {
       const __val = String(activeTab())
-      if (__Tabs_s5El.value !== __val) __Tabs_s5El.value = __val
+      if (__scope.value !== __val) __scope.value = __val
     }
     const [__TabsTrigger_s0El] = $c(__scope, 's0')
     if (__TabsTrigger_s0El) {
@@ -194,7 +193,7 @@ export function initTabsBasicDemo(__scope, _p = {}) {
   })
 
   // Initialize child components with props
-  initChild('Tabs', _s5, { get value() { return activeTab() }, onValueChange: setActiveTab })
+  initChild('Tabs', __scope, { get value() { return activeTab() }, onValueChange: setActiveTab })
   initChild('TabsList', _s2, {})
   initChild('TabsTrigger', _s0, { value: "account", get selected() { return isAccountSelected() }, get disabled() { return false }, onClick: () => setActiveTab('account') })
   initChild('TabsTrigger', _s1, { value: "password", get selected() { return isPasswordSelected() }, get disabled() { return false }, onClick: () => setActiveTab('password') })
@@ -214,14 +213,14 @@ export function initTabsMultipleDemo(__scope, _p = {}) {
   const isReportsSelected = createMemo(() => activeTab() === 'reports')
   const isNotificationsSelected = createMemo(() => activeTab() === 'notifications')
 
-  const [_s9, _s0, _s1, _s2, _s3, _s5, _s6, _s7, _s8, _s4] = $c(__scope, 's9', 's0', 's1', 's2', 's3', 's5', 's6', 's7', 's8', 's4')
+  const [_s0, _s1, _s2, _s3, _s5, _s6, _s7, _s8, _s4] = $c(__scope, 's0', 's1', 's2', 's3', 's5', 's6', 's7', 's8', 's4')
 
 
   // Reactive prop bindings
   createEffect(() => {
-    if (_s9) {
+    if (__scope) {
       const __val = String(activeTab())
-      if (_s9.value !== __val) _s9.value = __val
+      if (__scope.value !== __val) __scope.value = __val
     }
     if (_s0) {
       _s0.setAttribute('aria-selected', String(isOverviewSelected()))
@@ -279,10 +278,9 @@ export function initTabsMultipleDemo(__scope, _p = {}) {
 
   // Reactive child component props
   createEffect(() => {
-    const [__Tabs_s9El] = $c(__scope, 's9')
-    if (__Tabs_s9El) {
+    if (__scope) {
       const __val = String(activeTab())
-      if (__Tabs_s9El.value !== __val) __Tabs_s9El.value = __val
+      if (__scope.value !== __val) __scope.value = __val
     }
     const [__TabsTrigger_s0El] = $c(__scope, 's0')
     if (__TabsTrigger_s0El) {
@@ -319,7 +317,7 @@ export function initTabsMultipleDemo(__scope, _p = {}) {
   })
 
   // Initialize child components with props
-  initChild('Tabs', _s9, { get value() { return activeTab() }, onValueChange: setActiveTab })
+  initChild('Tabs', __scope, { get value() { return activeTab() }, onValueChange: setActiveTab })
   initChild('TabsList', _s4, {})
   initChild('TabsTrigger', _s0, { value: "overview", get selected() { return isOverviewSelected() }, get disabled() { return false }, onClick: () => setActiveTab('overview') })
   initChild('TabsTrigger', _s1, { value: "analytics", get selected() { return isAnalyticsSelected() }, get disabled() { return false }, onClick: () => setActiveTab('analytics') })
@@ -341,14 +339,14 @@ export function initTabsDisabledDemo(__scope, _p = {}) {
   const isActiveSelected = createMemo(() => activeTab() === 'active')
   const isAnotherSelected = createMemo(() => activeTab() === 'another')
 
-  const [_s6, _s0, _s2, _s4, _s5, _s3, _s1] = $c(__scope, 's6', 's0', 's2', 's4', 's5', 's3', 's1')
+  const [_s0, _s2, _s4, _s5, _s3, _s1] = $c(__scope, 's0', 's2', 's4', 's5', 's3', 's1')
 
 
   // Reactive prop bindings
   createEffect(() => {
-    if (_s6) {
+    if (__scope) {
       const __val = String(activeTab())
-      if (_s6.value !== __val) _s6.value = __val
+      if (__scope.value !== __val) __scope.value = __val
     }
     if (_s0) {
       _s0.setAttribute('aria-selected', String(isActiveSelected()))
@@ -380,10 +378,9 @@ export function initTabsDisabledDemo(__scope, _p = {}) {
 
   // Reactive child component props
   createEffect(() => {
-    const [__Tabs_s6El] = $c(__scope, 's6')
-    if (__Tabs_s6El) {
+    if (__scope) {
       const __val = String(activeTab())
-      if (__Tabs_s6El.value !== __val) __Tabs_s6El.value = __val
+      if (__scope.value !== __val) __scope.value = __val
     }
     const [__TabsTrigger_s0El] = $c(__scope, 's0')
     if (__TabsTrigger_s0El) {
@@ -404,7 +401,7 @@ export function initTabsDisabledDemo(__scope, _p = {}) {
   })
 
   // Initialize child components with props
-  initChild('Tabs', _s6, { get value() { return activeTab() } })
+  initChild('Tabs', __scope, { get value() { return activeTab() } })
   initChild('TabsList', _s3, {})
   initChild('TabsTrigger', _s0, { value: "active", get selected() { return isActiveSelected() }, get disabled() { return false }, onClick: () => setActiveTab('active') })
   initChild('TabsTrigger', _s1, { value: "disabled", get selected() { return false }, get disabled() { return true } })

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -220,19 +220,24 @@ function renderChild(name, props, key, suffix) {
   // output asserts the same shape SSR emits.
   const slotAttrs = suffix ? ' bf-h="' + __parentScope + '" bf-m="' + suffix + '"' : ''
   if (!template) return '<div bf-s="' + scopeId + '"' + slotAttrs + keyAttr + '>[' + name + ']</div>'
-  // NOTE: does NOT push \`__parentScope\` to this child's own derived
-  // scope while \`template\` evaluates — mirrors production's renderChild
-  // (@barefootjs/client/runtime, component.ts, the NOTE above its
-  // \`templateFn(props)\` call). Pushing was tried there to fix a third
-  // composition level collapsing onto the second (\`grandchild-composition\`)
-  // but it collides with \`comment: true\` wrapper transparency's $cSingle
-  // short-suffix self-match, so production intentionally leaves
-  // grandchild-composition a known limitation (#2649) rather than pushing.
-  // This mock must reproduce that bug, not silently cure it.
-  const __rawHtml = template(props)
+  // Push \`__parentScope\` to this child's own derived scope while
+  // \`template\` evaluates — mirrors production's renderChild
+  // (@barefootjs/client/runtime, component.ts, its \`_parentScopeId\` push
+  // around \`templateFn(props)\`, #2649) so a grandchild rendered inside
+  // this child derives its scope from THIS scope rather than the
+  // caller's, matching SSR (\`test_s0_s0\` instead of collapsing onto
+  // \`test_s0\`).
+  const __prevParentScope = __parentScope
+  __parentScope = scopeId
+  let __rawHtml
+  try {
+    __rawHtml = template(props)
+  } finally {
+    __parentScope = __prevParentScope
+  }
   // #1320: substitute the hoisted-children placeholder with the CALLER's
-  // scope (\`__parentScope\`, unchanged since renderChild doesn't push).
-  // Mirrors the production renderChild in @barefootjs/client/runtime.
+  // scope (\`__parentScope\`, restored by the \`finally\` above before this
+  // line runs). Mirrors the production renderChild in @barefootjs/client/runtime.
   // Anchored to the exact attribute shape so user text containing the
   // sentinel is left alone.
   const html = __rawHtml.trim()

--- a/packages/adapter-tests/src/csr-skip-set.ts
+++ b/packages/adapter-tests/src/csr-skip-set.ts
@@ -67,12 +67,13 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   // reaches the CSR insert as `bfMarkup()`-branded HTML, matching the
   // claim-plan 'markup' classification instead of the stray `escapeText`
   // path that mangled the `__BF_PARENT_SCOPE__` sentinel.
-  // `grandchild-composition`: third level reuses the parent scope id
-  // (`test_s0`) in CSR instead of deriving `test_s0_s0` as SSR does. #2444
-  // fixed the sibling case, but deriving here via `renderChild`'s
-  // `_parentScopeId` push collided with `comment: true` wrapper self-lookup
-  // (`$cSingle`'s short-suffix fallback in `query.ts`), breaking hydration
-  // when an inner component's first slot id coincides with the wrapper's slot
-  // number (site/ui xyflow Highlight-Depth regression) — known limitation #2649.
-  'grandchild-composition',
+  // `grandchild-composition` graduated (#2649 fixed): `renderChild` now
+  // pushes `_parentScopeId` to a child's own derived scope while its
+  // template evaluates, so a third composition level derives `test_s0_s0`
+  // instead of collapsing onto `test_s0`. The `comment: true` wrapper
+  // self-lookup collision that reverted the first attempt at this is
+  // fixed at its source: a `comment: true` component's own root-level
+  // child needs no `$c` lookup at all (it IS `__scope`) — see
+  // `ClientJsContext.commentScopeRootSlotId` and
+  // `comment-wrapper-grandchild-slot-collision.test.ts`.
 ])

--- a/packages/client/__tests__/runtime/comment-wrapper-grandchild-slot-collision.test.ts
+++ b/packages/client/__tests__/runtime/comment-wrapper-grandchild-slot-collision.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Regression test for #2649 (grandchild composition through a
+ * `comment: true` wrapper).
+ *
+ * `renderChild` pushes `_parentScopeId` to a child's OWN derived scope
+ * while that child's `templateFn` evaluates (`component.ts`), so a
+ * grandchild rendered inside it derives its `bf-s` from THIS child rather
+ * than the caller — the fix for a third composition level collapsing onto
+ * the second (`grandchild-composition`, `create-component-parent-scope
+ * .test.ts` covers the parallel `createComponent` path).
+ *
+ * That push, on its own, reopens a DIFFERENT bug for a `comment: true`
+ * wrapper (#1211 synthesized inline-JSX-callback wrappers, e.g. `<Flow
+ * renderNode={(n) => <Body id={n.id} />}>`): the wrapper's own element IS
+ * its single real child's element (no separate DOM node), so the
+ * wrapper's init used to resolve that child via `$c(scope, 's0')`'s
+ * self-match fallback (`comment-wrapper-create-component.test.ts`). Once
+ * the real child's OWN first grandchild also derives a `bf-s` ending in
+ * `_s0` (the exact scenario the push fixes), `$c(scope, 's0')`'s PRECISE
+ * suffix search matches that grandchild first and never reaches the
+ * self-match fallback — the wrapper's `initChild` receives the wrong
+ * element, silently misrouting props/events onto a grandchild instead of
+ * the real child (confirmed via `site/ui`'s xyflow Highlight-Depth demo,
+ * where an early attempt at this exact push broke the `--node-glow`
+ * style effect).
+ *
+ * Fix: a `comment: true` component's own root-level child needs no `$c`
+ * lookup at all — it IS `__scope` (`ClientJsContext.commentScopeRootSlotId`,
+ * `provider-and-child-inits.ts` / `emit-reactive.ts`). This test mirrors
+ * that codegen shape directly (`__scope` for the wrapper's own child,
+ * `$c` for the real child's OWN grandchildren) rather than routing the
+ * wrapper's lookup through `$c` — the configuration this test guards
+ * against is a wrapper init that goes back to `$c(scope, 's0')` for its
+ * own child once a same-suffix grandchild exists underneath it.
+ */
+
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+describe('comment: true wrapper + grandchild slot collision (#2649)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('wrapper resolves its own (merged) child via __scope, not a same-suffix grandchild', async () => {
+    const { hydrate, createComponent, renderChild, $c, initChild } = await import('../../src/runtime')
+
+    const handleInitCalls: Array<{ kind: unknown; scope: string | null }> = []
+    const bodyInitCalls: Array<{ id: unknown; scope: string | null }> = []
+
+    // Handle: a real child component with no children of its own — the
+    // "grandchild" whose slot suffix (`s0`, the first child) coincides
+    // with the wrapper's own mount slot in its caller.
+    hydrate('Handle_test2649', {
+      init: (scope: Element | null, p: any) => {
+        handleInitCalls.push({ kind: p?.kind, scope: scope?.getAttribute('bf-s') ?? null })
+      },
+      template: (p: any) => `<div data-role="handle">${p.kind}</div>`,
+      name: 'Handle',
+    })
+
+    // Body: the real component the wrapper renders. Its FIRST child is
+    // Handle at slot s0 — the same slot label the wrapper itself is
+    // mounted at, one level up.
+    hydrate('Body_test2649', {
+      init: (scope: Element | null, p: any) => {
+        bodyInitCalls.push({ id: p?.id, scope: scope?.getAttribute('bf-s') ?? null })
+        const [s0, s1] = $c(scope, 's0', 's1')
+        initChild('Handle_test2649', s0, { kind: 'target' })
+        initChild('Handle_test2649', s1, { kind: 'source' })
+      },
+      template: (p: any) =>
+        `<div data-role="body">${renderChild('Handle_test2649', { kind: 'target' }, undefined, 's0')}<span>${p.id}</span>${renderChild('Handle_test2649', { kind: 'source' }, undefined, 's1')}</div>`,
+      name: 'Body',
+    })
+
+    // Wrapper: `comment: true` — transparent, its element IS Body's own
+    // element. Mirrors the compiler's fix: the wrapper's own child slot
+    // (`s0` relative to ITS caller) is `__scope` directly, never `$c`.
+    hydrate('Wrapper_test2649', {
+      init: (scope: Element | null, p: any) => {
+        initChild('Body_test2649', scope, { id: p?.id })
+      },
+      template: (p: any) => `${renderChild('Body_test2649', { id: p.id }, undefined, 's0')}`,
+      comment: true,
+      name: 'Wrapper',
+    })
+
+    // Mount the wrapper as slot `s0` of some caller — the same slot
+    // label Body's own first child (Handle target) will end up with,
+    // once `renderChild`'s push makes Body derive its OWN scope.
+    const el = createComponent('Wrapper_test2649', { id: 'n1' }, undefined, {
+      parent: 'Flow_root',
+      mount: 's0',
+    })
+    document.body.appendChild(el)
+
+    // Body's own scope is the wrapper's borrowed identity: `Flow_root_s0`.
+    expect(el.getAttribute('bf-s')).toBe('Flow_root_s0')
+
+    // Body's init ran exactly once, on the correct (self-merged) element —
+    // not skipped, not run on a grandchild.
+    expect(bodyInitCalls).toHaveLength(1)
+    expect(bodyInitCalls[0]).toEqual({ id: 'n1', scope: 'Flow_root_s0' })
+
+    // Both Handle children resolved and initialised — the collapse bug
+    // left the SECOND handle's `$c` lookup null (the first one
+    // coincidentally matched the wrapper's own misrouted resolution).
+    expect(handleInitCalls).toHaveLength(2)
+    expect(handleInitCalls).toEqual(
+      expect.arrayContaining([
+        { kind: 'target', scope: 'Flow_root_s0_s0' },
+        { kind: 'source', scope: 'Flow_root_s0_s1' },
+      ]),
+    )
+  })
+})

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -441,25 +441,25 @@ export function renderChild(
     return `<div ${bfsAttr}${slotAttrs}${keyAttr}></div>`
   }
 
-  // NOTE: does NOT push `_parentScopeId` to this child's own derived scope
-  // while `templateFn` evaluates. That was tried (deriving a GRANDCHILD's
-  // scope from this scope rather than the caller's, to fix a third
-  // composition level collapsing onto the second — `grandchild-composition`)
-  // but it collides with `comment: true` wrapper transparency (#1211
-  // synthesized inline-JSX-callback wrappers, e.g. a `renderNode` callback
-  // prop): such a wrapper's OWN scope element IS its single child's element,
-  // and its init resolves itself via `$c(scope, 's0')`'s short-suffix
-  // self-match fallback (`query.ts`'s `$cSingle`). Pushing this scope makes
-  // a nested descendant of that SAME child derive `..._s0_s0` whenever the
-  // descendant's own first slot id also happens to be `s0` — the PRECISE
-  // suffix match then finds that unrelated descendant instead of falling
-  // through to the self-match, silently misrouting `initChild` (confirmed
-  // via `site/ui`'s xyflow Highlight-Depth demo, where this broke the
-  // `--node-glow` style effect). `grandchild-composition` stays a known
-  // limitation (CSR conformance skip) until the self-match lookup can be
-  // made unambiguous against a nested descendant sharing the same slot
-  // suffix.
-  const raw = templateFn(props)
+  // Push `_parentScopeId` to THIS child's own derived scope while its
+  // `templateFn` evaluates, so a grandchild rendered inside it derives its
+  // scope from THIS scope rather than the caller's (#2649). Without this a
+  // third composition level collapses onto the second: with `_parentScopeId`
+  // left at the caller's id, a grandchild whose slot suffix happens to match
+  // this child's OWN slot suffix computes the exact same string as this
+  // child's bf-s (`grandchild-composition`'s `test_s0` reused instead of
+  // deriving `test_s0_s0`). Restored via `finally` so a sibling rendered
+  // after this call (or the caller's own remaining template) sees the
+  // original `_parentScopeId`, matching the caller-restore discipline
+  // `materializeComponent` already uses around its own `templateFn` call.
+  const prevParentScopeId = _parentScopeId
+  _parentScopeId = `${scopePrefix}${suffix}`
+  let raw: string
+  try {
+    raw = templateFn(props)
+  } finally {
+    _parentScopeId = prevParentScopeId
+  }
 
   // The placeholder substitution is anchored to the exact `bf-s="…"`
   // shape so user content that contains the sentinel as text survives

--- a/packages/jsx/src/__tests__/child-components-in-map.test.ts
+++ b/packages/jsx/src/__tests__/child-components-in-map.test.ts
@@ -292,6 +292,12 @@ describe('child components inside .map() (#344)', () => {
   })
 
   test('no duplicate variable declaration when .map() slot ID matches component slot ID (#360)', () => {
+    // Wrapped in a `<div>` so `Wrapper` is a genuine, separately-addressed
+    // child (needs a `$c` ref) rather than the component's own `comment:
+    // true` root child — a BARE `<Wrapper>{...}</Wrapper>` return needs no
+    // `$c` ref at all since #2649 (the child IS `__scope`), which would
+    // make this test's collision between the component's `$c` ref and the
+    // loop's `mapArray` ref never arise in the first place.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -299,9 +305,11 @@ describe('child components inside .map() (#344)', () => {
       export function Parent() {
         const [items, setItems] = createSignal([{ name: 'a' }, { name: 'b' }])
         return (
-          <Wrapper>
-            {items().map((item, i) => <span key={i}>{item.name}</span>)}
-          </Wrapper>
+          <div>
+            <Wrapper>
+              {items().map((item, i) => <span key={i}>{item.name}</span>)}
+            </Wrapper>
+          </div>
         )
       }
     `

--- a/packages/jsx/src/__tests__/inline-jsx-callback.test.ts
+++ b/packages/jsx/src/__tests__/inline-jsx-callback.test.ts
@@ -464,3 +464,58 @@ describe('inline JSX as object-literal arrow value (#1663)', () => {
     expect(js).toMatch(/lazySlots[^']*from '@barefootjs\/client\/runtime'/)
   })
 })
+
+describe('synthesized wrapper root-child resolution (#2649)', () => {
+  test('the wrapper\'s own (comment: true) child init uses __scope directly, not a $c lookup', () => {
+    // `Flow`'s callback is hoisted into a `comment: true` synthesized
+    // wrapper (BFInlineJsxCallback1) whose entire body is the single
+    // `<Body id={n.id} />` call — the wrapper's element IS Body's own
+    // element, no separate DOM node exists to look up. Body itself
+    // nests two REAL child components (Handle) whose own slot suffixes
+    // (`s0`, `s1`) can coincide with whatever slot the wrapper is
+    // mounted at in ITS caller once a grandchild's scope is correctly
+    // derived from Body's own scope (#2649) — so the wrapper's init
+    // must reference `__scope` directly rather than re-deriving it via
+    // `$c`, which cannot distinguish "I already am this slot" from a
+    // same-suffix grandchild underneath it.
+    const source = `
+      'use client'
+      import { Flow } from './Flow'
+
+      function Handle(props: { kind: string }) {
+        return <div class="handle">{props.kind}</div>
+      }
+
+      function Body(props: { id: string }) {
+        return (
+          <div>
+            <Handle kind="target" />
+            <span>{props.id}</span>
+            <Handle kind="source" />
+          </div>
+        )
+      }
+
+      export function Demo() {
+        return <Flow renderNode={(n) => <Body id={n.id} />} />
+      }
+    `
+    const js = clientJs(source)
+
+    // The synthesized wrapper's init must not query its own root child
+    // via $c — it already has it as `__scope`.
+    const wrapperInit = js.match(/function initBFInlineJsxCallback1\b[\s\S]*?\n\}/)
+    expect(wrapperInit).not.toBeNull()
+    expect(wrapperInit![0]).not.toMatch(/\$c\(__scope/)
+    expect(wrapperInit![0]).toMatch(/initChild\('Body[^,]*',\s*__scope,/)
+
+    // Body's OWN nested Handle children are unaffected — they are real,
+    // separate DOM nodes and still resolve through $c as normal (slot
+    // numbering interleaves with the `<span>` text marker in between, so
+    // the second Handle isn't necessarily 's1' — only that both go
+    // through $c, unlike the wrapper's own root child above).
+    const bodyInit = js.match(/function initBody\b[\s\S]*?\n\}/)
+    expect(bodyInit).not.toBeNull()
+    expect(bodyInit![0]).toMatch(/\$c\(__scope,\s*'s0',\s*'s\d+'\)/)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/element-refs.ts
+++ b/packages/jsx/src/ir-to-client-js/element-refs.ts
@@ -71,6 +71,14 @@ export function generateElementRefs(ctx: ClientJsContext): string {
     regularSlots.delete(slotId)
   }
 
+  // The component's own `comment: true` root slot needs no `$c` ref at
+  // all — its consumers (provider-and-child-inits.ts, emit-reactive.ts)
+  // reference `__scope` directly instead (#2649, see
+  // `ClientJsContext.commentScopeRootSlotId`'s docstring).
+  if (ctx.commentScopeRootSlotId) {
+    componentSlots.delete(ctx.commentScopeRootSlotId)
+  }
+
   if (regularSlots.size === 0 && componentSlots.size === 0) return ''
 
   const refLines: string[] = []

--- a/packages/jsx/src/ir-to-client-js/emit-reactive.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-reactive.ts
@@ -462,24 +462,28 @@ export function emitReactivePropBindings(lines: string[], ctx: ClientJsContext):
     }
 
     for (const [slotId, props] of propsBySlot) {
-      const v = varSlotId(slotId)
-      lines.push(`    if (_${v}) {`)
+      // The component's own `comment: true` root child IS `__scope` — no
+      // `$c` ref was declared for it (element-refs.ts), so reference
+      // `__scope` directly instead of a `_sN` var that doesn't exist
+      // (#2649, see `ClientJsContext.commentScopeRootSlotId`'s docstring).
+      const ref = slotId === ctx.commentScopeRootSlotId ? '__scope' : `_${varSlotId(slotId)}`
+      lines.push(`    if (${ref}) {`)
       for (const prop of props) {
         const value = `${prop.expression}()`
         if (prop.propName === 'selected') {
           if (prop.componentName === 'TabsContent') {
-            lines.push(`      _${v}.setAttribute('data-state', ${value} ? 'active' : 'inactive')`)
+            lines.push(`      ${ref}.setAttribute('data-state', ${value} ? 'active' : 'inactive')`)
             lines.push(`      if (${value}) {`)
-            lines.push(`        _${v}.classList.remove('hidden')`)
+            lines.push(`        ${ref}.classList.remove('hidden')`)
             lines.push(`      } else {`)
-            lines.push(`        _${v}.classList.add('hidden')`)
+            lines.push(`        ${ref}.classList.add('hidden')`)
             lines.push(`      }`)
           } else {
             // Update data-state and aria-selected attributes.
             // Visual styling is driven by CSS data-[state=active/inactive]: selectors.
-            lines.push(`      _${v}.setAttribute('aria-selected', String(${value}))`)
-            lines.push(`      _${v}.setAttribute('data-state', ${value} ? 'active' : 'inactive')`)
-            lines.push(`      _${v}.setAttribute('tabindex', ${value} ? '0' : '-1')`)
+            lines.push(`      ${ref}.setAttribute('aria-selected', String(${value}))`)
+            lines.push(`      ${ref}.setAttribute('data-state', ${value} ? 'active' : 'inactive')`)
+            lines.push(`      ${ref}.setAttribute('tabindex', ${value} ? '0' : '-1')`)
           }
         // Use DOM property assignment for value and boolean attrs.
         // setAttribute('value', x) only sets the initial HTML attribute; after user
@@ -488,11 +492,11 @@ export function emitReactivePropBindings(lines: string[], ctx: ClientJsContext):
         // truthy, so setAttribute('disabled', 'false') still disables the element.
         } else if (prop.propName === 'value') {
           lines.push(`      const __val = String(${value})`)
-          lines.push(`      if (_${v}.value !== __val) _${v}.value = __val`)
+          lines.push(`      if (${ref}.value !== __val) ${ref}.value = __val`)
         } else if (isBooleanAttr(prop.propName)) {
-          lines.push(`      _${v}.${prop.propName} = !!(${value})`)
+          lines.push(`      ${ref}.${prop.propName} = !!(${value})`)
         } else {
-          lines.push(`      _${v}.setAttribute('${prop.propName}', String(${value}))`)
+          lines.push(`      ${ref}.setAttribute('${prop.propName}', String(${value}))`)
         }
       }
       lines.push(`    }`)
@@ -520,10 +524,17 @@ export function emitReactiveChildProps(lines: string[], ctx: ClientJsContext): v
 
     for (const [, props] of propsByComponent) {
       const first = props[0]
+      // The component's own `comment: true` root child IS `__scope` — query
+      // it directly rather than through `$c`, which cannot tell "I already
+      // am this slot" apart from a coincidentally-matching descendant
+      // (#2649, see `ClientJsContext.commentScopeRootSlotId`'s docstring).
+      const isCommentRoot = first.slotId !== null && first.slotId === ctx.commentScopeRootSlotId
       const varSuffix = first.slotId ? varSlotId(first.slotId).replace(/-/g, '_') : first.componentName
-      const varName = `__${first.componentName}_${varSuffix}El`
-      const selectorArg = first.slotId ? first.slotId : first.componentName
-      lines.push(`    const [${varName}] = $c(__scope, '${selectorArg}')`)
+      const varName = isCommentRoot ? '__scope' : `__${first.componentName}_${varSuffix}El`
+      if (!isCommentRoot) {
+        const selectorArg = first.slotId ? first.slotId : first.componentName
+        lines.push(`    const [${varName}] = $c(__scope, '${selectorArg}')`)
+      }
       lines.push(`    if (${varName}) {`)
       for (const prop of props) {
         for (const stmt of emitAttrUpdate(varName, prop.attrName, prop.expression, prop)) {

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -185,6 +185,10 @@ function createContext(
     refElements: [],
     childInits: [],
     deferredChildSlots: new Set(),
+    // Mirrors `emit-registration.ts`'s `isCommentScope` component-root
+    // disjunct (not the fragment disjunct — that case is disambiguated at
+    // runtime by `commentScopeRegistry`, not by this slot-id shortcut).
+    commentScopeRootSlotId: ir.root.type === 'component' ? ir.root.slotId : null,
     reactiveProps: [],
     reactiveChildProps: [],
     reactiveAttrs: [],

--- a/packages/jsx/src/ir-to-client-js/phases/provider-and-child-inits.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/provider-and-child-inits.ts
@@ -39,7 +39,11 @@ export function emitProviderAndChildInits(lines: string[], ctx: ClientJsContext)
         lines.push(`  upsertChild(__scope, '${registryName}', '${child.slotId}', ${child.propsExpr})`)
         continue
       }
-      const scopeRef = child.slotId ? `_${varSlotId(child.slotId)}` : '__scope'
+      // The component's own `comment: true` root child IS `__scope` (no
+      // separate DOM node exists for it to be looked up at) — see
+      // `ClientJsContext.commentScopeRootSlotId`'s docstring (#2649).
+      const isCommentRoot = child.slotId !== null && child.slotId === ctx.commentScopeRootSlotId
+      const scopeRef = !child.slotId || isCommentRoot ? '__scope' : `_${varSlotId(child.slotId)}`
       lines.push(`  initChild('${registryName}', ${scopeRef}, ${child.propsExpr})`)
     }
   }

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -104,8 +104,9 @@ export interface ClientJsContext {
   deferredChildSlots: Set<string>
   /**
    * Slot id of the component's own root, when the ENTIRE render is a single
-   * child component call (`ir.root.type === 'component'`, the `comment: true`
-   * def flag — see `emit-registration.ts`'s `isCommentScope`). Such a child
+   * child component call (`ir.root.type === 'component'` — the IR shape is
+   * the sole source of truth; `emit-registration.ts`'s `isCommentScope`
+   * derives the def's `comment: true` from the same shape). Such a child
    * never gets its own DOM node: `materializeComponent`/`renderChild` leave
    * `bf-s` unset and the child's markup becomes `__scope` itself (#2649).
    * A generic `$c(__scope, slotId)` lookup for this one slot is therefore

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -102,6 +102,26 @@ export interface ClientJsContext {
    * registration-template emit so both agree on which children defer.
    */
   deferredChildSlots: Set<string>
+  /**
+   * Slot id of the component's own root, when the ENTIRE render is a single
+   * child component call (`ir.root.type === 'component'`, the `comment: true`
+   * def flag — see `emit-registration.ts`'s `isCommentScope`). Such a child
+   * never gets its own DOM node: `materializeComponent`/`renderChild` leave
+   * `bf-s` unset and the child's markup becomes `__scope` itself (#2649).
+   * A generic `$c(__scope, slotId)` lookup for this one slot is therefore
+   * not just redundant but actively ambiguous — a genuine grandchild
+   * nested inside it can derive a `bf-s` whose suffix collides with this
+   * same slot id (see `component.ts`'s `_parentScopeId` push), and
+   * `$cSingle` cannot tell "I already am this slot" apart from "a
+   * coincidentally-matching descendant is this slot" from the DOM alone.
+   * Emission sites that would otherwise query this slot via `$c`
+   * (`element-refs.ts`, `provider-and-child-inits.ts`,
+   * `emit-reactive.ts`) use `__scope` directly instead, sidestepping the
+   * ambiguity entirely rather than trying to make the query precise
+   * enough to resolve it. `null` for a component whose root is a regular
+   * element/fragment (the overwhelmingly common case).
+   */
+  commentScopeRootSlotId: string | null
   reactiveProps: ReactiveComponentProp[]
   reactiveChildProps: ReactiveChildProp[]
   reactiveAttrs: ReactiveAttribute[]


### PR DESCRIPTION
## Summary

Fixes #2649: at composition depth 3, CSR reused the parent's scope id (`test_s0`) instead of deriving the grandchild's own (`test_s0_s0`, as SSR correctly does). Root cause: `renderChild` never pushed `_parentScopeId` while a child's `templateFn` evaluated, so a grandchild derived its scope from the **grandparent's** id — and whenever its slot suffix matched the child's own, both computed the identical string.

## Why the previous attempt was reverted, and how this lands it safely

Pushing `_parentScopeId` was tried before and reverted: it broke `comment: true` synthesized wrappers (#1211, e.g. a `renderNode` callback prop), whose own DOM element IS their single child's element and whose init resolved "my own child" via `$c(scope, 's0')`'s self-match fallback. Once a real grandchild derives a `bf-s` ending in the same slot suffix, `$c`'s precise suffix search matches that unrelated grandchild first and never reaches the self-match — reproduced end-to-end (wrapper's `initChild` misrouted to a Handle's scope, second Handle resolved `null`), the exact regression that broke the xyflow Highlight-Depth demo.

The ambiguity was **proven structurally unresolvable by tuning `$cSingle`'s selectors**: the same DOM node / `cleanId` pair legitimately needs different answers depending on which logical component is asking, and both scenarios produce string-identical marker shapes. So instead of query-time heuristics, the fix removes the ambiguous query at its source:

1. **`renderChild` (`component.ts`)** pushes `_parentScopeId` to the child's own derived scope around `templateFn`, restored via `finally` (same discipline `materializeComponent` already uses).
2. **Compiler codegen**: a `comment: true` component's own root-level child needs no `$c` lookup at all — it already IS `__scope`. New `ClientJsContext.commentScopeRootSlotId` routes the three emission sites that queried that slot (`element-refs.ts` ref declarations, `provider-and-child-inits.ts`'s `initChild`, `emit-reactive.ts`'s reactive-prop effects) to reference `__scope` directly.

The CSR-conformance harness's `renderChild` mock (`csr-render.ts`) previously reproduced the bug by design; it now mirrors production's push — the same harness-fidelity principle as the s7 work.

## Regression pins (written before finalizing the fix)

The revert-cause collision had no existing coverage (the #1222 pin covers only the 2-level case; the mock-CSR layer can't observe hydration wiring). Added:
- `comment-wrapper-grandchild-slot-collision.test.ts` (`packages/client`) — end-to-end through real `renderChild`/`createComponent`/`$c`/`initChild`; verified red with the old `$c(scope,'s0')` init (exact predicted misrouting) and green with the fix.
- A compiler-unit pin in `inline-jsx-callback.test.ts` asserting the wrapper's init emits `initChild('Body…', __scope, …)` with no `$c(__scope` — verified red if the codegen half is reverted alone.
- `grandchild-composition` graduates off `csr-skip-set.ts` — its fixture flips into the regression test.

One existing test (`child-components-in-map.test.ts`, #360) used a bare `<Wrapper>` component-root body — exactly the shape now optimized away from `$c` — and was rewrapped in a `<div>` to keep `Wrapper` a genuine `$c`-tracked child (verified this still reproduces the original `_s1` collision #360 pins).

## Verification

- `site/ui` e2e `xyflow.spec.ts` — 24 pass / 1 pre-existing skip, **including Highlight Depth** (the demo the original revert cited) and the `renderNode` JSX-callback suite; run both before and after merging `origin/main`.
- SSR-side depth-3 audit (issue's step): all 9 adapters pass `grandchild-composition` SSR conformance — no SSR gap; #2444 fully covers it.
- Suites (serial): client 645/0, csr-conformance 314/0 (fixture un-skipped), csr-skip-rot 22/0, jsx full 3144/0, all 9 adapter conformance suites 0 fail (run twice, pre/post main merge), test/router/ui-components 0 fail, adapter-tests+compat meta 0 fail post-merge (pre-merge failures confirmed pre-existing stale pins fixed upstream by #2704).
- Locks: `compat:lock` 558/558 ok, `support-matrix:lock` zero diff (expected — hydration behavior, not subset capability), `git diff -- ui/` empty.
- Changeset: patch on `@barefootjs/client` + `@barefootjs/jsx`.

Closes #2649 — the last open `bug`-tier silent divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_