### PR TITLE
Fix nested-loop conditional container resolution (#2705) and give nested-row conditionals real insert() parity (#2706)

### DIFF
--- a/.changeset/nested-loop-cond-container-2705.md
+++ b/.changeset/nested-loop-cond-container-2705.md
@@ -1,0 +1,8 @@
+---
+"@barefootjs/client": patch
+"@barefootjs/jsx": patch
+---
+
+Fix #2705: a keyed inner `.map()` living inside a loop-row `&&`-conditional whose branch content sits behind an intervening wrapper element (e.g. `<article>{cond && items.map(...)}</article>`) used to search for its own loop markers against the WHOLE conditional's bind scope instead of the wrapper — `collectInnerLoops` never assigns the loop a `containerSlotId` in this shape, because the wrapper sits outside the branch's own IR subtree and the collector's slot-tracking walk never observes it. `mapArray`'s marker lookup only scans a container's direct children, so it silently misdetected the wrapper itself as the first item (stamping the wrong `data-key`) and appended any further items as siblings OUTSIDE the wrapper. Reproduced on the very first hydration pass.
+
+`buildBranchInnerLoopsPlan` now falls back to a new runtime helper, `findCondContainer(scopeVar, condSlotId)` (`@barefootjs/client/runtime`), which resolves the conditional's own `<!--bf-cond-start:id-->` marker and returns its parent element — the one DOM anchor guaranteed to sit inside the real wrapper regardless of adoption vs. fresh-splice.

--- a/.changeset/nested-loop-row-conditional-insert-2706.md
+++ b/.changeset/nested-loop-row-conditional-insert-2706.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2706: a per-item conditional living inside a NESTED (inner) `.map()`'s own row (`rows().map(row => <div>{row.items.map(item => cond ? <span/> : null)}</div>)`) used to be baked directly into the row's static HTML template — the condition evaluated exactly once, at row creation, and never revisited, even when it read a signal (a silent divergence, confirmed by experiment: an independent signal read by the condition kept flipping while the DOM stayed frozen). The reactive text nested in the true branch still assumed `insert()` kept the branch's marker mounted, so when a row was first created with the false branch active — the marker never rendered at all — its `claimSlots` effect warned `slot sN marker not found; skipping` / `no claimed slot for id sN; write ignored` on the very first run.
+
+A NESTED loop's own row conditionals now get the same `insert()` parity a top-level loop's row conditionals already had: `collectInnerLoops` collects `bindings.conditionals` for every inner loop (branch-scoped or not), routes them through the existing `buildLoopChildConditionalsPlan`/`stringifyLoopChildConditionals` machinery the branch-arm path already used, and stops flattening a reactive conditional's own content into the old bake-and-reclaim path (`stopAtReactiveConditionals: true`) so the two mechanisms never double-bind the same text.

--- a/packages/client/__tests__/runtime/issue-2705-nested-loop-branch-container-slot.test.ts
+++ b/packages/client/__tests__/runtime/issue-2705-nested-loop-branch-container-slot.test.ts
@@ -1,5 +1,6 @@
 /**
- * Repro for https://github.com/piconic-ai/barefootjs/issues/2705
+ * Regression test for https://github.com/piconic-ai/barefootjs/issues/2705
+ * (fixed).
  *
  * `groups().map(group => <div><article>{group.show && group.items.map(item =>
  * <section key={item.id}>{item.label}</section>)}</article></div>)` — a
@@ -35,7 +36,19 @@
  *     `<article>`, directly under the outer row `<div>` — landing OUTSIDE
  *     `<article>` entirely.
  *
- * Reproduces on the very FIRST hydration pass — no click/update required.
+ * Reproduced on the very FIRST hydration pass — no click/update required.
+ *
+ * Fix: `buildBranchInnerLoopsPlan` (build-loop-child-arm.ts) now falls back
+ * to `findCondContainer(scopeVar, condSlotId)` (runtime/insert.ts, new)
+ * instead of the raw `scopeVar` when `containerSlotId` is null.
+ * `findCondContainer` walks the branch scope's comments for the enclosing
+ * conditional's own `<!--bf-cond-start:id-->` marker and returns ITS
+ * parent element — the marker is always a direct child of the real
+ * wrapper (`<article>`), since `insert()` keeps it as one of the range's
+ * boundaries regardless of whether the branch content was SSR-adopted or
+ * freshly spliced. `condSlotId` (the conditional's own slot id) is now
+ * threaded down through `buildOuterArm` / `buildLoopChildArmPlan` so it's
+ * always available at the fallback site.
  *
  * A different mechanism from #2706 (that one is a compiler codegen gap for
  * per-item conditionals inside a nested loop's OWN row; this one is a
@@ -107,12 +120,11 @@ function clientJsFor(source: string, filename: string): string {
 describe('#2705 — keyed nested loop behind a wrapped loop-row conditional', () => {
   beforeEach(() => { document.body.innerHTML = '' })
 
-  // Pinned failing (Bun's `test.failing`): passes today because the bug
-  // exists. Will start FAILING once `collectInnerLoops`/`buildBranchInner
-  // LoopsPlan` resolve the loop's real container (`<article>`) instead of
-  // falling back to the whole conditional's bind scope — flip back to
-  // `test` at that point.
-  test.failing('SSR hydration does not misplace the last item outside <article> or mis-key it', async () => {
+  // Graduated (#2705 fixed): `buildBranchInnerLoopsPlan` now falls back to
+  // `findCondContainer(scopeVar, condSlotId)` (runtime/insert.ts) instead of
+  // the whole conditional's bind scope when the inner loop's own IR never
+  // got a `containerSlotId` — see build-loop-child-arm.ts.
+  test('SSR hydration does not misplace the last item outside <article> or mis-key it', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'bf-2705-'))
     const file = join(dir, 'Repro.mjs')
     writeFileSync(file, clientJsFor(SOURCE, 'BarefootNestedLoopDuplicateRepro.tsx'))

--- a/packages/client/__tests__/runtime/issue-2705-nested-loop-branch-container-slot.test.ts
+++ b/packages/client/__tests__/runtime/issue-2705-nested-loop-branch-container-slot.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Repro for https://github.com/piconic-ai/barefootjs/issues/2705
+ *
+ * `groups().map(group => <div><article>{group.show && group.items.map(item =>
+ * <section key={item.id}>{item.label}</section>)}</article></div>)` — a
+ * KEYED inner `.map()` living inside a `&&`-conditional that is itself
+ * inside a wrapper element (`<article>`) inside an OUTER loop's row.
+ *
+ * Root cause: `collectInnerLoops` (ir-to-client-js/collect-elements.ts),
+ * called with `branchInnerLoopOptions` from `summarizeLoopChildBranch` to
+ * gather the inner loops living inside a loop-row conditional's branch,
+ * seeds its slot-tracking walk with `parentSlotId: null` and only updates it
+ * by walking INTO elements inside the branch's own subtree (`element:
+ * descend({ ...scope, parentSlotId: el.slotId ?? scope.parentSlotId })`).
+ * Here the branch's rendered content IS the loop itself (no wrapping
+ * element inside the branch — `<article>` sits OUTSIDE the conditional, one
+ * level up), so the walk never observes an element with a slot id and
+ * `containerSlotId: scope.parentSlotId` (collect-elements.ts ~line 400)
+ * resolves to `null`.
+ *
+ * Downstream, `buildBranchInnerLoopsPlan` (control-flow/plan/build-loop-
+ * child-arm.ts) falls back to `containerExpr = scopeVar` (i.e. `__branchScope`
+ * verbatim) whenever `containerSlotId` is falsy — so the nested `mapArray`'s
+ * `container` argument is the WHOLE conditional's bind scope (the outer
+ * loop's row root, here the `<div>` wrapping `<article>`), not `<article>`
+ * itself. `mapArray`'s own marker lookup (`findLoopMarkers`, runtime/
+ * map-array.ts) only scans `container`'s DIRECT children for the
+ * `<!--bf-loop:l0-->` markers — which actually live one level deeper, inside
+ * `<article>` — so it never finds them, falls back to treating
+ * `container.children` (i.e. `<article>` itself, the row's one direct
+ * child) as the loop's "existing" item list, and:
+ *   - adopts `<article>` as if it were item[0] — stamping the WRONG
+ *     `data-key`/`data-key-1` (the first item's key) onto `<article>`;
+ *   - appends any items beyond the first as fresh `<section>` siblings of
+ *     `<article>`, directly under the outer row `<div>` — landing OUTSIDE
+ *     `<article>` entirely.
+ *
+ * Reproduces on the very FIRST hydration pass — no click/update required.
+ *
+ * A different mechanism from #2706 (that one is a compiler codegen gap for
+ * per-item conditionals inside a nested loop's OWN row; this one is a
+ * slot-id propagation gap for a loop nested inside a loop-row conditional's
+ * branch) — no shared root-cause line, though both are the same THEME: a
+ * nested `.map()` whose slot/container resolution assumes a shape a
+ * surrounding conditional silently breaks.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { renderHonoComponent } from '../../../adapter-hono/src/test-render'
+import { HonoAdapter } from '../../../adapter-hono/src/adapter/hono-adapter'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+
+const SOURCE = `"use client";
+import { createSignal } from '@barefootjs/client'
+type Item = { id: string; label: string }
+type Group = { id: string; show: boolean; items: Item[] }
+export function BarefootNestedLoopDuplicateRepro() {
+  const [groups, setGroups] = createSignal<Group[]>([
+    { id: 'group', show: true, items: [
+      { id: 'first', label: 'First' },
+      { id: 'second', label: 'Second' },
+    ]},
+  ])
+  return (
+    <div>
+      <button onClick={() => setGroups([...groups()])}>Replace</button>
+      {groups().map((group) => (
+        <div key={group.id}>
+          <article>
+            Group
+            {group.show &&
+              group.items.map((item) => (
+                <section key={item.id}>{item.label}</section>
+              ))}
+          </article>
+        </div>
+      ))}
+    </div>
+  )
+}
+`
+
+function clientJsFor(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compile errors in ${filename}:\n${errors.map(e => `${e.code}: ${e.message}`).join('\n')}`)
+  }
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error(`No client JS for ${filename}`)
+  return clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+}
+
+describe('#2705 — keyed nested loop behind a wrapped loop-row conditional', () => {
+  beforeEach(() => { document.body.innerHTML = '' })
+
+  // Pinned failing (Bun's `test.failing`): passes today because the bug
+  // exists. Will start FAILING once `collectInnerLoops`/`buildBranchInner
+  // LoopsPlan` resolve the loop's real container (`<article>`) instead of
+  // falling back to the whole conditional's bind scope — flip back to
+  // `test` at that point.
+  test.failing('SSR hydration does not misplace the last item outside <article> or mis-key it', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bf-2705-'))
+    const file = join(dir, 'Repro.mjs')
+    writeFileSync(file, clientJsFor(SOURCE, 'BarefootNestedLoopDuplicateRepro.tsx'))
+    await import(file)
+
+    const ssrHtml = await renderHonoComponent({
+      adapter: new HonoAdapter(),
+      source: SOURCE,
+      props: { __instanceId: 'BarefootNestedLoopDuplicateRepro_test' },
+    })
+    document.body.innerHTML = ssrHtml
+
+    const { rehydrateAll, flushHydration } = await import(runtimePath)
+    rehydrateAll()
+    flushHydration()
+
+    const article = document.querySelector('article')!
+    expect(article.getAttribute('data-key')).toBeNull()
+    expect(article.querySelectorAll('section').length).toBe(2)
+    expect(document.querySelectorAll('section').length).toBe(2)
+  })
+
+  // Not pinned: the SSR markup itself (pre-hydration) is correct — the
+  // divergence is purely a hydration-time DOM mutation, so this passes
+  // today and stays a normal regression pin for the SSR half.
+  test('the pre-hydration SSR markup nests both sections correctly inside <article>', async () => {
+    const ssrHtml = await renderHonoComponent({
+      adapter: new HonoAdapter(),
+      source: SOURCE,
+      props: { __instanceId: 'BarefootNestedLoopDuplicateRepro_test' },
+    })
+    document.body.innerHTML = ssrHtml
+    const article = document.querySelector('article')!
+    expect(article.getAttribute('data-key')).toBeNull()
+    expect(article.querySelectorAll('section').length).toBe(2)
+    expect(document.querySelectorAll('section').length).toBe(2)
+  })
+})

--- a/packages/client/__tests__/runtime/issue-2706-nested-loop-conditional-slot.test.ts
+++ b/packages/client/__tests__/runtime/issue-2706-nested-loop-conditional-slot.test.ts
@@ -1,33 +1,41 @@
 /**
- * Repro for https://github.com/piconic-ai/barefootjs/issues/2706
+ * Regression test for https://github.com/piconic-ai/barefootjs/issues/2706
+ * (fixed).
  *
  * `rows().map(row => <div>{row.items.map(item => <p>{cond ? <span/> : null}</p>)}</div>)`
  * — a per-item conditional living inside an INNER (nested) `.map()` row.
  *
- * `stringifyInnerLoops`'s `emitReactive` (ir-to-client-js/control-flow/
- * stringify/inner-loop.ts) unconditionally emits a re-claiming
- * `createEffect(() => { claimSlots(...).write(...) })` for any reactive text
- * flagged `insideConditional` (`InnerLoopText.insideConditional`,
- * ir-to-client-js/control-flow/plan/inner-loop.ts) — a pattern whose
- * correctness assumes `insert()` mounts/unmounts the branch so the marker is
- * always (re)present whenever the effect runs. But `buildInnerLoopsPlan` /
- * `InnerLoopReactiveEmit` (control-flow/plan/build-inner-loop.ts) has no
- * `conditionals` field at all — unlike the top-level loop's
- * `ReactiveEffectsPlan.conditionals` (control-flow/plan/build-reactive-
- * effects.ts), which DOES route a loop-row conditional through `insert()`.
- * So a per-item conditional inside a NESTED loop's row is baked directly
- * into the row's static HTML template (condition evaluated once, at row
- * creation, never revisited) with no `insert()` at all — yet the reactive
- * text nested in its true branch still gets the "insert()-will-keep-the-
- * marker-around" treatment. When the row is first created with the false
- * branch active, the marker never existed, and the effect's first run warns
- * `slot sN marker not found; skipping` / `no claimed slot for id sN; write
- * ignored` — even though nothing is actually broken visually (the DOM is
- * byte-correct; only the console is polluted and the pattern is fragile).
+ * Root cause: `buildInnerLoopsPlan` / `InnerLoopReactiveEmit` (control-flow/
+ * plan/build-inner-loop.ts) had no `conditionals` field at all — unlike the
+ * top-level loop's `ReactiveEffectsPlan.conditionals` (control-flow/plan/
+ * build-reactive-effects.ts), which DOES route a loop-row conditional
+ * through `insert()`. So a per-item conditional inside a NESTED loop's row
+ * was baked directly into the row's static HTML template — the condition
+ * evaluated exactly ONCE, at row creation, and never revisited even when it
+ * read a signal (a genuine SILENT DIVERGENCE, confirmed by experiment: an
+ * independent `createSignal` read by the condition kept flipping while the
+ * DOM stayed frozen — deeper than the originally-reported console warning).
+ * The reactive text nested in the branch still got the
+ * "insert()-will-keep-the-marker-around" re-claim treatment regardless, so
+ * when the row was first created with the false branch active, the marker
+ * never existed and the effect's first run warned `slot sN marker not
+ * found; skipping` / `no claimed slot for id sN; write ignored`.
+ *
+ * Fix: `collectInnerLoops` (ir-to-client-js/collect-elements.ts) now
+ * collects `bindings.conditionals` for EVERY inner loop (branch or not,
+ * previously gated behind branch-only `collectItemBindings`), and passes
+ * `stopAtReactiveConditionals: true` to `collectLoopChildReactiveTexts` /
+ * `collectLoopChildReactiveAttrs` so a reactive conditional's own content is
+ * no longer ALSO flattened into the old bake-and-reclaim path. `buildReactiveEmit`
+ * (build-inner-loop.ts) feeds those conditionals through the same
+ * `buildLoopChildConditionalsPlan` the branch-arm path already used, and
+ * `stringifyInnerLoops`'s `emitReactive` (stringify/inner-loop.ts) now emits
+ * a real `insert()` over the row's own element — full parity with the
+ * top-level loop's row-conditional handling.
  *
  * Confirmed adapter-independent: `generateClientJs` output is byte-identical
  * whether compiled via TestAdapter, HonoAdapter, or GoTemplateAdapter — the
- * defect is in `packages/jsx`'s codegen, not any one adapter.
+ * defect (and the fix) is in `packages/jsx`'s codegen, not any one adapter.
  */
 import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
@@ -90,15 +98,10 @@ const SOURCE = `
   }
 `
 
-describe('#2706 — nested-loop conditional slot claimed against a marker that was never rendered', () => {
+describe('#2706 — nested-loop row conditional gets real insert() parity', () => {
   beforeEach(() => { document.body.innerHTML = '' })
 
-  // Pinned failing (Bun's `test.failing`): passes today because the bug
-  // exists (no console warnings expected, but warnings fire); will start
-  // FAILING — the intended graduation signal — once the compiler routes
-  // this shape through `insert()` (or otherwise stops claiming a slot the
-  // active branch never rendered). At that point flip this back to `test`.
-  test.failing('adding a row whose item does not satisfy the conditional does not warn', async () => {
+  test('adding a row whose item does not satisfy the conditional does not warn', async () => {
     const el = await mount(SOURCE, 'BarefootSlotRepro.tsx', 'BarefootSlotRepro')
 
     const warnings: string[] = []
@@ -114,10 +117,7 @@ describe('#2706 — nested-loop conditional slot claimed against a marker that w
     expect(warnings).toEqual([])
   })
 
-  // Not pinned: the DOM shape itself is correct even though the console
-  // warns — this is the "silent" half of the divergence (only the console
-  // is wrong), so it stays a normal, currently-passing assertion.
-  test('the rendered DOM is structurally correct despite the console warnings', async () => {
+  test('the rendered DOM is structurally correct', async () => {
     const el = await mount(SOURCE, 'BarefootSlotRepro.tsx', 'BarefootSlotRepro')
     const button = el.querySelector('button')!
     button.dispatchEvent(new window.Event('click', { bubbles: true }))
@@ -125,5 +125,47 @@ describe('#2706 — nested-loop conditional slot claimed against a marker that w
     const p = el.querySelector('p')!
     expect(p.textContent?.trim()).toBe('Item')
     expect(p.querySelector('span')).toBeNull()
+  })
+
+  // The deeper half of the bug (found via experiment while diagnosing the
+  // fix direction, not in the original report): before the fix, a nested
+  // loop's row conditional was baked ONCE at row creation and never
+  // revisited — even when the condition read an INDEPENDENT signal totally
+  // unrelated to the row's own data. This asserts the DOM now genuinely
+  // follows the signal, not just that the console stays quiet.
+  test('a nested-loop row conditional on an independent signal updates the DOM when that signal changes', async () => {
+    const source = `
+      "use client";
+      import { createSignal } from '@barefootjs/client'
+      type Item = { id: string; label: string }
+      type Row = { id: string; items: Item[] }
+      export function ExtraToggleRepro() {
+        const [rows] = createSignal<Row[]>([{ id: 'row', items: [{ id: 'item', label: 'X' }] }])
+        const [show, setShow] = createSignal(false)
+        return (
+          <div>
+            <button onClick={() => setShow((v) => !v)}>Toggle</button>
+            {rows().map((row) => (
+              <div key={row.id}>
+                {row.items.map((item) => (
+                  <p key={item.id}>
+                    Item {item.label}
+                    {show() ? <span>Extra</span> : null}
+                  </p>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const el = await mount(source, 'ExtraToggleRepro.tsx', 'ExtraToggleRepro')
+    expect(el.querySelector('span')).toBeNull()
+
+    el.querySelector('button')!.dispatchEvent(new window.Event('click', { bubbles: true }))
+    expect(el.querySelector('span')?.textContent).toBe('Extra')
+
+    el.querySelector('button')!.dispatchEvent(new window.Event('click', { bubbles: true }))
+    expect(el.querySelector('span')).toBeNull()
   })
 })

--- a/packages/client/__tests__/runtime/issue-2706-nested-loop-conditional-slot.test.ts
+++ b/packages/client/__tests__/runtime/issue-2706-nested-loop-conditional-slot.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Repro for https://github.com/piconic-ai/barefootjs/issues/2706
+ *
+ * `rows().map(row => <div>{row.items.map(item => <p>{cond ? <span/> : null}</p>)}</div>)`
+ * — a per-item conditional living inside an INNER (nested) `.map()` row.
+ *
+ * `stringifyInnerLoops`'s `emitReactive` (ir-to-client-js/control-flow/
+ * stringify/inner-loop.ts) unconditionally emits a re-claiming
+ * `createEffect(() => { claimSlots(...).write(...) })` for any reactive text
+ * flagged `insideConditional` (`InnerLoopText.insideConditional`,
+ * ir-to-client-js/control-flow/plan/inner-loop.ts) — a pattern whose
+ * correctness assumes `insert()` mounts/unmounts the branch so the marker is
+ * always (re)present whenever the effect runs. But `buildInnerLoopsPlan` /
+ * `InnerLoopReactiveEmit` (control-flow/plan/build-inner-loop.ts) has no
+ * `conditionals` field at all — unlike the top-level loop's
+ * `ReactiveEffectsPlan.conditionals` (control-flow/plan/build-reactive-
+ * effects.ts), which DOES route a loop-row conditional through `insert()`.
+ * So a per-item conditional inside a NESTED loop's row is baked directly
+ * into the row's static HTML template (condition evaluated once, at row
+ * creation, never revisited) with no `insert()` at all — yet the reactive
+ * text nested in its true branch still gets the "insert()-will-keep-the-
+ * marker-around" treatment. When the row is first created with the false
+ * branch active, the marker never existed, and the effect's first run warns
+ * `slot sN marker not found; skipping` / `no claimed slot for id sN; write
+ * ignored` — even though nothing is actually broken visually (the DOM is
+ * byte-correct; only the console is polluted and the pattern is fragile).
+ *
+ * Confirmed adapter-independent: `generateClientJs` output is byte-identical
+ * whether compiled via TestAdapter, HonoAdapter, or GoTemplateAdapter — the
+ * defect is in `packages/jsx`'s codegen, not any one adapter.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+
+async function mount(source: string, filename: string, name: string): Promise<HTMLElement> {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter((e) => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compile errors in ${filename}:\n${errors.map((e) => `${e.code}: ${e.message}`).join('\n')}`)
+  }
+  const clientJs = result.files.find((f) => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error('No client JS emitted')
+  const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+  const rewritten = clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+  const dir = mkdtempSync(join(tmpdir(), 'bf-2706-'))
+  const file = join(dir, `${filename.replace(/\W/g, '_')}.mjs`)
+  writeFileSync(file, rewritten)
+  await import(file)
+  const { createComponent } = await import(runtimePath)
+  const el = createComponent(name, {}) as HTMLElement
+  document.body.appendChild(el)
+  return el
+}
+
+const SOURCE = `
+  "use client";
+  import { createSignal } from '@barefootjs/client'
+  type Item = { id: string; minimum: number }
+  type Row = { id: string; items: Item[] }
+  export function BarefootSlotRepro() {
+    const [rows, setRows] = createSignal<Row[]>([])
+    return (
+      <div>
+        <button onClick={() => setRows([{ id: 'row', items: [{ id: 'item', minimum: 1 }] }])}>Add</button>
+        {rows().map((row) => (
+          <div key={row.id}>
+            {row.items.map((item) => (
+              <p key={item.id}>
+                Item
+                {item.minimum > 1 ? <span>Minimum: {item.minimum}</span> : null}
+              </p>
+            ))}
+          </div>
+        ))}
+      </div>
+    )
+  }
+`
+
+describe('#2706 — nested-loop conditional slot claimed against a marker that was never rendered', () => {
+  beforeEach(() => { document.body.innerHTML = '' })
+
+  // Pinned failing (Bun's `test.failing`): passes today because the bug
+  // exists (no console warnings expected, but warnings fire); will start
+  // FAILING — the intended graduation signal — once the compiler routes
+  // this shape through `insert()` (or otherwise stops claiming a slot the
+  // active branch never rendered). At that point flip this back to `test`.
+  test.failing('adding a row whose item does not satisfy the conditional does not warn', async () => {
+    const el = await mount(SOURCE, 'BarefootSlotRepro.tsx', 'BarefootSlotRepro')
+
+    const warnings: string[] = []
+    const origWarn = console.warn
+    console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(' ')) }
+    try {
+      const button = el.querySelector('button')!
+      button.dispatchEvent(new window.Event('click', { bubbles: true }))
+    } finally {
+      console.warn = origWarn
+    }
+
+    expect(warnings).toEqual([])
+  })
+
+  // Not pinned: the DOM shape itself is correct even though the console
+  // warns — this is the "silent" half of the divergence (only the console
+  // is wrong), so it stays a normal, currently-passing assertion.
+  test('the rendered DOM is structurally correct despite the console warnings', async () => {
+    const el = await mount(SOURCE, 'BarefootSlotRepro.tsx', 'BarefootSlotRepro')
+    const button = el.querySelector('button')!
+    button.dispatchEvent(new window.Event('click', { bubbles: true }))
+
+    const p = el.querySelector('p')!
+    expect(p.textContent?.trim()).toBe('Item')
+    expect(p.querySelector('span')).toBeNull()
+  })
+})

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -125,7 +125,7 @@ export { findScope, find, $, $c, $t, qsa, qsaChildScope, qsaChildScopes, cssEsca
 export { date } from './date.ts'
 export { hydrate, rehydrateAll, rehydrateScope, disposeScope, flushHydration, getRegisteredDef } from './hydrate.ts'
 export { registerComponent, getComponentInit, initChild, upsertChild } from './registry.ts'
-export { insert, type BranchConfig, type BranchTemplateResult } from './insert.ts'
+export { insert, findCondContainer, type BranchConfig, type BranchTemplateResult } from './insert.ts'
 export { __bfSlot } from './branch-slot.ts'
 // `__bfText` (dynamic-text.ts) and `$t` (query.ts) are kept: one narrow
 // emission site — a `@client`-nested-inside-a-top-level-conditional dynamic

--- a/packages/client/src/runtime/insert.ts
+++ b/packages/client/src/runtime/insert.ts
@@ -88,6 +88,36 @@ function findCondStartInRange(anchor: Comment, id: string): Comment | null {
 }
 
 /**
+ * Resolve the DOM element that actually hosts an element-scoped loop-row
+ * conditional's branch content (#2705). A nested `mapArray` inside the
+ * branch's `bindEvents` needs a container to search for its own loop
+ * markers, but has no `bf="<slot>"` marker to query when the conditional
+ * sits inside a wrapper element the container-slot collector never visits
+ * (`collectInnerLoops`'s branch walk only sees elements INSIDE the
+ * branch's own IR subtree — a wrapper enclosing the conditional from the
+ * outside, e.g. `<article>{cond && items.map(...)}</article>`, is never
+ * one of them, so `containerSlotId` comes back `null`).
+ *
+ * The one DOM anchor available in that case is the conditional's own
+ * `<!--bf-cond-start:id-->` marker: whatever element that marker's parent
+ * is, is where `insert()` keeps the branch's content — adopted from SSR or
+ * freshly spliced by `updateFragmentConditional`, either way the marker
+ * stays put as one of the range's boundaries. Falls back to `scope` itself
+ * when no such marker is found (an element-conditional branch with no
+ * comment markers, or a conditional with no wrapper at all — `scope` IS
+ * the right container in that shape too) — never throws.
+ */
+export function findCondContainer(scope: Element, id: string): Element {
+  const want = `bf-cond-start:${id}`
+  for (const comment of commentsInScope(scope)) {
+    if (comment.nodeValue === want) {
+      return (comment.parentElement as Element | null) ?? scope
+    }
+  }
+  return scope
+}
+
+/**
  * Result returned by a branch's `template()` when the template captures
  * live DOM nodes via `__bfSlot` (#1213). `html` carries the marker-bearing
  * HTML string; `slots[N]` is the actual `Node` referenced by the

--- a/packages/jsx/src/__tests__/issue-2705-branch-inner-loop-container.test.ts
+++ b/packages/jsx/src/__tests__/issue-2705-branch-inner-loop-container.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Compiler-unit regression pin for #2705 (fixed).
+ *
+ * A loop nested inside a loop-row conditional's branch, behind a wrapper
+ * element the branch's own IR subtree never sees (`<article>{cond &&
+ * items.map(...)}</article>`), gets no `containerSlotId` of its own
+ * (`collectInnerLoops`'s branch walk in ir-to-client-js/collect-elements.ts
+ * never observes an ancestor outside the branch). `buildBranchInnerLoopsPlan`
+ * (control-flow/plan/build-loop-child-arm.ts) must fall back to
+ * `findCondContainer(__branchScope, '<condSlotId>')` — NOT the raw
+ * `__branchScope` (the whole conditional's bind scope, several elements
+ * wider than the loop's actual container; the pre-fix behavior that caused
+ * the runtime defect in issue-2705-nested-loop-branch-container-slot.test.ts).
+ */
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('#2705 — branch inner-loop container fallback', () => {
+  test('inner loop behind a wrapped loop-row `&&` conditional resolves its container via findCondContainer', () => {
+    const source = `
+      "use client";
+      import { createSignal } from '@barefootjs/client'
+      type Item = { id: string; label: string }
+      type Group = { id: string; show: boolean; items: Item[] }
+      export function Repro() {
+        const [groups] = createSignal<Group[]>([])
+        return (
+          <div>
+            {groups().map((group) => (
+              <div key={group.id}>
+                <article>
+                  Group
+                  {group.show &&
+                    group.items.map((item) => (
+                      <section key={item.id}>{item.label}</section>
+                    ))}
+                </article>
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'Repro.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const content = result.files.find(f => f.type === 'clientJs')!.content
+
+    // The conditional's own slot id feeds `findCondContainer` — never a raw
+    // `__branchScope` container for this inner mapArray.
+    expect(content).toMatch(/const __bic\w+ = findCondContainer\(__branchScope, '(s\d+)'\)/)
+    expect(content).not.toMatch(/const __bic\w+ = __branchScope\s*$/m)
+    expect(content).toContain('findCondContainer')
+  })
+
+  test('an existing (non-null containerSlotId) inner-loop container is unaffected', () => {
+    // Control: a loop DIRECTLY inside a component whose own element carries
+    // a slot id continues to resolve via the qsa/bf-h fallback chain, not
+    // `findCondContainer` — the fix only changes the previously-null path.
+    const source = `
+      "use client";
+      import { createSignal } from '@barefootjs/client'
+      type TreeNode = { id: number; name: string; type: 'file' | 'folder'; expanded: boolean; children: TreeNode[] }
+      export function FileBrowser() {
+        const [tree] = createSignal<TreeNode[]>([])
+        return (
+          <div>
+            {tree().map(node => (
+              <div key={node.id}>
+                {node.expanded ? (
+                  <div>
+                    {node.children.map(child => (
+                      <div key={child.id}>{child.name}</div>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'FileBrowser.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const content = result.files.find(f => f.type === 'clientJs')!.content
+    expect(content).not.toContain('findCondContainer')
+    expect(content).toMatch(/\.querySelector\('\[bf="s\d+"\]'\)/)
+  })
+})

--- a/packages/jsx/src/__tests__/nested-loop-conditional.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-conditional.test.ts
@@ -134,14 +134,15 @@ describe('nested loops/conditionals inside mapArray (#830, #839)', () => {
     expect(mapArrayCount).toBeGreaterThanOrEqual(3)
   })
 
-  test('reactive text inside conditional inside inner loop uses re-claim pattern (#840)', () => {
-    // When a reactive text is inside a conditional branch inside a nested (inner) loop,
-    // insert() may replace the SSR element after the text node is captured.
-    // Slot unification A3: the generated code must re-claim on EVERY run via
-    // a fresh `claimSlots(...).write(...)` call inside the effect body — not
-    // a `lazySlots` writer built once outside it, which would go stale once
-    // insert() swaps the branch's DOM (see `stringifyInnerLoops`' docstring
-    // in `ir-to-client-js/control-flow/stringify/inner-loop.ts`).
+  test('reactive text inside conditional inside inner loop gets a real insert() (#840, fixed by #2706)', () => {
+    // A per-item conditional living inside a NESTED (inner) loop's row now
+    // gets full insert() parity with a top-level loop's row conditional
+    // (#2706) — the condition is a real reactive `createEffect` dependency,
+    // not baked once at row creation, and the branch's reactive text binds
+    // through the arm's own `lazySlots(__branchScope, ...)` +
+    // `createDisposableEffect` (same shape `stringifyLoopChildArm` emits for
+    // any other insert() arm), never a bare-claimSlots reclaim racing
+    // against a marker the active branch may not have rendered.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -176,9 +177,17 @@ describe('nested loops/conditionals inside mapArray (#830, #839)', () => {
     expect(clientJs).toBeDefined()
     const content = clientJs!.content
 
-    // Re-claim pattern: a fresh `claimSlots(...)` call inside createEffect so
-    // it always resolves against the live node, never a cached stale ref.
-    expect(content).toMatch(/createEffect\(\(\) => \{ claimSlots\(__innerEl\w*, \[\{ id: 's\d+', kind: 'text', path: \[\] \}\]\)\.write\('s\d+', String\(/)
+    // A real insert() over the row's own element, keyed to the conditional's
+    // slot id and condition — not a static bake.
+    expect(content).toMatch(/insert\(__innerEl\w*, 's\d+', \(\) => child\(\)\.type === 'text', \{/)
+
+    // The branch's reactive text binds inside `bindEvents` via the standard
+    // arm-text shape (`lazySlots` + `createDisposableEffect`), scoped to
+    // `__branchScope` — the node insert() actually mounts for this branch —
+    // never a bare `claimSlots` reclaim against `__innerEl<uid>` racing the
+    // branch's own mount/unmount.
+    expect(content).toMatch(/const __bfw_s\d+ = lazySlots\(__branchScope, \[\{ id: 's\d+', kind: 'markup', path: \[\] \}\]\)/)
+    expect(content).toMatch(/createDisposableEffect\(\(\) => \{ __bfw_s\d+\('s\d+', escapeTextOrNode\(child\(\)\.label\)\) \}\)/)
   })
 
   test('event handler inside conditional branch of loop item appears in bindEvents (#839)', () => {

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -325,24 +325,47 @@ export function collectInnerLoops(
         // param) silently dropped its text-child update effect while the
         // sibling attribute effect (ungated) still fired. Refs need to fire
         // on every renderItem invocation (#1244).
-        //   - events / conditionals: only in `collectBindings` (branch)
-        //     mode; the legacy non-branch path didn't wire them on
-        //     `NestedLoop` because event delegation handles them through
-        //     the parent's bindings instead.
+        //   - events: only in `collectBindings` (branch) mode; the
+        //     legacy non-branch path didn't wire them on `NestedLoop`
+        //     because event delegation handles them through the parent's
+        //     bindings instead.
+        //   - conditionals: collected for EVERY inner loop, branch or not
+        //     (#2706) — see the `stopAtReactiveConditionals: true` note
+        //     below for why this must not be gated the same way events are.
         const bindings: LoopChildBindings = emptyLoopChildBindings()
         // Hoisted: one Set per loop, not one per child (Copilot review).
         const innerPreambleNames = preambleNamesOf(n)
         if (ctx) {
           for (const child of n.children) {
-            bindings.reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param, n.paramBindings, false, innerPreambleNames, n.index))
-            bindings.reactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param, n.paramBindings, false, innerPreambleNames, n.index))
+            // `stopAtReactiveConditionals: true` (#2347's parameter, #2706's
+            // fix here) — a per-item conditional inside THIS loop's own row
+            // now always gets its own `bindings.conditionals` entry (below)
+            // and its own `insert()`, regardless of branch/general mode.
+            // Descending past it here too (the pre-#2706 default) would
+            // double-bind: once via insert()'s bindEvents, once via this
+            // flat `insideConditional`-flagged reclaim-on-every-run effect
+            // — the latter is also unsound on its own, since nothing
+            // guarantees the branch's marker is mounted the moment this
+            // effect first runs (issue-2706-nested-loop-conditional-slot
+            // .test.ts's original repro).
+            bindings.reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param, n.paramBindings, true, innerPreambleNames, n.index))
+            bindings.reactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param, n.paramBindings, true, innerPreambleNames, n.index))
             bindings.refs.push(...collectLoopChildRefs(child))
           }
+          bindings.conditionals.push(...collectLoopChildConditionals(
+            { type: 'fragment', children: n.children, loc: n.loc } as unknown as IRNode,
+            ctx,
+            siblingOffsets,
+            n.param,
+            n.paramBindings,
+            innerPreambleNames,
+            n.index,
+          ))
         }
 
         // Per-item bindings for branch-mode callers (child components,
-        // events, nested conditionals) — matches the pre-Phase 2
-        // `collectBranchInnerLoops` behaviour.
+        // events) — matches the pre-Phase 2 `collectBranchInnerLoops`
+        // behaviour. Conditionals are collected above, uniformly.
         let childComponents: import('../types.ts').IRLoopChildComponent[] | undefined
         if (collectBindings) {
           // skipConditionals=true: components inside conditional branches
@@ -368,18 +391,6 @@ export function collectInnerLoops(
 
           for (const child of n.children) {
             bindings.events.push(...collectLoopChildEventsWithNesting(child))
-          }
-
-          if (ctx) {
-            bindings.conditionals.push(...collectLoopChildConditionals(
-              { type: 'fragment', children: n.children, loc: n.loc } as unknown as IRNode,
-              ctx,
-              siblingOffsets,
-              n.param,
-              n.paramBindings,
-              innerPreambleNames,
-              n.index,
-            ))
           }
         }
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
@@ -30,6 +30,8 @@ import {
 } from '../../utils.ts'
 import { buildChildRefBindings, buildStaticChildRefBindings } from '../shared.ts'
 import { renderPreamble, irToHtmlTemplate } from '../../html-template.ts'
+import { buildLoopChildConditionalsPlan } from './build-loop-child-arm.ts'
+import type { LoopChildConditionalPlan } from './loop-child-arm.ts'
 
 /**
  * Mirror of the helper in `build-loop-child-arm.ts` — kept local to avoid
@@ -160,6 +162,7 @@ function buildReactiveEmit(
   outerLoopParamBindings?: readonly LoopParamBinding[],
 ): InnerLoopReactiveEmit {
   const wrapInner = (expr: string) => wrapLoopParamAsAccessor(expr, inner.param, inner.paramBindings)
+  const wrapBoth = (expr: string) => wrapLoopParamAsAccessor(wrapOuter(expr), inner.param, inner.paramBindings)
   const { head: paramHead, unwrap: paramUnwrap } = destructureLoopParam(inner.param, inner.paramBindings)
   const wrappedKey = inner.key
     ? wrapLoopParamAsAccessor(inner.key, inner.param, inner.paramBindings)
@@ -249,6 +252,21 @@ function buildReactiveEmit(
 
   const childRefs = buildChildRefBindings(inner.bindings.refs, inner.param, inner.paramBindings)
 
+  // Per-item conditionals inside THIS loop's own row (#2706) — same
+  // insert()-parity treatment the top-level loop's row conditionals
+  // already get (`buildLoopReactiveEffectsPlan`), now extended to a
+  // NESTED loop's row too. `scopeVar` is the row's own element
+  // (`__innerEl<uidSuffix>`, matching `stringifyInnerLoops`'s emission),
+  // and `wrapBoth` matches every other per-item expression in this emit
+  // (outer accessor, then inner accessor).
+  const conditionals: LoopChildConditionalPlan[] = buildLoopChildConditionalsPlan({
+    conditionals: inner.bindings.conditionals,
+    scopeVar: `__innerEl${uidSuffix}`,
+    wrap: wrapBoth,
+    loopParam: inner.param,
+    loopParamBindings: inner.paramBindings,
+  })
+
   return {
     mode: 'reactive',
     keyFn: loopKeyFn(inner),
@@ -261,6 +279,7 @@ function buildReactiveEmit(
     events,
     reactiveTexts,
     reactiveAttrs,
+    conditionals,
     childRefs,
   }
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop-child-arm.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop-child-arm.ts
@@ -190,6 +190,14 @@ export interface BuildBranchInnerLoopsArgs {
   innerLoops: readonly NestedLoop[] | undefined
   /** The variable expression naming the parent scope element (e.g. `__branchScope`). */
   scopeVar: string
+  /**
+   * The enclosing conditional's own slot id — every call site of this
+   * builder originates from a conditional branch's arm, so this is always
+   * a real id. Used as the `containerExpr` fallback (`findCondContainer`,
+   * #2705) for an inner loop whose IR never got a `containerSlotId` of its
+   * own (its wrapper element sits outside the branch's IR subtree).
+   */
+  condSlotId: string
   /** Outer loop param identifier (the conditional's enclosing loop). */
   outerLoopParam: string
   /** Outer loop param destructuring metadata. */
@@ -214,6 +222,7 @@ export function buildBranchInnerLoopsPlan(
   const {
     innerLoops,
     scopeVar,
+    condSlotId,
     outerLoopParam,
     outerLoopParamBindings,
     wrapOuter,
@@ -230,10 +239,15 @@ export function buildBranchInnerLoopsPlan(
 
     const csl = inner.containerSlotId
     // Inner loop's container: host-side `bf="<slot>"` slot marker first,
-    // then (bf-h, bf-m) when the container is itself a child scope.
+    // then (bf-h, bf-m) when the container is itself a child scope. When
+    // neither exists — the loop's own IR never got a `containerSlotId`
+    // because its wrapper element sits outside the branch's IR subtree
+    // (#2705) — resolve via the conditional's OWN comment marker instead
+    // of falling back to the whole branch scope, which may be several
+    // elements wider than the loop's actual container.
     const containerExpr = csl
       ? `(${scopeVar}.querySelector('[bf="${csl}"]') ?? ${scopeVar}.querySelector(\`[${BF_HOST}="\${__scopeId}"][${BF_AT}="${csl}"]\`) ?? ${scopeVar})`
-      : scopeVar
+      : `findCondContainer(${scopeVar}, '${condSlotId}')`
 
     const { head: paramHead, unwrap: paramUnwrap } = destructureLoopParam(inner.param, inner.paramBindings)
     const wrappedKey = inner.key
@@ -372,12 +386,14 @@ export function buildLoopChildConditionalsPlan(
         wrap,
         loopParam,
         loopParamBindings,
+        condId: cond.slotId,
       }),
       whenFalseArm: buildLoopChildArmPlan({
         branch: cond.whenFalse,
         wrap,
         loopParam,
         loopParamBindings,
+        condId: cond.slotId,
       }),
     })
   }
@@ -439,10 +455,12 @@ interface BuildLoopChildArmArgs {
   wrap: (expr: string) => string
   loopParam: string
   loopParamBindings?: readonly LoopParamBinding[]
+  /** The enclosing conditional's own slot id — threaded to `buildBranchInnerLoopsPlan`'s `condSlotId` (#2705). */
+  condId: string
 }
 
 function buildLoopChildArmPlan(args: BuildLoopChildArmArgs): LoopChildArmPlan {
-  const { branch, wrap, loopParam, loopParamBindings } = args
+  const { branch, wrap, loopParam, loopParamBindings, condId } = args
   return {
     events: buildBranchEventBindingsPlan({
       events: branch.events,
@@ -455,6 +473,7 @@ function buildLoopChildArmPlan(args: BuildLoopChildArmArgs): LoopChildArmPlan {
     innerLoops: buildBranchInnerLoopsPlan({
       innerLoops: branch.innerLoops,
       scopeVar: '__branchScope',
+      condSlotId: condId,
       outerLoopParam: loopParam,
       outerLoopParamBindings: loopParamBindings,
       wrapOuter: wrap,

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-reactive-effects.ts
@@ -110,8 +110,8 @@ export function buildReactiveEffectsPlan(
         wrappedCondition: wrap(cond.condition),
         whenTrueTemplateHtml: addCondAttrToTemplate(wrap(cond.whenTrueHtml), cond.slotId),
         whenFalseTemplateHtml: addCondAttrToTemplate(wrap(cond.whenFalseHtml), cond.slotId),
-        whenTrueArm: buildOuterArm(cond.whenTrue, wrap, loopParam, loopParamBindings, profileComponentName),
-        whenFalseArm: buildOuterArm(cond.whenFalse, wrap, loopParam, loopParamBindings, profileComponentName),
+        whenTrueArm: buildOuterArm(cond.whenTrue, wrap, loopParam, loopParamBindings, cond.slotId, profileComponentName),
+        whenFalseArm: buildOuterArm(cond.whenFalse, wrap, loopParam, loopParamBindings, cond.slotId, profileComponentName),
         ...(cond.readsPreamble && { readsPreamble: true }),
       })
     }
@@ -130,6 +130,8 @@ function buildOuterArm(
   wrap: (expr: string) => string,
   loopParam: string,
   loopParamBindings: readonly LoopParamBinding[] | undefined,
+  /** The conditional's own slot id — threaded to `buildBranchInnerLoopsPlan`'s `condSlotId` (#2705). */
+  condSlotId: string,
   profileComponentName?: string,
 ): LoopChildArmPlan {
   return {
@@ -145,6 +147,7 @@ function buildOuterArm(
     innerLoops: buildBranchInnerLoopsPlan({
       innerLoops: branch.innerLoops,
       scopeVar: '__branchScope',
+      condSlotId,
       outerLoopParam: loopParam,
       outerLoopParamBindings: loopParamBindings,
       wrapOuter: wrap,

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
@@ -17,6 +17,7 @@ import type {
   LoopParamBinding,
 } from '../../../types.ts'
 import type { LoopChildRefBinding } from './loop.ts'
+import type { LoopChildConditionalPlan } from './loop-child-arm.ts'
 
 /**
  * Body-entry statements emitted in order at the top of a `mapArray`
@@ -148,6 +149,17 @@ export interface InnerLoopReactiveEmit {
   reactiveTexts: readonly InnerLoopText[]
   /** Pre-wrapped reactive attribute effects for the inner-item body. */
   reactiveAttrs: readonly InnerLoopReactiveAttr[]
+  /**
+   * Per-item conditionals inside THIS loop's own row (#2706) — each gets
+   * its own `insert()` call, the same insert()-parity the top-level loop's
+   * row conditionals already have (`ReactiveEffectsPlan.conditionals`).
+   * Before this field existed, a per-item conditional inside a nested
+   * loop's row was baked into the static row template ONCE at row
+   * creation and never revisited — silently frozen against later signal
+   * changes — while its reactive text still (unsoundly) assumed insert()
+   * kept the branch's marker around.
+   */
+  conditionals: readonly LoopChildConditionalPlan[]
   /** Pre-wrapped imperative ref callbacks for the inner-item body (#1244). */
   childRefs: readonly LoopChildRefBinding[]
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
@@ -14,6 +14,7 @@
  *     <indent>  emitComponentAndEventSetup(...)
  *     <indent>  recurse on childLevels
  *     <indent>  reactive text effects
+ *     <indent>  per-item conditionals: insert() over __innerEl<uid> (#2706)
  *     <indent>  return __innerEl<uid>
  *     <indent>}) }
  *
@@ -36,6 +37,7 @@ import { emitAttrUpdate } from '../../emit-reactive.ts'
 import { emitMultiRootTemplateCloneLines, namespaceWrapForTemplate } from './template-parse.ts'
 import { emitLoopChildRefs } from './loop.ts'
 import { claimPlanLiteral, claimWriterVarName, type ClaimSlotSpec } from './claim-plan.ts'
+import { stringifyLoopChildConditionals } from './loop-child-arm.ts'
 import type {
   InnerLoopPlan,
   InnerLoopsPlan,
@@ -138,6 +140,13 @@ function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string, pc:
       lines.push(`${indent}    ${stmt}`)
     }
     lines.push(`${indent}  }${profileBindingId(pc, attr.slotId)}) }`)
+  }
+  // Per-item conditionals inside THIS loop's own row (#2706) — each is a
+  // real `insert()` over `__innerEl<uid>`, not a bake-once-at-creation
+  // ternary. Mirrors `stringifyBranchInnerLoops`'s identical call for a
+  // branch-scoped inner loop's own conditionals.
+  if (emit.conditionals.length > 0) {
+    stringifyLoopChildConditionals(lines, emit.conditionals, `${indent}  `, pc)
   }
   // Imperative ref callbacks fire on every renderItem invocation, which
   // means every mount: SSR hydration, initial CSR creation, and same-key

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -11,6 +11,11 @@ import { identifierCallPattern } from '../identifier-pattern.ts'
 export const RUNTIME_IMPORT_CANDIDATES = [
   'createSignal', 'createMemo', 'createEffect', 'onCleanup', 'onMount',
   'hydrate', 'insert', 'getLoopChildren', 'getLoopNodes', 'mapArray', 'mapArrayAnchored', 'mapArrayLazy', 'patchLeaf', 'createDisposableEffect',
+  // Resolves the real DOM container for a loop nested inside a loop-row
+  // conditional's branch when the conditional's wrapper element carries no
+  // `bf="<slot>"` marker of its own (#2705) — see `findCondContainer`'s
+  // docstring (runtime/insert.ts) for why the marker collector can't see it.
+  'findCondContainer',
   'createComponent', 'renderChild', 'registerComponent', 'registerTemplate', 'initChild', 'upsertChild',
   // Connects a template-clone loop row before the body's tail runs, so a child
   // that inits inside it resolves context against real ancestors rather than


### PR DESCRIPTION
Fixes #2705. Fixes #2706.

Two externally-reported nested-loop bugs (both adapter-independent — the compiled client JS is byte-identical across adapters, so these are `packages/jsx` codegen defects, not go-template ones). Distinct root causes, no shared fix; landed as one commit per bug with the pinned repro tests graduating in the same PR.

## #2705 — keyed inner loop behind a wrapped loop-row conditional (commit 2)

`<article>{group.show && group.items.map(...)}</article>` inside a loop row: `collectInnerLoops`'s branch walk only observes elements *inside* the branch's own IR subtree, so a wrapper enclosing the conditional from the outside never yields a `containerSlotId`, and `buildBranchInnerLoopsPlan` fell back to the **whole row root** as the `mapArray` container. `mapArray`'s marker lookup scans only direct children, missed the real `<!--bf-loop-->` markers inside `<article>`, adopted `<article>` itself as item[0] (wrong `data-key` stamping), and appended further items *outside* `<article>` — on the very first hydration pass, before any interaction.

**Fix**: no new slot ids. The conditional's own `<!--bf-cond-start:id-->` marker is the one DOM anchor guaranteed to sit inside the real wrapper, so the fallback now resolves through a new runtime helper `findCondContainer(scope, id)` (`@barefootjs/client/runtime`) that returns that marker's parent element. The `containerSlotId`-present path is unchanged.

## #2706 — per-item conditional inside a nested loop's own row (commit 3)

The reported symptom was console pollution (`slot s2 marker not found` / `no claimed slot`) with a visually correct DOM. Triage found the deeper defect: a nested row's conditional was **baked once into the static row template and never revisited** — an independent signal read by the condition kept flipping while the DOM stayed frozen (confirmed by experiment; the top-level loop path routes the same shape through `insert()`). The warnings were the visible edge of that gap: the branch's reactive text assumed `insert()` kept its marker mounted, but no `insert()` existed.

**Fix**: full insert() parity. `collectInnerLoops` now collects `bindings.conditionals` for every inner loop (not just branch-mode), routes them through the existing `buildLoopChildConditionalsPlan` / `stringifyLoopChildConditionals` machinery, and stops flattening a reactive conditional's content into the old bake-and-reclaim path (`stopAtReactiveConditionals: true`) so the two mechanisms never double-bind. The pre-existing #840 pin asserting the old reclaim pattern now asserts the correct insert() shape instead.

## Tests

- `packages/client/__tests__/runtime/issue-2705-…` / `issue-2706-…`: pinned repro tests (commit 1, `test.failing`) graduated to plain `test` with the fixes; #2706's spec also gained a DOM-follows-signal-flip assertion.
- `packages/jsx/src/__tests__/issue-2705-branch-inner-loop-container.test.ts`: compiler-level pin for the `findCondContainer` wiring.
- Suites: `packages/jsx` 3146 tests 0 fail, `packages/client` 650 pass, `packages/adapter-tests` 2142 pass, `packages/compat` 508 pass; `tsc --noEmit` clean on jsx + client.
- `generate-expected-html.ts`, `compat:lock`, `support-matrix:lock` all re-run against freshly built dist: **zero diffs** (no existing fixture covers these shapes — corpus fixtures for them are queued as part of the #2481 sweep work).

## Changesets

`@barefootjs/jsx` patch ×2, `@barefootjs/client` patch (new runtime helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_